### PR TITLE
feat(exousia): authentication and authorization (P2-04)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +66,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -232,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +322,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -339,9 +430,24 @@ dependencies = [
 name = "exousia"
 version = "0.1.0"
 dependencies = [
+ "argon2",
+ "axum",
  "harmonia-common",
+ "harmonia-db",
+ "horismos",
+ "http",
+ "jsonwebtoken",
+ "rand 0.9.2",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2",
  "snafu",
+ "sqlx",
+ "tokio",
+ "tower",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -709,6 +815,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +833,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -969,6 +1082,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kritike"
 version = "0.1.0"
 dependencies = [
@@ -1068,6 +1196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1232,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1109,6 +1259,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -1142,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parking"
@@ -1185,6 +1341,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1372,16 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1290,6 +1467,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1765,6 +1948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +2025,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -2189,6 +2395,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2497,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2360,6 +2609,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2431,6 +2681,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2762,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/exousia/Cargo.toml
+++ b/crates/exousia/Cargo.toml
@@ -7,5 +7,22 @@ description = "Auth — JWT, API keys, user roles"
 
 [dependencies]
 harmonia-common.workspace = true
+horismos.workspace = true
+harmonia-db.workspace = true
 snafu.workspace = true
 tracing.workspace = true
+jsonwebtoken.workspace = true
+argon2.workspace = true
+rand.workspace = true
+uuid.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+axum.workspace = true
+sha2 = "0.10"
+rand_core = { version = "0.6", features = ["getrandom"] }
+
+[dev-dependencies]
+tokio = { workspace = true }
+sqlx = { workspace = true }
+tower = { workspace = true }
+http = "1"

--- a/crates/exousia/src/api_key.rs
+++ b/crates/exousia/src/api_key.rs
@@ -1,0 +1,113 @@
+use harmonia_common::ids::ApiKeyId;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+pub struct ApiKeyRecord {
+    pub id: ApiKeyId,
+    pub short_token: String,
+    pub long_token_hash: String,
+}
+
+fn random_alphanum(len: usize) -> String {
+    const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+    let mut rng = rand::rng();
+    let mut buf = [0u8; 32];
+    rng.fill_bytes(&mut buf);
+    buf.iter()
+        .take(len)
+        .map(|b| CHARS[(*b as usize) % CHARS.len()] as char)
+        .collect()
+}
+
+fn sha256_hex(input: &[u8]) -> String {
+    let result = Sha256::digest(input);
+    result.iter().fold(String::with_capacity(64), |mut s, b| {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").unwrap();
+        s
+    })
+}
+
+fn build_key(prefix: &str) -> (String, ApiKeyRecord) {
+    let short_token = random_alphanum(8);
+    let long_token = random_alphanum(24);
+    let long_token_hash = sha256_hex(long_token.as_bytes());
+    let full_key = format!("{prefix}_{short_token}_{long_token}");
+    let record = ApiKeyRecord {
+        id: ApiKeyId::new(),
+        short_token,
+        long_token_hash,
+    };
+    (full_key, record)
+}
+
+pub fn generate_api_key() -> (String, ApiKeyRecord) {
+    build_key("hmn")
+}
+
+pub fn generate_renderer_key() -> (String, ApiKeyRecord) {
+    build_key("hmn_rnd")
+}
+
+/// Validates a full API key string against the stored SHA-256 hash of the long token.
+pub fn validate_api_key(key: &str, stored_hash: &str) -> bool {
+    let parts: Vec<&str> = key.split('_').collect();
+    let long_token = match parts.as_slice() {
+        ["hmn", _short, long] => *long,
+        ["hmn", "rnd", _short, long] => *long,
+        _ => return false,
+    };
+    sha256_hex(long_token.as_bytes()) == stored_hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_key_format_correct() {
+        let (key, record) = generate_api_key();
+        assert!(key.starts_with("hmn_"), "key={key}");
+        let parts: Vec<&str> = key.split('_').collect();
+        assert_eq!(parts.len(), 3, "expected 3 parts, got: {parts:?}");
+        assert_eq!(parts[1].len(), 8, "short token len");
+        assert_eq!(parts[2].len(), 24, "long token len");
+        assert_eq!(record.short_token, parts[1]);
+    }
+
+    #[test]
+    fn renderer_key_format_correct() {
+        let (key, record) = generate_renderer_key();
+        assert!(key.starts_with("hmn_rnd_"), "key={key}");
+        let parts: Vec<&str> = key.split('_').collect();
+        assert_eq!(parts.len(), 4, "expected 4 parts");
+        assert_eq!(parts[2].len(), 8, "short token len");
+        assert_eq!(parts[3].len(), 24, "long token len");
+        assert_eq!(record.short_token, parts[2]);
+    }
+
+    #[test]
+    fn validate_api_key_succeeds_with_correct_hash() {
+        let (key, record) = generate_api_key();
+        assert!(validate_api_key(&key, &record.long_token_hash));
+    }
+
+    #[test]
+    fn validate_api_key_fails_with_wrong_hash() {
+        let (key, _) = generate_api_key();
+        assert!(!validate_api_key(&key, "wronghash"));
+    }
+
+    #[test]
+    fn validate_renderer_key_succeeds() {
+        let (key, record) = generate_renderer_key();
+        assert!(validate_api_key(&key, &record.long_token_hash));
+    }
+
+    #[test]
+    fn keys_are_unique() {
+        let (k1, _) = generate_api_key();
+        let (k2, _) = generate_api_key();
+        assert_ne!(k1, k2);
+    }
+}

--- a/crates/exousia/src/error.rs
+++ b/crates/exousia/src/error.rs
@@ -1,0 +1,77 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ExousiaError {
+    #[snafu(display("invalid credentials"))]
+    InvalidCredentials {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("token has expired"))]
+    TokenExpired {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("token is invalid: {error}"))]
+    TokenInvalid {
+        error: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("user not found: {username}"))]
+    UserNotFound {
+        username: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("user account is inactive"))]
+    UserInactive {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("API key has been revoked"))]
+    ApiKeyRevoked {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("insufficient permission for this operation"))]
+    InsufficientPermission {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("password hashing error: {error}"))]
+    PasswordHash {
+        error: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("JWT encoding error: {source}"))]
+    JwtEncode {
+        source: jsonwebtoken::errors::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("JWT decoding error: {source}"))]
+    JwtDecode {
+        source: jsonwebtoken::errors::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("database error: {source}"))]
+    Database {
+        source: harmonia_db::DbError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/exousia/src/jwt.rs
+++ b/crates/exousia/src/jwt.rs
@@ -1,0 +1,159 @@
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::error::{ExousiaError, JwtEncodeSnafu};
+use crate::user::User;
+
+fn new_jti() -> String {
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 16];
+    rng.fill_bytes(&mut bytes);
+    bytes.iter().fold(String::with_capacity(32), |mut s, b| {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").unwrap();
+        s
+    })
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub sub: String,
+    pub iss: String,
+    pub aud: String,
+    pub exp: u64,
+    pub iat: u64,
+    pub jti: String,
+    pub role: String,
+    pub display_name: String,
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_secs()
+}
+
+pub fn create_access_token(
+    user: &User,
+    secret: &[u8],
+    ttl_secs: u64,
+) -> Result<String, ExousiaError> {
+    let now = unix_now();
+    let claims = Claims {
+        sub: user.id.into_uuid().to_string(),
+        iss: "harmonia".to_string(),
+        aud: "harmonia-clients".to_string(),
+        exp: now + ttl_secs,
+        iat: now,
+        jti: new_jti(),
+        role: user.role.as_str().to_string(),
+        display_name: user.display_name.clone(),
+    };
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret),
+    )
+    .context(JwtEncodeSnafu)
+}
+
+pub fn validate_token(token: &str, secret: &[u8]) -> Result<Claims, ExousiaError> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.set_issuer(&["harmonia"]);
+    validation.set_audience(&["harmonia-clients"]);
+
+    decode::<Claims>(token, &DecodingKey::from_secret(secret), &validation)
+        .map(|data| data.claims)
+        .map_err(|e| {
+            if *e.kind() == jsonwebtoken::errors::ErrorKind::ExpiredSignature {
+                ExousiaError::TokenExpired {
+                    location: snafu::location!(),
+                }
+            } else {
+                ExousiaError::TokenInvalid {
+                    error: e.to_string(),
+                    location: snafu::location!(),
+                }
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::user::UserRole;
+    use harmonia_common::ids::UserId;
+
+    fn test_user() -> User {
+        User {
+            id: UserId::new(),
+            username: "alice".to_string(),
+            display_name: "Alice".to_string(),
+            password_hash: "hash".to_string(),
+            role: UserRole::Member,
+            is_active: true,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            last_login_at: None,
+        }
+    }
+
+    #[test]
+    fn roundtrip_access_token() {
+        let secret = b"test-secret-32-bytes-long-enough!";
+        let user = test_user();
+        let token = create_access_token(&user, secret, 900).unwrap();
+        let claims = validate_token(&token, secret).unwrap();
+        assert_eq!(claims.iss, "harmonia");
+        assert_eq!(claims.aud, "harmonia-clients");
+        assert_eq!(claims.role, "member");
+        assert_eq!(claims.display_name, "Alice");
+        assert_eq!(claims.sub, user.id.into_uuid().to_string());
+    }
+
+    #[test]
+    fn expired_token_returns_token_expired() {
+        let secret = b"test-secret-32-bytes-long-enough!";
+        let user = test_user();
+        let now = unix_now();
+        let claims = Claims {
+            sub: user.id.into_uuid().to_string(),
+            iss: "harmonia".to_string(),
+            aud: "harmonia-clients".to_string(),
+            exp: now - 100,
+            iat: now - 1000,
+            jti: new_jti(),
+            role: "member".to_string(),
+            display_name: "Alice".to_string(),
+        };
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret),
+        )
+        .unwrap();
+        let err = validate_token(&token, secret).unwrap_err();
+        assert!(matches!(err, ExousiaError::TokenExpired { .. }));
+    }
+
+    #[test]
+    fn wrong_secret_returns_token_invalid() {
+        let secret = b"test-secret-32-bytes-long-enough!";
+        let user = test_user();
+        let token = create_access_token(&user, secret, 900).unwrap();
+        let err = validate_token(&token, b"wrong-secret-for-validation!!!!!").unwrap_err();
+        assert!(matches!(err, ExousiaError::TokenInvalid { .. }));
+    }
+
+    #[test]
+    fn admin_role_encoded_correctly() {
+        let secret = b"test-secret-32-bytes-long-enough!";
+        let mut user = test_user();
+        user.role = UserRole::Admin;
+        let token = create_access_token(&user, secret, 900).unwrap();
+        let claims = validate_token(&token, secret).unwrap();
+        assert_eq!(claims.role, "admin");
+    }
+}

