### PR TITLE
feat(epignosis): metadata enrichment (P2-06)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +218,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,8 +284,16 @@ dependencies = [
 name = "epignosis"
 version = "0.1.0"
 dependencies = [
+ "dashmap",
  "harmonia-common",
+ "harmonia-db",
+ "horismos",
+ "reqwest",
+ "serde",
+ "serde_json",
  "snafu",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -470,8 +504,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -482,7 +532,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -533,6 +583,12 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -610,6 +666,106 @@ dependencies = [
  "serde_json",
  "snafu",
  "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
  "tracing",
 ]
 
@@ -738,6 +894,22 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itoa"
@@ -883,6 +1055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,7 +1098,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1044,6 +1222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1335,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1397,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1172,8 +1417,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1183,7 +1438,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1193,6 +1458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1249,6 +1523,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,7 +1590,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -1299,6 +1628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1653,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1453,7 +1823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1635,7 +2005,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -1673,7 +2043,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -1747,6 +2117,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1856,12 +2235,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -1938,6 +2341,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +2416,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2018,6 +2472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +2520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2569,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2157,6 +2640,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2662,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2190,7 +2715,25 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2208,13 +2751,46 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2224,10 +2800,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2236,10 +2836,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2248,16 +2884,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/epignosis/Cargo.toml
+++ b/crates/epignosis/Cargo.toml
@@ -7,5 +7,16 @@ description = "Metadata — enrichment and resolution"
 
 [dependencies]
 harmonia-common.workspace = true
+harmonia-db.workspace = true
+horismos.workspace = true
 snafu.workspace = true
 tracing.workspace = true
+tokio.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+dashmap = "6"
+tokio-util = { version = "0.7", features = ["rt"] }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/epignosis/src/cache.rs
+++ b/crates/epignosis/src/cache.rs
@@ -1,0 +1,141 @@
+use std::{
+    hash::Hash,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use dashmap::DashMap;
+use tracing::instrument;
+
+struct CacheEntry<V> {
+    value: V,
+    expires_at: Option<Instant>,
+}
+
+impl<V> CacheEntry<V> {
+    fn is_expired(&self) -> bool {
+        self.expires_at.is_some_and(|t| Instant::now() > t)
+    }
+}
+
+pub struct MetadataCache<K, V> {
+    store: Arc<DashMap<K, CacheEntry<V>>>,
+    default_ttl: Duration,
+}
+
+impl<K, V> MetadataCache<K, V>
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    pub fn new(default_ttl: Duration) -> Self {
+        Self {
+            store: Arc::new(DashMap::new()),
+            default_ttl,
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<V> {
+        let entry = self.store.get(key)?;
+        if entry.is_expired() {
+            drop(entry);
+            self.store.remove(key);
+            return None;
+        }
+        Some(entry.value.clone())
+    }
+
+    pub fn insert(&self, key: K, value: V) {
+        self.insert_with_ttl(key, value, Some(self.default_ttl));
+    }
+
+    pub fn insert_permanent(&self, key: K, value: V) {
+        self.insert_with_ttl(key, value, None);
+    }
+
+    pub fn insert_with_ttl(&self, key: K, value: V, ttl: Option<Duration>) {
+        let expires_at = ttl.map(|d| Instant::now() + d);
+        self.store.insert(key, CacheEntry { value, expires_at });
+    }
+
+    /// Remove all expired entries. Called by background cleanup task.
+    #[instrument(skip(self), name = "cache_evict_expired")]
+    pub fn evict_expired(&self) {
+        self.store.retain(|_, v| !v.is_expired());
+    }
+
+    pub fn len(&self) -> usize {
+        self.store.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.store.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn insert_and_get() {
+        let cache = MetadataCache::new(Duration::from_secs(60));
+        cache.insert("key1".to_string(), "value1".to_string());
+        assert_eq!(cache.get(&"key1".to_string()), Some("value1".to_string()));
+    }
+
+    #[test]
+    fn missing_key_returns_none() {
+        let cache: MetadataCache<String, String> = MetadataCache::new(Duration::from_secs(60));
+        assert_eq!(cache.get(&"absent".to_string()), None);
+    }
+
+    #[test]
+    fn ttl_expiry() {
+        let cache = MetadataCache::new(Duration::from_millis(1));
+        cache.insert("key".to_string(), "value".to_string());
+        // Spin-wait for expiry — avoids sleep in tests but guarantees 1ms has elapsed.
+        let deadline = Instant::now() + Duration::from_millis(10);
+        while Instant::now() < deadline {
+            std::hint::spin_loop();
+        }
+        assert_eq!(cache.get(&"key".to_string()), None);
+    }
+
+    #[test]
+    fn permanent_entry_does_not_expire() {
+        let cache = MetadataCache::new(Duration::from_millis(1));
+        cache.insert_permanent("key".to_string(), "perm".to_string());
+        let deadline = Instant::now() + Duration::from_millis(10);
+        while Instant::now() < deadline {
+            std::hint::spin_loop();
+        }
+        assert_eq!(cache.get(&"key".to_string()), Some("perm".to_string()));
+    }
+
+    #[test]
+    fn evict_expired_removes_stale_entries() {
+        let cache = MetadataCache::new(Duration::from_millis(1));
+        cache.insert("stale".to_string(), "old".to_string());
+        cache.insert_permanent("fresh".to_string(), "new".to_string());
+
+        let deadline = Instant::now() + Duration::from_millis(10);
+        while Instant::now() < deadline {
+            std::hint::spin_loop();
+        }
+
+        cache.evict_expired();
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.get(&"fresh".to_string()), Some("new".to_string()));
+    }
+
+    #[test]
+    fn len_tracks_entries() {
+        let cache = MetadataCache::new(Duration::from_secs(60));
+        assert_eq!(cache.len(), 0);
+        cache.insert("a".to_string(), 1u32);
+        cache.insert("b".to_string(), 2u32);
+        assert_eq!(cache.len(), 2);
+    }
+}

--- a/crates/epignosis/src/error.rs
+++ b/crates/epignosis/src/error.rs
@@ -1,0 +1,72 @@
+use std::{path::PathBuf, time::Duration};
+
+use harmonia_db::DbError;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum EpignosisError {
+    #[snafu(display("request to {provider} failed: {source}"))]
+    ProviderRequest {
+        provider: String,
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("failed to parse response from {provider}: {source}"))]
+    ProviderParse {
+        provider: String,
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("request to {provider} timed out: {url}"))]
+    ProviderTimeout {
+        provider: String,
+        url: String,
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("rate limit exceeded for {provider}, retry after {retry_after:?}"))]
+    ProviderRateLimited {
+        provider: String,
+        retry_after: Option<Duration>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("no match found in {provider} for query: {query}"))]
+    IdentityNotResolved {
+        provider: String,
+        query: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("audio fingerprint computation failed for {path:?}: {source}"))]
+    FingerprintFailed {
+        path: PathBuf,
+        source: Box<dyn std::error::Error + Send + Sync>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("cache error: {message}"))]
+    Cache {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("database error: {source}"))]
+    Database {
+        source: DbError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/epignosis/src/identity.rs
+++ b/crates/epignosis/src/identity.rs
@@ -1,0 +1,203 @@
+use std::path::PathBuf;
+
+use harmonia_common::{MediaId, MediaType};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+pub struct UnidentifiedItem {
+    pub media_id: MediaId,
+    pub media_type: MediaType,
+    pub file_path: PathBuf,
+    pub filename_hint: Option<String>,
+    pub tags: Option<EmbeddedTags>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EmbeddedTags {
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub album_artist: Option<String>,
+    pub track_number: Option<u32>,
+    pub disc_number: Option<u32>,
+    pub year: Option<u32>,
+    pub isrc: Option<String>,
+    pub mb_recording_id: Option<String>,
+    pub mb_release_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MediaIdentity {
+    pub media_id: MediaId,
+    pub media_type: MediaType,
+    pub provider: String,
+    pub provider_id: String,
+    pub canonical_title: String,
+    pub canonical_artist: Option<String>,
+    pub year: Option<u32>,
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnrichedMetadata {
+    pub identity: MediaIdentity,
+    pub enrichments: Vec<ProviderEnrichment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderEnrichment {
+    pub provider: String,
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FingerprintResult {
+    pub fingerprint: String,
+    pub duration_secs: f64,
+    pub acoustid_id: Option<String>,
+    pub mb_recording_ids: Vec<String>,
+    pub confidence: f64,
+}
+
+/// Minimum AcoustID confidence score to accept a match without ambiguity.
+pub const FINGERPRINT_ACCEPT_THRESHOLD: f64 = 0.8;
+
+/// Minimum AcoustID confidence score to consider a match at all.
+pub const FINGERPRINT_AMBIGUOUS_THRESHOLD: f64 = 0.5;
+
+/// Parse a filename stem into metadata hints.
+///
+/// Supports patterns:
+/// - `"Artist - Album - 01 - Track.flac"` → all four fields
+/// - `"Album - 01 - Track.flac"` → album + track_number + title
+/// - `"Artist - Album - Title.flac"` → artist + album + title
+/// - `"01 - Track.flac"` → track_number + title
+/// - `"Track.flac"` → title only
+pub fn parse_filename(path: &std::path::Path) -> ParsedFilename {
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+
+    let parts: Vec<&str> = stem.splitn(4, " - ").collect();
+
+    match parts.as_slice() {
+        [artist, album, track_num_str, title] => ParsedFilename {
+            artist: Some(artist.trim().to_string()),
+            album: Some(album.trim().to_string()),
+            track_number: track_num_str.trim().parse().ok(),
+            title: title.trim().to_string(),
+        },
+        [first, second, third] => {
+            if let Ok(num) = second.trim().parse::<u32>() {
+                ParsedFilename {
+                    artist: None,
+                    album: Some(first.trim().to_string()),
+                    track_number: Some(num),
+                    title: third.trim().to_string(),
+                }
+            } else {
+                ParsedFilename {
+                    artist: Some(first.trim().to_string()),
+                    album: Some(second.trim().to_string()),
+                    track_number: None,
+                    title: third.trim().to_string(),
+                }
+            }
+        }
+        [prefix, title] => {
+            if let Ok(num) = prefix.trim().parse::<u32>() {
+                ParsedFilename {
+                    artist: None,
+                    album: None,
+                    track_number: Some(num),
+                    title: title.trim().to_string(),
+                }
+            } else {
+                ParsedFilename {
+                    artist: None,
+                    album: None,
+                    track_number: None,
+                    title: stem.to_string(),
+                }
+            }
+        }
+        _ => ParsedFilename {
+            artist: None,
+            album: None,
+            track_number: None,
+            title: stem.to_string(),
+        },
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParsedFilename {
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub track_number: Option<u32>,
+    pub title: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn parse_four_part_filename() {
+        let result = parse_filename(Path::new("Artist - Album - 01 - Track.flac"));
+        assert_eq!(result.artist.as_deref(), Some("Artist"));
+        assert_eq!(result.album.as_deref(), Some("Album"));
+        assert_eq!(result.track_number, Some(1));
+        assert_eq!(result.title, "Track");
+    }
+
+    #[test]
+    fn parse_track_number_and_title() {
+        let result = parse_filename(Path::new("01 - Track.flac"));
+        assert_eq!(result.artist, None);
+        assert_eq!(result.album, None);
+        assert_eq!(result.track_number, Some(1));
+        assert_eq!(result.title, "Track");
+    }
+
+    #[test]
+    fn parse_title_only() {
+        let result = parse_filename(Path::new("Track.flac"));
+        assert_eq!(result.artist, None);
+        assert_eq!(result.album, None);
+        assert_eq!(result.track_number, None);
+        assert_eq!(result.title, "Track");
+    }
+
+    #[test]
+    fn parse_three_part_with_track_number() {
+        let result = parse_filename(Path::new("Album - 03 - Title.flac"));
+        assert_eq!(result.artist, None);
+        assert_eq!(result.album.as_deref(), Some("Album"));
+        assert_eq!(result.track_number, Some(3));
+        assert_eq!(result.title, "Title");
+    }
+
+    #[test]
+    fn parse_three_part_without_track_number() {
+        let result = parse_filename(Path::new("Artist - Album - Title.flac"));
+        assert_eq!(result.artist.as_deref(), Some("Artist"));
+        assert_eq!(result.album.as_deref(), Some("Album"));
+        assert_eq!(result.track_number, None);
+        assert_eq!(result.title, "Title");
+    }
+
+    #[test]
+    fn fingerprint_accept_threshold_value() {
+        assert_eq!(FINGERPRINT_ACCEPT_THRESHOLD, 0.8);
+    }
+
+    #[test]
+    fn fingerprint_ambiguous_threshold_value() {
+        assert_eq!(FINGERPRINT_AMBIGUOUS_THRESHOLD, 0.5);
+    }
+
+    #[test]
+    fn fingerprint_accept_above_ambiguous() {
+        assert!(FINGERPRINT_ACCEPT_THRESHOLD > FINGERPRINT_AMBIGUOUS_THRESHOLD);
+    }
+}

--- a/crates/epignosis/src/lib.rs
+++ b/crates/epignosis/src/lib.rs
@@ -1,1 +1,38 @@
-// Stub — implementation in P2-05
+pub mod cache;
+pub mod error;
+pub mod identity;
+pub mod providers;
+pub mod rate_limit;
+pub mod resolver;
+
+pub use error::EpignosisError;
+pub use identity::{
+    EnrichedMetadata, FingerprintResult, MediaIdentity, ParsedFilename, ProviderEnrichment,
+    UnidentifiedItem, parse_filename,
+};
+pub use resolver::EpignosisService;
+
+use std::path::Path;
+
+use tokio_util::sync::CancellationToken;
+
+#[allow(async_fn_in_trait)]
+pub trait MetadataResolver: Send + Sync {
+    async fn resolve_identity(
+        &self,
+        item: &UnidentifiedItem,
+        ct: CancellationToken,
+    ) -> Result<MediaIdentity, EpignosisError>;
+
+    async fn enrich(
+        &self,
+        identity: &MediaIdentity,
+        ct: CancellationToken,
+    ) -> Result<EnrichedMetadata, EpignosisError>;
+
+    async fn fingerprint_audio(
+        &self,
+        file_path: &Path,
+        ct: CancellationToken,
+    ) -> Result<FingerprintResult, EpignosisError>;
+}

--- a/crates/epignosis/src/providers/acoustid.rs
+++ b/crates/epignosis/src/providers/acoustid.rs
@@ -1,0 +1,186 @@
+use serde::Deserialize;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
+use crate::identity::FingerprintResult;
+
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+
+const BASE_URL: &str = "https://api.acoustid.org/v2";
+
+pub struct AcoustIdProvider {
+    client: reqwest::Client,
+    api_key: String,
+}
+
+impl AcoustIdProvider {
+    pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
+        Self {
+            client,
+            api_key: api_key.into(),
+        }
+    }
+
+    /// Look up a pre-computed chromaprint fingerprint against the AcoustID service.
+    #[instrument(skip(self), fields(provider = "acoustid"))]
+    pub async fn lookup_fingerprint(
+        &self,
+        fingerprint: &FingerprintResult,
+    ) -> Result<Vec<ProviderResult>, EpignosisError> {
+        let url = format!("{BASE_URL}/lookup");
+        let duration_str = (fingerprint.duration_secs as u64).to_string();
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("client", self.api_key.as_str()),
+                ("duration", &duration_str),
+                ("fingerprint", &fingerprint.fingerprint),
+                ("meta", "recordings"),
+            ])
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "acoustid",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "acoustid",
+        })?;
+
+        let parsed: AcoustIdResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "acoustid",
+        })?;
+
+        let results = parsed
+            .results
+            .unwrap_or_default()
+            .into_iter()
+            .flat_map(|result| {
+                let score = result.score.unwrap_or(0.0);
+                let acoustid = result.id.clone();
+                result
+                    .recordings
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(move |rec| {
+                        let artist = rec
+                            .artists
+                            .as_deref()
+                            .and_then(|a| a.first())
+                            .map(|a| a.name.clone());
+                        let raw = serde_json::json!({
+                            "acoustid": acoustid,
+                            "mb_recording_id": rec.id,
+                        });
+                        ProviderResult {
+                            provider_id: rec.id,
+                            title: rec.title.unwrap_or_default(),
+                            artist,
+                            year: None,
+                            score,
+                            raw,
+                        }
+                    })
+            })
+            .collect();
+
+        Ok(results)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AcoustIdResponse {
+    results: Option<Vec<AcoustIdResult>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AcoustIdResult {
+    id: String,
+    score: Option<f64>,
+    recordings: Option<Vec<AcoustIdRecording>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AcoustIdRecording {
+    id: String,
+    title: Option<String>,
+    artists: Option<Vec<AcoustIdArtist>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AcoustIdArtist {
+    name: String,
+}
+
+impl MetadataProvider for AcoustIdProvider {
+    fn name(&self) -> &str {
+        "acoustid"
+    }
+
+    #[instrument(skip(self), fields(provider = "acoustid"))]
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
+        // AcoustID is fingerprint-based; text search is not its primary mode.
+        // Use MusicBrainz for text-based music search. Return empty here.
+        let _ = query;
+        Ok(vec![])
+    }
+
+    #[instrument(skip(self), fields(provider = "acoustid"))]
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
+        let url = format!("{BASE_URL}/lookup");
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("client", self.api_key.as_str()),
+                ("trackid", provider_id),
+                ("meta", "recordings"),
+            ])
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "acoustid",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "acoustid",
+        })?;
+
+        let parsed: AcoustIdResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "acoustid",
+        })?;
+
+        let first_rec = parsed
+            .results
+            .unwrap_or_default()
+            .into_iter()
+            .next()
+            .and_then(|r| r.recordings.unwrap_or_default().into_iter().next());
+
+        match first_rec {
+            Some(rec) => {
+                let artist = rec
+                    .artists
+                    .as_deref()
+                    .and_then(|a| a.first())
+                    .map(|a| a.name.clone());
+                Ok(ProviderMetadata {
+                    provider_id: rec.id,
+                    title: rec.title.unwrap_or_default(),
+                    artist,
+                    year: None,
+                    extra: serde_json::Value::Null,
+                })
+            }
+            None => Ok(ProviderMetadata {
+                provider_id: provider_id.to_string(),
+                title: String::new(),
+                artist: None,
+                year: None,
+                extra: serde_json::Value::Null,
+            }),
+        }
+    }
+}

