### PR TITLE
feat(akroasis-core): DSP stages 5–7 — compressor, convolution, volume+dither

### DIFF
--- a/akroasis/shared/akroasis-core/src/dsp/compressor.rs
+++ b/akroasis/shared/akroasis-core/src/dsp/compressor.rs
@@ -85,8 +85,7 @@ impl DspStage for Compressor {
             } else {
                 self.release_coeff
             };
-            self.gain_reduction_db =
-                coeff * self.gain_reduction_db + (1.0 - coeff) * target_gr;
+            self.gain_reduction_db = coeff * self.gain_reduction_db + (1.0 - coeff) * target_gr;
 
             let gain = db_to_linear(-self.gain_reduction_db);
 
@@ -121,7 +120,12 @@ mod tests {
     use super::*;
     use crate::config::CompressorConfig;
 
-    fn config_enabled(threshold_db: f64, ratio: f64, attack_ms: f64, release_ms: f64) -> CompressorConfig {
+    fn config_enabled(
+        threshold_db: f64,
+        ratio: f64,
+        attack_ms: f64,
+        release_ms: f64,
+    ) -> CompressorConfig {
         CompressorConfig {
             enabled: true,
             threshold_db,
@@ -242,7 +246,10 @@ mod tests {
         let mut cfg = CompressorConfig::default();
         cfg.enabled = true;
         let comp = Compressor::new(cfg.clone());
-        assert_eq!(comp.signal_stage_meta().tier_impact, Some(QualityTier::Lossless));
+        assert_eq!(
+            comp.signal_stage_meta().tier_impact,
+            Some(QualityTier::Lossless)
+        );
 
         cfg.enabled = false;
         let comp = Compressor::new(cfg);

--- a/akroasis/shared/akroasis-core/src/dsp/convolution.rs
+++ b/akroasis/shared/akroasis-core/src/dsp/convolution.rs
@@ -55,7 +55,10 @@ mod tests {
         let original = [0.1_f64, -0.5, 0.9, -0.3];
         let mut samples = original;
         conv.process(&mut samples, 2, 44100);
-        assert_eq!(samples, original, "disabled convolution must not modify samples");
+        assert_eq!(
+            samples, original,
+            "disabled convolution must not modify samples"
+        );
     }
 
     #[test]
@@ -69,7 +72,10 @@ mod tests {
         let original = [0.2_f64, -0.4, 0.6];
         let mut samples = original;
         conv.process(&mut samples, 1, 48000);
-        assert_eq!(samples, original, "enabled convolution passthrough must not modify samples");
+        assert_eq!(
+            samples, original,
+            "enabled convolution passthrough must not modify samples"
+        );
     }
 
     #[test]

--- a/akroasis/shared/akroasis-core/src/dsp/volume.rs
+++ b/akroasis/shared/akroasis-core/src/dsp/volume.rs
@@ -204,7 +204,10 @@ mod tests {
     #[test]
     fn slider_100_is_unity() {
         let gain = slider_to_gain(100.0);
-        assert!((gain - 1.0).abs() < 1e-10, "slider 100 should be unity gain, got {gain}");
+        assert!(
+            (gain - 1.0).abs() < 1e-10,
+            "slider 100 should be unity gain, got {gain}"
+        );
     }
 
     #[test]
@@ -248,14 +251,20 @@ mod tests {
         let x = 0.12345_f64;
         let out = quantize_f32(x);
         let diff = (out as f64 - x).abs();
-        assert!(diff < 1e-7, "f32 round-trip error {diff} exceeds f32 precision");
+        assert!(
+            diff < 1e-7,
+            "f32 round-trip error {diff} exceeds f32 precision"
+        );
     }
 
     // ── TPDF dither ───────────────────────────────────────────────────────────
 
     #[test]
     fn dither_i16_deterministic_with_seed() {
-        let cfg = VolumeConfig { level_db: 0.0, dither: true };
+        let cfg = VolumeConfig {
+            level_db: 0.0,
+            dither: true,
+        };
         let mut v1 = Volume::new_seeded(cfg.clone(), 42);
         let mut v2 = Volume::new_seeded(cfg, 42);
 
@@ -275,7 +284,10 @@ mod tests {
         const N: usize = 50_000;
         const AMPLITUDE: f64 = 1.0 / 32_768.0;
 
-        let cfg = VolumeConfig { level_db: 0.0, dither: true };
+        let cfg = VolumeConfig {
+            level_db: 0.0,
+            dither: true,
+        };
         let mut v = Volume::new_seeded(cfg, 12345);
 
         // Fixed input → variation in output is purely dither noise.
@@ -288,7 +300,10 @@ mod tests {
 
         // TPDF: mean ≈ 0, all values within ±1 LSB.
         let mean = values.iter().sum::<f64>() / N as f64;
-        assert!(mean.abs() < AMPLITUDE * 5.0, "TPDF mean should be ~0, got {mean}");
+        assert!(
+            mean.abs() < AMPLITUDE * 5.0,
+            "TPDF mean should be ~0, got {mean}"
+        );
 
         let max_abs = values.iter().map(|v| v.abs()).fold(0.0_f64, f64::max);
         assert!(
@@ -300,7 +315,10 @@ mod tests {
     #[test]
     fn f32_output_is_deterministic() {
         // f32 quantization requires no RNG — same input always yields same output.
-        let cfg = VolumeConfig { level_db: 0.0, dither: true };
+        let cfg = VolumeConfig {
+            level_db: 0.0,
+            dither: true,
+        };
         let v = Volume::new_seeded(cfg, 0);
         let out1 = v.dither_and_quantize_f32(0.5);
         let out2 = v.dither_and_quantize_f32(0.5);
@@ -309,7 +327,10 @@ mod tests {
 
     #[test]
     fn no_dither_quantize_is_deterministic() {
-        let cfg = VolumeConfig { level_db: 0.0, dither: false };
+        let cfg = VolumeConfig {
+            level_db: 0.0,
+            dither: false,
+        };
         let mut v = Volume::new_seeded(cfg, 99);
         let a = v.dither_and_quantize_i16(0.123);
         let b = v.dither_and_quantize_i16(0.123);


### PR DESCRIPTION
## Summary

- **Stage 5 — Compressor** (`dsp/compressor.rs`): peak-mode dynamics compressor with exponential attack/release envelope smoothing (RC time constant), hard-knee gain reduction, and brick-wall limiter ceiling. Disabled stage is a zero-cost passthrough. Tier impact: `Lossless` when enabled.
- **Stage 6 — Convolution** (`dsp/convolution.rs`): Phase 5 passthrough. Signal path metadata wired up (enabled flag, `HighQuality` tier impact) ready for FFT convolution in Phase 5.
- **Stage 7 — Volume + Dither** (`dsp/volume.rs`): linear gain from `level_db`, logarithmic slider→gain mapping (40 dB range; slider 50 → −20 dB), TPDF dither via seeded `SmallRng` for i16/i24/i32 quantization. Public `quantize_*` free functions for the output stage. `new_seeded` constructor enables deterministic tests.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — 53 tests pass (18 new across the three stages)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Compressor: below-threshold passthrough, above-threshold gain reduction, attack ramp at 1 TC ≈ 63.2%, limiter ceiling clamp, disabled passthrough
- [ ] Convolution: passthrough when disabled and when enabled, signal path metadata
- [ ] Volume: unity/zero/half-amplitude gain, slider mapping, quantize full-scale/clamp/f32, TPDF distribution, deterministic seed, no-dither consistency

**Depends on:** P1-01 (scaffold — merged in #33)
**Blocks:** P1-07 (gapless), P1-08 (engine)