--- a/crates/exousia/src/lib.rs
+++ b/crates/exousia/src/lib.rs
@@ -1,1 +1,192 @@
-// Stub — implementation in P2-04
+pub mod api_key;
+pub mod error;
+pub mod jwt;
+pub mod middleware;
+pub mod password;
+pub mod service;
+pub mod user;
+
+use harmonia_common::ids::{ApiKeyId, UserId};
+
+pub use error::ExousiaError;
+pub use middleware::{AuthMethod, AuthenticatedUser, RequireAdmin};
+pub use service::ExousiaServiceImpl;
+pub use user::{CreateUserRequest, User, UserRole};
+
+#[derive(Debug, Clone)]
+pub struct TokenPair {
+    pub access_token: String,
+    pub refresh_token: String,
+}
+
+#[allow(async_fn_in_trait)]
+pub trait AuthService: Send + Sync {
+    async fn login(&self, username: &str, password: &str) -> Result<TokenPair, ExousiaError>;
+    async fn refresh(&self, refresh_token: &str) -> Result<TokenPair, ExousiaError>;
+    async fn logout(&self, refresh_token: &str) -> Result<(), ExousiaError>;
+    async fn validate_bearer(&self, token: &str) -> Result<AuthenticatedUser, ExousiaError>;
+    async fn validate_api_key(&self, key: &str) -> Result<AuthenticatedUser, ExousiaError>;
+    async fn create_user(&self, req: CreateUserRequest) -> Result<User, ExousiaError>;
+    async fn create_api_key(&self, user_id: UserId, label: &str) -> Result<String, ExousiaError>;
+    async fn revoke_api_key(&self, key_id: ApiKeyId) -> Result<(), ExousiaError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use harmonia_db::{DbPools, migrate::MIGRATOR};
+    use horismos::ExousiaConfig;
+    use jsonwebtoken::{Algorithm, EncodingKey, Header};
+    use rand::RngCore;
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::{
+        AuthService,
+        jwt::Claims,
+        service::ExousiaServiceImpl,
+        user::{CreateUserRequest, UserRole},
+    };
+
+    async fn setup() -> Arc<ExousiaServiceImpl> {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let pools = Arc::new(DbPools {
+            read: pool.clone(),
+            write: pool,
+        });
+        let config = ExousiaConfig {
+            access_token_ttl_secs: 900,
+            refresh_token_ttl_days: 30,
+            jwt_secret: "test-secret-that-is-long-enough-for-hs256".to_string(),
+        };
+        Arc::new(ExousiaServiceImpl::new(pools, config))
+    }
+
+    async fn create_test_user(service: &Arc<ExousiaServiceImpl>) -> User {
+        service
+            .create_user(CreateUserRequest {
+                username: "testuser".to_string(),
+                display_name: "Test User".to_string(),
+                password: "password123".to_string(),
+                role: UserRole::Member,
+            })
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn login_flow_returns_valid_tokens() {
+        let service = setup().await;
+        create_test_user(&service).await;
+        let pair = service.login("testuser", "password123").await.unwrap();
+        assert!(!pair.access_token.is_empty());
+        assert!(!pair.refresh_token.is_empty());
+        let authenticated = service.validate_bearer(&pair.access_token).await.unwrap();
+        assert_eq!(authenticated.role, UserRole::Member);
+    }
+
+    #[tokio::test]
+    async fn login_wrong_password_fails() {
+        let service = setup().await;
+        create_test_user(&service).await;
+        let err = service.login("testuser", "wrong").await.unwrap_err();
+        assert!(matches!(err, ExousiaError::InvalidCredentials { .. }));
+    }
+
+    #[tokio::test]
+    async fn login_unknown_user_fails() {
+        let service = setup().await;
+        let err = service.login("nobody", "password").await.unwrap_err();
+        assert!(matches!(err, ExousiaError::InvalidCredentials { .. }));
+    }
+
+    #[tokio::test]
+    async fn refresh_flow_rotates_token() {
+        let service = setup().await;
+        create_test_user(&service).await;
+        let pair1 = service.login("testuser", "password123").await.unwrap();
+        let pair2 = service.refresh(&pair1.refresh_token).await.unwrap();
+        assert!(!pair2.access_token.is_empty());
+        assert_ne!(pair1.refresh_token, pair2.refresh_token);
+        let err = service.refresh(&pair1.refresh_token).await.unwrap_err();
+        assert!(matches!(err, ExousiaError::TokenInvalid { .. }));
+    }
+
+    #[tokio::test]
+    async fn logout_revokes_refresh_token() {
+        let service = setup().await;
+        create_test_user(&service).await;
+        let pair = service.login("testuser", "password123").await.unwrap();
+        service.logout(&pair.refresh_token).await.unwrap();
+        let err = service.refresh(&pair.refresh_token).await.unwrap_err();
+        assert!(matches!(err, ExousiaError::TokenInvalid { .. }));
+    }
+
+    #[tokio::test]
+    async fn expired_token_rejected() {
+        let service = setup().await;
+        let user = create_test_user(&service).await;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let claims = Claims {
+            sub: user.id.into_uuid().to_string(),
+            iss: "harmonia".to_string(),
+            aud: "harmonia-clients".to_string(),
+            exp: now - 100,
+            iat: now - 1000,
+            jti: {
+                let mut rng = rand::rng();
+                let mut bytes = [0u8; 16];
+                rng.fill_bytes(&mut bytes);
+                bytes.iter().fold(String::new(), |mut s, b| {
+                    use std::fmt::Write;
+                    write!(s, "{b:02x}").unwrap();
+                    s
+                })
+            },
+            role: "member".to_string(),
+            display_name: "Test User".to_string(),
+        };
+        let expired_token = jsonwebtoken::encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(b"test-secret-that-is-long-enough-for-hs256"),
+        )
+        .unwrap();
+        let err = service.validate_bearer(&expired_token).await.unwrap_err();
+        assert!(matches!(err, ExousiaError::TokenExpired { .. }));
+    }
+
+    #[tokio::test]
+    async fn api_key_generate_validate_revoke() {
+        let service = setup().await;
+        let user = create_test_user(&service).await;
+        let full_key = service.create_api_key(user.id, "test key").await.unwrap();
+        let authenticated = service.validate_api_key(&full_key).await.unwrap();
+        assert_eq!(authenticated.role, UserRole::Member);
+        let parts: Vec<&str> = full_key.split('_').collect();
+        let short_token = parts[1];
+        let db_key =
+            harmonia_db::repo::user::get_api_key_by_short_token(&service.pools().read, short_token)
+                .await
+                .unwrap()
+                .unwrap();
+        let key_id = ApiKeyId::from_uuid(uuid::Uuid::from_slice(&db_key.id).unwrap());
+        service.revoke_api_key(key_id).await.unwrap();
+        let err = service.validate_api_key(&full_key).await.unwrap_err();
+        assert!(matches!(err, ExousiaError::ApiKeyRevoked { .. }));
+    }
+
+    #[tokio::test]
+    async fn create_user_persists() {
+        let service = setup().await;
+        let user = create_test_user(&service).await;
+        assert_eq!(user.username, "testuser");
+        assert_eq!(user.role, UserRole::Member);
+        assert!(user.is_active);
+    }
+}

