### PR TITLE
docs: Phase 0 Batch 2 — news, vision, workspace deps

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@
 - [media/import-rename.md](media/import-rename.md) — Import and rename pipeline
 - [media/music.md](media/music.md) — Music-specific design: MusicBrainz, ReplayGain
 - [media/audiobooks.md](media/audiobooks.md) — Audiobook-specific design: M4B, chapters, position
+- [media/news.md](media/news.md) — News feed design: RSS/Atom aggregation, article storage
 - [media/subtitles.md](media/subtitles.md) — Subtitle management
 
 ## Serving & Integrations

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -2,7 +2,7 @@
 
 ## What Harmonia Is
 
-Harmonia is a unified, self-hosted media operations platform — a single Rust binary that replaces the entire *arr ecosystem, torrent client, indexers, and media servers. It manages, downloads, organizes, and serves all media types: music, audiobooks, books, comics, podcasts, movies, and TV shows. Video playback stays with Plex; everything else plays through Harmonia's own clients (see [GLOSSARY.md](GLOSSARY.md) for platform name definitions).
+Harmonia is a unified, self-hosted media operations platform — a single Rust binary that replaces the entire *arr ecosystem, torrent client, indexers, and media servers. It manages, downloads, organizes, and serves all media types: music, audiobooks, ebooks, podcasts, manga, news, movies, and TV shows. Video playback stays with Plex; everything else plays through Harmonia's own clients (see [GLOSSARY.md](GLOSSARY.md) for platform name definitions).
 
 Music and audiobooks are the priority. They carry the highest quality bar — bit-perfect playback, proper metadata, gapless transitions, ReplayGain — where the *arr tools have historically made compromises. Every other media type is in scope, but music and audiobooks define the quality floor.
 
@@ -84,3 +84,21 @@ These services are connected via API — Harmonia uses them, not replaces them.
 - **Parameterize, don't duplicate** — single source of truth for all config values; nothing updated in two places
 - **Consolidated config** — one subsystem for all configuration and private data; simplifies `.gitignore`
 - **Hierarchical structure** — applies to docs, code organization, and configuration
+
+## Architecture Decisions
+
+### D3: Mobile — Native Android + UniFFI
+
+**Decision:** Tauri Mobile rejected. Mobile app is native Android (Kotlin + Jetpack Compose)
+with Rust audio core exposed via UniFFI/JNI.
+
+**Rationale (R1 research):**
+- Background playback, lock screen controls, and audio focus have no Tauri Mobile solution
+- Zero confirmed Tauri Mobile music apps exist anywhere
+- Custom native app is required regardless — covers all 8 media types (audiobooks, podcasts,
+  manga, ebooks, etc.), not just music
+- Existing akroasis codebase has 29K lines of Kotlin validating this direction
+- Same Rust audio core (akroasis-core), different delivery mechanism
+
+**Secondary:** OpenSubsonic API (R11, ~25 endpoints) provides Symfonium/Ultrasonic
+compatibility for music-only mobile clients as a bonus, not the primary strategy.

--- a/docs/architecture/cargo.md
+++ b/docs/architecture/cargo.md
@@ -246,6 +246,129 @@ rand          = "0.9"
 
 ---
 