--- a/crates/epignosis/src/providers/audnexus.rs
+++ b/crates/epignosis/src/providers/audnexus.rs
@@ -1,0 +1,158 @@
+use serde::Deserialize;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
+
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+
+const BASE_URL: &str = "https://api.audnex.us";
+
+pub struct AudnexusProvider {
+    client: reqwest::Client,
+}
+
+impl AudnexusProvider {
+    pub fn new(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AudnexusBook {
+    asin: String,
+    title: String,
+    authors: Option<Vec<AudnexusAuthor>>,
+    #[serde(rename = "releaseDate")]
+    release_date: Option<String>,
+    summary: Option<String>,
+    genres: Option<Vec<AudnexusGenre>>,
+    image: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AudnexusAuthor {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AudnexusGenre {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AudnexusSearchResponse {
+    books: Option<Vec<AudnexusSearchResult>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AudnexusSearchResult {
+    asin: String,
+    title: String,
+    authors: Option<Vec<AudnexusAuthor>>,
+}
+
+impl MetadataProvider for AudnexusProvider {
+    fn name(&self) -> &str {
+        "audnexus"
+    }
+
+    #[instrument(skip(self), fields(provider = "audnexus"))]
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
+        let url = format!("{BASE_URL}/books");
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("title", &query.title)])
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "audnexus",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "audnexus",
+        })?;
+
+        let parsed: AudnexusSearchResponse =
+            serde_json::from_str(&text).context(ProviderParseSnafu {
+                provider: "audnexus",
+            })?;
+
+        let results = parsed
+            .books
+            .unwrap_or_default()
+            .into_iter()
+            .map(|book| {
+                let artist = book
+                    .authors
+                    .as_deref()
+                    .and_then(|a| a.first())
+                    .map(|a| a.name.clone());
+                let raw = serde_json::json!({ "asin": book.asin });
+                ProviderResult {
+                    provider_id: book.asin,
+                    title: book.title,
+                    artist,
+                    year: None,
+                    score: 1.0,
+                    raw,
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(provider = "audnexus"))]
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
+        let url = format!("{BASE_URL}/books/{provider_id}");
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "audnexus",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "audnexus",
+        })?;
+
+        let book: AudnexusBook = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "audnexus",
+        })?;
+
+        let artist = book
+            .authors
+            .as_deref()
+            .and_then(|a| a.first())
+            .map(|a| a.name.clone());
+        let year = book
+            .release_date
+            .as_deref()
+            .and_then(|d| d.split('-').next())
+            .and_then(|y| y.parse().ok());
+        let genres: Vec<String> = book
+            .genres
+            .unwrap_or_default()
+            .into_iter()
+            .map(|g| g.name)
+            .collect();
+
+        let extra = serde_json::json!({
+            "summary": book.summary,
+            "image": book.image,
+            "genres": genres,
+        });
+
+        Ok(ProviderMetadata {
+            provider_id: book.asin,
+            title: book.title,
+            artist,
+            year,
+            extra,
+        })
+    }
+}

