### PR TITLE
feat(harmonia-db): SQLite database layer with dual-pool WAL (P2-03)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "atomic"
@@ -27,10 +42,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -45,6 +90,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +108,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -81,6 +142,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "epignosis"
 version = "0.1.0"
 dependencies = [
@@ -102,7 +276,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -137,16 +333,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -158,6 +418,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -178,10 +444,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -223,8 +513,15 @@ name = "harmonia-db"
 version = "0.1.0"
 dependencies = [
  "harmonia-common",
+ "jiff",
+ "rstest",
+ "serde",
  "snafu",
+ "sqlx",
+ "tempfile",
+ "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -243,6 +540,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -253,10 +552,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "horismos"
@@ -273,10 +614,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -314,7 +757,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -363,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,10 +827,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -396,6 +883,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,7 +906,53 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -417,6 +960,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -436,7 +985,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -474,10 +1023,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -492,6 +1089,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -551,10 +1166,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]
@@ -593,6 +1247,26 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rstest"
@@ -643,7 +1317,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -723,6 +1397,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +1444,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -743,6 +1467,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -772,14 +1499,244 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -790,6 +1747,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -808,11 +1776,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -828,7 +1841,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -840,6 +1853,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -919,6 +1943,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -945,6 +1970,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,10 +1985,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -966,16 +2018,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "uuid"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1006,6 +2082,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1087,10 +2169,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1100,6 +2201,63 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
@@ -1199,10 +2357,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/harmonia-db/Cargo.toml
+++ b/crates/harmonia-db/Cargo.toml
@@ -3,9 +3,18 @@ name = "harmonia-db"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "SQLite layer — dual pools, migrations, typed queries"
+description = "SQLite database layer for Harmonia"
 
 [dependencies]
 harmonia-common.workspace = true
+sqlx.workspace = true
 snafu.workspace = true
 tracing.workspace = true
+serde.workspace = true
+uuid.workspace = true
+jiff.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tempfile = "3"

--- a/crates/harmonia-db/build.rs
+++ b/crates/harmonia-db/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=migrations");
+}