+## Workspace Dependencies
+
+Complete `[workspace.dependencies]` block for the root `Cargo.toml`. This is the canonical dependency reference — when Phase 1 implementation starts, this block drops directly into `Cargo.toml`. Feature flags are explicit; no implicit defaults that pull unwanted dependencies.
+
+**Pending before merging into `Cargo.toml`:**
+- Verify `sevenz-rust2` exact current version on crates.io and uncomment the entry
+- `oboe` is Android-only — declare locally in `akroasis-core/Cargo.toml` alongside the JNI/FFI boundary, not here
+- `dasp` intentionally omitted — inline what is needed in `akroasis-core`
+- `irc` intentionally omitted — use thin custom implementation (~300 lines)
+
+```toml
+[workspace.dependencies]
+# ── Internal crates ───────────────────────────────────────────────────────────
+harmonia-common = { path = "crates/harmonia-common" }
+horismos        = { path = "crates/horismos" }
+harmonia-db     = { path = "crates/harmonia-db" }
+exousia         = { path = "crates/exousia" }
+syndesmos       = { path = "crates/syndesmos" }
+epignosis       = { path = "crates/epignosis" }
+zetesis         = { path = "crates/zetesis" }
+ergasia         = { path = "crates/ergasia" }
+syntaxis        = { path = "crates/syntaxis" }
+taxis           = { path = "crates/taxis" }
+kritike         = { path = "crates/kritike" }
+prostheke       = { path = "crates/prostheke" }
+paroche         = { path = "crates/paroche" }
+syndesis        = { path = "crates/syndesis" }
+episkope        = { path = "crates/episkope" }
+aitesis         = { path = "crates/aitesis" }
+
+# ── Async runtime ─────────────────────────────────────────────────────────────
+tokio           = { version = "1", features = ["full"] }
+
+# ── HTTP server ───────────────────────────────────────────────────────────────
+axum            = { version = "0.8", features = ["ws"] }
+tower           = "0.5"
+tower-http      = { version = "0.6", features = ["trace", "cors", "compression-full"] }
+
+# ── HTTP client ───────────────────────────────────────────────────────────────
+reqwest         = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+
+# ── Serialization ─────────────────────────────────────────────────────────────
+serde           = { version = "1", features = ["derive"] }
+serde_json      = "1"
+
+# ── Error handling ────────────────────────────────────────────────────────────
+snafu           = { version = "0.8", features = ["rust_1_65"] }
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+figment         = { version = "0.10", features = ["toml", "env"] }
+
+# ── Tracing ───────────────────────────────────────────────────────────────────
+tracing             = "0.1"
+tracing-subscriber  = { version = "0.3", features = ["env-filter", "json"] }
+
+# ── Database ──────────────────────────────────────────────────────────────────
+sqlx            = { version = "0.8.6", features = ["sqlite", "runtime-tokio", "macros", "migrate"] }
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+jsonwebtoken    = "9"
+argon2          = "0.5"
+rand            = "0.9"
+
+# ── IDs & strings ─────────────────────────────────────────────────────────────
+ulid            = { version = "1.2", features = ["serde"] }
+uuid            = { version = "1", features = ["v7", "serde"] }
+compact_str     = { version = "0.9", features = ["serde"] }
+
+# ── Time ──────────────────────────────────────────────────────────────────────
+jiff            = { version = "0.2", features = ["serde"] }
+
+# ── File system ───────────────────────────────────────────────────────────────
+walkdir         = "2.5"
+notify          = "8.2"
+
+# ── Audio metadata / tagging ──────────────────────────────────────────────────
+lofty           = "0.23"
+
+# ── Audio decoding ────────────────────────────────────────────────────────────
+symphonia       = { version = "0.5", features = ["all"] }
+# Opus decoder (symphonia has no Opus support — C bindings to libopus required)
+# NixOS build input: pkgs.libopus; or enable the crate's build-from-source feature
+opus            = "0.3"
+# Sample rate conversion — pure Rust, real-time safe, SIMD-accelerated
+rubato          = "1.0"
+# EBU R128 / ReplayGain loudness analysis
+ebur128         = "0.1"
+
+# ── Audio output ──────────────────────────────────────────────────────────────
+# cpal: desktop/Linux audio output via ALSA, PipeWire, JACK
+# (declare locally in akroasis-core if that crate is outside the workspace)
+cpal            = "0.17"
+
+# ── Image processing ──────────────────────────────────────────────────────────
+image               = "0.25"
+fast_image_resize   = "6.0"
+
+# ── QUIC transport ────────────────────────────────────────────────────────────
+quinn           = "0.11"
+
+# ── mDNS discovery ────────────────────────────────────────────────────────────
+mdns-sd         = "0.18"
+
+# ── Scheduling ────────────────────────────────────────────────────────────────
+tokio-cron-scheduler = "0.15"
+
+# ── Acquisition ───────────────────────────────────────────────────────────────
+# Pin to exact version — narrow documented embedding surface
+librqbit        = "=8.1.1"
+zip             = "8.2"
+# sevenz-rust2: verify exact version on crates.io before pinning
+# sevenz-rust2 = "X.Y.Z"
+nzb-rs          = "0.6"
+
+# ── Feeds ─────────────────────────────────────────────────────────────────────
+feed-rs         = "2.3"
+
+# ── Test ──────────────────────────────────────────────────────────────────────
+rstest          = "0.25"
+```
+
+---
+
 ## Per-Crate Cargo.toml Pattern
 
 Individual crate Cargo.toml files inherit version, edition, and license from the workspace. All shared external dependencies are declared with `.workspace = true`.

--- a/docs/data/media-schemas.md
+++ b/docs/data/media-schemas.md
@@ -1,6 +1,6 @@
 # Media Schemas
 
-> Per-type table definitions for all seven media types in Harmonia.
+> Per-type table definitions for all eight media types in Harmonia.
 > Related: [entity-registry.md](entity-registry.md) for registry FK pattern, [quality-profiles.md](quality-profiles.md) for quality score context, [want-release.md](want-release.md) for lifecycle tables that reference these tables.
 
 ## Design Principles