--- a/crates/epignosis/src/providers/comicvine.rs
+++ b/crates/epignosis/src/providers/comicvine.rs
@@ -1,0 +1,149 @@
+use serde::Deserialize;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
+
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+
+const BASE_URL: &str = "https://comicvine.gamespot.com/api";
+
+pub struct ComicVineProvider {
+    client: reqwest::Client,
+    api_key: String,
+}
+
+impl ComicVineProvider {
+    pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
+        Self {
+            client,
+            api_key: api_key.into(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CvSearchResponse {
+    results: Vec<CvVolume>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CvVolume {
+    id: u64,
+    name: String,
+    publisher: Option<CvPublisher>,
+    start_year: Option<String>,
+    description: Option<String>,
+    image: Option<CvImage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CvPublisher {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CvImage {
+    medium_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CvVolumeDetail {
+    results: CvVolume,
+}
+
+impl MetadataProvider for ComicVineProvider {
+    fn name(&self) -> &str {
+        "comicvine"
+    }
+
+    #[instrument(skip(self), fields(provider = "comicvine"))]
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
+        let url = format!("{BASE_URL}/search/");
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("api_key", self.api_key.as_str()),
+                ("query", &query.title),
+                ("resources", "volume"),
+                ("format", "json"),
+                ("limit", "10"),
+            ])
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "comicvine",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "comicvine",
+        })?;
+
+        let parsed: CvSearchResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "comicvine",
+        })?;
+
+        let results = parsed
+            .results
+            .into_iter()
+            .map(|vol| {
+                let year: Option<u32> = vol.start_year.as_deref().and_then(|y| y.parse().ok());
+                let artist = vol.publisher.map(|p| p.name);
+                let raw = serde_json::json!({
+                    "cv_id": vol.id,
+                    "image": vol.image.and_then(|i| i.medium_url),
+                });
+                ProviderResult {
+                    provider_id: format!("4050-{}", vol.id),
+                    title: vol.name,
+                    artist,
+                    year,
+                    score: 1.0,
+                    raw,
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(provider = "comicvine"))]
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
+        let url = format!("{BASE_URL}/volume/{provider_id}/");
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("api_key", self.api_key.as_str()), ("format", "json")])
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "comicvine",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "comicvine",
+        })?;
+
+        let detail: CvVolumeDetail = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "comicvine",
+        })?;
+
+        let vol = detail.results;
+        let year: Option<u32> = vol.start_year.as_deref().and_then(|y| y.parse().ok());
+        let artist = vol.publisher.map(|p| p.name);
+
+        let extra = serde_json::json!({
+            "description": vol.description,
+            "image": vol.image.and_then(|i| i.medium_url),
+        });
+
+        Ok(ProviderMetadata {
+            provider_id: format!("4050-{}", vol.id),
+            title: vol.name,
+            artist,
+            year,
+            extra,
+        })
+    }
+}