--- a/crates/exousia/src/middleware.rs
+++ b/crates/exousia/src/middleware.rs
@@ -1,0 +1,337 @@
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{FromRef, FromRequestParts},
+    http::{StatusCode, request::Parts},
+    response::{IntoResponse, Response},
+};
+use rand::RngCore;
+use serde_json::json;
+
+use crate::{AuthService, service::ExousiaServiceImpl, user::UserRole};
+use harmonia_common::ids::UserId;
+
+fn correlation_id() -> String {
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 16];
+    rng.fill_bytes(&mut bytes);
+    bytes.iter().fold(String::with_capacity(32), |mut s, b| {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").unwrap();
+        s
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMethod {
+    Bearer,
+    ApiKey,
+    QueryParam,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    pub user_id: UserId,
+    pub role: UserRole,
+    pub auth_method: AuthMethod,
+}
+
+pub struct RequireAdmin(pub AuthenticatedUser);
+
+fn unauthorized(message: &str) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": message,
+            "code": "UNAUTHORIZED",
+            "correlation_id": correlation_id()
+        })),
+    )
+        .into_response()
+}
+
+fn forbidden(message: &str) -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({
+            "error": message,
+            "code": "FORBIDDEN",
+            "correlation_id": correlation_id()
+        })),
+    )
+        .into_response()
+}
+
+fn extract_bearer(parts: &Parts) -> Option<String> {
+    parts
+        .headers
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|s| s.to_string())
+}
+
+fn extract_api_key_header(parts: &Parts) -> Option<String> {
+    parts
+        .headers
+        .get("X-Api-Key")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+}
+
+fn extract_query_token(parts: &Parts) -> Option<String> {
+    parts.uri.query().and_then(|q| {
+        q.split('&')
+            .find_map(|pair| pair.strip_prefix("token=").map(|v| v.to_string()))
+    })
+}
+
+impl<S> FromRequestParts<S> for AuthenticatedUser
+where
+    S: Send + Sync,
+    Arc<ExousiaServiceImpl>: FromRef<S>,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let service = Arc::<ExousiaServiceImpl>::from_ref(state);
+
+        if let Some(token) = extract_bearer(parts) {
+            return service
+                .validate_bearer(&token)
+                .await
+                .map_err(|_| unauthorized("invalid or expired bearer token"));
+        }
+
+        if let Some(key) = extract_api_key_header(parts) {
+            return service
+                .validate_api_key(&key)
+                .await
+                .map_err(|_| unauthorized("invalid or revoked API key"));
+        }
+
+        if let Some(token) = extract_query_token(parts) {
+            return service
+                .validate_bearer(&token)
+                .await
+                .map(|mut u| {
+                    u.auth_method = AuthMethod::QueryParam;
+                    u
+                })
+                .map_err(|_| unauthorized("invalid or expired token"));
+        }
+
+        Err(unauthorized("authentication required"))
+    }
+}
+
+impl<S> FromRequestParts<S> for RequireAdmin
+where
+    S: Send + Sync,
+    Arc<ExousiaServiceImpl>: FromRef<S>,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let user = AuthenticatedUser::from_request_parts(parts, state).await?;
+        if user.role != UserRole::Admin {
+            return Err(forbidden("admin access required"));
+        }
+        Ok(RequireAdmin(user))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AuthService, service::ExousiaServiceImpl, user::CreateUserRequest};
+    use axum::{Router, body::Body, routing::get};
+    use harmonia_db::{DbPools, migrate::MIGRATOR};
+    use horismos::ExousiaConfig;
+    use http::{Request, StatusCode};
+    use sqlx::SqlitePool;
+    use tower::ServiceExt;
+
+    async fn setup() -> Arc<ExousiaServiceImpl> {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let pools = Arc::new(DbPools {
+            read: pool.clone(),
+            write: pool,
+        });
+        let config = ExousiaConfig {
+            access_token_ttl_secs: 900,
+            refresh_token_ttl_days: 30,
+            jwt_secret: "test-secret-that-is-long-enough-for-hs256".to_string(),
+        };
+        Arc::new(ExousiaServiceImpl::new(pools, config))
+    }
+
+    async fn make_user_and_token(
+        service: &Arc<ExousiaServiceImpl>,
+        username: &str,
+        role: crate::user::UserRole,
+    ) -> (crate::user::User, String) {
+        let user = service
+            .create_user(CreateUserRequest {
+                username: username.to_string(),
+                display_name: username.to_string(),
+                password: "password123".to_string(),
+                role,
+            })
+            .await
+            .unwrap();
+        let pair = service.login(username, "password123").await.unwrap();
+        (user, pair.access_token)
+    }
+
+    async fn handler_ok(_user: AuthenticatedUser) -> StatusCode {
+        StatusCode::OK
+    }
+
+    async fn handler_admin(_admin: RequireAdmin) -> StatusCode {
+        StatusCode::OK
+    }
+
+    fn app(service: Arc<ExousiaServiceImpl>) -> Router {
+        Router::new()
+            .route("/auth", get(handler_ok))
+            .route("/admin", get(handler_admin))
+            .with_state(service)
+    }
+
+    #[tokio::test]
+    async fn bearer_token_produces_authenticated_user() {
+        let service = setup().await;
+        let (_, token) = make_user_and_token(&service, "alice", UserRole::Member).await;
+        let response = app(service)
+            .oneshot(
+                Request::builder()
+                    .uri("/auth")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn api_key_header_produces_authenticated_user() {
+        let service = setup().await;
+        let (user, _) = make_user_and_token(&service, "bob", UserRole::Member).await;
+        let key = service.create_api_key(user.id, "test key").await.unwrap();
+        let response = app(service)
+            .oneshot(
+                Request::builder()
+                    .uri("/auth")
+                    .header("X-Api-Key", key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn query_param_token_produces_authenticated_user() {
+        let service = setup().await;
+        let (_, token) = make_user_and_token(&service, "carol", UserRole::Member).await;
+        let response = app(service)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/auth?token={token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn no_auth_returns_401() {
+        let service = setup().await;
+        let response = app(service)
+            .oneshot(Request::builder().uri("/auth").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn require_admin_passes_for_admin() {
+        let service = setup().await;
+        let (_, token) = make_user_and_token(&service, "dave", UserRole::Admin).await;
+        let response = app(service)
+            .oneshot(
+                Request::builder()
+                    .uri("/admin")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn require_admin_returns_403_for_member() {
+        let service = setup().await;
+        let (_, token) = make_user_and_token(&service, "eve", UserRole::Member).await;
+        let response = app(service)
+            .oneshot(
+                Request::builder()
+                    .uri("/admin")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn bearer_takes_priority_over_api_key() {
+        let service = setup().await;
+        let (user, token) = make_user_and_token(&service, "frank", UserRole::Member).await;
+        let key = service
+            .create_api_key(user.id, "priority test")
+            .await
+            .unwrap();
+        let response = app(service)
+            .oneshot(
+                Request::builder()
+                    .uri("/auth")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("X-Api-Key", key)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn no_auth_response_has_structured_body() {
+        let service = setup().await;
+        let response = app(service)
+            .oneshot(Request::builder().uri("/auth").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.get("error").is_some());
+        assert_eq!(json["code"], "UNAUTHORIZED");
+        assert!(json.get("correlation_id").is_some());
+    }
+}

--- a/crates/exousia/src/password.rs
+++ b/crates/exousia/src/password.rs
@@ -1,0 +1,52 @@
+use argon2::{
+    Argon2,
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+};
+use rand_core::OsRng;
+
+use crate::error::ExousiaError;
+
+pub fn hash_password(password: &str) -> Result<String, ExousiaError> {
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| ExousiaError::PasswordHash {
+            error: e.to_string(),
+            location: snafu::location!(),
+        })
+}
+
+pub fn verify_password(password: &str, hash: &str) -> Result<bool, ExousiaError> {
+    let parsed = PasswordHash::new(hash).map_err(|e| ExousiaError::PasswordHash {
+        error: e.to_string(),
+        location: snafu::location!(),
+    })?;
+    Ok(Argon2::default()
+        .verify_password(password.as_bytes(), &parsed)
+        .is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_and_verify_correct_password() {
+        let hash = hash_password("correct-horse-battery-staple").unwrap();
+        assert!(verify_password("correct-horse-battery-staple", &hash).unwrap());
+    }
+
+    #[test]
+    fn wrong_password_fails_verification() {
+        let hash = hash_password("correct-horse-battery-staple").unwrap();
+        assert!(!verify_password("wrong-password", &hash).unwrap());
+    }
+
+    #[test]
+    fn hashes_are_unique_for_same_password() {
+        let h1 = hash_password("password").unwrap();
+        let h2 = hash_password("password").unwrap();
+        assert_ne!(h1, h2); // different salts
+    }
+}

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -1,0 +1,398 @@
+use std::sync::Arc;
+
+use harmonia_common::ids::{ApiKeyId, UserId};
+use harmonia_db::{DbPools, repo::user as db};
+use horismos::ExousiaConfig;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use snafu::ResultExt;
+
+use crate::{
+    AuthService, TokenPair, api_key,
+    error::{
+        ApiKeyRevokedSnafu, DatabaseSnafu, ExousiaError, InvalidCredentialsSnafu, UserInactiveSnafu,
+    },
+    jwt,
+    middleware::{AuthMethod, AuthenticatedUser},
+    password,
+    user::{CreateUserRequest, User, UserRole},
+};
+
+pub struct ExousiaServiceImpl {
+    pools: Arc<DbPools>,
+    config: ExousiaConfig,
+}
+
+impl ExousiaServiceImpl {
+    pub fn new(pools: Arc<DbPools>, config: ExousiaConfig) -> Self {
+        Self { pools, config }
+    }
+
+    pub fn pools(&self) -> &DbPools {
+        &self.pools
+    }
+}
+
+fn sha256_hex(input: &[u8]) -> String {
+    let result = Sha256::digest(input);
+    result.iter().fold(String::with_capacity(64), |mut s, b| {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").unwrap();
+        s
+    })
+}
+
+fn generate_refresh_token() -> (String, String) {
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 64];
+    rng.fill_bytes(&mut bytes);
+    let token: String = bytes.iter().fold(String::with_capacity(128), |mut s, b| {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").unwrap();
+        s
+    });
+    let hash = sha256_hex(token.as_bytes());
+    (token, hash)
+}
+
+fn now_iso() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock before epoch")
+        .as_secs();
+    let (y, mo, d, h, mi, s) = seconds_to_datetime(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+fn seconds_to_datetime(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let s = secs % 60;
+    let mins = secs / 60;
+    let mi = mins % 60;
+    let hours = mins / 60;
+    let h = hours % 24;
+    let days = hours / 24;
+    let (y, mo, d) = days_to_ymd(days);
+    (y, mo, d, h, mi, s)
+}
+
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    let mut y = 1970u64;
+    let mut remaining = days;
+    loop {
+        let leap = is_leap(y);
+        let days_in_year = if leap { 366 } else { 365 };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        y += 1;
+    }
+    let leap = is_leap(y);
+    let month_days: [u64; 12] = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut mo = 1u64;
+    for &md in &month_days {
+        if remaining < md {
+            break;
+        }
+        remaining -= md;
+        mo += 1;
+    }
+    (y, mo, remaining + 1)
+}
+
+fn is_leap(year: u64) -> bool {
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+}
+
+fn add_days_to_iso_now(days: u64) -> String {
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock before epoch")
+        .as_secs();
+    let future_secs = now_secs + days * 86400;
+    let (y, mo, d, h, mi, s) = seconds_to_datetime(future_secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+fn user_id_to_bytes(id: UserId) -> Vec<u8> {
+    id.as_bytes().to_vec()
+}
+
+fn bytes_to_user_id(bytes: &[u8]) -> Option<UserId> {
+    uuid::Uuid::from_slice(bytes).ok().map(UserId::from_uuid)
+}
+
+fn db_user_to_domain(u: db::User) -> Option<User> {
+    let id = bytes_to_user_id(&u.id)?;
+    let role = UserRole::parse(&u.role)?;
+    Some(User {
+        id,
+        username: u.username,
+        display_name: u.display_name,
+        password_hash: u.password_hash,
+        role,
+        is_active: u.is_active != 0,
+        created_at: u.created_at,
+        last_login_at: u.last_login_at,
+    })
+}
+
+impl AuthService for ExousiaServiceImpl {
+    async fn login(&self, username: &str, password: &str) -> Result<TokenPair, ExousiaError> {
+        let row = db::get_user_by_username(&self.pools.read, username)
+            .await
+            .context(DatabaseSnafu)?;
+        let row = row.ok_or_else(|| ExousiaError::InvalidCredentials {
+            location: snafu::location!(),
+        })?;
+        let user = db_user_to_domain(row).ok_or_else(|| ExousiaError::InvalidCredentials {
+            location: snafu::location!(),
+        })?;
+        if !user.is_active {
+            return Err(UserInactiveSnafu.build());
+        }
+        if !password::verify_password(password, &user.password_hash)? {
+            return Err(InvalidCredentialsSnafu.build());
+        }
+        let access_token = jwt::create_access_token(
+            &user,
+            self.config.jwt_secret.as_bytes(),
+            self.config.access_token_ttl_secs,
+        )?;
+        let (refresh_token, token_hash) = generate_refresh_token();
+        let token_id = uuid::Uuid::now_v7().as_bytes().to_vec();
+        let now = now_iso();
+        let expires_at = add_days_to_iso_now(self.config.refresh_token_ttl_days);
+        let refresh_row = db::RefreshToken {
+            id: token_id,
+            user_id: user_id_to_bytes(user.id),
+            token_hash,
+            created_at: now.clone(),
+            expires_at,
+            revoked: 0,
+        };
+        db::insert_refresh_token(&self.pools.write, &refresh_row)
+            .await
+            .context(DatabaseSnafu)?;
+        db::record_login(&self.pools.write, &user_id_to_bytes(user.id), &now)
+            .await
+            .context(DatabaseSnafu)?;
+        Ok(TokenPair {
+            access_token,
+            refresh_token,
+        })
+    }
+
+    async fn refresh(&self, refresh_token: &str) -> Result<TokenPair, ExousiaError> {
+        let token_hash = sha256_hex(refresh_token.as_bytes());
+        let row = db::get_refresh_token_by_hash(&self.pools.read, &token_hash)
+            .await
+            .context(DatabaseSnafu)?;
+        let row = row.ok_or_else(|| ExousiaError::TokenInvalid {
+            error: "refresh token not found".to_string(),
+            location: snafu::location!(),
+        })?;
+        if row.revoked != 0 {
+            return Err(ExousiaError::TokenInvalid {
+                error: "refresh token revoked".to_string(),
+                location: snafu::location!(),
+            });
+        }
+        let now = now_iso();
+        if row.expires_at < now {
+            return Err(ExousiaError::TokenExpired {
+                location: snafu::location!(),
+            });
+        }
+        let user_row = db::get_user(&self.pools.read, &row.user_id)
+            .await
+            .context(DatabaseSnafu)?
+            .ok_or_else(|| ExousiaError::TokenInvalid {
+                error: "user not found for refresh token".to_string(),
+                location: snafu::location!(),
+            })?;
+        let user = db_user_to_domain(user_row).ok_or_else(|| ExousiaError::TokenInvalid {
+            error: "invalid user data".to_string(),
+            location: snafu::location!(),
+        })?;
+        if !user.is_active {
+            return Err(UserInactiveSnafu.build());
+        }
+        db::revoke_refresh_token(&self.pools.write, &row.id)
+            .await
+            .context(DatabaseSnafu)?;
+        let access_token = jwt::create_access_token(
+            &user,
+            self.config.jwt_secret.as_bytes(),
+            self.config.access_token_ttl_secs,
+        )?;
+        let (new_refresh_token, new_hash) = generate_refresh_token();
+        let token_id = uuid::Uuid::now_v7().as_bytes().to_vec();
+        let new_row = db::RefreshToken {
+            id: token_id,
+            user_id: row.user_id,
+            token_hash: new_hash,
+            created_at: now_iso(),
+            expires_at: add_days_to_iso_now(self.config.refresh_token_ttl_days),
+            revoked: 0,
+        };
+        db::insert_refresh_token(&self.pools.write, &new_row)
+            .await
+            .context(DatabaseSnafu)?;
+        Ok(TokenPair {
+            access_token,
+            refresh_token: new_refresh_token,
+        })
+    }
+
+    async fn logout(&self, refresh_token: &str) -> Result<(), ExousiaError> {
+        let token_hash = sha256_hex(refresh_token.as_bytes());
+        let row = db::get_refresh_token_by_hash(&self.pools.read, &token_hash)
+            .await
+            .context(DatabaseSnafu)?;
+        if let Some(row) = row {
+            db::revoke_refresh_token(&self.pools.write, &row.id)
+                .await
+                .context(DatabaseSnafu)?;
+        }
+        Ok(())
+    }
+
+    async fn validate_bearer(&self, token: &str) -> Result<AuthenticatedUser, ExousiaError> {
+        let claims = jwt::validate_token(token, self.config.jwt_secret.as_bytes())?;
+        let uuid = uuid::Uuid::parse_str(&claims.sub).map_err(|_| ExousiaError::TokenInvalid {
+            error: "invalid sub claim".to_string(),
+            location: snafu::location!(),
+        })?;
+        let user_id = UserId::from_uuid(uuid);
+        let role = UserRole::parse(&claims.role).ok_or_else(|| ExousiaError::TokenInvalid {
+            error: "invalid role claim".to_string(),
+            location: snafu::location!(),
+        })?;
+        Ok(AuthenticatedUser {
+            user_id,
+            role,
+            auth_method: AuthMethod::Bearer,
+        })
+    }
+
+    async fn validate_api_key(&self, key: &str) -> Result<AuthenticatedUser, ExousiaError> {
+        let parts: Vec<&str> = key.split('_').collect();
+        let short_token = match parts.as_slice() {
+            ["hmn", short, _long] => *short,
+            ["hmn", "rnd", short, _long] => *short,
+            _ => {
+                return Err(ExousiaError::TokenInvalid {
+                    error: "invalid API key format".to_string(),
+                    location: snafu::location!(),
+                });
+            }
+        };
+        let row = db::get_api_key_by_short_token(&self.pools.read, short_token)
+            .await
+            .context(DatabaseSnafu)?
+            .ok_or_else(|| ExousiaError::TokenInvalid {
+                error: "API key not found".to_string(),
+                location: snafu::location!(),
+            })?;
+        if row.revoked != 0 {
+            return Err(ApiKeyRevokedSnafu.build());
+        }
+        if !api_key::validate_api_key(key, &row.long_token_hash) {
+            return Err(ExousiaError::TokenInvalid {
+                error: "API key validation failed".to_string(),
+                location: snafu::location!(),
+            });
+        }
+        let user_row = db::get_user(&self.pools.read, &row.user_id)
+            .await
+            .context(DatabaseSnafu)?
+            .ok_or_else(|| ExousiaError::TokenInvalid {
+                error: "user not found for API key".to_string(),
+                location: snafu::location!(),
+            })?;
+        let user = db_user_to_domain(user_row).ok_or_else(|| ExousiaError::TokenInvalid {
+            error: "invalid user data".to_string(),
+            location: snafu::location!(),
+        })?;
+        if !user.is_active {
+            return Err(UserInactiveSnafu.build());
+        }
+        db::update_api_key_last_used(&self.pools.write, &row.id, &now_iso())
+            .await
+            .context(DatabaseSnafu)?;
+        Ok(AuthenticatedUser {
+            user_id: user.id,
+            role: user.role,
+            auth_method: AuthMethod::ApiKey,
+        })
+    }
+
+    async fn create_user(&self, req: CreateUserRequest) -> Result<User, ExousiaError> {
+        let id = UserId::new();
+        let hash = password::hash_password(&req.password)?;
+        let now = now_iso();
+        let row = db::User {
+            id: user_id_to_bytes(id),
+            username: req.username.clone(),
+            display_name: req.display_name.clone(),
+            password_hash: hash.clone(),
+            role: req.role.as_str().to_string(),
+            is_active: 1,
+            created_at: now.clone(),
+            last_login_at: None,
+        };
+        db::insert_user(&self.pools.write, &row)
+            .await
+            .context(DatabaseSnafu)?;
+        Ok(User {
+            id,
+            username: req.username,
+            display_name: req.display_name,
+            password_hash: hash,
+            role: req.role,
+            is_active: true,
+            created_at: now,
+            last_login_at: None,
+        })
+    }
+
+    async fn create_api_key(&self, user_id: UserId, label: &str) -> Result<String, ExousiaError> {
+        let (full_key, record) = api_key::generate_api_key();
+        let now = now_iso();
+        let row = db::ApiKey {
+            id: record.id.as_bytes().to_vec(),
+            user_id: user_id_to_bytes(user_id),
+            short_token: record.short_token,
+            long_token_hash: record.long_token_hash,
+            label: label.to_string(),
+            created_at: now,
+            last_used_at: None,
+            revoked: 0,
+        };
+        db::insert_api_key(&self.pools.write, &row)
+            .await
+            .context(DatabaseSnafu)?;
+        Ok(full_key)
+    }
+
+    async fn revoke_api_key(&self, key_id: ApiKeyId) -> Result<(), ExousiaError> {
+        db::revoke_api_key(&self.pools.write, key_id.as_bytes())
+            .await
+            .context(DatabaseSnafu)?;
+        Ok(())
+    }
+}

--- a/crates/exousia/src/user.rs
+++ b/crates/exousia/src/user.rs
@@ -1,0 +1,60 @@
+use harmonia_common::ids::{ApiKeyId, UserId};
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum UserRole {
+    #[serde(rename = "admin")]
+    Admin,
+    #[serde(rename = "member")]
+    Member,
+}
+
+impl UserRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UserRole::Admin => "admin",
+            UserRole::Member => "member",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "admin" => Some(UserRole::Admin),
+            "member" => Some(UserRole::Member),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct User {
+    pub id: UserId,
+    pub username: String,
+    pub display_name: String,
+    pub password_hash: String,
+    pub role: UserRole,
+    pub is_active: bool,
+    pub created_at: String,
+    pub last_login_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApiKey {
+    pub id: ApiKeyId,
+    pub user_id: UserId,
+    pub short_token: String,
+    pub long_token_hash: String,
+    pub label: String,
+    pub created_at: String,
+    pub last_used_at: Option<String>,
+    pub revoked: bool,
+}
+
+#[derive(Debug)]
+pub struct CreateUserRequest {
+    pub username: String,
+    pub display_name: String,
+    pub password: String,
+    pub role: UserRole,
+}


### PR DESCRIPTION
## Summary

- Implements `crates/exousia/` — identity, authentication, and authorization for Harmonia
- JWT access tokens (HS256, 15 min TTL) with `Claims` struct per auth.md spec
- Rotated refresh tokens (30 day, 64 random bytes stored as SHA-256 hash)
- Prefixed API keys (`hmn_{8-char-short}_{24-char-long}` format; long token stored as SHA-256 hash; renderer variant `hmn_rnd_*`)
- `ExousiaServiceImpl` implementing the `AuthService` trait — login, refresh, logout, validate_bearer, validate_api_key, create_user, create_api_key, revoke_api_key
- Axum extractors: `AuthenticatedUser` (Bearer → X-Api-Key → query param priority) and `RequireAdmin`; both `FromRequestParts` returning structured `{ error, code, correlation_id }` JSON on failure
- Error enum per snafu + GreptimeDB pattern with location tracking

## Test plan

- 29 tests, all passing
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p exousia -- -D warnings` ✓
- `cargo test -p exousia` ✓ (29/29)

Covered:
- [x] Login flow: create user → login → valid tokens
- [x] Refresh flow: old token revoked, new token works
- [x] Logout: refresh token revoked
- [x] Expired token rejected
- [x] API key: generate → validate → revoke → validation fails
- [x] API key format: correct prefix, short/long token lengths
- [x] Password hashing: hash → verify succeeds, wrong password fails
- [x] Extractor: Bearer header, X-Api-Key header, query param token → AuthenticatedUser
- [x] RequireAdmin: Admin passes, Member gets 403
- [x] Priority order: Bearer takes precedence over API key
- [x] No auth headers → 401 with structured error body