@@ -540,6 +540,62 @@ CREATE TABLE tv_series_cast (
     PRIMARY KEY (series_id, person_id, role)
 );
 ```
+
+---
+
+## News
+
+News uses a two-table design: feeds (the RSS/Atom subscription) and articles (individual items). Like podcasts, news feeds are outside the want/release/have lifecycle — articles are fetched automatically on schedule. See `want-release.md` News Exception for the rationale.
+
+### `news_feeds`
+
+```sql
+CREATE TABLE news_feeds (
+    id                     BLOB NOT NULL PRIMARY KEY,
+    title                  TEXT NOT NULL,
+    url                    TEXT NOT NULL UNIQUE,
+    site_url               TEXT,
+    description            TEXT,
+    category               TEXT,
+    icon_url               TEXT,
+    last_fetched_at        TEXT,
+    fetch_interval_minutes INTEGER NOT NULL DEFAULT 60,
+    is_active              INTEGER NOT NULL DEFAULT 1,
+    added_at               TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at             TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE UNIQUE INDEX idx_nf_url ON news_feeds(url);
+```
+
+`url` is the RSS/Atom feed URL — unique constraint prevents duplicate subscriptions. `category` is a user-assigned label (free-text, no normalized taxonomy). `is_active = 0` suspends fetching without deleting the feed or its articles.
+
+### `news_articles`
+
+```sql
+CREATE TABLE news_articles (
+    id           BLOB NOT NULL PRIMARY KEY,
+    feed_id      BLOB NOT NULL REFERENCES news_feeds(id) ON DELETE CASCADE,
+    guid         TEXT NOT NULL,
+    title        TEXT NOT NULL,
+    url          TEXT NOT NULL,
+    author       TEXT,
+    content_html TEXT,
+    summary      TEXT,
+    published_at TEXT,
+    is_read      INTEGER NOT NULL DEFAULT 0,
+    is_starred   INTEGER NOT NULL DEFAULT 0,
+    source_type  TEXT NOT NULL DEFAULT 'rss' CHECK(source_type IN ('rss', 'atom')),
+    added_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(feed_id, guid)
+);
+
+CREATE INDEX idx_na_feed ON news_articles(feed_id);
+CREATE INDEX idx_na_pub_date ON news_articles(feed_id, published_at);
+CREATE INDEX idx_na_starred ON news_articles(is_starred) WHERE is_starred = 1;
+```
+
+`UNIQUE(feed_id, guid)` deduplicates articles on feed refresh — the same item_guid seen twice is an upsert, not a new row. `content_html` stores full article body when the feed provides it; `summary` stores the excerpt. `is_read` and `is_starred` are per-user in a multi-user context but stored flat in v1 (single-user assumption matches podcasts).
 
 ---
 

--- a/docs/data/want-release.md
+++ b/docs/data/want-release.md
@@ -45,7 +45,7 @@ CREATE INDEX idx_wants_registry ON wants(registry_id);
 | Column | Type | Notes |
 |--------|------|-------|
 | `id` | `BLOB NOT NULL PRIMARY KEY` | UUIDv7, 16-byte BLOB. |
-| `media_type` | `TEXT NOT NULL` | Constrained to seven values. Determines which per-type table the fulfilled have references. |
+| `media_type` | `TEXT NOT NULL` | Constrained to seven values (news feeds are excluded — see News Exception below). Determines which per-type table the fulfilled have references. |
 | `title` | `TEXT NOT NULL` | Human-readable title for display in the UI. Not a canonical identifier. |
 | `registry_id` | `BLOB` | NULLABLE. A want can exist before identity is resolved. Epignosis fills this in asynchronously after the want is created. |
 | `quality_profile_id` | `INTEGER NOT NULL` | FK to `quality_profiles(id)`. Determines floor, ceiling, and upgrade behaviour. |
@@ -201,6 +201,12 @@ total_score = release.quality_score + release.custom_format_score
 Podcast subscriptions do not use the want/release/have lifecycle. A `podcast_subscriptions` row auto-downloads new episodes from the feed without the search-evaluate-grab pipeline. The want lifecycle applies to individual podcast episodes only if the user explicitly creates a want for a specific episode.
 
 The `podcast_subscriptions` table and `podcast_episodes` table are defined in `media-schemas.md`. The `wants.media_type` CHECK constraint does not include `podcast_subscription` — there is no concept of "wanting" a subscription feed in the same way as an album or film.
+
+## News Exception
+
+News feeds follow the same pattern as podcasts. A `news_feeds` row fetches articles on a schedule; no search-evaluate-grab pipeline is involved. Articles arrive via the feed — there is no acquisition step in the torrent/usenet sense.
+
+The `news_feeds` table and `news_articles` table are defined in `media-schemas.md`. The `wants.media_type` CHECK constraint does not include `news_feed` — individual news articles are not wanted, they are pulled automatically.
 
 ---
 

--- a/docs/media/lifecycle.md
+++ b/docs/media/lifecycle.md
@@ -1,6 +1,6 @@
 # Media Lifecycle State Machine
 
-> Shared lifecycle state machine for all 7 media types, with per-type extensions.
+> Shared lifecycle state machine for all 8 media types, with per-type extensions.
 > See [architecture/subsystems.md](../architecture/subsystems.md) for state ownership by subsystem.
 > See [data/want-release.md](../data/want-release.md) for acquisition half (wants/releases/haves tables).
 > See [data/media-schemas.md](../data/media-schemas.md) for per-type table schemas.
@@ -9,7 +9,7 @@
 
 ## Core State Machine
 
-Six states apply to all 7 media types (music, audiobooks, books, comics, podcasts, movies, TV):
+Six states apply to all 8 media types (music, audiobooks, books, comics, podcasts, news, movies, TV):
 
 ```
 discovered -> wanted -> downloading -> imported -> [type-extensions] -> organized -> available

--- a/docs/media/metadata-providers.md
+++ b/docs/media/metadata-providers.md
@@ -23,6 +23,7 @@ If the canonical provider fails: the item stays in `imported` state and a retry 
 | Audiobooks | Audnexus | OpenLibrary (book identity, ISBN, author) |
 | Comics | ComicVine | — |
 | Podcasts | iTunes Podcast API | — |
+| News | Feed URL (self-describing) | — |
 
 ---
 

--- a/docs/media/news.md
+++ b/docs/media/news.md
@@ -1,0 +1,59 @@
+# News (RSS/Atom Feed Aggregation)
+
+> Related: [data/media-schemas.md](../data/media-schemas.md) for table definitions, [data/want-release.md](../data/want-release.md) for the News Exception, [media/lifecycle.md](lifecycle.md) for lifecycle state machine.
+
+## Overview
+
+News feeds are RSS/Atom sources aggregated into the Harmonia library. Articles are fetched on schedule, stored locally, and presented alongside other media types in the unified library view.
+
+News is the eighth media type. It sits alongside podcasts in the feed-based category — both use RSS/Atom as a transport — but they are distinct types. Podcasts have audio enclosures; news has text articles. They share no tables.
+
+## Acquisition
+
+- User adds feed URLs manually or via OPML import
+- Syntaxis schedules periodic feed fetches (default: hourly, configurable per feed)
+- feed-rs parses both RSS 2.0 and Atom 1.0
+- Articles stored with full content when the feed provides it; summary otherwise
+- Full article body extraction via readability is deferred to Phase 5
+
+Feed fetching does not use the want/release/have pipeline. There is no search or grab step — the feed URL is the source. See `want-release.md` News Exception.
+
+## Metadata
+
+**Feed-level** metadata comes directly from the feed document:
+
+| Field | Source |
+|-------|--------|
+| `title` | `<title>` element |
+| `site_url` | `<link>` element (the website, not the feed URL) |
+| `description` | `<description>` / `<subtitle>` element |
+| `icon_url` | `<image>` / `<icon>` element |
+
+**Article-level** metadata:
+
+| Field | Source |
+|-------|--------|
+| `title` | `<title>` element |
+| `url` | `<link>` element |
+| `author` | `<author>` / `<dc:creator>` element |
+| `content_html` | `<content:encoded>` or `<content>` element |
+| `summary` | `<description>` element (RSS) / `<summary>` (Atom) |
+| `published_at` | `<pubDate>` (RSS) / `<published>` (Atom) |
+| `guid` | `<guid>` (RSS) / `<id>` (Atom) — deduplication key |
+
+No external metadata provider is required. The feed is self-describing.
+
+## Integration
+
+- Podcast feeds and news feeds both use feed-rs but are separate media types with separate tables
+- Podcasts have enclosures (audio files); news has articles (text/HTML)
+- OPDS does not serve news — no OPDS standard exists for article feeds
+- `source_type` on `news_articles` is `rss` or `atom` — set by feed-rs at parse time
+
+## Read State
+
+`is_read` and `is_starred` are per-article boolean columns. In v1 (single-user), these are stored flat on `news_articles`. Multi-user read state is deferred — the column structure matches `podcast_episodes.listened` for consistency.
+
+## OPML Import
+
+OPML is the standard interchange format for feed lists. Import parses `<outline>` elements with `type="rss"` and creates `news_feeds` rows. Duplicate feed URLs (matching `news_feeds.url`) are skipped without error.


### PR DESCRIPTION
## Summary
- P0-06: Mobile decision documented (D3: native Android + UniFFI, Tauri rejection)
- P0-07: News as 8th media type with full schema (news_feeds, news_articles)
- P0-13: Workspace dependency entries (uuid v7, rstest)

## Prompts
P0-06, P0-07, P0-13