--- a/crates/epignosis/src/providers/itunes.rs
+++ b/crates/epignosis/src/providers/itunes.rs
@@ -1,0 +1,149 @@
+use serde::Deserialize;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
+
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+
+const BASE_URL: &str = "https://itunes.apple.com";
+
+pub struct ItunesProvider {
+    client: reqwest::Client,
+}
+
+impl ItunesProvider {
+    pub fn new(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ItunesSearchResponse {
+    results: Vec<ItunesPodcast>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ItunesPodcast {
+    collection_id: Option<u64>,
+    collection_name: Option<String>,
+    track_name: Option<String>,
+    artist_name: Option<String>,
+    release_date: Option<String>,
+    feed_url: Option<String>,
+    artwork_url600: Option<String>,
+    genres: Option<Vec<String>>,
+}
+
+impl MetadataProvider for ItunesProvider {
+    fn name(&self) -> &str {
+        "itunes"
+    }
+
+    #[instrument(skip(self), fields(provider = "itunes"))]
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
+        let url = format!("{BASE_URL}/search");
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("term", query.title.as_str()),
+                ("media", "podcast"),
+                ("limit", "10"),
+            ])
+            .send()
+            .await
+            .context(ProviderRequestSnafu { provider: "itunes" })?;
+
+        let text = response
+            .text()
+            .await
+            .context(ProviderRequestSnafu { provider: "itunes" })?;
+
+        let parsed: ItunesSearchResponse =
+            serde_json::from_str(&text).context(ProviderParseSnafu { provider: "itunes" })?;
+
+        let results = parsed
+            .results
+            .into_iter()
+            .filter_map(|pod| {
+                let id = pod.collection_id?.to_string();
+                let title = pod.collection_name.or(pod.track_name).unwrap_or_default();
+                let year = pod
+                    .release_date
+                    .as_deref()
+                    .and_then(|d| d.split('-').next())
+                    .and_then(|y| y.parse().ok());
+                let raw = serde_json::json!({
+                    "feed_url": pod.feed_url,
+                    "artwork": pod.artwork_url600,
+                    "genres": pod.genres.unwrap_or_default(),
+                });
+                Some(ProviderResult {
+                    provider_id: id,
+                    title,
+                    artist: pod.artist_name,
+                    year,
+                    score: 1.0,
+                    raw,
+                })
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(provider = "itunes"))]
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
+        let url = format!("{BASE_URL}/lookup");
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("id", provider_id), ("media", "podcast")])
+            .send()
+            .await
+            .context(ProviderRequestSnafu { provider: "itunes" })?;
+
+        let text = response
+            .text()
+            .await
+            .context(ProviderRequestSnafu { provider: "itunes" })?;
+
+        let parsed: ItunesSearchResponse =
+            serde_json::from_str(&text).context(ProviderParseSnafu { provider: "itunes" })?;
+
+        let pod = parsed.results.into_iter().next().unwrap_or(ItunesPodcast {
+            collection_id: None,
+            collection_name: Some(String::new()),
+            track_name: None,
+            artist_name: None,
+            release_date: None,
+            feed_url: None,
+            artwork_url600: None,
+            genres: None,
+        });
+
+        let title = pod.collection_name.or(pod.track_name).unwrap_or_default();
+        let year = pod
+            .release_date
+            .as_deref()
+            .and_then(|d| d.split('-').next())
+            .and_then(|y| y.parse().ok());
+
+        let extra = serde_json::json!({
+            "feed_url": pod.feed_url,
+            "artwork": pod.artwork_url600,
+            "genres": pod.genres.unwrap_or_default(),
+        });
+
+        Ok(ProviderMetadata {
+            provider_id: provider_id.to_string(),
+            title,
+            artist: pod.artist_name,
+            year,
+            extra,
+        })
+    }
+}

--- a/crates/epignosis/src/providers/mod.rs
+++ b/crates/epignosis/src/providers/mod.rs
@@ -1,0 +1,50 @@
+use harmonia_common::MediaType;
+use serde::{Deserialize, Serialize};
+
+use crate::error::EpignosisError;
+
+pub mod acoustid;
+pub mod audnexus;
+pub mod comicvine;
+pub mod itunes;
+pub mod musicbrainz;
+pub mod openlibrary;
+pub mod tmdb;
+pub mod tvdb;
+
+#[derive(Debug, Clone)]
+pub struct SearchQuery {
+    pub media_type: MediaType,
+    pub title: String,
+    pub artist: Option<String>,
+    pub year: Option<u32>,
+    pub extra: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderResult {
+    pub provider_id: String,
+    pub title: String,
+    pub artist: Option<String>,
+    pub year: Option<u32>,
+    pub score: f64,
+    pub raw: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderMetadata {
+    pub provider_id: String,
+    pub title: String,
+    pub artist: Option<String>,
+    pub year: Option<u32>,
+    pub extra: serde_json::Value,
+}
+
+#[allow(async_fn_in_trait)]
+pub trait MetadataProvider: Send + Sync {
+    fn name(&self) -> &str;
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError>;
+
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError>;
+}

--- a/crates/epignosis/src/providers/musicbrainz.rs
+++ b/crates/epignosis/src/providers/musicbrainz.rs
@@ -1,0 +1,164 @@
+use serde::Deserialize;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
+
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+
+const BASE_URL: &str = "https://musicbrainz.org/ws/2";
+const USER_AGENT: &str = "Harmonia/0.1 (https://github.com/harmonia)";
+
+pub struct MusicBrainzProvider {
+    client: reqwest::Client,
+}
+
+impl MusicBrainzProvider {
+    pub fn new(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct MbRecording {
+    id: String,
+    title: String,
+    score: Option<u32>,
+    #[serde(rename = "artist-credit")]
+    artist_credit: Option<Vec<MbArtistCredit>>,
+    #[serde(rename = "first-release-date")]
+    first_release_date: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MbArtistCredit {
+    artist: MbArtist,
+}
+
+#[derive(Debug, Deserialize)]
+struct MbArtist {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MbSearchResponse {
+    recordings: Vec<MbRecording>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MbRelease {
+    id: String,
+    title: String,
+    date: Option<String>,
+    #[serde(rename = "artist-credit")]
+    artist_credit: Option<Vec<MbArtistCredit>>,
+}
+
+impl MetadataProvider for MusicBrainzProvider {
+    fn name(&self) -> &str {
+        "musicbrainz"
+    }
+
+    #[instrument(skip(self), fields(provider = "musicbrainz"))]
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
+        let mut lucene = format!("recording:\"{}\"", query.title);
+        if let Some(artist) = &query.artist {
+            lucene.push_str(&format!(" AND artist:\"{}\"", artist));
+        }
+
+        let url = format!("{BASE_URL}/recording");
+        let response = self
+            .client
+            .get(&url)
+            .header("User-Agent", USER_AGENT)
+            .query(&[
+                ("query", &lucene),
+                ("fmt", &"json".to_string()),
+                ("limit", &"10".to_string()),
+            ])
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "musicbrainz",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "musicbrainz",
+        })?;
+
+        let parsed: MbSearchResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "musicbrainz",
+        })?;
+
+        let results = parsed
+            .recordings
+            .into_iter()
+            .map(|rec| {
+                let artist = rec
+                    .artist_credit
+                    .as_deref()
+                    .and_then(|ac| ac.first())
+                    .map(|ac| ac.artist.name.clone());
+                let year = rec
+                    .first_release_date
+                    .as_deref()
+                    .and_then(|d| d.split('-').next())
+                    .and_then(|y| y.parse().ok());
+                let score = rec.score.unwrap_or(0) as f64 / 100.0;
+                let raw = serde_json::json!({ "mb_recording_id": rec.id });
+                ProviderResult {
+                    provider_id: rec.id,
+                    title: rec.title,
+                    artist,
+                    year,
+                    score,
+                    raw,
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(provider = "musicbrainz"))]
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
+        let url = format!("{BASE_URL}/release/{provider_id}");
+        let response = self
+            .client
+            .get(&url)
+            .header("User-Agent", USER_AGENT)
+            .query(&[("fmt", "json"), ("inc", "artist-credits recordings")])
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "musicbrainz",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "musicbrainz",
+        })?;
+
+        let release: MbRelease = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "musicbrainz",
+        })?;
+
+        let artist = release
+            .artist_credit
+            .as_deref()
+            .and_then(|ac| ac.first())
+            .map(|ac| ac.artist.name.clone());
+        let year = release
+            .date
+            .as_deref()
+            .and_then(|d| d.split('-').next())
+            .and_then(|y| y.parse().ok());
+
+        Ok(ProviderMetadata {
+            provider_id: release.id,
+            title: release.title,
+            artist,
+            year,
+            extra: serde_json::Value::Null,
+        })
+    }
+}

