### PR TITLE
feat(akroasis): DSP stages 1–4 — skip silence, parametric EQ, crossfeed, ReplayGain

### DIFF
--- a/akroasis/shared/akroasis-core/src/config.rs
+++ b/akroasis/shared/akroasis-core/src/config.rs
@@ -84,10 +84,20 @@ pub struct EqConfig {
 impl EqConfig {
     /// Returns a 10-band EQ at ISO standard center frequencies, all gains at 0 dB.
     pub fn iso_10_band_default() -> Self {
-        const ISO_FREQS: [f64; 10] = [31.0, 63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0];
+        const ISO_FREQS: [f64; 10] = [
+            31.0, 63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0,
+        ];
         Self {
             enabled: false,
-            bands: ISO_FREQS.iter().map(|&f| EqBand { frequency: f, gain_db: 0.0, q: 1.414, filter_type: FilterType::Peaking }).collect(),
+            bands: ISO_FREQS
+                .iter()
+                .map(|&f| EqBand {
+                    frequency: f,
+                    gain_db: 0.0,
+                    q: 1.414,
+                    filter_type: FilterType::Peaking,
+                })
+                .collect(),
         }
     }
 }

--- a/akroasis/shared/akroasis-core/src/dsp/crossfeed.rs
+++ b/akroasis/shared/akroasis-core/src/dsp/crossfeed.rs
@@ -88,7 +88,9 @@ impl DspStage for Crossfeed {
 
     fn process(&mut self, samples: &mut [f64], channels: u16, sample_rate: u32) -> StageResult {
         if !self.config.enabled || channels != 2 {
-            return StageResult { meta: self.signal_stage_meta() };
+            return StageResult {
+                meta: self.signal_stage_meta(),
+            };
         }
 
         if self.last_sample_rate != sample_rate {
@@ -111,14 +113,18 @@ impl DspStage for Crossfeed {
             self.lp_delayed = [lp_l, lp_r];
         }
 
-        StageResult { meta: self.signal_stage_meta() }
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
     }
 
     fn signal_stage_meta(&self) -> SignalStageInfo {
         SignalStageInfo {
             name: self.name().to_owned(),
             enabled: self.config.enabled,
-            params: StageParams::Crossfeed { strength: self.config.strength },
+            params: StageParams::Crossfeed {
+                strength: self.config.strength,
+            },
             // Crossfeed modifies the stereo image; no longer bit-perfect when active.
             tier_impact: self.config.enabled.then_some(QualityTier::Lossless),
         }
@@ -130,16 +136,17 @@ mod tests {
     use super::*;
 
     fn make(strength: f64) -> Crossfeed {
-        Crossfeed::new(CrossfeedConfig { enabled: true, strength })
+        Crossfeed::new(CrossfeedConfig {
+            enabled: true,
+            strength,
+        })
     }
 
     fn measure_cross(strength: f64) -> f64 {
         let mut stage = make(strength);
         // Hard-panned left signal: [1.0, 0.0] repeated
         let frames = 4410usize; // 100 ms at 44.1 kHz
-        let mut samples: Vec<f64> = (0..frames)
-            .flat_map(|_| [0.5_f64, 0.0_f64])
-            .collect();
+        let mut samples: Vec<f64> = (0..frames).flat_map(|_| [0.5_f64, 0.0_f64]).collect();
         stage.process(&mut samples, 2, 44100);
 
         // Measure energy in the right channel after settling (last 50 ms)
@@ -169,13 +176,16 @@ mod tests {
     #[test]
     fn hard_panned_left_appears_in_right() {
         let cross = measure_cross(0.5);
-        assert!(cross > 0.0, "crossfeed signal should appear in opposite channel");
+        assert!(
+            cross > 0.0,
+            "crossfeed signal should appear in opposite channel"
+        );
     }
 
     #[test]
     fn three_presets_produce_different_levels() {
-        let s_easy = measure_cross(0.0);    // Easy:    cutoff 700 Hz, level −4.5 dB
-        let s_normal = measure_cross(0.5);  // Normal:  cutoff 650 Hz, level −6.0 dB
+        let s_easy = measure_cross(0.0); // Easy:    cutoff 700 Hz, level −4.5 dB
+        let s_normal = measure_cross(0.5); // Normal:  cutoff 650 Hz, level −6.0 dB
         let s_extreme = measure_cross(1.0); // Extreme: cutoff 500 Hz, level −9.0 dB
 
         // −4.5 dB > −6 dB > −9 dB in linear gain, so Easy mixes the most raw energy.
@@ -189,8 +199,13 @@ mod tests {
 
     #[test]
     fn disabled_passes_through_unchanged() {
-        let mut stage = Crossfeed::new(CrossfeedConfig { enabled: false, strength: 1.0 });
-        let input: Vec<f64> = (0..200).flat_map(|i| [i as f64 * 0.01, -(i as f64 * 0.01)]).collect();
+        let mut stage = Crossfeed::new(CrossfeedConfig {
+            enabled: false,
+            strength: 1.0,
+        });
+        let input: Vec<f64> = (0..200)
+            .flat_map(|i| [i as f64 * 0.01, -(i as f64 * 0.01)])
+            .collect();
         let mut buf = input.clone();
         stage.process(&mut buf, 2, 44100);
         assert_eq!(buf, input);

--- a/akroasis/shared/akroasis-core/src/dsp/eq.rs
+++ b/akroasis/shared/akroasis-core/src/dsp/eq.rs
@@ -17,7 +17,13 @@ struct Coeffs {
 
 impl Coeffs {
     fn passthrough() -> Self {
-        Self { b0: 1.0, b1: 0.0, b2: 0.0, a1: 0.0, a2: 0.0 }
+        Self {
+            b0: 1.0,
+            b1: 0.0,
+            b2: 0.0,
+            a1: 0.0,
+            a2: 0.0,
+        }
     }
 
     /// Compute RBJ Audio EQ Cookbook coefficients for the given band and sample rate.
@@ -105,7 +111,13 @@ impl Coeffs {
             return Self::passthrough();
         }
 
-        Self { b0: b0 / a0, b1: b1 / a0, b2: b2 / a0, a1: a1 / a0, a2: a2 / a0 }
+        Self {
+            b0: b0 / a0,
+            b1: b1 / a0,
+            b2: b2 / a0,
+            a1: a1 / a0,
+            a2: a2 / a0,
+        }
     }
 }
 
@@ -141,7 +153,10 @@ impl BiquadBand {
         let y = self.coeffs.b0 * x + c.z1;
         let z1_next = self.coeffs.b1 * x - self.coeffs.a1 * y + c.z2;
         let z2_next = self.coeffs.b2 * x - self.coeffs.a2 * y;
-        self.chans[ch] = Chan { z1: z1_next, z2: z2_next };
+        self.chans[ch] = Chan {
+            z1: z1_next,
+            z2: z2_next,
+        };
         y
     }
 }
@@ -154,7 +169,11 @@ pub struct ParametricEq {
 
 impl ParametricEq {
     pub fn new(config: EqConfig) -> Self {
-        Self { config, bands: Vec::new(), last_sample_rate: 0 }
+        Self {
+            config,
+            bands: Vec::new(),
+            last_sample_rate: 0,
+        }
     }
 
     fn rebuild(&mut self, channels: u16, sample_rate: u32) {
@@ -175,7 +194,9 @@ impl DspStage for ParametricEq {
 
     fn process(&mut self, samples: &mut [f64], channels: u16, sample_rate: u32) -> StageResult {
         if !self.config.enabled || self.config.bands.is_empty() {
-            return StageResult { meta: self.signal_stage_meta() };
+            return StageResult {
+                meta: self.signal_stage_meta(),
+            };
         }
 
         if self.last_sample_rate != sample_rate || self.bands.len() != self.config.bands.len() {
@@ -194,11 +215,18 @@ impl DspStage for ParametricEq {
             }
         }
 
-        StageResult { meta: self.signal_stage_meta() }
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
     }
 
     fn signal_stage_meta(&self) -> SignalStageInfo {
-        let bands = self.config.bands.iter().map(|b| (b.frequency, b.gain_db, b.q)).collect();
+        let bands = self
+            .config
+            .bands
+            .iter()
+            .map(|b| (b.frequency, b.gain_db, b.q))
+            .collect();
         SignalStageInfo {
             name: self.name().to_owned(),
             enabled: self.config.enabled,
@@ -216,11 +244,19 @@ mod tests {
     const SR: u32 = 44100;
 
     fn peaking(freq: f64, gain_db: f64, q: f64) -> EqBand {
-        EqBand { frequency: freq, gain_db, q, filter_type: FilterType::Peaking }
+        EqBand {
+            frequency: freq,
+            gain_db,
+            q,
+            filter_type: FilterType::Peaking,
+        }
     }
 
     fn make_eq(band: EqBand) -> ParametricEq {
-        ParametricEq::new(EqConfig { enabled: true, bands: vec![band] })
+        ParametricEq::new(EqConfig {
+            enabled: true,
+            bands: vec![band],
+        })
     }
 
     /// Measure steady-state gain (dB) at `freq_hz` by driving the filter with a sinusoid
@@ -267,7 +303,10 @@ mod tests {
         let mut buf = input.clone();
         eq.process(&mut buf, 1, SR);
         for (a, b) in buf.iter().zip(input.iter()) {
-            assert!((a - b).abs() < 1e-10, "zero-gain peaking should be transparent");
+            assert!(
+                (a - b).abs() < 1e-10,
+                "zero-gain peaking should be transparent"
+            );
         }
     }
 
@@ -304,8 +343,14 @@ mod tests {
         });
         let low = measure_gain_db(&mut eq, 50.0, 0.5);
         let high = measure_gain_db(&mut eq, 4000.0, 0.5);
-        assert!(low > 5.0, "low shelf should boost low frequencies, got {low:.2} dB at 50 Hz");
-        assert!(high.abs() < 2.0, "low shelf should leave highs flat, got {high:.2} dB at 4 kHz");
+        assert!(
+            low > 5.0,
+            "low shelf should boost low frequencies, got {low:.2} dB at 50 Hz"
+        );
+        assert!(
+            high.abs() < 2.0,
+            "low shelf should leave highs flat, got {high:.2} dB at 4 kHz"
+        );
     }
 
     #[test]
@@ -318,8 +363,14 @@ mod tests {
         });
         let low = measure_gain_db(&mut eq, 200.0, 0.5);
         let high = measure_gain_db(&mut eq, 16000.0, 0.5);
-        assert!(low.abs() < 2.0, "high shelf should leave lows flat, got {low:.2} dB at 200 Hz");
-        assert!(high > 5.0, "high shelf should boost highs, got {high:.2} dB at 16 kHz");
+        assert!(
+            low.abs() < 2.0,
+            "high shelf should leave lows flat, got {low:.2} dB at 200 Hz"
+        );
+        assert!(
+            high > 5.0,
+            "high shelf should boost highs, got {high:.2} dB at 16 kHz"
+        );
     }
 
     #[test]
@@ -334,13 +385,19 @@ mod tests {
 
     #[test]
     fn iso_10_band_default_all_zero_gain_is_transparent() {
-        let cfg = EqConfig { enabled: true, ..EqConfig::iso_10_band_default() };
+        let cfg = EqConfig {
+            enabled: true,
+            ..EqConfig::iso_10_band_default()
+        };
         let mut eq = ParametricEq::new(cfg);
         let input: Vec<f64> = (0..4096).map(|i| (i as f64 * 0.01).sin() * 0.5).collect();
         let mut buf = input.clone();
         eq.process(&mut buf, 1, SR);
         for (a, b) in buf.iter().zip(input.iter()) {
-            assert!((a - b).abs() < 1e-9, "10-band ISO default should be transparent at 0 dB gains");
+            assert!(
+                (a - b).abs() < 1e-9,
+                "10-band ISO default should be transparent at 0 dB gains"
+            );
         }
     }
 
@@ -349,11 +406,21 @@ mod tests {
         let mut eq = make_eq(peaking(1000.0, 6.0, 1.414));
         // Stereo: ch0 = sine, ch1 = silence. After EQ, ch1 should remain near-zero.
         let mut buf: Vec<f64> = (0..2048)
-            .map(|i| if i % 2 == 0 { (i as f64 * 0.1).sin() * 0.5 } else { 0.0 })
+            .map(|i| {
+                if i % 2 == 0 {
+                    (i as f64 * 0.1).sin() * 0.5
+                } else {
+                    0.0
+                }
+            })
             .collect();
         eq.process(&mut buf, 2, SR);
         for i in (1..2048).step_by(2) {
-            assert!(buf[i].abs() < 1e-10, "silent channel should stay silent, got {}", buf[i]);
+            assert!(
+                buf[i].abs() < 1e-10,
+                "silent channel should stay silent, got {}",
+                buf[i]
+            );
         }
     }
 }

--- a/akroasis/shared/akroasis-core/src/dsp/replaygain.rs
+++ b/akroasis/shared/akroasis-core/src/dsp/replaygain.rs
@@ -11,21 +11,25 @@ pub struct ReplayGainStage {
 impl ReplayGainStage {
     pub fn new(config: ReplayGainConfig) -> Self {
         let applied_gain_db = Self::compute_gain_db(&config);
-        Self { config, applied_gain_db }
+        Self {
+            config,
+            applied_gain_db,
+        }
     }
 
     /// Select the base gain (dB) from tag metadata according to the configured mode.
     fn selected_gain_db(config: &ReplayGainConfig) -> f64 {
         match config.mode {
-            ReplayGainMode::Track => {
-                config.track_gain_db.unwrap_or(config.fallback_gain_db)
-            }
-            ReplayGainMode::Album => {
-                config
-                    .album_gain_db
-                    .or_else(|| config.fallback_to_track.then_some(config.track_gain_db).flatten())
-                    .unwrap_or(config.fallback_gain_db)
-            }
+            ReplayGainMode::Track => config.track_gain_db.unwrap_or(config.fallback_gain_db),
+            ReplayGainMode::Album => config
+                .album_gain_db
+                .or_else(|| {
+                    config
+                        .fallback_to_track
+                        .then_some(config.track_gain_db)
+                        .flatten()
+                })
+                .unwrap_or(config.fallback_gain_db),
             ReplayGainMode::R128 => {
                 // Prefer R128 track gain, fall back to legacy track gain, then fallback.
                 config
@@ -39,9 +43,7 @@ impl ReplayGainStage {
     /// Select the peak value corresponding to the active gain mode.
     fn selected_peak(config: &ReplayGainConfig) -> Option<f64> {
         match config.mode {
-            ReplayGainMode::Album => {
-                config.album_peak.or(config.track_peak)
-            }
+            ReplayGainMode::Album => config.album_peak.or(config.track_peak),
             _ => config.track_peak,
         }
     }
@@ -81,7 +83,9 @@ impl DspStage for ReplayGainStage {
             }
         }
 
-        StageResult { meta: self.signal_stage_meta() }
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
     }
 
     fn signal_stage_meta(&self) -> SignalStageInfo {
@@ -173,7 +177,10 @@ mod tests {
         };
         let expected = 10f64.powf(-5.0_f64 / 20.0);
         let result = apply(config, 1.0);
-        assert!((result - expected).abs() < 1e-10, "should fall back to track gain");
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "should fall back to track gain"
+        );
     }
 
     #[test]
@@ -193,7 +200,10 @@ mod tests {
             r128_album_gain: None,
         };
         let result = apply(config, 0.7);
-        assert!((result - 0.7).abs() < 1e-10, "no tags + 0 dB fallback should be transparent");
+        assert!(
+            (result - 0.7).abs() < 1e-10,
+            "no tags + 0 dB fallback should be transparent"
+        );
     }
 
     #[test]
@@ -219,7 +229,10 @@ mod tests {
             "clipping prevention should keep output ≤ 1.0, got {result}"
         );
         // The actual gain should be 1/peak = 2.0×
-        assert!((result - 1.0).abs() < 1e-9, "peak sample should be brought to exactly 1.0");
+        assert!(
+            (result - 1.0).abs() < 1e-9,
+            "peak sample should be brought to exactly 1.0"
+        );
     }
 
     #[test]
@@ -241,7 +254,10 @@ mod tests {
         };
         let expected = 10f64.powf(-6.0_f64 / 20.0);
         let result = apply(config, 1.0);
-        assert!((result - expected).abs() < 1e-9, "no clipping risk → gain should be applied as-is");
+        assert!(
+            (result - expected).abs() < 1e-9,
+            "no clipping risk → gain should be applied as-is"
+        );
     }
 
     #[test]
@@ -263,7 +279,10 @@ mod tests {
         };
         let expected = 10f64.powf(r128_gain / 20.0);
         let result = apply(config, 1.0);
-        assert!((result - expected).abs() < 1e-10, "R128 mode should use r128_track_gain");
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "R128 mode should use r128_track_gain"
+        );
     }
 
     #[test]
@@ -292,6 +311,9 @@ mod tests {
         };
         let expected = 10f64.powf((-6.0_f64 + 3.0) / 20.0);
         let result = apply(config, 1.0);
-        assert!((result - expected).abs() < 1e-9, "preamp should be added to track gain");
+        assert!(
+            (result - expected).abs() < 1e-9,
+            "preamp should be added to track gain"
+        );
     }
 }

--- a/akroasis/shared/akroasis-core/src/dsp/silence.rs
+++ b/akroasis/shared/akroasis-core/src/dsp/silence.rs
@@ -10,7 +10,10 @@ pub struct SkipSilence {
 
 impl SkipSilence {
     pub fn new(config: SkipSilenceConfig) -> Self {
-        Self { config, consecutive_silent: 0 }
+        Self {
+            config,
+            consecutive_silent: 0,
+        }
     }
 
     fn rms_db(samples: &[f64]) -> f64 {
@@ -51,14 +54,18 @@ impl DspStage for SkipSilence {
             }
         }
 
-        StageResult { meta: self.signal_stage_meta() }
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
     }
 
     fn signal_stage_meta(&self) -> SignalStageInfo {
         SignalStageInfo {
             name: self.name().to_owned(),
             enabled: self.config.enabled,
-            params: StageParams::SkipSilence { threshold_db: self.config.threshold_db },
+            params: StageParams::SkipSilence {
+                threshold_db: self.config.threshold_db,
+            },
             tier_impact: None,
         }
     }
@@ -109,7 +116,10 @@ mod tests {
         // After >200 ms of accumulated silence, frames should be zeroed.
         let mut extra = near_silence(frame);
         stage.process(&mut extra, 1, 44100);
-        assert!(extra.iter().all(|&s| s == 0.0), "silence should be zeroed after min threshold");
+        assert!(
+            extra.iter().all(|&s| s == 0.0),
+            "silence should be zeroed after min threshold"
+        );
     }
 
     #[test]
@@ -130,7 +140,10 @@ mod tests {
         let mut short = near_silence(441); // 10 ms
         let original = short.clone();
         stage.process(&mut short, 1, 44100);
-        assert_eq!(short, original, "short silence should pass through (below min threshold)");
+        assert_eq!(
+            short, original,
+            "short silence should pass through (below min threshold)"
+        );
     }
 
     #[test]
@@ -147,7 +160,10 @@ mod tests {
         let original = near_silence(frame);
         let mut extra = original.clone();
         stage.process(&mut extra, 1, 44100);
-        assert_eq!(extra, original, "silence beyond max should pass through unchanged");
+        assert_eq!(
+            extra, original,
+            "silence beyond max should pass through unchanged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Stage 1 — SkipSilence** (`dsp/silence.rs`): RMS-based per-frame silence detection. Frames accumulate a consecutive-silent counter; frames in `[min_silence_samples, max_silence_samples)` are zeroed. Pauses beyond the max pass through unchanged to preserve intentional pauses in audiobooks/podcasts.

- **Stage 2 — ParametricEq** (`dsp/eq.rs`): Direct Form II Transposed biquad bank. RBJ Audio EQ Cookbook coefficients for all seven filter types (Peaking, LowShelf, HighShelf, LowPass, HighPass, Notch, AllPass). Per-channel `z1`/`z2` state maintained between frames; coefficients recomputed only on sample rate change. `EqConfig::iso_10_band_default()` provides the 10-band ISO layout.

- **Stage 3 — Crossfeed** (`dsp/crossfeed.rs`): bs2b-style binaural crossfeed. `strength` (0–1) interpolates between Easy (700 Hz / −4.5 dB), Normal (650 Hz / −6 dB), and Extreme (500 Hz / −9 dB) presets. Uses a 2nd-order Butterworth LP filter and 1-sample ITD delay (~23 µs). Stereo-only; all other channel counts pass through.

- **Stage 4 — ReplayGainStage** (`dsp/replaygain.rs`): Tag-based loudness normalization. Supports Track, Album, and EBU R128 modes. Applies preamp offset, album→track fallback, peak-based clipping prevention, and configurable fallback gain for untagged tracks. All arithmetic in f64 domain.

- **config.rs**: added `FilterType` enum, `max_silence_samples`, `EqConfig::iso_10_band_default()`, and full per-track ReplayGain metadata fields (`track_gain_db`, `track_peak`, `album_gain_db`, `album_peak`, `r128_track_gain`, `r128_album_gain`, `prevent_clipping`, `fallback_gain_db`).

## Test plan

- [ ] `cargo check` — clean
- [ ] `cargo test` — 57 tests pass (0 failures)
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] Silence: detects region, respects min/max thresholds, resets on tone, disabled passthrough
- [ ] EQ: bypass (disabled + zero gain), peaking boost at center, unity at ±2 octaves, shelf asymptotic behaviour, no NaN/Inf at extreme Q, ISO 10-band transparent at 0 dB, stereo channel isolation
- [ ] Crossfeed: mono signal stays symmetric, hard-panned signal appears in opposite channel, three presets produce distinct levels, disabled passthrough, mono channel count passthrough
- [ ] ReplayGain: track/album/R128 mode selection, album→track fallback, no-tags passthrough, clipping prevention (with and without), preamp stacking, disabled passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)