### PR TITLE
chore(deps): batch safe dependency updates

### DIFF
--- a/.github/workflows/akroasis-android.yml
+++ b/.github/workflows/akroasis-android.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/akroasis-web.yml
+++ b/.github/workflows/akroasis-web.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/mouseion.yml
+++ b/.github/workflows/mouseion.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
 

--- a/akroasis/android/gradle/libs.versions.toml
+++ b/akroasis/android/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.7.3"
 kotlin = "2.3.10"
 ksp = "2.3.6"
-compose = "1.10.3"
+compose = "1.10.4"
 composeCompiler = "1.5.15"
 hilt = "2.59.2"
 retrofit = "2.11.0"
@@ -30,7 +30,7 @@ androidx-compose-graphics = { group = "androidx.compose.ui", name = "ui-graphics
 androidx-compose-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
-androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version = "1.1.0-alpha06" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version = "1.1.0" }
 androidx-media = { group = "androidx.media", name = "media", version = "1.7.1" }
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }

--- a/akroasis/web/package-lock.json
+++ b/akroasis/web/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.13.0",
+        "react-router-dom": "^7.13.1",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -29,10 +29,10 @@
         "@vitejs/plugin-react": "^5.1.4",
         "@vitest/coverage-v8": "^4.0.18",
         "@vitest/ui": "^4.0.16",
-        "autoprefixer": "^10.4.24",
+        "autoprefixer": "^10.4.27",
         "eslint": "^9.39.3",
         "eslint-plugin-react-hooks": "^7.0.1",
-        "eslint-plugin-react-refresh": "^0.5.0",
+        "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^16.5.0",
         "happy-dom": "^20.7.0",
         "msw": "^2.12.10",
@@ -4306,9 +4306,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.24",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
-      "integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
       "dev": true,
       "funding": [
         {
@@ -4327,7 +4327,7 @@
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001766",
+        "caniuse-lite": "^1.0.30001774",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -4578,9 +4578,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001770",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
-      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "version": "1.0.30001775",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001775.tgz",
+      "integrity": "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==",
       "dev": true,
       "funding": [
         {
@@ -5350,13 +5350,13 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.0.tgz",
-      "integrity": "sha512-ZYvmh7VfVgqR/7wR71I3Zl6hK/C5CcxdWYKZSpHawS5JCNgE4efhQWg/+/WPpgGAp9Ngp/rRZYyaIwmPQBq/lA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
+      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "eslint": ">=9"
+        "eslint": "^9 || ^10"
       }
     },
     "node_modules/eslint-scope": {
@@ -7863,9 +7863,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -7885,12 +7885,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
-      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.0"
+        "react-router": "7.13.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/akroasis/web/package.json
+++ b/akroasis/web/package.json
@@ -23,7 +23,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.13.0",
+    "react-router-dom": "^7.13.1",
     "zustand": "^5.0.11"
   },
   "devDependencies": {
@@ -39,10 +39,10 @@
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.16",
-    "autoprefixer": "^10.4.24",
+    "autoprefixer": "^10.4.27",
     "eslint": "^9.39.3",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.5.0",
+    "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^16.5.0",
     "happy-dom": "^20.7.0",
     "msw": "^2.12.10",

--- a/mouseion/tests/Mouseion.Api.Tests/Mouseion.Api.Tests.csproj
+++ b/mouseion/tests/Mouseion.Api.Tests/Mouseion.Api.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0" />
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />

--- a/mouseion/tests/Mouseion.Common.Tests/Mouseion.Common.Tests.csproj
+++ b/mouseion/tests/Mouseion.Common.Tests/Mouseion.Common.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/mouseion/tests/Mouseion.Core.Tests/Mouseion.Core.Tests.csproj
+++ b/mouseion/tests/Mouseion.Core.Tests/Mouseion.Core.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Summary

Batches 9 safe dependabot PRs into a single update. Supersedes #3, #5, #6, #9, #10, #12, #14, #15, #16.

| Component | Package | Change | Risk |
|-----------|---------|--------|------|
| CI | actions/setup-dotnet | v4 → v5 | CI-only |
| CI | gradle/actions | v4 → v5 | CI-only |
| CI | actions/setup-node | v4 → v6 | CI-only |
| Android | compose-material | 1.10.3 → 1.10.4 | Patch |
| Android | security-crypto | 1.1.0-alpha06 → 1.1.0 | Alpha → stable |
| Web | autoprefixer | 10.4.24 → 10.4.27 | Patch |
| Web | react-router-dom | 7.13.0 → 7.13.1 | Patch |
| Web | eslint-plugin-react-refresh | 0.5.0 → 0.5.2 | Patch |
| Backend | coverlet.collector | 6.0.4 → 8.0.0 | Test tooling |

### Rejected (closed)
- #8 tailwindcss 3→4 — full rewrite, needs manual migration
- #11 @eslint/js 9→10 — conflicts with eslint v9

### Held (still open, need testing)
- #4 compose-bom 2024→2026 (major, 14-month jump)
- #7 retrofit 2→3 (major, coordinate with okhttp)
- #13 okhttp 4→5 (major, coordinate with retrofit)
- #17 FluentAssertions 7→8 (major API changes)
- #18 FluentMigrator 7→8 (major, pair with #19)
- #19 FluentMigrator.Runner 7→8 (major, pair with #18)

## Test plan
- [ ] CI workflows trigger correctly with updated action versions
- [ ] Android build passes with compose-material patch + security-crypto stable
- [ ] Web build passes with npm patch updates
- [ ] Backend tests pass with coverlet 8.0.0