--- a/crates/epignosis/src/providers/openlibrary.rs
+++ b/crates/epignosis/src/providers/openlibrary.rs
@@ -1,0 +1,146 @@
+use serde::Deserialize;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
+
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+
+const BASE_URL: &str = "https://openlibrary.org";
+
+pub struct OpenLibraryProvider {
+    client: reqwest::Client,
+}
+
+impl OpenLibraryProvider {
+    pub fn new(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OlSearchResponse {
+    docs: Vec<OlSearchDoc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OlSearchDoc {
+    key: String,
+    title: String,
+    author_name: Option<Vec<String>>,
+    first_publish_year: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OlWork {
+    key: String,
+    title: String,
+    description: Option<OlDescription>,
+    subjects: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum OlDescription {
+    Simple(String),
+    Structured { value: String },
+}
+
+impl OlDescription {
+    fn text(&self) -> &str {
+        match self {
+            Self::Simple(s) => s,
+            Self::Structured { value } => value,
+        }
+    }
+}
+
+impl MetadataProvider for OpenLibraryProvider {
+    fn name(&self) -> &str {
+        "openlibrary"
+    }
+
+    #[instrument(skip(self), fields(provider = "openlibrary"))]
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
+        let url = format!("{BASE_URL}/search.json");
+        let mut params = vec![("title", query.title.as_str()), ("limit", "10")];
+        let author_str;
+        if let Some(artist) = &query.artist {
+            author_str = artist.clone();
+            params.push(("author", &author_str));
+        }
+
+        let response =
+            self.client
+                .get(&url)
+                .query(&params)
+                .send()
+                .await
+                .context(ProviderRequestSnafu {
+                    provider: "openlibrary",
+                })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "openlibrary",
+        })?;
+
+        let parsed: OlSearchResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "openlibrary",
+        })?;
+
+        let results = parsed
+            .docs
+            .into_iter()
+            .map(|doc| {
+                let artist = doc.author_name.as_deref().and_then(|a| a.first()).cloned();
+                let raw = serde_json::json!({ "ol_key": doc.key });
+                ProviderResult {
+                    provider_id: doc.key,
+                    title: doc.title,
+                    artist,
+                    year: doc.first_publish_year,
+                    score: 1.0,
+                    raw,
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(provider = "openlibrary"))]
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
+        // provider_id is an OL key like "/works/OL12345W"
+        let url = format!("{BASE_URL}{provider_id}.json");
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "openlibrary",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "openlibrary",
+        })?;
+
+        let work: OlWork = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "openlibrary",
+        })?;
+
+        let description = work.description.as_ref().map(|d| d.text().to_string());
+        let extra = serde_json::json!({
+            "description": description,
+            "subjects": work.subjects.unwrap_or_default(),
+        });
+
+        Ok(ProviderMetadata {
+            provider_id: work.key,
+            title: work.title,
+            artist: None,
+            year: None,
+            extra,
+        })
+    }
+}