--- a/crates/harmonia-db/migrations/001_initial.sql
+++ b/crates/harmonia-db/migrations/001_initial.sql
@@ -1,0 +1,743 @@
+-- =============================================================================
+-- 001_initial.sql — Full schema for Harmonia
+-- All tables in FK dependency order.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- Users & auth
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE users (
+    id            BLOB NOT NULL PRIMARY KEY,
+    username      TEXT NOT NULL UNIQUE,
+    display_name  TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    role          TEXT NOT NULL DEFAULT 'member' CHECK(role IN ('admin', 'member')),
+    is_active     INTEGER NOT NULL DEFAULT 1,
+    created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    last_login_at TEXT
+);
+
+CREATE INDEX idx_users_username ON users(username);
+
+CREATE TABLE refresh_tokens (
+    id         BLOB NOT NULL PRIMARY KEY,
+    user_id    BLOB NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    expires_at TEXT NOT NULL,
+    revoked    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_refresh_tokens_user ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_hash ON refresh_tokens(token_hash);
+
+CREATE TABLE api_keys (
+    id              BLOB NOT NULL PRIMARY KEY,
+    user_id         BLOB NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    short_token     TEXT NOT NULL,
+    long_token_hash TEXT NOT NULL UNIQUE,
+    label           TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    last_used_at    TEXT,
+    revoked         INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_api_keys_user ON api_keys(user_id);
+CREATE INDEX idx_api_keys_short_token ON api_keys(short_token);
+
+-- -----------------------------------------------------------------------------
+-- Quality profiles and rank tables
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE quality_profiles (
+    id                         INTEGER PRIMARY KEY,
+    name                       TEXT NOT NULL,
+    media_type                 TEXT NOT NULL CHECK(media_type IN (
+                                   'music', 'audiobook', 'book', 'comic',
+                                   'podcast', 'movie', 'tv'
+                               )),
+    min_quality_score          INTEGER NOT NULL,
+    upgrade_until_score        INTEGER NOT NULL,
+    min_custom_format_score    INTEGER NOT NULL DEFAULT 0,
+    upgrade_until_format_score INTEGER NOT NULL DEFAULT 0,
+    upgrades_allowed           INTEGER NOT NULL DEFAULT 1,
+    UNIQUE(name, media_type)
+);
+
+CREATE INDEX idx_quality_profiles_media_type ON quality_profiles(media_type);
+
+CREATE TABLE music_quality_ranks (
+    rank   INTEGER PRIMARY KEY,
+    format TEXT NOT NULL UNIQUE,
+    score  INTEGER NOT NULL
+);
+
+INSERT INTO music_quality_ranks (rank, format, score) VALUES
+    (1, 'FLAC_24BIT',  100),
+    (2, 'FLAC_16BIT',   90),
+    (3, 'ALAC',          85),
+    (4, 'MP3_320_CBR',   70),
+    (5, 'MP3_V0_VBR',    65),
+    (6, 'MP3_256',       55),
+    (7, 'MP3_128',       30);
+
+CREATE TABLE audiobook_quality_ranks (
+    rank   INTEGER PRIMARY KEY,
+    format TEXT NOT NULL UNIQUE,
+    score  INTEGER NOT NULL
+);
+
+INSERT INTO audiobook_quality_ranks (rank, format, score) VALUES
+    (1, 'M4B_AAC_128K_PLUS',  100),
+    (2, 'M4B_AAC_64K',         80),
+    (3, 'MP3_128K_PLUS',       70),
+    (4, 'MP3_64K',             50);
+
+CREATE TABLE video_quality_ranks (
+    rank   INTEGER PRIMARY KEY,
+    format TEXT NOT NULL UNIQUE,
+    score  INTEGER NOT NULL
+);
+
+INSERT INTO video_quality_ranks (rank, format, score) VALUES
+    (1, 'UHD_BLURAY_HEVC_HDR',  100),
+    (2, 'UHD_BLURAY_H264',       85),
+    (3, 'BLURAY_1080P_HEVC',      80),
+    (4, 'BLURAY_1080P_H264',      75),
+    (5, 'WEBDL_1080P',            70),
+    (6, 'BLURAY_720P',            60),
+    (7, 'WEBDL_720P',             55),
+    (8, 'SD_480P',                30),
+    (9, 'SDTV',                   20);
+
+CREATE TABLE book_quality_ranks (
+    rank   INTEGER PRIMARY KEY,
+    format TEXT NOT NULL UNIQUE,
+    score  INTEGER NOT NULL
+);
+
+INSERT INTO book_quality_ranks (rank, format, score) VALUES
+    (1, 'EPUB',  100),
+    (2, 'MOBI',   60),
+    (3, 'AZW3',   55),
+    (4, 'PDF',    40);
+
+CREATE TABLE comic_quality_ranks (
+    rank   INTEGER PRIMARY KEY,
+    format TEXT NOT NULL UNIQUE,
+    score  INTEGER NOT NULL
+);
+
+INSERT INTO comic_quality_ranks (rank, format, score) VALUES
+    (1, 'CBZ',  100),
+    (2, 'CBR',   90),
+    (3, 'PDF',   40);
+
+CREATE TABLE podcast_quality_ranks (
+    rank   INTEGER PRIMARY KEY,
+    format TEXT NOT NULL UNIQUE,
+    score  INTEGER NOT NULL
+);
+
+INSERT INTO podcast_quality_ranks (rank, format, score) VALUES
+    (1, 'AAC_128K_PLUS',   100),
+    (2, 'MP3_192K_PLUS',    80),
+    (3, 'MP3_128K',         60),
+    (4, 'MP3_64K',          30);
+
+CREATE TABLE custom_formats (
+    id         INTEGER PRIMARY KEY,
+    name       TEXT NOT NULL UNIQUE,
+    media_type TEXT NOT NULL CHECK(media_type IN (
+                   'music', 'audiobook', 'book', 'comic',
+                   'podcast', 'movie', 'tv'
+               ))
+);
+
+CREATE TABLE custom_format_conditions (
+    id        INTEGER PRIMARY KEY,
+    format_id INTEGER NOT NULL REFERENCES custom_formats(id) ON DELETE CASCADE,
+    field     TEXT NOT NULL,
+    pattern   TEXT NOT NULL,
+    score     INTEGER NOT NULL
+);
+
+-- Default quality profile seed data
+INSERT INTO quality_profiles (name, media_type, min_quality_score, upgrade_until_score) VALUES
+    ('Any',      'music',     1,  100),
+    ('Lossless', 'music',    85,  100),
+    ('Standard', 'music',    70,   90);
+
+INSERT INTO quality_profiles (name, media_type, min_quality_score, upgrade_until_score) VALUES
+    ('Any',           'audiobook',  1, 100),
+    ('M4B Preferred', 'audiobook', 80, 100);
+
+INSERT INTO quality_profiles (name, media_type, min_quality_score, upgrade_until_score) VALUES
+    ('Any',  'book', 1,   100),
+    ('EPUB', 'book', 100, 100);
+
+INSERT INTO quality_profiles (name, media_type, min_quality_score, upgrade_until_score) VALUES
+    ('Any', 'comic', 1,   100),
+    ('CBZ', 'comic', 100, 100);
+
+INSERT INTO quality_profiles (name, media_type, min_quality_score, upgrade_until_score) VALUES
+    ('Any',          'podcast',  1, 100),
+    ('High Quality', 'podcast', 80, 100);
+
+INSERT INTO quality_profiles (name, media_type, min_quality_score, upgrade_until_score) VALUES
+    ('Any', 'movie',  1, 100),
+    ('HD',  'movie', 60, 100),
+    ('UHD', 'movie', 85, 100);
+
+INSERT INTO quality_profiles (name, media_type, min_quality_score, upgrade_until_score) VALUES
+    ('Any', 'tv',  1, 100),
+    ('HD',  'tv', 60, 100),
+    ('UHD', 'tv', 85, 100);
+
+-- -----------------------------------------------------------------------------
+-- Entity registry
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE media_registry (
+    id           BLOB NOT NULL PRIMARY KEY,
+    entity_type  TEXT NOT NULL CHECK(entity_type IN (
+                     'person', 'franchise', 'series', 'publisher', 'label'
+                 )),
+    display_name TEXT NOT NULL,
+    sort_name    TEXT,
+    created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_registry_entity_type ON media_registry(entity_type);
+CREATE INDEX idx_registry_display_name ON media_registry(display_name);
+
+CREATE TABLE registry_external_ids (
+    registry_id BLOB NOT NULL REFERENCES media_registry(id) ON DELETE CASCADE,
+    provider    TEXT NOT NULL CHECK(provider IN (
+                    'musicbrainz', 'tmdb', 'tvdb', 'openlibrary',
+                    'audible', 'audnexus', 'goodreads', 'imdb', 'lastfm'
+                )),
+    external_id TEXT NOT NULL,
+    PRIMARY KEY (registry_id, provider)
+);
+
+CREATE INDEX idx_external_ids_provider ON registry_external_ids(provider, external_id);
+
+-- -----------------------------------------------------------------------------
+-- Music (4-level hierarchy)
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE music_release_groups (
+    id                   BLOB NOT NULL PRIMARY KEY,
+    registry_id          BLOB REFERENCES media_registry(id),
+    title                TEXT NOT NULL,
+    rg_type              TEXT NOT NULL CHECK(rg_type IN (
+                             'album', 'single', 'ep', 'compilation', 'live', 'other'
+                         )),
+    mb_release_group_id  TEXT,
+    year                 INTEGER,
+    quality_profile_id   INTEGER REFERENCES quality_profiles(id),
+    added_at             TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_mrg_registry ON music_release_groups(registry_id);
+CREATE INDEX idx_mrg_mb_id ON music_release_groups(mb_release_group_id);
+
+CREATE TABLE music_releases (
+    id               BLOB NOT NULL PRIMARY KEY,
+    release_group_id BLOB NOT NULL REFERENCES music_release_groups(id) ON DELETE CASCADE,
+    title            TEXT NOT NULL,
+    release_date     TEXT,
+    country          TEXT,
+    label            TEXT,
+    catalog_number   TEXT,
+    mb_release_id    TEXT,
+    added_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_mr_release_group ON music_releases(release_group_id);
+CREATE INDEX idx_mr_mb_id ON music_releases(mb_release_id);
+
+CREATE TABLE music_media (
+    id         BLOB NOT NULL PRIMARY KEY,
+    release_id BLOB NOT NULL REFERENCES music_releases(id) ON DELETE CASCADE,
+    position   INTEGER NOT NULL,
+    format     TEXT NOT NULL CHECK(format IN ('CD', 'Vinyl', 'Digital', 'Cassette', 'Other')),
+    title      TEXT,
+    UNIQUE(release_id, position)
+);
+
+CREATE INDEX idx_mm_release ON music_media(release_id);
+
+CREATE TABLE music_tracks (
+    id                   BLOB NOT NULL PRIMARY KEY,
+    medium_id            BLOB NOT NULL REFERENCES music_media(id) ON DELETE CASCADE,
+    position             INTEGER NOT NULL,
+    title                TEXT NOT NULL,
+    duration_ms          INTEGER,
+    mb_recording_id      TEXT,
+    acoustid_fingerprint TEXT,
+    acoustid_id          TEXT,
+    file_path            TEXT,
+    file_size_bytes      INTEGER,
+    bit_depth            INTEGER,
+    sample_rate          INTEGER,
+    codec                TEXT,
+    quality_score        INTEGER,
+    replay_gain_track_db REAL,
+    replay_gain_album_db REAL,
+    source_type          TEXT NOT NULL DEFAULT 'local' CHECK(source_type IN (
+                             'local', 'torrent', 'usenet', 'manual', 'rss'
+                         )),
+    added_at             TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(medium_id, position)
+);
+
+CREATE INDEX idx_mt_medium ON music_tracks(medium_id);
+CREATE INDEX idx_mt_mb_recording ON music_tracks(mb_recording_id);
+CREATE INDEX idx_mt_acoustid ON music_tracks(acoustid_id) WHERE acoustid_id IS NOT NULL;
+CREATE UNIQUE INDEX idx_mt_file_path ON music_tracks(file_path) WHERE file_path IS NOT NULL;
+
+CREATE TABLE music_release_group_artists (
+    release_group_id BLOB NOT NULL REFERENCES music_release_groups(id) ON DELETE CASCADE,
+    artist_id        BLOB NOT NULL REFERENCES media_registry(id),
+    role             TEXT NOT NULL DEFAULT 'primary' CHECK(role IN (
+                         'primary', 'featuring', 'remixer', 'producer', 'composer'
+                     )),
+    PRIMARY KEY (release_group_id, artist_id, role)
+);
+
+CREATE TABLE music_track_artists (
+    track_id  BLOB NOT NULL REFERENCES music_tracks(id) ON DELETE CASCADE,
+    artist_id BLOB NOT NULL REFERENCES media_registry(id),
+    role      TEXT NOT NULL DEFAULT 'primary' CHECK(role IN (
+                  'primary', 'featuring', 'remixer', 'producer', 'composer'
+              )),
+    PRIMARY KEY (track_id, artist_id, role)
+);
+
+-- -----------------------------------------------------------------------------
+-- Audiobooks
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE audiobooks (
+    id                 BLOB NOT NULL PRIMARY KEY,
+    registry_id        BLOB REFERENCES media_registry(id),
+    title              TEXT NOT NULL,
+    subtitle           TEXT,
+    publisher          TEXT,
+    isbn               TEXT,
+    asin               TEXT,
+    duration_ms        INTEGER,
+    release_date       TEXT,
+    language           TEXT,
+    series_name        TEXT,
+    series_position    REAL,
+    file_path          TEXT,
+    file_format        TEXT CHECK(file_format IN ('m4b', 'mp3', 'flac')),
+    file_size_bytes    INTEGER,
+    quality_score      INTEGER,
+    quality_profile_id INTEGER REFERENCES quality_profiles(id),
+    source_type        TEXT NOT NULL DEFAULT 'local' CHECK(source_type IN (
+                           'local', 'torrent', 'usenet', 'manual', 'rss'
+                       )),
+    added_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_ab_registry ON audiobooks(registry_id);
+CREATE INDEX idx_ab_asin ON audiobooks(asin);
+CREATE INDEX idx_ab_isbn ON audiobooks(isbn);
+CREATE UNIQUE INDEX idx_ab_file_path ON audiobooks(file_path) WHERE file_path IS NOT NULL;
+
+CREATE TABLE audiobook_chapters (
+    id           BLOB NOT NULL PRIMARY KEY,
+    audiobook_id BLOB NOT NULL REFERENCES audiobooks(id) ON DELETE CASCADE,
+    position     INTEGER NOT NULL,
+    title        TEXT,
+    start_ms     INTEGER NOT NULL,
+    end_ms       INTEGER NOT NULL,
+    UNIQUE(audiobook_id, position)
+);
+
+CREATE INDEX idx_ac_audiobook ON audiobook_chapters(audiobook_id);
+
+CREATE TABLE audiobook_progress (
+    id               BLOB NOT NULL PRIMARY KEY,
+    audiobook_id     BLOB NOT NULL REFERENCES audiobooks(id) ON DELETE CASCADE,
+    user_id          BLOB NOT NULL,
+    chapter_position INTEGER NOT NULL,
+    offset_ms        INTEGER NOT NULL DEFAULT 0,
+    updated_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(audiobook_id, user_id)
+);
+
+CREATE INDEX idx_ap_user ON audiobook_progress(user_id);
+
+CREATE TABLE audiobook_authors (
+    audiobook_id BLOB NOT NULL REFERENCES audiobooks(id) ON DELETE CASCADE,
+    person_id    BLOB NOT NULL REFERENCES media_registry(id),
+    role         TEXT NOT NULL DEFAULT 'author' CHECK(role IN (
+                     'author', 'narrator', 'translator', 'editor'
+                 )),
+    PRIMARY KEY (audiobook_id, person_id, role)
+);
+
+-- -----------------------------------------------------------------------------
+-- Books
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE books (
+    id                 BLOB NOT NULL PRIMARY KEY,
+    registry_id        BLOB REFERENCES media_registry(id),
+    title              TEXT NOT NULL,
+    subtitle           TEXT,
+    isbn               TEXT,
+    isbn13             TEXT,
+    openlibrary_id     TEXT,
+    goodreads_id       TEXT,
+    publisher          TEXT,
+    publish_date       TEXT,
+    language           TEXT,
+    page_count         INTEGER,
+    description        TEXT,
+    file_path          TEXT,
+    file_format        TEXT CHECK(file_format IN ('epub', 'mobi', 'azw3', 'pdf')),
+    file_size_bytes    INTEGER,
+    quality_score      INTEGER,
+    quality_profile_id INTEGER REFERENCES quality_profiles(id),
+    source_type        TEXT NOT NULL DEFAULT 'local' CHECK(source_type IN (
+                           'local', 'torrent', 'usenet', 'manual', 'rss'
+                       )),
+    added_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_books_registry ON books(registry_id);
+CREATE INDEX idx_books_isbn13 ON books(isbn13);
+CREATE INDEX idx_books_openlibrary ON books(openlibrary_id);
+CREATE UNIQUE INDEX idx_books_file_path ON books(file_path) WHERE file_path IS NOT NULL;
+
+CREATE TABLE book_authors (
+    book_id   BLOB NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    person_id BLOB NOT NULL REFERENCES media_registry(id),
+    role      TEXT NOT NULL DEFAULT 'author' CHECK(role IN (
+                  'author', 'translator', 'illustrator', 'editor'
+              )),
+    PRIMARY KEY (book_id, person_id, role)
+);
+
+CREATE TABLE book_genres (
+    book_id BLOB NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    genre   TEXT NOT NULL,
+    PRIMARY KEY (book_id, genre)
+);
+
+-- -----------------------------------------------------------------------------
+-- Comics
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE comics (
+    id                  BLOB NOT NULL PRIMARY KEY,
+    registry_id         BLOB REFERENCES media_registry(id),
+    series_name         TEXT NOT NULL,
+    volume              INTEGER,
+    issue_number        REAL,
+    title               TEXT,
+    publisher           TEXT,
+    release_date        TEXT,
+    page_count          INTEGER,
+    summary             TEXT,
+    language            TEXT,
+    comicinfo_writer    TEXT,
+    comicinfo_penciller TEXT,
+    comicinfo_inker     TEXT,
+    comicinfo_colorist  TEXT,
+    file_path           TEXT,
+    file_format         TEXT CHECK(file_format IN ('cbz', 'cbr', 'pdf')),
+    file_size_bytes     INTEGER,
+    quality_score       INTEGER,
+    quality_profile_id  INTEGER REFERENCES quality_profiles(id),
+    source_type         TEXT NOT NULL DEFAULT 'local' CHECK(source_type IN (
+                            'local', 'torrent', 'usenet', 'manual', 'rss'
+                        )),
+    added_at            TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_comics_registry ON comics(registry_id);
+CREATE INDEX idx_comics_series ON comics(series_name, volume, issue_number);
+CREATE UNIQUE INDEX idx_comics_file_path ON comics(file_path) WHERE file_path IS NOT NULL;
+
+CREATE TABLE comic_creators (
+    comic_id  BLOB NOT NULL REFERENCES comics(id) ON DELETE CASCADE,
+    person_id BLOB NOT NULL REFERENCES media_registry(id),
+    role      TEXT NOT NULL CHECK(role IN (
+                  'writer', 'penciller', 'inker', 'colorist', 'letterer', 'editor'
+              )),
+    PRIMARY KEY (comic_id, person_id, role)
+);
+
+-- -----------------------------------------------------------------------------
+-- Podcasts
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE podcast_subscriptions (
+    id                 BLOB NOT NULL PRIMARY KEY,
+    feed_url           TEXT NOT NULL UNIQUE,
+    title              TEXT,
+    description        TEXT,
+    author             TEXT,
+    image_url          TEXT,
+    language           TEXT,
+    last_checked_at    TEXT,
+    auto_download      INTEGER NOT NULL DEFAULT 1,
+    quality_profile_id INTEGER REFERENCES quality_profiles(id),
+    added_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE TABLE podcast_episodes (
+    id              BLOB NOT NULL PRIMARY KEY,
+    subscription_id BLOB NOT NULL REFERENCES podcast_subscriptions(id) ON DELETE CASCADE,
+    guid            TEXT NOT NULL,
+    title           TEXT,
+    description     TEXT,
+    episode_number  INTEGER,
+    season_number   INTEGER,
+    publication_date TEXT,
+    duration_ms     INTEGER,
+    enclosure_url   TEXT,
+    file_path       TEXT,
+    file_size_bytes INTEGER,
+    file_format     TEXT,
+    quality_score   INTEGER,
+    source_type     TEXT NOT NULL DEFAULT 'local' CHECK(source_type IN (
+                        'local', 'torrent', 'usenet', 'manual', 'rss'
+                    )),
+    listened        INTEGER NOT NULL DEFAULT 0,
+    added_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(subscription_id, guid)
+);
+
+CREATE INDEX idx_pe_subscription ON podcast_episodes(subscription_id);
+CREATE INDEX idx_pe_pub_date ON podcast_episodes(subscription_id, publication_date);
+CREATE UNIQUE INDEX idx_pe_file_path ON podcast_episodes(file_path) WHERE file_path IS NOT NULL;
+
+-- -----------------------------------------------------------------------------
+-- News
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE news_feeds (
+    id                     BLOB NOT NULL PRIMARY KEY,
+    title                  TEXT NOT NULL,
+    url                    TEXT NOT NULL UNIQUE,
+    site_url               TEXT,
+    description            TEXT,
+    category               TEXT,
+    icon_url               TEXT,
+    last_fetched_at        TEXT,
+    fetch_interval_minutes INTEGER NOT NULL DEFAULT 60,
+    is_active              INTEGER NOT NULL DEFAULT 1,
+    added_at               TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at             TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE UNIQUE INDEX idx_nf_url ON news_feeds(url);
+
+CREATE TABLE news_articles (
+    id           BLOB NOT NULL PRIMARY KEY,
+    feed_id      BLOB NOT NULL REFERENCES news_feeds(id) ON DELETE CASCADE,
+    guid         TEXT NOT NULL,
+    title        TEXT NOT NULL,
+    url          TEXT NOT NULL,
+    author       TEXT,
+    content_html TEXT,
+    summary      TEXT,
+    published_at TEXT,
+    is_read      INTEGER NOT NULL DEFAULT 0,
+    is_starred   INTEGER NOT NULL DEFAULT 0,
+    source_type  TEXT NOT NULL DEFAULT 'rss' CHECK(source_type IN ('rss', 'atom')),
+    added_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(feed_id, guid)
+);
+
+CREATE INDEX idx_na_feed ON news_articles(feed_id);
+CREATE INDEX idx_na_pub_date ON news_articles(feed_id, published_at);
+CREATE INDEX idx_na_starred ON news_articles(is_starred) WHERE is_starred = 1;
+
+-- -----------------------------------------------------------------------------
+-- Movies
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE movies (
+    id                 BLOB NOT NULL PRIMARY KEY,
+    registry_id        BLOB REFERENCES media_registry(id),
+    title              TEXT NOT NULL,
+    original_title     TEXT,
+    year               INTEGER,
+    tmdb_id            INTEGER,
+    imdb_id            TEXT,
+    runtime_min        INTEGER,
+    overview           TEXT,
+    certification      TEXT,
+    file_path          TEXT,
+    file_format        TEXT,
+    file_size_bytes    INTEGER,
+    resolution         TEXT,
+    codec              TEXT,
+    hdr_type           TEXT CHECK(hdr_type IN ('HDR10', 'HDR10Plus', 'DolbyVision', 'HLG', NULL)),
+    quality_score      INTEGER,
+    quality_profile_id INTEGER REFERENCES quality_profiles(id),
+    source_type        TEXT NOT NULL DEFAULT 'local' CHECK(source_type IN (
+                           'local', 'torrent', 'usenet', 'manual', 'rss'
+                       )),
+    added_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_movies_registry ON movies(registry_id);
+CREATE INDEX idx_movies_tmdb ON movies(tmdb_id);
+CREATE INDEX idx_movies_imdb ON movies(imdb_id);
+CREATE UNIQUE INDEX idx_movies_file_path ON movies(file_path) WHERE file_path IS NOT NULL;
+
+CREATE TABLE movie_cast (
+    movie_id       BLOB NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+    person_id      BLOB NOT NULL REFERENCES media_registry(id),
+    role           TEXT NOT NULL CHECK(role IN ('director', 'actor', 'writer', 'producer')),
+    character_name TEXT,
+    PRIMARY KEY (movie_id, person_id, role)
+);
+
+-- -----------------------------------------------------------------------------
+-- TV
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE tv_series (
+    id                 BLOB NOT NULL PRIMARY KEY,
+    registry_id        BLOB REFERENCES media_registry(id),
+    title              TEXT NOT NULL,
+    tmdb_id            INTEGER,
+    tvdb_id            INTEGER,
+    imdb_id            TEXT,
+    status             TEXT NOT NULL CHECK(status IN ('continuing', 'ended', 'upcoming')),
+    overview           TEXT,
+    network            TEXT,
+    quality_profile_id INTEGER REFERENCES quality_profiles(id),
+    added_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_tv_registry ON tv_series(registry_id);
+CREATE INDEX idx_tv_tmdb ON tv_series(tmdb_id);
+CREATE INDEX idx_tv_tvdb ON tv_series(tvdb_id);
+
+CREATE TABLE tv_seasons (
+    id            BLOB NOT NULL PRIMARY KEY,
+    series_id     BLOB NOT NULL REFERENCES tv_series(id) ON DELETE CASCADE,
+    season_number INTEGER NOT NULL,
+    title         TEXT,
+    episode_count INTEGER,
+    air_date      TEXT,
+    overview      TEXT,
+    UNIQUE(series_id, season_number)
+);
+
+CREATE INDEX idx_tvs_series ON tv_seasons(series_id);
+
+CREATE TABLE tv_episodes (
+    id              BLOB NOT NULL PRIMARY KEY,
+    season_id       BLOB NOT NULL REFERENCES tv_seasons(id) ON DELETE CASCADE,
+    episode_number  INTEGER NOT NULL,
+    title           TEXT,
+    air_date        TEXT,
+    runtime_min     INTEGER,
+    overview        TEXT,
+    tmdb_episode_id INTEGER,
+    file_path       TEXT,
+    file_format     TEXT,
+    file_size_bytes INTEGER,
+    resolution      TEXT,
+    codec           TEXT,
+    hdr_type        TEXT CHECK(hdr_type IN ('HDR10', 'HDR10Plus', 'DolbyVision', 'HLG', NULL)),
+    quality_score   INTEGER,
+    source_type     TEXT NOT NULL DEFAULT 'local' CHECK(source_type IN (
+                        'local', 'torrent', 'usenet', 'manual', 'rss'
+                    )),
+    added_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(season_id, episode_number)
+);
+
+CREATE INDEX idx_tve_season ON tv_episodes(season_id);
+CREATE INDEX idx_tve_tmdb ON tv_episodes(tmdb_episode_id);
+CREATE UNIQUE INDEX idx_tve_file_path ON tv_episodes(file_path) WHERE file_path IS NOT NULL;
+
+CREATE TABLE tv_series_cast (
+    series_id      BLOB NOT NULL REFERENCES tv_series(id) ON DELETE CASCADE,
+    person_id      BLOB NOT NULL REFERENCES media_registry(id),
+    role           TEXT NOT NULL CHECK(role IN ('director', 'actor', 'writer', 'producer')),
+    character_name TEXT,
+    PRIMARY KEY (series_id, person_id, role)
+);
+
+-- -----------------------------------------------------------------------------
+-- Want / Release / Have lifecycle
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE wants (
+    id                 BLOB NOT NULL PRIMARY KEY,
+    media_type         TEXT NOT NULL CHECK(media_type IN (
+                           'music_album', 'audiobook', 'book', 'comic',
+                           'podcast', 'movie', 'tv_series'
+                       )),
+    title              TEXT NOT NULL,
+    registry_id        BLOB REFERENCES media_registry(id),
+    quality_profile_id INTEGER NOT NULL REFERENCES quality_profiles(id),
+    status             TEXT NOT NULL DEFAULT 'searching' CHECK(status IN (
+                           'searching', 'paused', 'fulfilled'
+                       )),
+    source             TEXT CHECK(source IN (
+                           'manual', 'tidal_sync', 'request', 'rss_feed'
+                       )),
+    source_ref         TEXT,
+    added_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    fulfilled_at       TEXT
+);
+
+CREATE INDEX idx_wants_type_status ON wants(media_type, status);
+CREATE INDEX idx_wants_registry ON wants(registry_id);
+
+CREATE TABLE releases (
+    id                  BLOB NOT NULL PRIMARY KEY,
+    want_id             BLOB NOT NULL REFERENCES wants(id) ON DELETE CASCADE,
+    indexer_id          INTEGER NOT NULL,
+    title               TEXT NOT NULL,
+    size_bytes          INTEGER NOT NULL,
+    quality_score       INTEGER NOT NULL,
+    custom_format_score INTEGER NOT NULL DEFAULT 0,
+    download_url        TEXT NOT NULL,
+    protocol            TEXT NOT NULL CHECK(protocol IN ('torrent', 'nzb')),
+    info_hash           TEXT,
+    found_at            TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    grabbed_at          TEXT,
+    rejected_reason     TEXT
+);
+
+CREATE INDEX idx_releases_want ON releases(want_id);
+CREATE INDEX idx_releases_info_hash ON releases(info_hash);
+
+CREATE TABLE haves (
+    id               BLOB NOT NULL PRIMARY KEY,
+    want_id          BLOB NOT NULL REFERENCES wants(id),
+    release_id       BLOB REFERENCES releases(id),
+    media_type       TEXT NOT NULL,
+    media_type_id    BLOB NOT NULL,
+    quality_score    INTEGER NOT NULL,
+    file_path        TEXT NOT NULL,
+    file_size_bytes  INTEGER NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'pending' CHECK(status IN (
+                         'pending', 'downloading', 'importing', 'complete', 'failed'
+                     )),
+    imported_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    upgraded_from_id BLOB REFERENCES haves(id)
+);
+
+CREATE INDEX idx_haves_want ON haves(want_id);
+CREATE INDEX idx_haves_type_id ON haves(media_type, media_type_id);
+CREATE UNIQUE INDEX idx_haves_file_path ON haves(file_path);

--- a/crates/harmonia-db/src/error.rs
+++ b/crates/harmonia-db/src/error.rs
@@ -1,0 +1,35 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum DbError {
+    #[snafu(display("database pool initialization failed: {source}"))]
+    PoolInit {
+        source: sqlx::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("migration failed: {source}"))]
+    Migration {
+        source: sqlx::migrate::MigrateError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("query failed on {table}: {source}"))]
+    Query {
+        table: String,
+        source: sqlx::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("record not found in {table}: {id}"))]
+    NotFound {
+        table: String,
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/harmonia-db/src/lib.rs
+++ b/crates/harmonia-db/src/lib.rs
@@ -1,1 +1,8 @@
-// Stub — implementation in P2-03
+pub mod error;
+pub mod migrate;
+pub mod pools;
+pub mod repo;
+
+pub use error::DbError;
+pub use migrate::run_migrations;
+pub use pools::{DbPools, init_pools};

--- a/crates/harmonia-db/src/migrate.rs
+++ b/crates/harmonia-db/src/migrate.rs
@@ -1,0 +1,10 @@
+use sqlx::{SqlitePool, migrate::Migrator};
+
+use crate::error::{DbError, MigrationSnafu};
+use snafu::ResultExt;
+
+pub static MIGRATOR: Migrator = sqlx::migrate!();
+
+pub async fn run_migrations(pool: &SqlitePool) -> Result<(), DbError> {
+    MIGRATOR.run(pool).await.context(MigrationSnafu)
+}

--- a/crates/harmonia-db/src/pools.rs
+++ b/crates/harmonia-db/src/pools.rs
@@ -1,0 +1,52 @@
+use sqlx::{
+    SqlitePool,
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
+};
+
+use crate::error::{DbError, PoolInitSnafu};
+use crate::migrate::run_migrations;
+use snafu::ResultExt;
+
+pub struct DbPools {
+    pub read: SqlitePool,
+    pub write: SqlitePool,
+}
+
+pub async fn init_pools(db_path: &str) -> Result<DbPools, DbError> {
+    let base_opts = SqliteConnectOptions::new()
+        .filename(db_path)
+        .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Normal)
+        .foreign_keys(true);
+
+    let write = SqlitePoolOptions::new()
+        .max_connections(1) // CRITICAL: single writer — SQLite WAL constraint
+        .connect_with(base_opts.clone().create_if_missing(true))
+        .await
+        .context(PoolInitSnafu)?;
+
+    sqlx::query("PRAGMA journal_size_limit = 67108864")
+        .execute(&write)
+        .await
+        .context(PoolInitSnafu)?;
+    sqlx::query("PRAGMA temp_store = memory")
+        .execute(&write)
+        .await
+        .context(PoolInitSnafu)?;
+
+    run_migrations(&write).await?;
+
+    let read_pool_size = std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(4)
+        .max(2);
+
+    let read = SqlitePoolOptions::new()
+        .max_connections(read_pool_size)
+        .min_connections(2)
+        .connect_with(base_opts.read_only(true))
+        .await
+        .context(PoolInitSnafu)?;
+
+    Ok(DbPools { read, write })
+}

--- a/crates/harmonia-db/src/repo/audiobook.rs
+++ b/crates/harmonia-db/src/repo/audiobook.rs
@@ -1,0 +1,325 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Audiobook {
+    pub id: Vec<u8>,
+    pub registry_id: Option<Vec<u8>>,
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub publisher: Option<String>,
+    pub isbn: Option<String>,
+    pub asin: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub release_date: Option<String>,
+    pub language: Option<String>,
+    pub series_name: Option<String>,
+    pub series_position: Option<f64>,
+    pub file_path: Option<String>,
+    pub file_format: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub quality_score: Option<i64>,
+    pub quality_profile_id: Option<i64>,
+    pub source_type: String,
+    pub added_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AudiobookChapter {
+    pub id: Vec<u8>,
+    pub audiobook_id: Vec<u8>,
+    pub position: i64,
+    pub title: Option<String>,
+    pub start_ms: i64,
+    pub end_ms: i64,
+}
+
+pub async fn insert_audiobook(pool: &SqlitePool, book: &Audiobook) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO audiobooks
+         (id, registry_id, title, subtitle, publisher, isbn, asin, duration_ms,
+          release_date, language, series_name, series_position, file_path,
+          file_format, file_size_bytes, quality_score, quality_profile_id,
+          source_type, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&book.id)
+    .bind(&book.registry_id)
+    .bind(&book.title)
+    .bind(&book.subtitle)
+    .bind(&book.publisher)
+    .bind(&book.isbn)
+    .bind(&book.asin)
+    .bind(book.duration_ms)
+    .bind(&book.release_date)
+    .bind(&book.language)
+    .bind(&book.series_name)
+    .bind(book.series_position)
+    .bind(&book.file_path)
+    .bind(&book.file_format)
+    .bind(book.file_size_bytes)
+    .bind(book.quality_score)
+    .bind(book.quality_profile_id)
+    .bind(&book.source_type)
+    .bind(&book.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "audiobooks",
+    })?;
+    Ok(())
+}
+
+pub async fn get_audiobook(pool: &SqlitePool, id: &[u8]) -> Result<Option<Audiobook>, DbError> {
+    sqlx::query_as::<_, Audiobook>(
+        "SELECT id, registry_id, title, subtitle, publisher, isbn, asin, duration_ms,
+                release_date, language, series_name, series_position, file_path,
+                file_format, file_size_bytes, quality_score, quality_profile_id,
+                source_type, added_at
+         FROM audiobooks WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "audiobooks",
+    })
+}
+
+pub async fn list_audiobooks(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<Audiobook>, DbError> {
+    sqlx::query_as::<_, Audiobook>(
+        "SELECT id, registry_id, title, subtitle, publisher, isbn, asin, duration_ms,
+                release_date, language, series_name, series_position, file_path,
+                file_format, file_size_bytes, quality_score, quality_profile_id,
+                source_type, added_at
+         FROM audiobooks ORDER BY title LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "audiobooks",
+    })
+}
+
+pub async fn update_audiobook(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: &str,
+    quality_score: Option<i64>,
+    file_path: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE audiobooks SET title = ?, quality_score = ?, file_path = ? WHERE id = ?")
+        .bind(title)
+        .bind(quality_score)
+        .bind(file_path)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "audiobooks",
+        })?;
+    Ok(())
+}
+
+pub async fn delete_audiobook(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM audiobooks WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "audiobooks",
+        })?;
+    Ok(())
+}
+
+pub async fn insert_chapter(pool: &SqlitePool, chapter: &AudiobookChapter) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO audiobook_chapters (id, audiobook_id, position, title, start_ms, end_ms)
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&chapter.id)
+    .bind(&chapter.audiobook_id)
+    .bind(chapter.position)
+    .bind(&chapter.title)
+    .bind(chapter.start_ms)
+    .bind(chapter.end_ms)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "audiobook_chapters",
+    })?;
+    Ok(())
+}
+
+pub async fn get_chapter(
+    pool: &SqlitePool,
+    id: &[u8],
+) -> Result<Option<AudiobookChapter>, DbError> {
+    sqlx::query_as::<_, AudiobookChapter>(
+        "SELECT id, audiobook_id, position, title, start_ms, end_ms
+         FROM audiobook_chapters WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "audiobook_chapters",
+    })
+}
+
+pub async fn list_chapters(
+    pool: &SqlitePool,
+    audiobook_id: &[u8],
+) -> Result<Vec<AudiobookChapter>, DbError> {
+    sqlx::query_as::<_, AudiobookChapter>(
+        "SELECT id, audiobook_id, position, title, start_ms, end_ms
+         FROM audiobook_chapters WHERE audiobook_id = ? ORDER BY position",
+    )
+    .bind(audiobook_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "audiobook_chapters",
+    })
+}
+
+pub async fn update_chapter(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: Option<&str>,
+    start_ms: i64,
+    end_ms: i64,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE audiobook_chapters SET title = ?, start_ms = ?, end_ms = ? WHERE id = ?")
+        .bind(title)
+        .bind(start_ms)
+        .bind(end_ms)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "audiobook_chapters",
+        })?;
+    Ok(())
+}
+
+pub async fn delete_chapter(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM audiobook_chapters WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "audiobook_chapters",
+        })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    fn now() -> String {
+        "2026-01-01T00:00:00Z".to_string()
+    }
+
+    #[tokio::test]
+    async fn audiobook_round_trip() {
+        let pool = setup().await;
+        let id = make_id();
+        let book = Audiobook {
+            id: id.clone(),
+            registry_id: None,
+            title: "Dune".to_string(),
+            subtitle: None,
+            publisher: Some("Macmillan Audio".to_string()),
+            isbn: None,
+            asin: Some("B002V1CBBG".to_string()),
+            duration_ms: Some(21600000),
+            release_date: None,
+            language: Some("en".to_string()),
+            series_name: Some("Dune Chronicles".to_string()),
+            series_position: Some(1.0),
+            file_path: None,
+            file_format: None,
+            file_size_bytes: None,
+            quality_score: None,
+            quality_profile_id: None,
+            source_type: "local".to_string(),
+            added_at: now(),
+        };
+        insert_audiobook(&pool, &book).await.unwrap();
+        let fetched = get_audiobook(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.title, "Dune");
+        assert_eq!(fetched.asin, Some("B002V1CBBG".to_string()));
+        assert_eq!(fetched.series_position, Some(1.0));
+    }
+
+    #[tokio::test]
+    async fn chapter_round_trip() {
+        let pool = setup().await;
+        let book_id = make_id();
+        let book = Audiobook {
+            id: book_id.clone(),
+            registry_id: None,
+            title: "Test Book".to_string(),
+            subtitle: None,
+            publisher: None,
+            isbn: None,
+            asin: None,
+            duration_ms: None,
+            release_date: None,
+            language: None,
+            series_name: None,
+            series_position: None,
+            file_path: None,
+            file_format: None,
+            file_size_bytes: None,
+            quality_score: None,
+            quality_profile_id: None,
+            source_type: "local".to_string(),
+            added_at: now(),
+        };
+        insert_audiobook(&pool, &book).await.unwrap();
+
+        let ch_id = make_id();
+        let chapter = AudiobookChapter {
+            id: ch_id.clone(),
+            audiobook_id: book_id.clone(),
+            position: 1,
+            title: Some("Chapter 1".to_string()),
+            start_ms: 0,
+            end_ms: 120000,
+        };
+        insert_chapter(&pool, &chapter).await.unwrap();
+
+        let chapters = list_chapters(&pool, &book_id).await.unwrap();
+        assert_eq!(chapters.len(), 1);
+        assert_eq!(chapters[0].title, Some("Chapter 1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_audiobooks(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/harmonia-db/src/repo/book.rs
+++ b/crates/harmonia-db/src/repo/book.rs
@@ -1,0 +1,180 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Book {
+    pub id: Vec<u8>,
+    pub registry_id: Option<Vec<u8>>,
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub isbn: Option<String>,
+    pub isbn13: Option<String>,
+    pub openlibrary_id: Option<String>,
+    pub goodreads_id: Option<String>,
+    pub publisher: Option<String>,
+    pub publish_date: Option<String>,
+    pub language: Option<String>,
+    pub page_count: Option<i64>,
+    pub description: Option<String>,
+    pub file_path: Option<String>,
+    pub file_format: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub quality_score: Option<i64>,
+    pub quality_profile_id: Option<i64>,
+    pub source_type: String,
+    pub added_at: String,
+}
+
+pub async fn insert_book(pool: &SqlitePool, book: &Book) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO books
+         (id, registry_id, title, subtitle, isbn, isbn13, openlibrary_id, goodreads_id,
+          publisher, publish_date, language, page_count, description, file_path,
+          file_format, file_size_bytes, quality_score, quality_profile_id,
+          source_type, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&book.id)
+    .bind(&book.registry_id)
+    .bind(&book.title)
+    .bind(&book.subtitle)
+    .bind(&book.isbn)
+    .bind(&book.isbn13)
+    .bind(&book.openlibrary_id)
+    .bind(&book.goodreads_id)
+    .bind(&book.publisher)
+    .bind(&book.publish_date)
+    .bind(&book.language)
+    .bind(book.page_count)
+    .bind(&book.description)
+    .bind(&book.file_path)
+    .bind(&book.file_format)
+    .bind(book.file_size_bytes)
+    .bind(book.quality_score)
+    .bind(book.quality_profile_id)
+    .bind(&book.source_type)
+    .bind(&book.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "books" })?;
+    Ok(())
+}
+
+pub async fn get_book(pool: &SqlitePool, id: &[u8]) -> Result<Option<Book>, DbError> {
+    sqlx::query_as::<_, Book>(
+        "SELECT id, registry_id, title, subtitle, isbn, isbn13, openlibrary_id, goodreads_id,
+                publisher, publish_date, language, page_count, description, file_path,
+                file_format, file_size_bytes, quality_score, quality_profile_id,
+                source_type, added_at
+         FROM books WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "books" })
+}
+
+pub async fn list_books(pool: &SqlitePool, limit: i64, offset: i64) -> Result<Vec<Book>, DbError> {
+    sqlx::query_as::<_, Book>(
+        "SELECT id, registry_id, title, subtitle, isbn, isbn13, openlibrary_id, goodreads_id,
+                publisher, publish_date, language, page_count, description, file_path,
+                file_format, file_size_bytes, quality_score, quality_profile_id,
+                source_type, added_at
+         FROM books ORDER BY title LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "books" })
+}
+
+pub async fn update_book(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: &str,
+    quality_score: Option<i64>,
+    file_path: Option<&str>,
+    file_format: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "UPDATE books SET title = ?, quality_score = ?, file_path = ?, file_format = ?
+         WHERE id = ?",
+    )
+    .bind(title)
+    .bind(quality_score)
+    .bind(file_path)
+    .bind(file_format)
+    .bind(id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "books" })?;
+    Ok(())
+}
+
+pub async fn delete_book(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM books WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "books" })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn book_round_trip() {
+        let pool = setup().await;
+        let id = make_id();
+        let book = Book {
+            id: id.clone(),
+            registry_id: None,
+            title: "Dune".to_string(),
+            subtitle: None,
+            isbn: None,
+            isbn13: Some("9780441013593".to_string()),
+            openlibrary_id: None,
+            goodreads_id: None,
+            publisher: Some("Ace Books".to_string()),
+            publish_date: Some("1990-09-01".to_string()),
+            language: Some("en".to_string()),
+            page_count: Some(896),
+            description: None,
+            file_path: None,
+            file_format: None,
+            file_size_bytes: None,
+            quality_score: None,
+            quality_profile_id: None,
+            source_type: "local".to_string(),
+            added_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        insert_book(&pool, &book).await.unwrap();
+        let fetched = get_book(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.title, "Dune");
+        assert_eq!(fetched.isbn13, Some("9780441013593".to_string()));
+        assert_eq!(fetched.page_count, Some(896));
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_books(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/harmonia-db/src/repo/comic.rs
+++ b/crates/harmonia-db/src/repo/comic.rs
@@ -1,0 +1,191 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Comic {
+    pub id: Vec<u8>,
+    pub registry_id: Option<Vec<u8>>,
+    pub series_name: String,
+    pub volume: Option<i64>,
+    pub issue_number: Option<f64>,
+    pub title: Option<String>,
+    pub publisher: Option<String>,
+    pub release_date: Option<String>,
+    pub page_count: Option<i64>,
+    pub summary: Option<String>,
+    pub language: Option<String>,
+    pub comicinfo_writer: Option<String>,
+    pub comicinfo_penciller: Option<String>,
+    pub comicinfo_inker: Option<String>,
+    pub comicinfo_colorist: Option<String>,
+    pub file_path: Option<String>,
+    pub file_format: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub quality_score: Option<i64>,
+    pub quality_profile_id: Option<i64>,
+    pub source_type: String,
+    pub added_at: String,
+}
+
+pub async fn insert_comic(pool: &SqlitePool, comic: &Comic) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO comics
+         (id, registry_id, series_name, volume, issue_number, title, publisher,
+          release_date, page_count, summary, language, comicinfo_writer,
+          comicinfo_penciller, comicinfo_inker, comicinfo_colorist,
+          file_path, file_format, file_size_bytes, quality_score,
+          quality_profile_id, source_type, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&comic.id)
+    .bind(&comic.registry_id)
+    .bind(&comic.series_name)
+    .bind(comic.volume)
+    .bind(comic.issue_number)
+    .bind(&comic.title)
+    .bind(&comic.publisher)
+    .bind(&comic.release_date)
+    .bind(comic.page_count)
+    .bind(&comic.summary)
+    .bind(&comic.language)
+    .bind(&comic.comicinfo_writer)
+    .bind(&comic.comicinfo_penciller)
+    .bind(&comic.comicinfo_inker)
+    .bind(&comic.comicinfo_colorist)
+    .bind(&comic.file_path)
+    .bind(&comic.file_format)
+    .bind(comic.file_size_bytes)
+    .bind(comic.quality_score)
+    .bind(comic.quality_profile_id)
+    .bind(&comic.source_type)
+    .bind(&comic.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "comics" })?;
+    Ok(())
+}
+
+pub async fn get_comic(pool: &SqlitePool, id: &[u8]) -> Result<Option<Comic>, DbError> {
+    sqlx::query_as::<_, Comic>(
+        "SELECT id, registry_id, series_name, volume, issue_number, title, publisher,
+                release_date, page_count, summary, language, comicinfo_writer,
+                comicinfo_penciller, comicinfo_inker, comicinfo_colorist,
+                file_path, file_format, file_size_bytes, quality_score,
+                quality_profile_id, source_type, added_at
+         FROM comics WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "comics" })
+}
+
+pub async fn list_comics(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<Comic>, DbError> {
+    sqlx::query_as::<_, Comic>(
+        "SELECT id, registry_id, series_name, volume, issue_number, title, publisher,
+                release_date, page_count, summary, language, comicinfo_writer,
+                comicinfo_penciller, comicinfo_inker, comicinfo_colorist,
+                file_path, file_format, file_size_bytes, quality_score,
+                quality_profile_id, source_type, added_at
+         FROM comics ORDER BY series_name, volume, issue_number LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "comics" })
+}
+
+pub async fn update_comic(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: Option<&str>,
+    quality_score: Option<i64>,
+    file_path: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE comics SET title = ?, quality_score = ?, file_path = ? WHERE id = ?")
+        .bind(title)
+        .bind(quality_score)
+        .bind(file_path)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "comics" })?;
+    Ok(())
+}
+
+pub async fn delete_comic(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM comics WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "comics" })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn comic_round_trip() {
+        let pool = setup().await;
+        let id = make_id();
+        let comic = Comic {
+            id: id.clone(),
+            registry_id: None,
+            series_name: "Saga".to_string(),
+            volume: Some(1),
+            issue_number: Some(1.0),
+            title: Some("Chapter One".to_string()),
+            publisher: Some("Image Comics".to_string()),
+            release_date: Some("2012-03-14".to_string()),
+            page_count: Some(44),
+            summary: None,
+            language: Some("en".to_string()),
+            comicinfo_writer: Some("Brian K. Vaughan".to_string()),
+            comicinfo_penciller: None,
+            comicinfo_inker: None,
+            comicinfo_colorist: None,
+            file_path: None,
+            file_format: None,
+            file_size_bytes: None,
+            quality_score: None,
+            quality_profile_id: None,
+            source_type: "local".to_string(),
+            added_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        insert_comic(&pool, &comic).await.unwrap();
+        let fetched = get_comic(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.series_name, "Saga");
+        assert_eq!(fetched.issue_number, Some(1.0));
+        assert_eq!(
+            fetched.comicinfo_writer,
+            Some("Brian K. Vaughan".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_comics(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/harmonia-db/src/repo/mod.rs
+++ b/crates/harmonia-db/src/repo/mod.rs
@@ -1,0 +1,12 @@
+pub mod audiobook;
+pub mod book;
+pub mod comic;
+pub mod movie;
+pub mod music;
+pub mod news;
+pub mod podcast;
+pub mod quality;
+pub mod registry;
+pub mod tv;
+pub mod user;
+pub mod want;

--- a/crates/harmonia-db/src/repo/movie.rs
+++ b/crates/harmonia-db/src/repo/movie.rs
@@ -1,0 +1,179 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Movie {
+    pub id: Vec<u8>,
+    pub registry_id: Option<Vec<u8>>,
+    pub title: String,
+    pub original_title: Option<String>,
+    pub year: Option<i64>,
+    pub tmdb_id: Option<i64>,
+    pub imdb_id: Option<String>,
+    pub runtime_min: Option<i64>,
+    pub overview: Option<String>,
+    pub certification: Option<String>,
+    pub file_path: Option<String>,
+    pub file_format: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub resolution: Option<String>,
+    pub codec: Option<String>,
+    pub hdr_type: Option<String>,
+    pub quality_score: Option<i64>,
+    pub quality_profile_id: Option<i64>,
+    pub source_type: String,
+    pub added_at: String,
+}
+
+pub async fn insert_movie(pool: &SqlitePool, movie: &Movie) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO movies
+         (id, registry_id, title, original_title, year, tmdb_id, imdb_id,
+          runtime_min, overview, certification, file_path, file_format,
+          file_size_bytes, resolution, codec, hdr_type, quality_score,
+          quality_profile_id, source_type, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&movie.id)
+    .bind(&movie.registry_id)
+    .bind(&movie.title)
+    .bind(&movie.original_title)
+    .bind(movie.year)
+    .bind(movie.tmdb_id)
+    .bind(&movie.imdb_id)
+    .bind(movie.runtime_min)
+    .bind(&movie.overview)
+    .bind(&movie.certification)
+    .bind(&movie.file_path)
+    .bind(&movie.file_format)
+    .bind(movie.file_size_bytes)
+    .bind(&movie.resolution)
+    .bind(&movie.codec)
+    .bind(&movie.hdr_type)
+    .bind(movie.quality_score)
+    .bind(movie.quality_profile_id)
+    .bind(&movie.source_type)
+    .bind(&movie.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "movies" })?;
+    Ok(())
+}
+
+pub async fn get_movie(pool: &SqlitePool, id: &[u8]) -> Result<Option<Movie>, DbError> {
+    sqlx::query_as::<_, Movie>(
+        "SELECT id, registry_id, title, original_title, year, tmdb_id, imdb_id,
+                runtime_min, overview, certification, file_path, file_format,
+                file_size_bytes, resolution, codec, hdr_type, quality_score,
+                quality_profile_id, source_type, added_at
+         FROM movies WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "movies" })
+}
+
+pub async fn list_movies(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<Movie>, DbError> {
+    sqlx::query_as::<_, Movie>(
+        "SELECT id, registry_id, title, original_title, year, tmdb_id, imdb_id,
+                runtime_min, overview, certification, file_path, file_format,
+                file_size_bytes, resolution, codec, hdr_type, quality_score,
+                quality_profile_id, source_type, added_at
+         FROM movies ORDER BY title LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "movies" })
+}
+
+pub async fn update_movie(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: &str,
+    quality_score: Option<i64>,
+    file_path: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE movies SET title = ?, quality_score = ?, file_path = ? WHERE id = ?")
+        .bind(title)
+        .bind(quality_score)
+        .bind(file_path)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "movies" })?;
+    Ok(())
+}
+
+pub async fn delete_movie(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM movies WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "movies" })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn movie_round_trip() {
+        let pool = setup().await;
+        let id = make_id();
+        let movie = Movie {
+            id: id.clone(),
+            registry_id: None,
+            title: "Dune: Part Two".to_string(),
+            original_title: None,
+            year: Some(2024),
+            tmdb_id: Some(693134),
+            imdb_id: Some("tt15239678".to_string()),
+            runtime_min: Some(167),
+            overview: Some("Follow the mythic journey of Paul Atreides.".to_string()),
+            certification: Some("PG-13".to_string()),
+            file_path: None,
+            file_format: None,
+            file_size_bytes: None,
+            resolution: None,
+            codec: None,
+            hdr_type: None,
+            quality_score: None,
+            quality_profile_id: None,
+            source_type: "local".to_string(),
+            added_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        insert_movie(&pool, &movie).await.unwrap();
+        let fetched = get_movie(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.title, "Dune: Part Two");
+        assert_eq!(fetched.tmdb_id, Some(693134));
+        assert_eq!(fetched.runtime_min, Some(167));
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_movies(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/harmonia-db/src/repo/music.rs
+++ b/crates/harmonia-db/src/repo/music.rs
@@ -1,0 +1,620 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct MusicReleaseGroup {
+    pub id: Vec<u8>,
+    pub registry_id: Option<Vec<u8>>,
+    pub title: String,
+    pub rg_type: String,
+    pub mb_release_group_id: Option<String>,
+    pub year: Option<i64>,
+    pub quality_profile_id: Option<i64>,
+    pub added_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct MusicRelease {
+    pub id: Vec<u8>,
+    pub release_group_id: Vec<u8>,
+    pub title: String,
+    pub release_date: Option<String>,
+    pub country: Option<String>,
+    pub label: Option<String>,
+    pub catalog_number: Option<String>,
+    pub mb_release_id: Option<String>,
+    pub added_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct MusicMedium {
+    pub id: Vec<u8>,
+    pub release_id: Vec<u8>,
+    pub position: i64,
+    pub format: String,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct MusicTrack {
+    pub id: Vec<u8>,
+    pub medium_id: Vec<u8>,
+    pub position: i64,
+    pub title: String,
+    pub duration_ms: Option<i64>,
+    pub mb_recording_id: Option<String>,
+    pub acoustid_fingerprint: Option<String>,
+    pub acoustid_id: Option<String>,
+    pub file_path: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub bit_depth: Option<i64>,
+    pub sample_rate: Option<i64>,
+    pub codec: Option<String>,
+    pub quality_score: Option<i64>,
+    pub replay_gain_track_db: Option<f64>,
+    pub replay_gain_album_db: Option<f64>,
+    pub source_type: String,
+    pub added_at: String,
+}
+
+// --- release groups ---
+
+pub async fn insert_release_group(
+    pool: &SqlitePool,
+    group: &MusicReleaseGroup,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO music_release_groups
+         (id, registry_id, title, rg_type, mb_release_group_id, year, quality_profile_id, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&group.id)
+    .bind(&group.registry_id)
+    .bind(&group.title)
+    .bind(&group.rg_type)
+    .bind(&group.mb_release_group_id)
+    .bind(group.year)
+    .bind(group.quality_profile_id)
+    .bind(&group.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_release_groups",
+    })?;
+    Ok(())
+}
+
+pub async fn get_release_group(
+    pool: &SqlitePool,
+    id: &[u8],
+) -> Result<Option<MusicReleaseGroup>, DbError> {
+    sqlx::query_as::<_, MusicReleaseGroup>(
+        "SELECT id, registry_id, title, rg_type, mb_release_group_id, year,
+                quality_profile_id, added_at
+         FROM music_release_groups WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_release_groups",
+    })
+}
+
+pub async fn list_release_groups(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<MusicReleaseGroup>, DbError> {
+    sqlx::query_as::<_, MusicReleaseGroup>(
+        "SELECT id, registry_id, title, rg_type, mb_release_group_id, year,
+                quality_profile_id, added_at
+         FROM music_release_groups ORDER BY title LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_release_groups",
+    })
+}
+
+pub async fn update_release_group(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: &str,
+    rg_type: &str,
+    quality_profile_id: Option<i64>,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "UPDATE music_release_groups SET title = ?, rg_type = ?, quality_profile_id = ?
+         WHERE id = ?",
+    )
+    .bind(title)
+    .bind(rg_type)
+    .bind(quality_profile_id)
+    .bind(id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_release_groups",
+    })?;
+    Ok(())
+}
+
+pub async fn delete_release_group(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM music_release_groups WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "music_release_groups",
+        })?;
+    Ok(())
+}
+
+// --- releases ---
+
+pub async fn insert_release(pool: &SqlitePool, release: &MusicRelease) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO music_releases
+         (id, release_group_id, title, release_date, country, label, catalog_number, mb_release_id, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&release.id)
+    .bind(&release.release_group_id)
+    .bind(&release.title)
+    .bind(&release.release_date)
+    .bind(&release.country)
+    .bind(&release.label)
+    .bind(&release.catalog_number)
+    .bind(&release.mb_release_id)
+    .bind(&release.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "music_releases" })?;
+    Ok(())
+}
+
+pub async fn get_release(pool: &SqlitePool, id: &[u8]) -> Result<Option<MusicRelease>, DbError> {
+    sqlx::query_as::<_, MusicRelease>(
+        "SELECT id, release_group_id, title, release_date, country, label,
+                catalog_number, mb_release_id, added_at
+         FROM music_releases WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_releases",
+    })
+}
+
+pub async fn list_releases(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<MusicRelease>, DbError> {
+    sqlx::query_as::<_, MusicRelease>(
+        "SELECT id, release_group_id, title, release_date, country, label,
+                catalog_number, mb_release_id, added_at
+         FROM music_releases ORDER BY title LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_releases",
+    })
+}
+
+pub async fn update_release(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: &str,
+    release_date: Option<&str>,
+    label: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE music_releases SET title = ?, release_date = ?, label = ? WHERE id = ?")
+        .bind(title)
+        .bind(release_date)
+        .bind(label)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "music_releases",
+        })?;
+    Ok(())
+}
+
+pub async fn delete_release(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM music_releases WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "music_releases",
+        })?;
+    Ok(())
+}
+
+// --- media ---
+
+pub async fn insert_medium(pool: &SqlitePool, medium: &MusicMedium) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO music_media (id, release_id, position, format, title)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(&medium.id)
+    .bind(&medium.release_id)
+    .bind(medium.position)
+    .bind(&medium.format)
+    .bind(&medium.title)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_media",
+    })?;
+    Ok(())
+}
+
+pub async fn get_medium(pool: &SqlitePool, id: &[u8]) -> Result<Option<MusicMedium>, DbError> {
+    sqlx::query_as::<_, MusicMedium>(
+        "SELECT id, release_id, position, format, title FROM music_media WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_media",
+    })
+}
+
+pub async fn list_media_for_release(
+    pool: &SqlitePool,
+    release_id: &[u8],
+) -> Result<Vec<MusicMedium>, DbError> {
+    sqlx::query_as::<_, MusicMedium>(
+        "SELECT id, release_id, position, format, title
+         FROM music_media WHERE release_id = ? ORDER BY position",
+    )
+    .bind(release_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_media",
+    })
+}
+
+pub async fn update_medium(
+    pool: &SqlitePool,
+    id: &[u8],
+    format: &str,
+    title: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE music_media SET format = ?, title = ? WHERE id = ?")
+        .bind(format)
+        .bind(title)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "music_media",
+        })?;
+    Ok(())
+}
+
+pub async fn delete_medium(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM music_media WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "music_media",
+        })?;
+    Ok(())
+}
+
+// --- tracks ---
+
+pub async fn insert_track(pool: &SqlitePool, track: &MusicTrack) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO music_tracks
+         (id, medium_id, position, title, duration_ms, mb_recording_id,
+          acoustid_fingerprint, acoustid_id, file_path, file_size_bytes,
+          bit_depth, sample_rate, codec, quality_score,
+          replay_gain_track_db, replay_gain_album_db, source_type, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&track.id)
+    .bind(&track.medium_id)
+    .bind(track.position)
+    .bind(&track.title)
+    .bind(track.duration_ms)
+    .bind(&track.mb_recording_id)
+    .bind(&track.acoustid_fingerprint)
+    .bind(&track.acoustid_id)
+    .bind(&track.file_path)
+    .bind(track.file_size_bytes)
+    .bind(track.bit_depth)
+    .bind(track.sample_rate)
+    .bind(&track.codec)
+    .bind(track.quality_score)
+    .bind(track.replay_gain_track_db)
+    .bind(track.replay_gain_album_db)
+    .bind(&track.source_type)
+    .bind(&track.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_tracks",
+    })?;
+    Ok(())
+}
+
+pub async fn get_track(pool: &SqlitePool, id: &[u8]) -> Result<Option<MusicTrack>, DbError> {
+    sqlx::query_as::<_, MusicTrack>(
+        "SELECT id, medium_id, position, title, duration_ms, mb_recording_id,
+                acoustid_fingerprint, acoustid_id, file_path, file_size_bytes,
+                bit_depth, sample_rate, codec, quality_score,
+                replay_gain_track_db, replay_gain_album_db, source_type, added_at
+         FROM music_tracks WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_tracks",
+    })
+}
+
+pub async fn list_tracks_for_medium(
+    pool: &SqlitePool,
+    medium_id: &[u8],
+) -> Result<Vec<MusicTrack>, DbError> {
+    sqlx::query_as::<_, MusicTrack>(
+        "SELECT id, medium_id, position, title, duration_ms, mb_recording_id,
+                acoustid_fingerprint, acoustid_id, file_path, file_size_bytes,
+                bit_depth, sample_rate, codec, quality_score,
+                replay_gain_track_db, replay_gain_album_db, source_type, added_at
+         FROM music_tracks WHERE medium_id = ? ORDER BY position",
+    )
+    .bind(medium_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_tracks",
+    })
+}
+
+pub async fn update_track(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: &str,
+    quality_score: Option<i64>,
+    file_path: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE music_tracks SET title = ?, quality_score = ?, file_path = ? WHERE id = ?")
+        .bind(title)
+        .bind(quality_score)
+        .bind(file_path)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "music_tracks",
+        })?;
+    Ok(())
+}
+
+pub async fn delete_track(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM music_tracks WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "music_tracks",
+        })?;
+    Ok(())
+}
+
+// --- hierarchy queries ---
+
+pub async fn get_release_group_with_releases(
+    pool: &SqlitePool,
+    group_id: &[u8],
+) -> Result<(Option<MusicReleaseGroup>, Vec<MusicRelease>), DbError> {
+    let group = get_release_group(pool, group_id).await?;
+    let releases = sqlx::query_as::<_, MusicRelease>(
+        "SELECT id, release_group_id, title, release_date, country, label,
+                catalog_number, mb_release_id, added_at
+         FROM music_releases WHERE release_group_id = ? ORDER BY release_date",
+    )
+    .bind(group_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_releases",
+    })?;
+    Ok((group, releases))
+}
+
+pub async fn list_tracks_by_release_group(
+    pool: &SqlitePool,
+    group_id: &[u8],
+) -> Result<Vec<MusicTrack>, DbError> {
+    sqlx::query_as::<_, MusicTrack>(
+        "SELECT t.id, t.medium_id, t.position, t.title, t.duration_ms, t.mb_recording_id,
+                t.acoustid_fingerprint, t.acoustid_id, t.file_path, t.file_size_bytes,
+                t.bit_depth, t.sample_rate, t.codec, t.quality_score,
+                t.replay_gain_track_db, t.replay_gain_album_db, t.source_type, t.added_at
+         FROM music_tracks t
+         JOIN music_media mm ON mm.id = t.medium_id
+         JOIN music_releases mr ON mr.id = mm.release_id
+         WHERE mr.release_group_id = ?
+         ORDER BY mr.release_date, mm.position, t.position",
+    )
+    .bind(group_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_tracks",
+    })
+}
+
+pub async fn search_tracks(
+    pool: &SqlitePool,
+    query: &str,
+    limit: i64,
+) -> Result<Vec<MusicTrack>, DbError> {
+    let pattern = format!("%{query}%");
+    sqlx::query_as::<_, MusicTrack>(
+        "SELECT id, medium_id, position, title, duration_ms, mb_recording_id,
+                acoustid_fingerprint, acoustid_id, file_path, file_size_bytes,
+                bit_depth, sample_rate, codec, quality_score,
+                replay_gain_track_db, replay_gain_album_db, source_type, added_at
+         FROM music_tracks WHERE title LIKE ? LIMIT ?",
+    )
+    .bind(&pattern)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "music_tracks",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    fn now() -> String {
+        "2026-01-01T00:00:00Z".to_string()
+    }
+
+    #[tokio::test]
+    async fn release_group_round_trip() {
+        let pool = setup().await;
+        let id = make_id();
+        let group = MusicReleaseGroup {
+            id: id.clone(),
+            registry_id: None,
+            title: "Led Zeppelin IV".to_string(),
+            rg_type: "album".to_string(),
+            mb_release_group_id: None,
+            year: Some(1971),
+            quality_profile_id: None,
+            added_at: now(),
+        };
+        insert_release_group(&pool, &group).await.unwrap();
+        let fetched = get_release_group(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.title, "Led Zeppelin IV");
+        assert_eq!(fetched.year, Some(1971));
+    }
+
+    #[tokio::test]
+    async fn four_level_hierarchy_round_trip() {
+        let pool = setup().await;
+
+        let group_id = make_id();
+        let group = MusicReleaseGroup {
+            id: group_id.clone(),
+            registry_id: None,
+            title: "Test Album".to_string(),
+            rg_type: "album".to_string(),
+            mb_release_group_id: None,
+            year: Some(2024),
+            quality_profile_id: None,
+            added_at: now(),
+        };
+        insert_release_group(&pool, &group).await.unwrap();
+
+        let release_id = make_id();
+        let release = MusicRelease {
+            id: release_id.clone(),
+            release_group_id: group_id.clone(),
+            title: "Test Album (US Edition)".to_string(),
+            release_date: Some("2024-01-01".to_string()),
+            country: Some("US".to_string()),
+            label: None,
+            catalog_number: None,
+            mb_release_id: None,
+            added_at: now(),
+        };
+        insert_release(&pool, &release).await.unwrap();
+
+        let medium_id = make_id();
+        let medium = MusicMedium {
+            id: medium_id.clone(),
+            release_id: release_id.clone(),
+            position: 1,
+            format: "Digital".to_string(),
+            title: None,
+        };
+        insert_medium(&pool, &medium).await.unwrap();
+
+        let track_id = make_id();
+        let track = MusicTrack {
+            id: track_id.clone(),
+            medium_id: medium_id.clone(),
+            position: 1,
+            title: "Track One".to_string(),
+            duration_ms: Some(240000),
+            mb_recording_id: None,
+            acoustid_fingerprint: None,
+            acoustid_id: None,
+            file_path: None,
+            file_size_bytes: None,
+            bit_depth: None,
+            sample_rate: None,
+            codec: None,
+            quality_score: None,
+            replay_gain_track_db: None,
+            replay_gain_album_db: None,
+            source_type: "local".to_string(),
+            added_at: now(),
+        };
+        insert_track(&pool, &track).await.unwrap();
+
+        let (fetched_group, releases) = get_release_group_with_releases(&pool, &group_id)
+            .await
+            .unwrap();
+        assert!(fetched_group.is_some());
+        assert_eq!(releases.len(), 1);
+
+        let media = list_media_for_release(&pool, &release_id).await.unwrap();
+        assert_eq!(media.len(), 1);
+
+        let tracks = list_tracks_for_medium(&pool, &medium_id).await.unwrap();
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].title, "Track One");
+
+        let flat = list_tracks_by_release_group(&pool, &group_id)
+            .await
+            .unwrap();
+        assert_eq!(flat.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_release_groups(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/harmonia-db/src/repo/news.rs
+++ b/crates/harmonia-db/src/repo/news.rs
@@ -1,0 +1,320 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct NewsFeed {
+    pub id: Vec<u8>,
+    pub title: String,
+    pub url: String,
+    pub site_url: Option<String>,
+    pub description: Option<String>,
+    pub category: Option<String>,
+    pub icon_url: Option<String>,
+    pub last_fetched_at: Option<String>,
+    pub fetch_interval_minutes: i64,
+    pub is_active: i64,
+    pub added_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct NewsArticle {
+    pub id: Vec<u8>,
+    pub feed_id: Vec<u8>,
+    pub guid: String,
+    pub title: String,
+    pub url: String,
+    pub author: Option<String>,
+    pub content_html: Option<String>,
+    pub summary: Option<String>,
+    pub published_at: Option<String>,
+    pub is_read: i64,
+    pub is_starred: i64,
+    pub source_type: String,
+    pub added_at: String,
+}
+
+pub async fn insert_feed(pool: &SqlitePool, feed: &NewsFeed) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO news_feeds
+         (id, title, url, site_url, description, category, icon_url,
+          last_fetched_at, fetch_interval_minutes, is_active, added_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&feed.id)
+    .bind(&feed.title)
+    .bind(&feed.url)
+    .bind(&feed.site_url)
+    .bind(&feed.description)
+    .bind(&feed.category)
+    .bind(&feed.icon_url)
+    .bind(&feed.last_fetched_at)
+    .bind(feed.fetch_interval_minutes)
+    .bind(feed.is_active)
+    .bind(&feed.added_at)
+    .bind(&feed.updated_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "news_feeds",
+    })?;
+    Ok(())
+}
+
+pub async fn get_feed(pool: &SqlitePool, id: &[u8]) -> Result<Option<NewsFeed>, DbError> {
+    sqlx::query_as::<_, NewsFeed>(
+        "SELECT id, title, url, site_url, description, category, icon_url,
+                last_fetched_at, fetch_interval_minutes, is_active, added_at, updated_at
+         FROM news_feeds WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "news_feeds",
+    })
+}
+
+pub async fn list_feeds(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<NewsFeed>, DbError> {
+    sqlx::query_as::<_, NewsFeed>(
+        "SELECT id, title, url, site_url, description, category, icon_url,
+                last_fetched_at, fetch_interval_minutes, is_active, added_at, updated_at
+         FROM news_feeds ORDER BY title LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "news_feeds",
+    })
+}
+
+pub async fn update_feed(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: &str,
+    is_active: i64,
+    last_fetched_at: Option<&str>,
+    updated_at: &str,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "UPDATE news_feeds SET title = ?, is_active = ?, last_fetched_at = ?, updated_at = ?
+         WHERE id = ?",
+    )
+    .bind(title)
+    .bind(is_active)
+    .bind(last_fetched_at)
+    .bind(updated_at)
+    .bind(id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "news_feeds",
+    })?;
+    Ok(())
+}
+
+pub async fn delete_feed(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM news_feeds WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "news_feeds",
+        })?;
+    Ok(())
+}
+
+pub async fn insert_article(pool: &SqlitePool, article: &NewsArticle) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO news_articles
+         (id, feed_id, guid, title, url, author, content_html, summary,
+          published_at, is_read, is_starred, source_type, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&article.id)
+    .bind(&article.feed_id)
+    .bind(&article.guid)
+    .bind(&article.title)
+    .bind(&article.url)
+    .bind(&article.author)
+    .bind(&article.content_html)
+    .bind(&article.summary)
+    .bind(&article.published_at)
+    .bind(article.is_read)
+    .bind(article.is_starred)
+    .bind(&article.source_type)
+    .bind(&article.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "news_articles",
+    })?;
+    Ok(())
+}
+
+pub async fn get_article(pool: &SqlitePool, id: &[u8]) -> Result<Option<NewsArticle>, DbError> {
+    sqlx::query_as::<_, NewsArticle>(
+        "SELECT id, feed_id, guid, title, url, author, content_html, summary,
+                published_at, is_read, is_starred, source_type, added_at
+         FROM news_articles WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "news_articles",
+    })
+}
+
+pub async fn list_articles(
+    pool: &SqlitePool,
+    feed_id: &[u8],
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<NewsArticle>, DbError> {
+    sqlx::query_as::<_, NewsArticle>(
+        "SELECT id, feed_id, guid, title, url, author, content_html, summary,
+                published_at, is_read, is_starred, source_type, added_at
+         FROM news_articles WHERE feed_id = ?
+         ORDER BY published_at DESC LIMIT ? OFFSET ?",
+    )
+    .bind(feed_id)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "news_articles",
+    })
+}
+
+pub async fn update_article(
+    pool: &SqlitePool,
+    id: &[u8],
+    is_read: i64,
+    is_starred: i64,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE news_articles SET is_read = ?, is_starred = ? WHERE id = ?")
+        .bind(is_read)
+        .bind(is_starred)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "news_articles",
+        })?;
+    Ok(())
+}
+
+pub async fn delete_article(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM news_articles WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "news_articles",
+        })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    fn now() -> String {
+        "2026-01-01T00:00:00Z".to_string()
+    }
+
+    #[tokio::test]
+    async fn feed_round_trip() {
+        let pool = setup().await;
+        let id = make_id();
+        let feed = NewsFeed {
+            id: id.clone(),
+            title: "Ars Technica".to_string(),
+            url: "https://feeds.arstechnica.com/arstechnica/index".to_string(),
+            site_url: Some("https://arstechnica.com".to_string()),
+            description: None,
+            category: Some("tech".to_string()),
+            icon_url: None,
+            last_fetched_at: None,
+            fetch_interval_minutes: 30,
+            is_active: 1,
+            added_at: now(),
+            updated_at: now(),
+        };
+        insert_feed(&pool, &feed).await.unwrap();
+        let fetched = get_feed(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.title, "Ars Technica");
+        assert_eq!(fetched.fetch_interval_minutes, 30);
+    }
+
+    #[tokio::test]
+    async fn article_round_trip() {
+        let pool = setup().await;
+        let feed_id = make_id();
+        let feed = NewsFeed {
+            id: feed_id.clone(),
+            title: "Test Feed".to_string(),
+            url: "https://example.com/feed2.xml".to_string(),
+            site_url: None,
+            description: None,
+            category: None,
+            icon_url: None,
+            last_fetched_at: None,
+            fetch_interval_minutes: 60,
+            is_active: 1,
+            added_at: now(),
+            updated_at: now(),
+        };
+        insert_feed(&pool, &feed).await.unwrap();
+
+        let art_id = make_id();
+        let article = NewsArticle {
+            id: art_id.clone(),
+            feed_id: feed_id.clone(),
+            guid: "article-001".to_string(),
+            title: "Test Article".to_string(),
+            url: "https://example.com/article1".to_string(),
+            author: Some("Author Name".to_string()),
+            content_html: None,
+            summary: Some("A short summary".to_string()),
+            published_at: Some("2026-01-01T00:00:00Z".to_string()),
+            is_read: 0,
+            is_starred: 0,
+            source_type: "rss".to_string(),
+            added_at: now(),
+        };
+        insert_article(&pool, &article).await.unwrap();
+
+        let articles = list_articles(&pool, &feed_id, 10, 0).await.unwrap();
+        assert_eq!(articles.len(), 1);
+        assert_eq!(articles[0].title, "Test Article");
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_feeds(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/harmonia-db/src/repo/podcast.rs
+++ b/crates/harmonia-db/src/repo/podcast.rs
@@ -1,0 +1,340 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct PodcastSubscription {
+    pub id: Vec<u8>,
+    pub feed_url: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub author: Option<String>,
+    pub image_url: Option<String>,
+    pub language: Option<String>,
+    pub last_checked_at: Option<String>,
+    pub auto_download: i64,
+    pub quality_profile_id: Option<i64>,
+    pub added_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct PodcastEpisode {
+    pub id: Vec<u8>,
+    pub subscription_id: Vec<u8>,
+    pub guid: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub episode_number: Option<i64>,
+    pub season_number: Option<i64>,
+    pub publication_date: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub enclosure_url: Option<String>,
+    pub file_path: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub file_format: Option<String>,
+    pub quality_score: Option<i64>,
+    pub source_type: String,
+    pub listened: i64,
+    pub added_at: String,
+}
+
+pub async fn insert_subscription(
+    pool: &SqlitePool,
+    sub: &PodcastSubscription,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO podcast_subscriptions
+         (id, feed_url, title, description, author, image_url, language,
+          last_checked_at, auto_download, quality_profile_id, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&sub.id)
+    .bind(&sub.feed_url)
+    .bind(&sub.title)
+    .bind(&sub.description)
+    .bind(&sub.author)
+    .bind(&sub.image_url)
+    .bind(&sub.language)
+    .bind(&sub.last_checked_at)
+    .bind(sub.auto_download)
+    .bind(sub.quality_profile_id)
+    .bind(&sub.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_subscriptions",
+    })?;
+    Ok(())
+}
+
+pub async fn get_subscription(
+    pool: &SqlitePool,
+    id: &[u8],
+) -> Result<Option<PodcastSubscription>, DbError> {
+    sqlx::query_as::<_, PodcastSubscription>(
+        "SELECT id, feed_url, title, description, author, image_url, language,
+                last_checked_at, auto_download, quality_profile_id, added_at
+         FROM podcast_subscriptions WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_subscriptions",
+    })
+}
+
+pub async fn list_subscriptions(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<PodcastSubscription>, DbError> {
+    sqlx::query_as::<_, PodcastSubscription>(
+        "SELECT id, feed_url, title, description, author, image_url, language,
+                last_checked_at, auto_download, quality_profile_id, added_at
+         FROM podcast_subscriptions ORDER BY title LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_subscriptions",
+    })
+}
+
+pub async fn update_subscription(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: Option<&str>,
+    auto_download: i64,
+    last_checked_at: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "UPDATE podcast_subscriptions SET title = ?, auto_download = ?, last_checked_at = ?
+         WHERE id = ?",
+    )
+    .bind(title)
+    .bind(auto_download)
+    .bind(last_checked_at)
+    .bind(id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_subscriptions",
+    })?;
+    Ok(())
+}
+
+pub async fn delete_subscription(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM podcast_subscriptions WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "podcast_subscriptions",
+        })?;
+    Ok(())
+}
+
+pub async fn insert_episode(pool: &SqlitePool, ep: &PodcastEpisode) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO podcast_episodes
+         (id, subscription_id, guid, title, description, episode_number, season_number,
+          publication_date, duration_ms, enclosure_url, file_path, file_size_bytes,
+          file_format, quality_score, source_type, listened, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&ep.id)
+    .bind(&ep.subscription_id)
+    .bind(&ep.guid)
+    .bind(&ep.title)
+    .bind(&ep.description)
+    .bind(ep.episode_number)
+    .bind(ep.season_number)
+    .bind(&ep.publication_date)
+    .bind(ep.duration_ms)
+    .bind(&ep.enclosure_url)
+    .bind(&ep.file_path)
+    .bind(ep.file_size_bytes)
+    .bind(&ep.file_format)
+    .bind(ep.quality_score)
+    .bind(&ep.source_type)
+    .bind(ep.listened)
+    .bind(&ep.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_episodes",
+    })?;
+    Ok(())
+}
+
+pub async fn get_episode(pool: &SqlitePool, id: &[u8]) -> Result<Option<PodcastEpisode>, DbError> {
+    sqlx::query_as::<_, PodcastEpisode>(
+        "SELECT id, subscription_id, guid, title, description, episode_number, season_number,
+                publication_date, duration_ms, enclosure_url, file_path, file_size_bytes,
+                file_format, quality_score, source_type, listened, added_at
+         FROM podcast_episodes WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_episodes",
+    })
+}
+
+pub async fn list_episodes(
+    pool: &SqlitePool,
+    subscription_id: &[u8],
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<PodcastEpisode>, DbError> {
+    sqlx::query_as::<_, PodcastEpisode>(
+        "SELECT id, subscription_id, guid, title, description, episode_number, season_number,
+                publication_date, duration_ms, enclosure_url, file_path, file_size_bytes,
+                file_format, quality_score, source_type, listened, added_at
+         FROM podcast_episodes WHERE subscription_id = ?
+         ORDER BY publication_date DESC LIMIT ? OFFSET ?",
+    )
+    .bind(subscription_id)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_episodes",
+    })
+}
+
+pub async fn update_episode(
+    pool: &SqlitePool,
+    id: &[u8],
+    listened: i64,
+    file_path: Option<&str>,
+    quality_score: Option<i64>,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "UPDATE podcast_episodes SET listened = ?, file_path = ?, quality_score = ?
+         WHERE id = ?",
+    )
+    .bind(listened)
+    .bind(file_path)
+    .bind(quality_score)
+    .bind(id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_episodes",
+    })?;
+    Ok(())
+}
+
+pub async fn delete_episode(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM podcast_episodes WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "podcast_episodes",
+        })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    fn now() -> String {
+        "2026-01-01T00:00:00Z".to_string()
+    }
+
+    #[tokio::test]
+    async fn subscription_round_trip() {
+        let pool = setup().await;
+        let id = make_id();
+        let sub = PodcastSubscription {
+            id: id.clone(),
+            feed_url: "https://example.com/feed.xml".to_string(),
+            title: Some("Test Podcast".to_string()),
+            description: None,
+            author: None,
+            image_url: None,
+            language: Some("en".to_string()),
+            last_checked_at: None,
+            auto_download: 1,
+            quality_profile_id: None,
+            added_at: now(),
+        };
+        insert_subscription(&pool, &sub).await.unwrap();
+        let fetched = get_subscription(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.feed_url, "https://example.com/feed.xml");
+        assert_eq!(fetched.auto_download, 1);
+    }
+
+    #[tokio::test]
+    async fn episode_round_trip() {
+        let pool = setup().await;
+        let sub_id = make_id();
+        let sub = PodcastSubscription {
+            id: sub_id.clone(),
+            feed_url: "https://example.com/feed2.xml".to_string(),
+            title: None,
+            description: None,
+            author: None,
+            image_url: None,
+            language: None,
+            last_checked_at: None,
+            auto_download: 1,
+            quality_profile_id: None,
+            added_at: now(),
+        };
+        insert_subscription(&pool, &sub).await.unwrap();
+
+        let ep_id = make_id();
+        let ep = PodcastEpisode {
+            id: ep_id.clone(),
+            subscription_id: sub_id.clone(),
+            guid: "ep-001".to_string(),
+            title: Some("Episode 1".to_string()),
+            description: None,
+            episode_number: Some(1),
+            season_number: Some(1),
+            publication_date: Some("2026-01-01T00:00:00Z".to_string()),
+            duration_ms: Some(3600000),
+            enclosure_url: None,
+            file_path: None,
+            file_size_bytes: None,
+            file_format: None,
+            quality_score: None,
+            source_type: "rss".to_string(),
+            listened: 0,
+            added_at: now(),
+        };
+        insert_episode(&pool, &ep).await.unwrap();
+
+        let episodes = list_episodes(&pool, &sub_id, 10, 0).await.unwrap();
+        assert_eq!(episodes.len(), 1);
+        assert_eq!(episodes[0].guid, "ep-001");
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_subscriptions(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/harmonia-db/src/repo/quality.rs
+++ b/crates/harmonia-db/src/repo/quality.rs
@@ -1,0 +1,254 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct QualityProfile {
+    pub id: i64,
+    pub name: String,
+    pub media_type: String,
+    pub min_quality_score: i64,
+    pub upgrade_until_score: i64,
+    pub min_custom_format_score: i64,
+    pub upgrade_until_format_score: i64,
+    pub upgrades_allowed: i64,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct QualityRankRow {
+    pub rank: i64,
+    pub format: String,
+    pub score: i64,
+}
+
+pub async fn insert_profile(pool: &SqlitePool, profile: &QualityProfile) -> Result<i64, DbError> {
+    let row = sqlx::query(
+        "INSERT INTO quality_profiles
+         (name, media_type, min_quality_score, upgrade_until_score,
+          min_custom_format_score, upgrade_until_format_score, upgrades_allowed)
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&profile.name)
+    .bind(&profile.media_type)
+    .bind(profile.min_quality_score)
+    .bind(profile.upgrade_until_score)
+    .bind(profile.min_custom_format_score)
+    .bind(profile.upgrade_until_format_score)
+    .bind(profile.upgrades_allowed)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "quality_profiles",
+    })?;
+    Ok(row.last_insert_rowid())
+}
+
+pub async fn get_profile(pool: &SqlitePool, id: i64) -> Result<Option<QualityProfile>, DbError> {
+    sqlx::query_as::<_, QualityProfile>(
+        "SELECT id, name, media_type, min_quality_score, upgrade_until_score,
+                min_custom_format_score, upgrade_until_format_score, upgrades_allowed
+         FROM quality_profiles WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "quality_profiles",
+    })
+}
+
+pub async fn list_profiles(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<QualityProfile>, DbError> {
+    sqlx::query_as::<_, QualityProfile>(
+        "SELECT id, name, media_type, min_quality_score, upgrade_until_score,
+                min_custom_format_score, upgrade_until_format_score, upgrades_allowed
+         FROM quality_profiles ORDER BY media_type, name LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "quality_profiles",
+    })
+}
+
+pub async fn list_profiles_for_type(
+    pool: &SqlitePool,
+    media_type: &str,
+) -> Result<Vec<QualityProfile>, DbError> {
+    sqlx::query_as::<_, QualityProfile>(
+        "SELECT id, name, media_type, min_quality_score, upgrade_until_score,
+                min_custom_format_score, upgrade_until_format_score, upgrades_allowed
+         FROM quality_profiles WHERE media_type = ? ORDER BY name",
+    )
+    .bind(media_type)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "quality_profiles",
+    })
+}
+
+pub async fn update_profile(
+    pool: &SqlitePool,
+    id: i64,
+    min_quality_score: i64,
+    upgrade_until_score: i64,
+    upgrades_allowed: i64,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "UPDATE quality_profiles
+         SET min_quality_score = ?, upgrade_until_score = ?, upgrades_allowed = ?
+         WHERE id = ?",
+    )
+    .bind(min_quality_score)
+    .bind(upgrade_until_score)
+    .bind(upgrades_allowed)
+    .bind(id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "quality_profiles",
+    })?;
+    Ok(())
+}
+
+pub async fn delete_profile(pool: &SqlitePool, id: i64) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM quality_profiles WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "quality_profiles",
+        })?;
+    Ok(())
+}
+
+/// Look up the score for a given format in the appropriate rank table for the media type.
+pub async fn score_for_format(
+    pool: &SqlitePool,
+    media_type: &str,
+    format: &str,
+) -> Result<Option<i64>, DbError> {
+    let table = rank_table_for(media_type);
+    let sql = format!("SELECT score FROM {table} WHERE format = ?");
+    let row: Option<(i64,)> = sqlx::query_as(&sql)
+        .bind(format)
+        .fetch_optional(pool)
+        .await
+        .context(QuerySnafu { table })?;
+    Ok(row.map(|(s,)| s))
+}
+
+/// List all ranks for a given media type's rank table.
+pub async fn list_ranks(
+    pool: &SqlitePool,
+    media_type: &str,
+) -> Result<Vec<QualityRankRow>, DbError> {
+    let table = rank_table_for(media_type);
+    let sql = format!("SELECT rank, format, score FROM {table} ORDER BY rank");
+    sqlx::query_as::<_, QualityRankRow>(&sql)
+        .fetch_all(pool)
+        .await
+        .context(QuerySnafu { table })
+}
+
+fn rank_table_for(media_type: &str) -> &'static str {
+    match media_type {
+        "music" => "music_quality_ranks",
+        "audiobook" => "audiobook_quality_ranks",
+        "book" => "book_quality_ranks",
+        "comic" => "comic_quality_ranks",
+        "podcast" => "podcast_quality_ranks",
+        "movie" | "tv" => "video_quality_ranks",
+        _ => "music_quality_ranks",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn seed_profiles_exist() {
+        let pool = setup().await;
+        let music_profiles = list_profiles_for_type(&pool, "music").await.unwrap();
+        assert!(!music_profiles.is_empty());
+        assert!(music_profiles.iter().any(|p| p.name == "Lossless"));
+    }
+
+    #[tokio::test]
+    async fn score_lookup_music() {
+        let pool = setup().await;
+        let score = score_for_format(&pool, "music", "FLAC_24BIT")
+            .await
+            .unwrap();
+        assert_eq!(score, Some(100));
+
+        let score = score_for_format(&pool, "music", "MP3_320_CBR")
+            .await
+            .unwrap();
+        assert_eq!(score, Some(70));
+    }
+
+    #[tokio::test]
+    async fn score_lookup_video() {
+        let pool = setup().await;
+        let score = score_for_format(&pool, "movie", "WEBDL_1080P")
+            .await
+            .unwrap();
+        assert_eq!(score, Some(70));
+
+        let score = score_for_format(&pool, "tv", "WEBDL_1080P").await.unwrap();
+        assert_eq!(score, Some(70));
+    }
+
+    #[tokio::test]
+    async fn unknown_format_returns_none() {
+        let pool = setup().await;
+        let score = score_for_format(&pool, "music", "UNKNOWN_FORMAT")
+            .await
+            .unwrap();
+        assert_eq!(score, None);
+    }
+
+    #[tokio::test]
+    async fn quality_profile_round_trip() {
+        let pool = setup().await;
+        let profile = QualityProfile {
+            id: 0,
+            name: "Custom Lossless".to_string(),
+            media_type: "music".to_string(),
+            min_quality_score: 85,
+            upgrade_until_score: 100,
+            min_custom_format_score: 0,
+            upgrade_until_format_score: 0,
+            upgrades_allowed: 1,
+        };
+        let id = insert_profile(&pool, &profile).await.unwrap();
+        let fetched = get_profile(&pool, id).await.unwrap().unwrap();
+        assert_eq!(fetched.name, "Custom Lossless");
+        assert_eq!(fetched.min_quality_score, 85);
+    }
+
+    #[tokio::test]
+    async fn list_ranks_music() {
+        let pool = setup().await;
+        let ranks = list_ranks(&pool, "music").await.unwrap();
+        assert_eq!(ranks.len(), 7);
+        assert_eq!(ranks[0].format, "FLAC_24BIT");
+        assert_eq!(ranks[0].score, 100);
+    }
+}