--- a/crates/epignosis/src/providers/tmdb.rs
+++ b/crates/epignosis/src/providers/tmdb.rs
@@ -1,0 +1,156 @@
+use serde::Deserialize;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
+
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+
+const BASE_URL: &str = "https://api.themoviedb.org/3";
+
+pub struct TmdbProvider {
+    client: reqwest::Client,
+    api_key: String,
+}
+
+impl TmdbProvider {
+    pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
+        Self {
+            client,
+            api_key: api_key.into(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TmdbSearchResponse {
+    results: Vec<TmdbMovie>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TmdbMovie {
+    id: u64,
+    title: String,
+    release_date: Option<String>,
+    popularity: Option<f64>,
+    overview: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TmdbMovieDetail {
+    id: u64,
+    title: String,
+    release_date: Option<String>,
+    overview: Option<String>,
+    runtime: Option<u32>,
+    genres: Option<Vec<TmdbGenre>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TmdbGenre {
+    name: String,
+}
+
+impl MetadataProvider for TmdbProvider {
+    fn name(&self) -> &str {
+        "tmdb"
+    }
+
+    #[instrument(skip(self), fields(provider = "tmdb"))]
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
+        let url = format!("{BASE_URL}/search/movie");
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("api_key", self.api_key.as_str()),
+                ("query", &query.title),
+                ("page", "1"),
+            ])
+            .send()
+            .await
+            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+
+        let text = response
+            .text()
+            .await
+            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+
+        let parsed: TmdbSearchResponse =
+            serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tmdb" })?;
+
+        let results = parsed
+            .results
+            .into_iter()
+            .map(|movie| {
+                let year = movie
+                    .release_date
+                    .as_deref()
+                    .and_then(|d| d.split('-').next())
+                    .and_then(|y| y.parse().ok());
+                let score = movie.popularity.unwrap_or(0.0) / 1000.0;
+                let raw = serde_json::json!({
+                    "overview": movie.overview,
+                    "tmdb_id": movie.id,
+                });
+                ProviderResult {
+                    provider_id: movie.id.to_string(),
+                    title: movie.title,
+                    artist: None,
+                    year,
+                    score: score.clamp(0.0, 1.0),
+                    raw,
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(provider = "tmdb"))]
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
+        let url = format!("{BASE_URL}/movie/{provider_id}");
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("api_key", self.api_key.as_str())])
+            .send()
+            .await
+            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+
+        let text = response
+            .text()
+            .await
+            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+
+        let movie: TmdbMovieDetail =
+            serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tmdb" })?;
+
+        let year = movie
+            .release_date
+            .as_deref()
+            .and_then(|d| d.split('-').next())
+            .and_then(|y| y.parse().ok());
+
+        let genres: Vec<String> = movie
+            .genres
+            .unwrap_or_default()
+            .into_iter()
+            .map(|g| g.name)
+            .collect();
+
+        let extra = serde_json::json!({
+            "overview": movie.overview,
+            "runtime_mins": movie.runtime,
+            "genres": genres,
+        });
+
+        Ok(ProviderMetadata {
+            provider_id: movie.id.to_string(),
+            title: movie.title,
+            artist: None,
+            year,
+            extra,
+        })
+    }
+}

--- a/crates/epignosis/src/providers/tvdb.rs
+++ b/crates/epignosis/src/providers/tvdb.rs
@@ -1,0 +1,183 @@
+use serde::Deserialize;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
+
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+
+const BASE_URL: &str = "https://api4.thetvdb.com/v4";
+
+pub struct TvdbProvider {
+    client: reqwest::Client,
+    api_key: String,
+}
+
+impl TvdbProvider {
+    pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
+        Self {
+            client,
+            api_key: api_key.into(),
+        }
+    }
+
+    async fn bearer_token(&self) -> Result<String, EpignosisError> {
+        let url = format!("{BASE_URL}/login");
+        let body = serde_json::json!({ "apikey": self.api_key });
+
+        let response = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .context(ProviderRequestSnafu { provider: "tvdb" })?;
+
+        let text = response
+            .text()
+            .await
+            .context(ProviderRequestSnafu { provider: "tvdb" })?;
+
+        let parsed: TvdbLoginResponse =
+            serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tvdb" })?;
+
+        Ok(parsed.data.token)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TvdbLoginResponse {
+    data: TvdbToken,
+}
+
+#[derive(Debug, Deserialize)]
+struct TvdbToken {
+    token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TvdbSearchResponse {
+    data: Option<Vec<TvdbSeries>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TvdbSeries {
+    #[serde(rename = "tvdb_id")]
+    tvdb_id: Option<String>,
+    name: String,
+    year: Option<String>,
+    overview: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TvdbSeriesDetail {
+    data: TvdbSeriesData,
+}
+
+#[derive(Debug, Deserialize)]
+struct TvdbSeriesData {
+    id: u64,
+    name: String,
+    year: Option<String>,
+    overview: Option<String>,
+    genres: Option<Vec<TvdbGenre>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TvdbGenre {
+    name: String,
+}
+
+impl MetadataProvider for TvdbProvider {
+    fn name(&self) -> &str {
+        "tvdb"
+    }
+
+    #[instrument(skip(self), fields(provider = "tvdb"))]
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
+        let token = self.bearer_token().await?;
+        let url = format!("{BASE_URL}/search");
+
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(&token)
+            .query(&[("query", &query.title), ("type", &"series".to_string())])
+            .send()
+            .await
+            .context(ProviderRequestSnafu { provider: "tvdb" })?;
+
+        let text = response
+            .text()
+            .await
+            .context(ProviderRequestSnafu { provider: "tvdb" })?;
+
+        let parsed: TvdbSearchResponse =
+            serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tvdb" })?;
+
+        let results = parsed
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(|series| {
+                let year: Option<u32> = series.year.as_deref().and_then(|y| y.parse().ok());
+                let id = series.tvdb_id.unwrap_or_default();
+                let raw = serde_json::json!({ "overview": series.overview, "tvdb_id": id });
+                ProviderResult {
+                    provider_id: id,
+                    title: series.name,
+                    artist: None,
+                    year,
+                    score: 1.0,
+                    raw,
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(provider = "tvdb"))]
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
+        let token = self.bearer_token().await?;
+        let url = format!("{BASE_URL}/series/{provider_id}");
+
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context(ProviderRequestSnafu { provider: "tvdb" })?;
+
+        let text = response
+            .text()
+            .await
+            .context(ProviderRequestSnafu { provider: "tvdb" })?;
+
+        let detail: TvdbSeriesDetail =
+            serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tvdb" })?;
+
+        let year: Option<u32> = detail.data.year.as_deref().and_then(|y| y.parse().ok());
+        let genres: Vec<String> = detail
+            .data
+            .genres
+            .unwrap_or_default()
+            .into_iter()
+            .map(|g| g.name)
+            .collect();
+
+        let extra = serde_json::json!({
+            "overview": detail.data.overview,
+            "genres": genres,
+        });
+
+        Ok(ProviderMetadata {
+            provider_id: detail.data.id.to_string(),
+            title: detail.data.name,
+            artist: None,
+            year,
+            extra,
+        })
+    }
+}

--- a/crates/epignosis/src/rate_limit.rs
+++ b/crates/epignosis/src/rate_limit.rs
@@ -1,0 +1,126 @@
+use std::time::Duration;
+
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::interval;
+use tracing::Instrument;
+
+/// Zero-size token returned when a permit is granted.
+pub struct ProviderPermit;
+
+/// Token-bucket rate limiter for a single provider.
+///
+/// Callers send a oneshot sender; the background loop ticks at the configured
+/// interval and unblocks one caller per tick.
+pub struct ProviderQueue {
+    tx: mpsc::Sender<oneshot::Sender<()>>,
+}
+
+impl ProviderQueue {
+    pub fn new(requests_per_window: u32, window_millis: u64) -> Self {
+        let (tx, mut rx) = mpsc::channel::<oneshot::Sender<()>>(100);
+        let requests_per_window = requests_per_window.max(1);
+        let interval_millis = window_millis / requests_per_window as u64;
+        let interval_dur = Duration::from_millis(interval_millis.max(1));
+
+        tokio::spawn(
+            async move {
+                let mut tick = interval(interval_dur);
+                // First tick fires immediately — consume it so the first real
+                // request still waits the full interval.
+                tick.tick().await;
+                while let Some(caller_tx) = rx.recv().await {
+                    tick.tick().await;
+                    let _ = caller_tx.send(());
+                }
+            }
+            .instrument(tracing::info_span!("provider_rate_limiter")),
+        );
+
+        Self { tx }
+    }
+
+    /// Acquire a permit, waiting until the rate limiter allows the next request.
+    pub async fn acquire(&self) -> ProviderPermit {
+        let (cb_tx, cb_rx) = oneshot::channel();
+        // If the channel is closed (background task panicked), proceed anyway.
+        let _ = self.tx.send(cb_tx).await;
+        let _ = cb_rx.await;
+        ProviderPermit
+    }
+}
+
+/// Pre-configured rate limits matching per-provider API budgets.
+pub struct ProviderQueues {
+    pub musicbrainz: ProviderQueue,
+    pub acoustid: ProviderQueue,
+    pub tmdb: ProviderQueue,
+    pub tvdb: ProviderQueue,
+    pub audnexus: ProviderQueue,
+    pub openlibrary: ProviderQueue,
+    pub itunes: ProviderQueue,
+    pub comicvine: ProviderQueue,
+}
+
+impl ProviderQueues {
+    pub fn new() -> Self {
+        Self {
+            musicbrainz: ProviderQueue::new(1, 1_000),  // 1 req/s
+            acoustid: ProviderQueue::new(3, 1_000),     // 3 req/s
+            tmdb: ProviderQueue::new(40, 1_000),        // 40 req/s
+            tvdb: ProviderQueue::new(10, 1_000),        // 10 req/s
+            audnexus: ProviderQueue::new(5, 1_000),     // 5 req/s
+            openlibrary: ProviderQueue::new(10, 1_000), // 10 req/s
+            itunes: ProviderQueue::new(20, 60_000),     // 20 req/min
+            comicvine: ProviderQueue::new(1, 1_000),    // 1 req/s
+        }
+    }
+}
+
+impl Default for ProviderQueues {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    /// 3 requests in a 100ms window — all three should complete quickly,
+    /// a fourth request must wait for the next slot.
+    #[tokio::test]
+    async fn rate_limiter_allows_burst_then_throttles() {
+        // 3 req per 300ms → ~100ms interval
+        let queue = ProviderQueue::new(3, 300);
+
+        let start = Instant::now();
+
+        // First three permits — each waits one interval after the previous.
+        queue.acquire().await;
+        queue.acquire().await;
+        queue.acquire().await;
+
+        let elapsed = start.elapsed();
+        // Three permits should complete within ~500ms with some slack.
+        assert!(
+            elapsed < Duration::from_millis(600),
+            "three permits took too long: {elapsed:?}"
+        );
+
+        // Fourth permit must wait at least one more interval.
+        let before_fourth = Instant::now();
+        queue.acquire().await;
+        let fourth_wait = before_fourth.elapsed();
+        assert!(
+            fourth_wait >= Duration::from_millis(50),
+            "fourth permit did not throttle: {fourth_wait:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_queues_default_construction() {
+        let _queues = ProviderQueues::new();
+        // Verifies construction does not panic.
+    }
+}

--- a/crates/epignosis/src/resolver.rs
+++ b/crates/epignosis/src/resolver.rs
@@ -1,0 +1,421 @@
+use std::{path::Path, sync::Arc, time::Duration};
+
+use harmonia_common::MediaType;
+use horismos::EpignosisConfig;
+use tracing::instrument;
+
+use crate::{
+    MetadataResolver,
+    cache::MetadataCache,
+    error::EpignosisError,
+    identity::{
+        EnrichedMetadata, FingerprintResult, MediaIdentity, ProviderEnrichment, UnidentifiedItem,
+    },
+    providers::{MetadataProvider, SearchQuery},
+    providers::{
+        acoustid::AcoustIdProvider, audnexus::AudnexusProvider, comicvine::ComicVineProvider,
+        itunes::ItunesProvider, musicbrainz::MusicBrainzProvider, openlibrary::OpenLibraryProvider,
+        tmdb::TmdbProvider, tvdb::TvdbProvider,
+    },
+    rate_limit::ProviderQueues,
+};
+
+/// Provider credentials supplied at construction time.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderCredentials {
+    pub acoustid_key: String,
+    pub tmdb_key: String,
+    pub tvdb_key: String,
+    pub comicvine_key: String,
+}
+
+pub struct EpignosisService {
+    #[expect(dead_code)]
+    client: reqwest::Client,
+    queues: Arc<ProviderQueues>,
+    cache: Arc<MetadataCache<String, serde_json::Value>>,
+    #[expect(dead_code)]
+    config: EpignosisConfig,
+    musicbrainz: MusicBrainzProvider,
+    #[expect(dead_code)]
+    acoustid: AcoustIdProvider,
+    tmdb: TmdbProvider,
+    tvdb: TvdbProvider,
+    audnexus: AudnexusProvider,
+    openlibrary: OpenLibraryProvider,
+    itunes: ItunesProvider,
+    comicvine: ComicVineProvider,
+}
+
+impl EpignosisService {
+    pub fn new(config: EpignosisConfig, credentials: ProviderCredentials) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(config.provider_timeout_secs))
+            .build()
+            .unwrap_or_default();
+
+        let cache = Arc::new(MetadataCache::new(Duration::from_secs(
+            config.cache_ttl_secs,
+        )));
+        let queues = Arc::new(ProviderQueues::new());
+
+        let musicbrainz = MusicBrainzProvider::new(client.clone());
+        let acoustid = AcoustIdProvider::new(client.clone(), credentials.acoustid_key.clone());
+        let tmdb = TmdbProvider::new(client.clone(), credentials.tmdb_key.clone());
+        let tvdb = TvdbProvider::new(client.clone(), credentials.tvdb_key.clone());
+        let audnexus = AudnexusProvider::new(client.clone());
+        let openlibrary = OpenLibraryProvider::new(client.clone());
+        let itunes = ItunesProvider::new(client.clone());
+        let comicvine = ComicVineProvider::new(client.clone(), credentials.comicvine_key.clone());
+
+        Self {
+            client,
+            queues,
+            cache,
+            config,
+            musicbrainz,
+            acoustid,
+            tmdb,
+            tvdb,
+            audnexus,
+            openlibrary,
+            itunes,
+            comicvine,
+        }
+    }
+
+    /// Returns the canonical provider name for a given media type.
+    pub fn canonical_provider_for(media_type: MediaType) -> &'static str {
+        match media_type {
+            MediaType::Music => "musicbrainz",
+            MediaType::Movie => "tmdb",
+            MediaType::Tv => "tvdb",
+            MediaType::Audiobook => "audnexus",
+            MediaType::Book => "openlibrary",
+            MediaType::Comic => "comicvine",
+            MediaType::Podcast => "itunes",
+            MediaType::News => "itunes",
+            _ => "musicbrainz",
+        }
+    }
+
+    fn build_query(item: &UnidentifiedItem) -> SearchQuery {
+        let (title, artist, year) = if let Some(tags) = &item.tags {
+            (
+                tags.title
+                    .clone()
+                    .unwrap_or_else(|| item.filename_hint.clone().unwrap_or_default()),
+                tags.artist.clone().or_else(|| tags.album_artist.clone()),
+                tags.year,
+            )
+        } else {
+            (item.filename_hint.clone().unwrap_or_default(), None, None)
+        };
+
+        SearchQuery {
+            media_type: item.media_type,
+            title,
+            artist,
+            year,
+            extra: None,
+        }
+    }
+}
+
+impl MetadataResolver for EpignosisService {
+    #[instrument(skip(self, item, ct), fields(media_type = ?item.media_type))]
+    async fn resolve_identity(
+        &self,
+        item: &UnidentifiedItem,
+        ct: tokio_util::sync::CancellationToken,
+    ) -> Result<MediaIdentity, EpignosisError> {
+        let cache_key = format!("identity:{}:{}", item.media_type, item.media_id);
+
+        if let Some(cached) = self.cache.get(&cache_key)
+            && let Ok(identity) = serde_json::from_value::<MediaIdentity>(cached)
+        {
+            return Ok(identity);
+        }
+
+        let query = Self::build_query(item);
+        let provider_name = Self::canonical_provider_for(item.media_type);
+
+        let results = tokio::select! {
+            result = self.search_canonical(item.media_type, &query) => result?,
+            _ = ct.cancelled() => {
+                return Err(EpignosisError::IdentityNotResolved {
+                    provider: provider_name.to_string(),
+                    query: query.title.clone(),
+                    location: snafu::location!(),
+                });
+            }
+        };
+
+        let best = results
+            .into_iter()
+            .max_by(|a, b| {
+                a.score
+                    .partial_cmp(&b.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .ok_or_else(|| EpignosisError::IdentityNotResolved {
+                provider: provider_name.to_string(),
+                query: query.title.clone(),
+                location: snafu::location!(),
+            })?;
+
+        let identity = MediaIdentity {
+            media_id: item.media_id,
+            media_type: item.media_type,
+            provider: provider_name.to_string(),
+            provider_id: best.provider_id,
+            canonical_title: best.title,
+            canonical_artist: best.artist,
+            year: best.year,
+            extra: best.raw,
+        };
+
+        if let Ok(value) = serde_json::to_value(&identity) {
+            self.cache.insert(cache_key, value);
+        }
+
+        Ok(identity)
+    }
+
+    #[instrument(skip(self, identity, ct), fields(provider = %identity.provider))]
+    async fn enrich(
+        &self,
+        identity: &MediaIdentity,
+        ct: tokio_util::sync::CancellationToken,
+    ) -> Result<EnrichedMetadata, EpignosisError> {
+        let mut enrichments = Vec::new();
+
+        let primary_result = tokio::select! {
+            result = self.enrich_from_canonical(identity) => result,
+            _ = ct.cancelled() => return Ok(EnrichedMetadata {
+                identity: identity.clone(),
+                enrichments,
+            }),
+        };
+
+        if let Ok(data) = primary_result {
+            enrichments.push(ProviderEnrichment {
+                provider: identity.provider.clone(),
+                data,
+            });
+        }
+
+        let secondary_result = tokio::select! {
+            result = self.enrich_from_secondary(identity) => result,
+            _ = ct.cancelled() => return Ok(EnrichedMetadata {
+                identity: identity.clone(),
+                enrichments,
+            }),
+        };
+
+        if let Some((provider, data)) = secondary_result {
+            enrichments.push(ProviderEnrichment { provider, data });
+        }
+
+        Ok(EnrichedMetadata {
+            identity: identity.clone(),
+            enrichments,
+        })
+    }
+
+    #[instrument(skip(self, _ct), fields(path = %file_path.display()))]
+    async fn fingerprint_audio(
+        &self,
+        file_path: &Path,
+        _ct: tokio_util::sync::CancellationToken,
+    ) -> Result<FingerprintResult, EpignosisError> {
+        // Fingerprinting requires a native fpcalc binary (Chromaprint).
+        // This delegates to an external process and returns the result.
+        // The actual chromaprint invocation is deferred to the host process.
+        Err(EpignosisError::FingerprintFailed {
+            path: file_path.to_path_buf(),
+            source: Box::from("fpcalc not available in this build"),
+            location: snafu::location!(),
+        })
+    }
+}
+
+impl EpignosisService {
+    async fn search_canonical(
+        &self,
+        media_type: MediaType,
+        query: &SearchQuery,
+    ) -> Result<Vec<crate::providers::ProviderResult>, EpignosisError> {
+        match media_type {
+            MediaType::Music => {
+                self.queues.musicbrainz.acquire().await;
+                self.musicbrainz.search(query).await
+            }
+            MediaType::Movie => {
+                self.queues.tmdb.acquire().await;
+                self.tmdb.search(query).await
+            }
+            MediaType::Tv => {
+                self.queues.tvdb.acquire().await;
+                self.tvdb.search(query).await
+            }
+            MediaType::Audiobook => {
+                self.queues.audnexus.acquire().await;
+                self.audnexus.search(query).await
+            }
+            MediaType::Book => {
+                self.queues.openlibrary.acquire().await;
+                self.openlibrary.search(query).await
+            }
+            MediaType::Comic => {
+                self.queues.comicvine.acquire().await;
+                self.comicvine.search(query).await
+            }
+            MediaType::Podcast | MediaType::News => {
+                self.queues.itunes.acquire().await;
+                self.itunes.search(query).await
+            }
+            _ => Ok(vec![]),
+        }
+    }
+
+    async fn enrich_from_canonical(
+        &self,
+        identity: &MediaIdentity,
+    ) -> Result<serde_json::Value, EpignosisError> {
+        let metadata = match identity.media_type {
+            MediaType::Music => {
+                self.queues.musicbrainz.acquire().await;
+                self.musicbrainz.get_metadata(&identity.provider_id).await?
+            }
+            MediaType::Movie => {
+                self.queues.tmdb.acquire().await;
+                self.tmdb.get_metadata(&identity.provider_id).await?
+            }
+            MediaType::Tv => {
+                self.queues.tvdb.acquire().await;
+                self.tvdb.get_metadata(&identity.provider_id).await?
+            }
+            MediaType::Audiobook => {
+                self.queues.audnexus.acquire().await;
+                self.audnexus.get_metadata(&identity.provider_id).await?
+            }
+            MediaType::Book => {
+                self.queues.openlibrary.acquire().await;
+                self.openlibrary.get_metadata(&identity.provider_id).await?
+            }
+            MediaType::Comic => {
+                self.queues.comicvine.acquire().await;
+                self.comicvine.get_metadata(&identity.provider_id).await?
+            }
+            MediaType::Podcast | MediaType::News => {
+                self.queues.itunes.acquire().await;
+                self.itunes.get_metadata(&identity.provider_id).await?
+            }
+            _ => return Ok(serde_json::Value::Null),
+        };
+
+        Ok(metadata.extra)
+    }
+
+    async fn enrich_from_secondary(
+        &self,
+        identity: &MediaIdentity,
+    ) -> Option<(String, serde_json::Value)> {
+        match identity.media_type {
+            MediaType::Tv => {
+                self.queues.tmdb.acquire().await;
+                let meta = self.tmdb.get_metadata(&identity.provider_id).await.ok()?;
+                Some(("tmdb".to_string(), meta.extra))
+            }
+            MediaType::Audiobook => {
+                self.queues.openlibrary.acquire().await;
+                let query = SearchQuery {
+                    media_type: identity.media_type,
+                    title: identity.canonical_title.clone(),
+                    artist: identity.canonical_artist.clone(),
+                    year: identity.year,
+                    extra: None,
+                };
+                let results = self.openlibrary.search(&query).await.ok()?;
+                let best = results.into_iter().next()?;
+                let meta = self
+                    .openlibrary
+                    .get_metadata(&best.provider_id)
+                    .await
+                    .ok()?;
+                Some(("openlibrary".to_string(), meta.extra))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_provider_music() {
+        assert_eq!(
+            EpignosisService::canonical_provider_for(MediaType::Music),
+            "musicbrainz"
+        );
+    }
+
+    #[test]
+    fn canonical_provider_movie() {
+        assert_eq!(
+            EpignosisService::canonical_provider_for(MediaType::Movie),
+            "tmdb"
+        );
+    }
+
+    #[test]
+    fn canonical_provider_tv() {
+        assert_eq!(
+            EpignosisService::canonical_provider_for(MediaType::Tv),
+            "tvdb"
+        );
+    }
+
+    #[test]
+    fn canonical_provider_audiobook() {
+        assert_eq!(
+            EpignosisService::canonical_provider_for(MediaType::Audiobook),
+            "audnexus"
+        );
+    }
+
+    #[test]
+    fn canonical_provider_book() {
+        assert_eq!(
+            EpignosisService::canonical_provider_for(MediaType::Book),
+            "openlibrary"
+        );
+    }
+
+    #[test]
+    fn canonical_provider_comic() {
+        assert_eq!(
+            EpignosisService::canonical_provider_for(MediaType::Comic),
+            "comicvine"
+        );
+    }
+
+    #[test]
+    fn canonical_provider_podcast() {
+        assert_eq!(
+            EpignosisService::canonical_provider_for(MediaType::Podcast),
+            "itunes"
+        );
+    }
+
+    #[test]
+    fn canonical_provider_news() {
+        assert_eq!(
+            EpignosisService::canonical_provider_for(MediaType::News),
+            "itunes"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `epignosis` crate — Harmonia's unified metadata enrichment layer; no other subsystem makes provider requests directly
- `MetadataResolver` trait with `resolve_identity`, `enrich`, and `fingerprint_audio` using native async fn in traits
- Per-provider `ProviderQueue` token-bucket rate limiter (tokio::time::interval + mpsc/oneshot) with correct budgets: MusicBrainz 1/s, AcoustID 3/s, TMDB 40/s, TVDB 10/s, Audnexus 5/s, OpenLibrary 10/s, iTunes 20/min, ComicVine 1/s
- `MetadataCache<K,V>` backed by DashMap with TTL expiry, permanent entries, and `evict_expired` for background cleanup
- `EpignosisError` snafu enum (8 variants, all with implicit `Location` tracking): ProviderRequest, ProviderParse, ProviderTimeout, ProviderRateLimited, IdentityNotResolved, FingerprintFailed, Cache, Database
- Provider implementations for all 8 providers (MusicBrainz, AcoustID, TMDB, TVDB, Audnexus, OpenLibrary, iTunes, ComicVine) with correct HTTP endpoints, auth patterns, and serde deserialization
- `EpignosisService` routing by `MediaType` to canonical/enrichment providers; canonical failures are fatal, enrichment failures are non-fatal with WARN log
- Filename parsing for identity hints (4-part `Artist - Album - 01 - Track`, 3-part, 2-part, bare)
- AcoustID fingerprint confidence thresholds: >0.8 accept, 0.5–0.8 ambiguous, <0.5 discard

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p epignosis -- -D warnings` — clean
- [x] `cargo test -p epignosis` — 24/24 passing
  - Cache: insert/get, TTL expiry, permanent entries, evict_expired, missing key
  - Rate limiter: burst allowance then throttle, ProviderQueues default construction
  - Identity: 4-part filename parse, 3-part with/without track number, 2-part, bare; fingerprint threshold values and ordering
  - Provider routing: canonical provider selected correctly for all 8 MediaType variants