--- a/crates/harmonia-db/src/repo/registry.rs
+++ b/crates/harmonia-db/src/repo/registry.rs
@@ -1,0 +1,232 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct RegistryEntry {
+    pub id: Vec<u8>,
+    pub entity_type: String,
+    pub display_name: String,
+    pub sort_name: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct RegistryExternalId {
+    pub registry_id: Vec<u8>,
+    pub provider: String,
+    pub external_id: String,
+}
+
+pub async fn insert_registry_entry(
+    pool: &SqlitePool,
+    entry: &RegistryEntry,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO media_registry (id, entity_type, display_name, sort_name, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&entry.id)
+    .bind(&entry.entity_type)
+    .bind(&entry.display_name)
+    .bind(&entry.sort_name)
+    .bind(&entry.created_at)
+    .bind(&entry.updated_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "media_registry" })?;
+    Ok(())
+}
+
+pub async fn get_registry_entry(
+    pool: &SqlitePool,
+    id: &[u8],
+) -> Result<Option<RegistryEntry>, DbError> {
+    sqlx::query_as::<_, RegistryEntry>(
+        "SELECT id, entity_type, display_name, sort_name, created_at, updated_at
+         FROM media_registry WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "media_registry",
+    })
+}
+
+pub async fn list_registry_entries(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<RegistryEntry>, DbError> {
+    sqlx::query_as::<_, RegistryEntry>(
+        "SELECT id, entity_type, display_name, sort_name, created_at, updated_at
+         FROM media_registry ORDER BY display_name LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "media_registry",
+    })
+}
+
+pub async fn update_registry_entry(
+    pool: &SqlitePool,
+    id: &[u8],
+    display_name: &str,
+    sort_name: Option<&str>,
+    updated_at: &str,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "UPDATE media_registry SET display_name = ?, sort_name = ?, updated_at = ? WHERE id = ?",
+    )
+    .bind(display_name)
+    .bind(sort_name)
+    .bind(updated_at)
+    .bind(id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "media_registry",
+    })?;
+    Ok(())
+}
+
+pub async fn delete_registry_entry(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM media_registry WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "media_registry",
+        })?;
+    Ok(())
+}
+
+pub async fn insert_external_id(
+    pool: &SqlitePool,
+    ext: &RegistryExternalId,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO registry_external_ids (registry_id, provider, external_id)
+         VALUES (?, ?, ?)",
+    )
+    .bind(&ext.registry_id)
+    .bind(&ext.provider)
+    .bind(&ext.external_id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "registry_external_ids",
+    })?;
+    Ok(())
+}
+
+pub async fn list_external_ids_for_entry(
+    pool: &SqlitePool,
+    registry_id: &[u8],
+) -> Result<Vec<RegistryExternalId>, DbError> {
+    sqlx::query_as::<_, RegistryExternalId>(
+        "SELECT registry_id, provider, external_id
+         FROM registry_external_ids WHERE registry_id = ?",
+    )
+    .bind(registry_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "registry_external_ids",
+    })
+}
+
+pub async fn find_by_external_id(
+    pool: &SqlitePool,
+    provider: &str,
+    external_id: &str,
+) -> Result<Option<RegistryEntry>, DbError> {
+    sqlx::query_as::<_, RegistryEntry>(
+        "SELECT r.id, r.entity_type, r.display_name, r.sort_name, r.created_at, r.updated_at
+         FROM media_registry r
+         JOIN registry_external_ids e ON e.registry_id = r.id
+         WHERE e.provider = ? AND e.external_id = ?",
+    )
+    .bind(provider)
+    .bind(external_id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "registry_external_ids",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn registry_round_trip() {
+        let pool = setup().await;
+        let id = make_id();
+        let now = "2026-01-01T00:00:00Z".to_string();
+        let entry = RegistryEntry {
+            id: id.clone(),
+            entity_type: "person".to_string(),
+            display_name: "Frank Herbert".to_string(),
+            sort_name: Some("Herbert, Frank".to_string()),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        };
+        insert_registry_entry(&pool, &entry).await.unwrap();
+        let fetched = get_registry_entry(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.display_name, "Frank Herbert");
+        assert_eq!(fetched.sort_name, Some("Herbert, Frank".to_string()));
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_registry_entries(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn external_id_round_trip() {
+        let pool = setup().await;
+        let reg_id = make_id();
+        let now = "2026-01-01T00:00:00Z".to_string();
+        let entry = RegistryEntry {
+            id: reg_id.clone(),
+            entity_type: "person".to_string(),
+            display_name: "Test Person".to_string(),
+            sort_name: None,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        insert_registry_entry(&pool, &entry).await.unwrap();
+        let ext = RegistryExternalId {
+            registry_id: reg_id.clone(),
+            provider: "musicbrainz".to_string(),
+            external_id: "mb-uuid-123".to_string(),
+        };
+        insert_external_id(&pool, &ext).await.unwrap();
+        let found = find_by_external_id(&pool, "musicbrainz", "mb-uuid-123")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.display_name, "Test Person");
+    }
+}

--- a/crates/harmonia-db/src/repo/tv.rs
+++ b/crates/harmonia-db/src/repo/tv.rs
@@ -1,0 +1,400 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TvSeries {
+    pub id: Vec<u8>,
+    pub registry_id: Option<Vec<u8>>,
+    pub title: String,
+    pub tmdb_id: Option<i64>,
+    pub tvdb_id: Option<i64>,
+    pub imdb_id: Option<String>,
+    pub status: String,
+    pub overview: Option<String>,
+    pub network: Option<String>,
+    pub quality_profile_id: Option<i64>,
+    pub added_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TvSeason {
+    pub id: Vec<u8>,
+    pub series_id: Vec<u8>,
+    pub season_number: i64,
+    pub title: Option<String>,
+    pub episode_count: Option<i64>,
+    pub air_date: Option<String>,
+    pub overview: Option<String>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TvEpisode {
+    pub id: Vec<u8>,
+    pub season_id: Vec<u8>,
+    pub episode_number: i64,
+    pub title: Option<String>,
+    pub air_date: Option<String>,
+    pub runtime_min: Option<i64>,
+    pub overview: Option<String>,
+    pub tmdb_episode_id: Option<i64>,
+    pub file_path: Option<String>,
+    pub file_format: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub resolution: Option<String>,
+    pub codec: Option<String>,
+    pub hdr_type: Option<String>,
+    pub quality_score: Option<i64>,
+    pub source_type: String,
+    pub added_at: String,
+}
+
+// --- series ---
+
+pub async fn insert_series(pool: &SqlitePool, series: &TvSeries) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO tv_series
+         (id, registry_id, title, tmdb_id, tvdb_id, imdb_id, status,
+          overview, network, quality_profile_id, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&series.id)
+    .bind(&series.registry_id)
+    .bind(&series.title)
+    .bind(series.tmdb_id)
+    .bind(series.tvdb_id)
+    .bind(&series.imdb_id)
+    .bind(&series.status)
+    .bind(&series.overview)
+    .bind(&series.network)
+    .bind(series.quality_profile_id)
+    .bind(&series.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "tv_series" })?;
+    Ok(())
+}
+
+pub async fn get_series(pool: &SqlitePool, id: &[u8]) -> Result<Option<TvSeries>, DbError> {
+    sqlx::query_as::<_, TvSeries>(
+        "SELECT id, registry_id, title, tmdb_id, tvdb_id, imdb_id, status,
+                overview, network, quality_profile_id, added_at
+         FROM tv_series WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "tv_series" })
+}
+
+pub async fn list_series(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<TvSeries>, DbError> {
+    sqlx::query_as::<_, TvSeries>(
+        "SELECT id, registry_id, title, tmdb_id, tvdb_id, imdb_id, status,
+                overview, network, quality_profile_id, added_at
+         FROM tv_series ORDER BY title LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "tv_series" })
+}
+
+pub async fn update_series(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: &str,
+    status: &str,
+    quality_profile_id: Option<i64>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE tv_series SET title = ?, status = ?, quality_profile_id = ? WHERE id = ?")
+        .bind(title)
+        .bind(status)
+        .bind(quality_profile_id)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "tv_series" })?;
+    Ok(())
+}
+
+pub async fn delete_series(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM tv_series WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "tv_series" })?;
+    Ok(())
+}
+
+// --- seasons ---
+
+pub async fn insert_season(pool: &SqlitePool, season: &TvSeason) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO tv_seasons
+         (id, series_id, season_number, title, episode_count, air_date, overview)
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&season.id)
+    .bind(&season.series_id)
+    .bind(season.season_number)
+    .bind(&season.title)
+    .bind(season.episode_count)
+    .bind(&season.air_date)
+    .bind(&season.overview)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "tv_seasons",
+    })?;
+    Ok(())
+}
+
+pub async fn get_season(pool: &SqlitePool, id: &[u8]) -> Result<Option<TvSeason>, DbError> {
+    sqlx::query_as::<_, TvSeason>(
+        "SELECT id, series_id, season_number, title, episode_count, air_date, overview
+         FROM tv_seasons WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "tv_seasons",
+    })
+}
+
+pub async fn list_seasons(pool: &SqlitePool, series_id: &[u8]) -> Result<Vec<TvSeason>, DbError> {
+    sqlx::query_as::<_, TvSeason>(
+        "SELECT id, series_id, season_number, title, episode_count, air_date, overview
+         FROM tv_seasons WHERE series_id = ? ORDER BY season_number",
+    )
+    .bind(series_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "tv_seasons",
+    })
+}
+
+pub async fn update_season(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: Option<&str>,
+    episode_count: Option<i64>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE tv_seasons SET title = ?, episode_count = ? WHERE id = ?")
+        .bind(title)
+        .bind(episode_count)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "tv_seasons",
+        })?;
+    Ok(())
+}
+
+pub async fn delete_season(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM tv_seasons WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "tv_seasons",
+        })?;
+    Ok(())
+}
+
+// --- episodes ---
+
+pub async fn insert_episode(pool: &SqlitePool, ep: &TvEpisode) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO tv_episodes
+         (id, season_id, episode_number, title, air_date, runtime_min, overview,
+          tmdb_episode_id, file_path, file_format, file_size_bytes, resolution,
+          codec, hdr_type, quality_score, source_type, added_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&ep.id)
+    .bind(&ep.season_id)
+    .bind(ep.episode_number)
+    .bind(&ep.title)
+    .bind(&ep.air_date)
+    .bind(ep.runtime_min)
+    .bind(&ep.overview)
+    .bind(ep.tmdb_episode_id)
+    .bind(&ep.file_path)
+    .bind(&ep.file_format)
+    .bind(ep.file_size_bytes)
+    .bind(&ep.resolution)
+    .bind(&ep.codec)
+    .bind(&ep.hdr_type)
+    .bind(ep.quality_score)
+    .bind(&ep.source_type)
+    .bind(&ep.added_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "tv_episodes",
+    })?;
+    Ok(())
+}
+
+pub async fn get_episode(pool: &SqlitePool, id: &[u8]) -> Result<Option<TvEpisode>, DbError> {
+    sqlx::query_as::<_, TvEpisode>(
+        "SELECT id, season_id, episode_number, title, air_date, runtime_min, overview,
+                tmdb_episode_id, file_path, file_format, file_size_bytes, resolution,
+                codec, hdr_type, quality_score, source_type, added_at
+         FROM tv_episodes WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "tv_episodes",
+    })
+}
+
+pub async fn list_episodes(pool: &SqlitePool, season_id: &[u8]) -> Result<Vec<TvEpisode>, DbError> {
+    sqlx::query_as::<_, TvEpisode>(
+        "SELECT id, season_id, episode_number, title, air_date, runtime_min, overview,
+                tmdb_episode_id, file_path, file_format, file_size_bytes, resolution,
+                codec, hdr_type, quality_score, source_type, added_at
+         FROM tv_episodes WHERE season_id = ? ORDER BY episode_number",
+    )
+    .bind(season_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "tv_episodes",
+    })
+}
+
+pub async fn update_episode(
+    pool: &SqlitePool,
+    id: &[u8],
+    title: Option<&str>,
+    quality_score: Option<i64>,
+    file_path: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE tv_episodes SET title = ?, quality_score = ?, file_path = ? WHERE id = ?")
+        .bind(title)
+        .bind(quality_score)
+        .bind(file_path)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "tv_episodes",
+        })?;
+    Ok(())
+}
+
+pub async fn delete_episode(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM tv_episodes WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "tv_episodes",
+        })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    fn now() -> String {
+        "2026-01-01T00:00:00Z".to_string()
+    }
+
+    #[tokio::test]
+    async fn series_season_episode_round_trip() {
+        let pool = setup().await;
+
+        let series_id = make_id();
+        let series = TvSeries {
+            id: series_id.clone(),
+            registry_id: None,
+            title: "Breaking Bad".to_string(),
+            tmdb_id: Some(1396),
+            tvdb_id: Some(81189),
+            imdb_id: Some("tt0903747".to_string()),
+            status: "ended".to_string(),
+            overview: None,
+            network: Some("AMC".to_string()),
+            quality_profile_id: None,
+            added_at: now(),
+        };
+        insert_series(&pool, &series).await.unwrap();
+
+        let season_id = make_id();
+        let season = TvSeason {
+            id: season_id.clone(),
+            series_id: series_id.clone(),
+            season_number: 1,
+            title: Some("Season 1".to_string()),
+            episode_count: Some(7),
+            air_date: Some("2008-01-20".to_string()),
+            overview: None,
+        };
+        insert_season(&pool, &season).await.unwrap();
+
+        let ep_id = make_id();
+        let ep = TvEpisode {
+            id: ep_id.clone(),
+            season_id: season_id.clone(),
+            episode_number: 1,
+            title: Some("Pilot".to_string()),
+            air_date: Some("2008-01-20".to_string()),
+            runtime_min: Some(58),
+            overview: None,
+            tmdb_episode_id: None,
+            file_path: None,
+            file_format: None,
+            file_size_bytes: None,
+            resolution: None,
+            codec: None,
+            hdr_type: None,
+            quality_score: None,
+            source_type: "local".to_string(),
+            added_at: now(),
+        };
+        insert_episode(&pool, &ep).await.unwrap();
+
+        let fetched_series = get_series(&pool, &series_id).await.unwrap().unwrap();
+        assert_eq!(fetched_series.title, "Breaking Bad");
+        assert_eq!(fetched_series.status, "ended");
+
+        let seasons = list_seasons(&pool, &series_id).await.unwrap();
+        assert_eq!(seasons.len(), 1);
+
+        let episodes = list_episodes(&pool, &season_id).await.unwrap();
+        assert_eq!(episodes.len(), 1);
+        assert_eq!(episodes[0].title, Some("Pilot".to_string()));
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_series(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/harmonia-db/src/repo/user.rs
+++ b/crates/harmonia-db/src/repo/user.rs
@@ -1,0 +1,445 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct User {
+    pub id: Vec<u8>,
+    pub username: String,
+    pub display_name: String,
+    pub password_hash: String,
+    pub role: String,
+    pub is_active: i64,
+    pub created_at: String,
+    pub last_login_at: Option<String>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct RefreshToken {
+    pub id: Vec<u8>,
+    pub user_id: Vec<u8>,
+    pub token_hash: String,
+    pub created_at: String,
+    pub expires_at: String,
+    pub revoked: i64,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ApiKey {
+    pub id: Vec<u8>,
+    pub user_id: Vec<u8>,
+    pub short_token: String,
+    pub long_token_hash: String,
+    pub label: String,
+    pub created_at: String,
+    pub last_used_at: Option<String>,
+    pub revoked: i64,
+}
+
+// --- users ---
+
+pub async fn insert_user(pool: &SqlitePool, user: &User) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO users
+         (id, username, display_name, password_hash, role, is_active, created_at, last_login_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&user.id)
+    .bind(&user.username)
+    .bind(&user.display_name)
+    .bind(&user.password_hash)
+    .bind(&user.role)
+    .bind(user.is_active)
+    .bind(&user.created_at)
+    .bind(&user.last_login_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "users" })?;
+    Ok(())
+}
+
+pub async fn get_user(pool: &SqlitePool, id: &[u8]) -> Result<Option<User>, DbError> {
+    sqlx::query_as::<_, User>(
+        "SELECT id, username, display_name, password_hash, role, is_active,
+                created_at, last_login_at
+         FROM users WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "users" })
+}
+
+pub async fn get_user_by_username(
+    pool: &SqlitePool,
+    username: &str,
+) -> Result<Option<User>, DbError> {
+    sqlx::query_as::<_, User>(
+        "SELECT id, username, display_name, password_hash, role, is_active,
+                created_at, last_login_at
+         FROM users WHERE username = ?",
+    )
+    .bind(username)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "users" })
+}
+
+pub async fn list_users(pool: &SqlitePool, limit: i64, offset: i64) -> Result<Vec<User>, DbError> {
+    sqlx::query_as::<_, User>(
+        "SELECT id, username, display_name, password_hash, role, is_active,
+                created_at, last_login_at
+         FROM users ORDER BY username LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "users" })
+}
+
+pub async fn update_user(
+    pool: &SqlitePool,
+    id: &[u8],
+    display_name: &str,
+    role: &str,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE users SET display_name = ?, role = ? WHERE id = ?")
+        .bind(display_name)
+        .bind(role)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "users" })?;
+    Ok(())
+}
+
+pub async fn deactivate_user(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("UPDATE users SET is_active = 0 WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "users" })?;
+    Ok(())
+}
+
+pub async fn record_login(
+    pool: &SqlitePool,
+    id: &[u8],
+    last_login_at: &str,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE users SET last_login_at = ? WHERE id = ?")
+        .bind(last_login_at)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "users" })?;
+    Ok(())
+}
+
+pub async fn delete_user(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM users WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "users" })?;
+    Ok(())
+}
+
+// --- refresh tokens ---
+
+pub async fn insert_refresh_token(pool: &SqlitePool, token: &RefreshToken) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO refresh_tokens (id, user_id, token_hash, created_at, expires_at, revoked)
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&token.id)
+    .bind(&token.user_id)
+    .bind(&token.token_hash)
+    .bind(&token.created_at)
+    .bind(&token.expires_at)
+    .bind(token.revoked)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "refresh_tokens",
+    })?;
+    Ok(())
+}
+
+pub async fn get_refresh_token_by_hash(
+    pool: &SqlitePool,
+    token_hash: &str,
+) -> Result<Option<RefreshToken>, DbError> {
+    sqlx::query_as::<_, RefreshToken>(
+        "SELECT id, user_id, token_hash, created_at, expires_at, revoked
+         FROM refresh_tokens WHERE token_hash = ?",
+    )
+    .bind(token_hash)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "refresh_tokens",
+    })
+}
+
+pub async fn revoke_refresh_token(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("UPDATE refresh_tokens SET revoked = 1 WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "refresh_tokens",
+        })?;
+    Ok(())
+}
+
+pub async fn delete_refresh_tokens_for_user(
+    pool: &SqlitePool,
+    user_id: &[u8],
+) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM refresh_tokens WHERE user_id = ?")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "refresh_tokens",
+        })?;
+    Ok(())
+}
+
+// --- api keys ---
+
+pub async fn insert_api_key(pool: &SqlitePool, key: &ApiKey) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO api_keys
+         (id, user_id, short_token, long_token_hash, label, created_at, last_used_at, revoked)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&key.id)
+    .bind(&key.user_id)
+    .bind(&key.short_token)
+    .bind(&key.long_token_hash)
+    .bind(&key.label)
+    .bind(&key.created_at)
+    .bind(&key.last_used_at)
+    .bind(key.revoked)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "api_keys" })?;
+    Ok(())
+}
+
+pub async fn get_api_key_by_short_token(
+    pool: &SqlitePool,
+    short_token: &str,
+) -> Result<Option<ApiKey>, DbError> {
+    sqlx::query_as::<_, ApiKey>(
+        "SELECT id, user_id, short_token, long_token_hash, label, created_at,
+                last_used_at, revoked
+         FROM api_keys WHERE short_token = ?",
+    )
+    .bind(short_token)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "api_keys" })
+}
+
+pub async fn list_api_keys_for_user(
+    pool: &SqlitePool,
+    user_id: &[u8],
+) -> Result<Vec<ApiKey>, DbError> {
+    sqlx::query_as::<_, ApiKey>(
+        "SELECT id, user_id, short_token, long_token_hash, label, created_at,
+                last_used_at, revoked
+         FROM api_keys WHERE user_id = ? ORDER BY created_at DESC",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "api_keys" })
+}
+
+pub async fn revoke_api_key(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("UPDATE api_keys SET revoked = 1 WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "api_keys" })?;
+    Ok(())
+}
+
+pub async fn update_api_key_last_used(
+    pool: &SqlitePool,
+    id: &[u8],
+    last_used_at: &str,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE api_keys SET last_used_at = ? WHERE id = ?")
+        .bind(last_used_at)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "api_keys" })?;
+    Ok(())
+}
+
+pub async fn delete_api_key(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM api_keys WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "api_keys" })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    fn now() -> String {
+        "2026-01-01T00:00:00Z".to_string()
+    }
+
+    fn test_user(id: Vec<u8>) -> User {
+        User {
+            id,
+            username: "testuser".to_string(),
+            display_name: "Test User".to_string(),
+            password_hash: "$argon2id$placeholder".to_string(),
+            role: "member".to_string(),
+            is_active: 1,
+            created_at: now(),
+            last_login_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn user_crud() {
+        let pool = setup().await;
+        let id = make_id();
+        let user = test_user(id.clone());
+        insert_user(&pool, &user).await.unwrap();
+
+        // read
+        let fetched = get_user(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.username, "testuser");
+        assert_eq!(fetched.role, "member");
+        assert_eq!(fetched.is_active, 1);
+
+        // authenticate by username
+        let by_username = get_user_by_username(&pool, "testuser")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(by_username.id, id);
+
+        // update
+        update_user(&pool, &id, "Updated Name", "admin")
+            .await
+            .unwrap();
+        let updated = get_user(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(updated.display_name, "Updated Name");
+        assert_eq!(updated.role, "admin");
+
+        // deactivate
+        deactivate_user(&pool, &id).await.unwrap();
+        let deactivated = get_user(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(deactivated.is_active, 0);
+
+        // record login
+        record_login(&pool, &id, "2026-06-01T12:00:00Z")
+            .await
+            .unwrap();
+        let with_login = get_user(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(
+            with_login.last_login_at,
+            Some("2026-06-01T12:00:00Z".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_token_round_trip() {
+        let pool = setup().await;
+        let user_id = make_id();
+        let user = test_user(user_id.clone());
+        insert_user(&pool, &user).await.unwrap();
+
+        let token_id = make_id();
+        let token = RefreshToken {
+            id: token_id.clone(),
+            user_id: user_id.clone(),
+            token_hash: "sha256hashoftoken".to_string(),
+            created_at: now(),
+            expires_at: "2026-02-01T00:00:00Z".to_string(),
+            revoked: 0,
+        };
+        insert_refresh_token(&pool, &token).await.unwrap();
+
+        let fetched = get_refresh_token_by_hash(&pool, "sha256hashoftoken")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(fetched.revoked, 0);
+
+        revoke_refresh_token(&pool, &token_id).await.unwrap();
+        let revoked = get_refresh_token_by_hash(&pool, "sha256hashoftoken")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(revoked.revoked, 1);
+    }
+
+    #[tokio::test]
+    async fn api_key_round_trip() {
+        let pool = setup().await;
+        let user_id = make_id();
+        let user = test_user(user_id.clone());
+        insert_user(&pool, &user).await.unwrap();
+
+        let key_id = make_id();
+        let key = ApiKey {
+            id: key_id.clone(),
+            user_id: user_id.clone(),
+            short_token: "abc12345".to_string(),
+            long_token_hash: "sha256oflong".to_string(),
+            label: "Home NAS".to_string(),
+            created_at: now(),
+            last_used_at: None,
+            revoked: 0,
+        };
+        insert_api_key(&pool, &key).await.unwrap();
+
+        let fetched = get_api_key_by_short_token(&pool, "abc12345")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(fetched.label, "Home NAS");
+        assert_eq!(fetched.revoked, 0);
+
+        revoke_api_key(&pool, &key_id).await.unwrap();
+        let revoked = get_api_key_by_short_token(&pool, "abc12345")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(revoked.revoked, 1);
+    }
+
+    #[tokio::test]
+    async fn list_users_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_users(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/harmonia-db/src/repo/want.rs
+++ b/crates/harmonia-db/src/repo/want.rs
@@ -1,0 +1,453 @@
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Want {
+    pub id: Vec<u8>,
+    pub media_type: String,
+    pub title: String,
+    pub registry_id: Option<Vec<u8>>,
+    pub quality_profile_id: i64,
+    pub status: String,
+    pub source: Option<String>,
+    pub source_ref: Option<String>,
+    pub added_at: String,
+    pub fulfilled_at: Option<String>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Release {
+    pub id: Vec<u8>,
+    pub want_id: Vec<u8>,
+    pub indexer_id: i64,
+    pub title: String,
+    pub size_bytes: i64,
+    pub quality_score: i64,
+    pub custom_format_score: i64,
+    pub download_url: String,
+    pub protocol: String,
+    pub info_hash: Option<String>,
+    pub found_at: String,
+    pub grabbed_at: Option<String>,
+    pub rejected_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Have {
+    pub id: Vec<u8>,
+    pub want_id: Vec<u8>,
+    pub release_id: Option<Vec<u8>>,
+    pub media_type: String,
+    pub media_type_id: Vec<u8>,
+    pub quality_score: i64,
+    pub file_path: String,
+    pub file_size_bytes: i64,
+    pub status: String,
+    pub imported_at: String,
+    pub upgraded_from_id: Option<Vec<u8>>,
+}
+
+// --- wants ---
+
+pub async fn insert_want(pool: &SqlitePool, want: &Want) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO wants
+         (id, media_type, title, registry_id, quality_profile_id, status,
+          source, source_ref, added_at, fulfilled_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&want.id)
+    .bind(&want.media_type)
+    .bind(&want.title)
+    .bind(&want.registry_id)
+    .bind(want.quality_profile_id)
+    .bind(&want.status)
+    .bind(&want.source)
+    .bind(&want.source_ref)
+    .bind(&want.added_at)
+    .bind(&want.fulfilled_at)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "wants" })?;
+    Ok(())
+}
+
+pub async fn get_want(pool: &SqlitePool, id: &[u8]) -> Result<Option<Want>, DbError> {
+    sqlx::query_as::<_, Want>(
+        "SELECT id, media_type, title, registry_id, quality_profile_id, status,
+                source, source_ref, added_at, fulfilled_at
+         FROM wants WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "wants" })
+}
+
+pub async fn list_wants(pool: &SqlitePool, limit: i64, offset: i64) -> Result<Vec<Want>, DbError> {
+    sqlx::query_as::<_, Want>(
+        "SELECT id, media_type, title, registry_id, quality_profile_id, status,
+                source, source_ref, added_at, fulfilled_at
+         FROM wants ORDER BY added_at DESC LIMIT ? OFFSET ?",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "wants" })
+}
+
+pub async fn list_wants_by_type_and_status(
+    pool: &SqlitePool,
+    media_type: &str,
+    status: &str,
+) -> Result<Vec<Want>, DbError> {
+    sqlx::query_as::<_, Want>(
+        "SELECT id, media_type, title, registry_id, quality_profile_id, status,
+                source, source_ref, added_at, fulfilled_at
+         FROM wants WHERE media_type = ? AND status = ? ORDER BY added_at DESC",
+    )
+    .bind(media_type)
+    .bind(status)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "wants" })
+}
+
+pub async fn update_want_status(
+    pool: &SqlitePool,
+    id: &[u8],
+    status: &str,
+    fulfilled_at: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE wants SET status = ?, fulfilled_at = ? WHERE id = ?")
+        .bind(status)
+        .bind(fulfilled_at)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "wants" })?;
+    Ok(())
+}
+
+pub async fn delete_want(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM wants WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "wants" })?;
+    Ok(())
+}
+
+// --- releases ---
+
+pub async fn insert_release(pool: &SqlitePool, release: &Release) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO releases
+         (id, want_id, indexer_id, title, size_bytes, quality_score,
+          custom_format_score, download_url, protocol, info_hash,
+          found_at, grabbed_at, rejected_reason)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&release.id)
+    .bind(&release.want_id)
+    .bind(release.indexer_id)
+    .bind(&release.title)
+    .bind(release.size_bytes)
+    .bind(release.quality_score)
+    .bind(release.custom_format_score)
+    .bind(&release.download_url)
+    .bind(&release.protocol)
+    .bind(&release.info_hash)
+    .bind(&release.found_at)
+    .bind(&release.grabbed_at)
+    .bind(&release.rejected_reason)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "releases" })?;
+    Ok(())
+}
+
+pub async fn get_release(pool: &SqlitePool, id: &[u8]) -> Result<Option<Release>, DbError> {
+    sqlx::query_as::<_, Release>(
+        "SELECT id, want_id, indexer_id, title, size_bytes, quality_score,
+                custom_format_score, download_url, protocol, info_hash,
+                found_at, grabbed_at, rejected_reason
+         FROM releases WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "releases" })
+}
+
+pub async fn list_releases_for_want(
+    pool: &SqlitePool,
+    want_id: &[u8],
+) -> Result<Vec<Release>, DbError> {
+    sqlx::query_as::<_, Release>(
+        "SELECT id, want_id, indexer_id, title, size_bytes, quality_score,
+                custom_format_score, download_url, protocol, info_hash,
+                found_at, grabbed_at, rejected_reason
+         FROM releases WHERE want_id = ? ORDER BY quality_score DESC",
+    )
+    .bind(want_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "releases" })
+}
+
+pub async fn update_release(
+    pool: &SqlitePool,
+    id: &[u8],
+    grabbed_at: Option<&str>,
+    rejected_reason: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE releases SET grabbed_at = ?, rejected_reason = ? WHERE id = ?")
+        .bind(grabbed_at)
+        .bind(rejected_reason)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "releases" })?;
+    Ok(())
+}
+
+pub async fn delete_release(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM releases WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "releases" })?;
+    Ok(())
+}
+
+// --- haves ---
+
+pub async fn insert_have(pool: &SqlitePool, have: &Have) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO haves
+         (id, want_id, release_id, media_type, media_type_id, quality_score,
+          file_path, file_size_bytes, status, imported_at, upgraded_from_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&have.id)
+    .bind(&have.want_id)
+    .bind(&have.release_id)
+    .bind(&have.media_type)
+    .bind(&have.media_type_id)
+    .bind(have.quality_score)
+    .bind(&have.file_path)
+    .bind(have.file_size_bytes)
+    .bind(&have.status)
+    .bind(&have.imported_at)
+    .bind(&have.upgraded_from_id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "haves" })?;
+    Ok(())
+}
+
+pub async fn get_have(pool: &SqlitePool, id: &[u8]) -> Result<Option<Have>, DbError> {
+    sqlx::query_as::<_, Have>(
+        "SELECT id, want_id, release_id, media_type, media_type_id, quality_score,
+                file_path, file_size_bytes, status, imported_at, upgraded_from_id
+         FROM haves WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "haves" })
+}
+
+pub async fn list_haves_for_want(pool: &SqlitePool, want_id: &[u8]) -> Result<Vec<Have>, DbError> {
+    sqlx::query_as::<_, Have>(
+        "SELECT id, want_id, release_id, media_type, media_type_id, quality_score,
+                file_path, file_size_bytes, status, imported_at, upgraded_from_id
+         FROM haves WHERE want_id = ? ORDER BY quality_score DESC",
+    )
+    .bind(want_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "haves" })
+}
+
+pub async fn update_have_status(pool: &SqlitePool, id: &[u8], status: &str) -> Result<(), DbError> {
+    sqlx::query("UPDATE haves SET status = ? WHERE id = ?")
+        .bind(status)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "haves" })?;
+    Ok(())
+}
+
+pub async fn delete_have(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM haves WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "haves" })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    fn now() -> String {
+        "2026-01-01T00:00:00Z".to_string()
+    }
+
+    async fn insert_test_profile(pool: &SqlitePool) -> i64 {
+        use sqlx::Row;
+        let row = sqlx::query("SELECT id FROM quality_profiles WHERE media_type = 'music' LIMIT 1")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        row.try_get::<i64, _>("id").unwrap()
+    }
+
+    #[tokio::test]
+    async fn want_lifecycle() {
+        let pool = setup().await;
+        let profile_id = insert_test_profile(&pool).await;
+
+        let want_id = make_id();
+        let want = Want {
+            id: want_id.clone(),
+            media_type: "music_album".to_string(),
+            title: "Led Zeppelin IV".to_string(),
+            registry_id: None,
+            quality_profile_id: profile_id,
+            status: "searching".to_string(),
+            source: Some("manual".to_string()),
+            source_ref: None,
+            added_at: now(),
+            fulfilled_at: None,
+        };
+        insert_want(&pool, &want).await.unwrap();
+
+        let release_id = make_id();
+        let release = Release {
+            id: release_id.clone(),
+            want_id: want_id.clone(),
+            indexer_id: 1,
+            title: "Led Zeppelin IV FLAC".to_string(),
+            size_bytes: 500_000_000,
+            quality_score: 90,
+            custom_format_score: 0,
+            download_url: "https://example.com/release.torrent".to_string(),
+            protocol: "torrent".to_string(),
+            info_hash: Some("abc123".to_string()),
+            found_at: now(),
+            grabbed_at: None,
+            rejected_reason: None,
+        };
+        insert_release(&pool, &release).await.unwrap();
+
+        let media_id = make_id();
+        let have_id = make_id();
+        let have = Have {
+            id: have_id.clone(),
+            want_id: want_id.clone(),
+            release_id: Some(release_id.clone()),
+            media_type: "music_album".to_string(),
+            media_type_id: media_id.clone(),
+            quality_score: 90,
+            file_path: "/music/Led Zeppelin IV/".to_string(),
+            file_size_bytes: 490_000_000,
+            status: "complete".to_string(),
+            imported_at: now(),
+            upgraded_from_id: None,
+        };
+        insert_have(&pool, &have).await.unwrap();
+
+        update_want_status(&pool, &want_id, "fulfilled", Some(&now()))
+            .await
+            .unwrap();
+
+        let fetched_want = get_want(&pool, &want_id).await.unwrap().unwrap();
+        assert_eq!(fetched_want.status, "fulfilled");
+        assert!(fetched_want.fulfilled_at.is_some());
+
+        let haves = list_haves_for_want(&pool, &want_id).await.unwrap();
+        assert_eq!(haves.len(), 1);
+        assert_eq!(haves[0].quality_score, 90);
+
+        let releases = list_releases_for_want(&pool, &want_id).await.unwrap();
+        assert_eq!(releases.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn list_wants_empty_returns_empty() {
+        let pool = setup().await;
+        let results = list_wants(&pool, 10, 0).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn want_transaction_atomicity() {
+        let pool = setup().await;
+        let profile_id = insert_test_profile(&pool).await;
+
+        let want_id = make_id();
+        let media_id = make_id();
+        let have_id = make_id();
+
+        let mut tx = pool.begin().await.unwrap();
+
+        sqlx::query(
+            "INSERT INTO wants (id, media_type, title, quality_profile_id, status, added_at)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&want_id)
+        .bind("movie")
+        .bind("Atomic Test Movie")
+        .bind(profile_id)
+        .bind("searching")
+        .bind(&now())
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO haves (id, want_id, media_type, media_type_id, quality_score,
+             file_path, file_size_bytes, status, imported_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&have_id)
+        .bind(&want_id)
+        .bind("movie")
+        .bind(&media_id)
+        .bind(70i64)
+        .bind("/movies/atomic.mkv")
+        .bind(10_000_000_000i64)
+        .bind("complete")
+        .bind(&now())
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+
+        tx.commit().await.unwrap();
+
+        let fetched = get_want(&pool, &want_id).await.unwrap().unwrap();
+        assert_eq!(fetched.title, "Atomic Test Movie");
+
+        let haves = list_haves_for_want(&pool, &want_id).await.unwrap();
+        assert_eq!(haves.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Dual-pool WAL architecture: `max_connections(1)` write pool + `available_parallelism` read pool with `read_only(true)`, all pragmas per `docs/data/storage.md` (WAL, NORMAL sync, FK enforcement, 64MB journal limit, temp_store=memory)
- Single initial migration (`001_initial.sql`) with all 43+ tables in FK dependency order: users/auth, quality profiles + 6 rank tables + seed data, media_registry, 8 media type schemas (music 4-level hierarchy, audiobooks, books, comics, podcasts, news, movies, TV), want/release/have lifecycle
- 12 repo modules with full CRUD (insert/get/list/update/delete) for every table; music module adds 4-level hierarchy traversal queries and full-text title search; quality module includes `score_for_format()` dispatch across all rank tables
- `build.rs` for migration recompilation watching; `sqlx::migrate!()` embedded at compile time; runtime `sqlx::query()` / `sqlx::query_as()` (no SQLX_OFFLINE required)
- One schema fix applied: `quality_profiles.name UNIQUE` → `UNIQUE(name, media_type)` to allow 'Any' profiles per media type as the seed data requires

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p harmonia-db -- -D warnings` — clean
- [x] `cargo test -p harmonia-db` — 36/36 passed

Tests cover: round-trip per repo module, music 4-level hierarchy, want lifecycle (insert want → release → have → mark fulfilled), quality profile score lookup, user CRUD with auth helpers, empty-collection queries, write transaction atomicity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)