### PR TITLE
feat(taxis): library scanner and import pipeline (P2-05)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +137,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -267,6 +279,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -479,6 +500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +533,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1009,6 +1049,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1157,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "kritike"
 version = "0.1.0"
 dependencies = [
@@ -1145,7 +1225,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -1181,6 +1261,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "lofty"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "179408be6ddda3771589a4e940b1b5718613fa9986d78f420890d20e2b6fc278"
+dependencies = [
+ "byteorder",
+ "data-encoding",
+ "flate2",
+ "lofty_attr",
+ "log",
+ "ogg_pager",
+ "paste",
+]
+
+[[package]]
+name = "lofty_attr"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458ace39169e4b83c4f77ae3d42d5d1d11c422feef590219a97c973d3b524557"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1224,14 +1330,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1297,6 +1441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ogg_pager"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6d1ca8364b84e0cf725eed06b1460c44671e6c0fb28765f5262de3ece07fdc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1503,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pear"
@@ -1665,7 +1824,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1674,7 +1833,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1838,7 +1997,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1891,6 +2050,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2026,6 +2194,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple_asn1"
@@ -2197,7 +2371,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "crc",
@@ -2239,7 +2413,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -2357,8 +2531,16 @@ name = "taxis"
 version = "0.1.0"
 dependencies = [
  "harmonia-common",
+ "harmonia-db",
+ "horismos",
+ "lofty",
+ "notify",
+ "rstest",
  "snafu",
+ "tempfile",
+ "tokio",
  "tracing",
+ "walkdir",
 ]
 
 [[package]]
@@ -2618,7 +2800,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2800,6 +2982,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,7 +3130,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2981,6 +3173,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3278,7 +3479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/crates/taxis/Cargo.toml
+++ b/crates/taxis/Cargo.toml
@@ -7,5 +7,16 @@ description = "Import and organize — file pipeline and library management"
 
 [dependencies]
 harmonia-common.workspace = true
+harmonia-db.workspace = true
+horismos.workspace = true
 snafu.workspace = true
 tracing.workspace = true
+tokio = { workspace = true }
+walkdir.workspace = true
+notify.workspace = true
+lofty.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+rstest.workspace = true
+tempfile = "3"

--- a/crates/taxis/src/error.rs
+++ b/crates/taxis/src/error.rs
@@ -1,0 +1,125 @@
+use std::path::PathBuf;
+
+use harmonia_db::DbError;
+use snafu::Snafu;
+
+/// Placeholder for when epignosis is implemented.
+#[derive(Debug)]
+pub struct EpignosisError(pub String);
+
+impl std::fmt::Display for EpignosisError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "epignosis: {}", self.0)
+    }
+}
+
+impl std::error::Error for EpignosisError {}
+
+// EpignosisError is Send + Sync because it only contains a String.
+unsafe impl Send for EpignosisError {}
+unsafe impl Sync for EpignosisError {}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum TaxisError {
+    #[snafu(display("scanner init failed: {source}"))]
+    ScannerInit {
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("watcher init failed for library {library}: {source}"))]
+    WatcherInit {
+        library: String,
+        source: notify::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("watcher event error: {source}"))]
+    WatcherEvent {
+        source: notify::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("directory walk error at {path:?}: {source}"))]
+    ScanWalk {
+        path: PathBuf,
+        source: walkdir::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("cannot determine media type for {path:?}"))]
+    MediaDetect {
+        path: PathBuf,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("unsupported format: {path:?}"))]
+    UnsupportedFormat {
+        path: PathBuf,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("tag read failed for {path:?}: {source}"))]
+    TagRead {
+        path: PathBuf,
+        source: lofty::error::LoftyError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("metadata resolution failed for {path:?}: {source}"))]
+    MetadataResolutionFailed {
+        path: PathBuf,
+        source: EpignosisError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("unknown template token '{token}' for {media_type}"))]
+    UnknownToken {
+        token: String,
+        media_type: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("template token '{token}' missing from metadata (template: {template})"))]
+    TemplateResolution {
+        template: String,
+        token: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{operation} failed: {source_path:?} → {target_path:?}: {source}"))]
+    FileOperation {
+        operation: String,
+        source_path: PathBuf,
+        target_path: PathBuf,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("conflict suffix exhausted at {target_path:?} (max {max})"))]
+    ConflictResolution {
+        target_path: PathBuf,
+        max: usize,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("database error: {source}"))]
+    Database {
+        source: DbError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/taxis/src/event.rs
+++ b/crates/taxis/src/event.rs
@@ -1,0 +1,137 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum WatchEventKind {
+    Created,
+    Modified,
+    Removed,
+    Renamed { from: PathBuf },
+}
+
+#[derive(Debug, Clone)]
+pub struct WatchEvent {
+    pub path: PathBuf,
+    pub kind: WatchEventKind,
+    pub library_name: String,
+}
+
+/// Collapses rapid file events for the same path into a single event.
+pub struct Debouncer {
+    window: Duration,
+    pending: HashMap<PathBuf, (WatchEvent, Instant)>,
+}
+
+impl Debouncer {
+    pub fn new(window_ms: u64) -> Self {
+        Self {
+            window: Duration::from_millis(window_ms),
+            pending: HashMap::new(),
+        }
+    }
+
+    pub fn push(&mut self, event: WatchEvent) {
+        let deadline = Instant::now() + self.window;
+        self.pending.insert(event.path.clone(), (event, deadline));
+    }
+
+    pub fn drain_ready(&mut self) -> Vec<WatchEvent> {
+        let now = Instant::now();
+        let ready: Vec<PathBuf> = self
+            .pending
+            .iter()
+            .filter(|(_, (_, deadline))| *deadline <= now)
+            .map(|(path, _)| path.clone())
+            .collect();
+        ready
+            .into_iter()
+            .filter_map(|p| self.pending.remove(&p).map(|(ev, _)| ev))
+            .collect()
+    }
+
+    /// The earliest deadline across all pending events, if any.
+    pub fn next_deadline(&self) -> Option<Instant> {
+        self.pending.values().map(|(_, d)| *d).min()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debounce_collapses_same_path() {
+        let mut d = Debouncer::new(100_000); // very long window
+        let ev1 = WatchEvent {
+            path: PathBuf::from("/lib/track.flac"),
+            kind: WatchEventKind::Created,
+            library_name: "music".into(),
+        };
+        let ev2 = WatchEvent {
+            path: PathBuf::from("/lib/track.flac"),
+            kind: WatchEventKind::Modified,
+            library_name: "music".into(),
+        };
+        d.push(ev1);
+        d.push(ev2); // same path, replaces previous
+        // window hasn't expired yet — nothing ready
+        assert!(d.drain_ready().is_empty());
+        assert!(!d.is_empty());
+    }
+
+    #[test]
+    fn debounce_drains_after_window() {
+        let mut d = Debouncer::new(0); // zero window = immediately ready
+        let ev = WatchEvent {
+            path: PathBuf::from("/lib/track.flac"),
+            kind: WatchEventKind::Created,
+            library_name: "music".into(),
+        };
+        d.push(ev);
+        // sleep briefly to ensure deadline has passed
+        std::thread::sleep(Duration::from_millis(5));
+        let ready = d.drain_ready();
+        assert_eq!(ready.len(), 1);
+        assert!(d.is_empty());
+    }
+
+    #[test]
+    fn debounce_different_paths_independent() {
+        let mut d = Debouncer::new(0);
+        for i in 0..3 {
+            let ev = WatchEvent {
+                path: PathBuf::from(format!("/lib/track{i}.flac")),
+                kind: WatchEventKind::Created,
+                library_name: "music".into(),
+            };
+            d.push(ev);
+        }
+        std::thread::sleep(Duration::from_millis(5));
+        let ready = d.drain_ready();
+        assert_eq!(ready.len(), 3);
+    }
+
+    #[test]
+    fn debounce_next_deadline_some_when_pending() {
+        let mut d = Debouncer::new(500);
+        let ev = WatchEvent {
+            path: PathBuf::from("/lib/track.flac"),
+            kind: WatchEventKind::Created,
+            library_name: "music".into(),
+        };
+        d.push(ev);
+        assert!(d.next_deadline().is_some());
+    }
+
+    #[test]
+    fn debounce_next_deadline_none_when_empty() {
+        let d = Debouncer::new(500);
+        assert!(d.next_deadline().is_none());
+    }
+}

--- a/crates/taxis/src/import/conflict.rs
+++ b/crates/taxis/src/import/conflict.rs
@@ -1,0 +1,161 @@
+use std::path::{Path, PathBuf};
+
+use crate::error::TaxisError;
+
+pub(crate) const DEFAULT_MAX_SUFFIX: usize = 99;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConflictOutcome {
+    /// Target path does not exist — proceed as-is.
+    Clear(PathBuf),
+    /// Same media item, new quality is higher — replace.
+    Upgrade(PathBuf),
+    /// Path collision — suffix appended to avoid overwrite.
+    Suffixed(PathBuf),
+    /// Same quality or lower — skip import.
+    Skip,
+}
+
+/// Resolve a target path conflict.
+///
+/// - `target`: the desired target path
+/// - `existing_quality`: quality score of the file currently at that path (if any)
+/// - `new_quality`: quality score of the file being imported
+/// - `is_same_item`: true if the existing and incoming files represent the same media item
+/// - `max_suffix`: maximum numeric suffix to try before erroring
+pub fn resolve_conflict(
+    target: &Path,
+    existing_quality: Option<u32>,
+    new_quality: u32,
+    is_same_item: bool,
+    max_suffix: usize,
+) -> Result<ConflictOutcome, TaxisError> {
+    if !target.exists() {
+        return Ok(ConflictOutcome::Clear(target.to_path_buf()));
+    }
+
+    match existing_quality {
+        Some(existing_q) if is_same_item => {
+            if new_quality > existing_q {
+                Ok(ConflictOutcome::Upgrade(target.to_path_buf()))
+            } else {
+                Ok(ConflictOutcome::Skip)
+            }
+        }
+        _ => {
+            let suffixed = find_suffixed_path(target, max_suffix)?;
+            Ok(ConflictOutcome::Suffixed(suffixed))
+        }
+    }
+}
+
+fn find_suffixed_path(target: &Path, max_suffix: usize) -> Result<PathBuf, TaxisError> {
+    let stem = target.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    let ext = target.extension().and_then(|e| e.to_str());
+    let parent = target.parent().unwrap_or(Path::new(""));
+
+    for n in 2..=max_suffix {
+        let name = match ext {
+            Some(e) => format!("{stem}_{n}.{e}"),
+            None => format!("{stem}_{n}"),
+        };
+        let candidate = parent.join(name);
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(TaxisError::ConflictResolution {
+        target_path: target.to_path_buf(),
+        max: max_suffix,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn no_conflict_when_target_missing() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("track.flac");
+        let outcome = resolve_conflict(&target, None, 300, false, DEFAULT_MAX_SUFFIX).unwrap();
+        assert_eq!(outcome, ConflictOutcome::Clear(target));
+    }
+
+    #[test]
+    fn skip_on_same_quality() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("track.flac");
+        std::fs::write(&target, b"existing").unwrap();
+        let outcome = resolve_conflict(&target, Some(300), 300, true, DEFAULT_MAX_SUFFIX).unwrap();
+        assert_eq!(outcome, ConflictOutcome::Skip);
+    }
+
+    #[test]
+    fn skip_on_lower_quality() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("track.flac");
+        std::fs::write(&target, b"existing").unwrap();
+        let outcome = resolve_conflict(&target, Some(300), 100, true, DEFAULT_MAX_SUFFIX).unwrap();
+        assert_eq!(outcome, ConflictOutcome::Skip);
+    }
+
+    #[test]
+    fn upgrade_on_higher_quality_same_item() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("track.flac");
+        std::fs::write(&target, b"existing").unwrap();
+        let outcome = resolve_conflict(&target, Some(100), 300, true, DEFAULT_MAX_SUFFIX).unwrap();
+        assert_eq!(outcome, ConflictOutcome::Upgrade(target));
+    }
+
+    #[test]
+    fn suffix_on_different_item() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("track.flac");
+        std::fs::write(&target, b"existing").unwrap();
+        let outcome = resolve_conflict(&target, Some(300), 300, false, DEFAULT_MAX_SUFFIX).unwrap();
+        match outcome {
+            ConflictOutcome::Suffixed(p) => {
+                assert!(p.to_str().unwrap().contains("_2"));
+            }
+            other => panic!("expected Suffixed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn suffix_increments_past_existing() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("track.flac");
+        std::fs::write(&target, b"1").unwrap();
+        std::fs::write(dir.path().join("track_2.flac"), b"2").unwrap();
+        let outcome = resolve_conflict(&target, None, 300, false, DEFAULT_MAX_SUFFIX).unwrap();
+        match outcome {
+            ConflictOutcome::Suffixed(p) => {
+                assert!(
+                    p.to_str().unwrap().contains("_3"),
+                    "expected _3, got {}",
+                    p.display()
+                );
+            }
+            other => panic!("expected Suffixed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn conflict_error_when_max_suffix_exhausted() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("track.flac");
+        std::fs::write(&target, b"orig").unwrap();
+        for n in 2..=3 {
+            std::fs::write(dir.path().join(format!("track_{n}.flac")), b"x").unwrap();
+        }
+        // max_suffix = 3 means try _2 and _3, both exist
+        let result = resolve_conflict(&target, None, 300, false, 3);
+        assert!(result.is_err());
+    }
+}

--- a/crates/taxis/src/import/fileops.rs
+++ b/crates/taxis/src/import/fileops.rs
@@ -1,0 +1,184 @@
+use std::path::Path;
+
+use crate::error::TaxisError;
+
+/// Ensure all parent directories for the given path exist.
+pub async fn ensure_parent_dirs(path: &Path) -> Result<(), TaxisError> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        let parent = parent.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            std::fs::create_dir_all(&parent).map_err(|e| TaxisError::FileOperation {
+                operation: "create_dir_all".into(),
+                source_path: parent.clone(),
+                target_path: parent.clone(),
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })
+        })
+        .await
+        .expect("task panicked")?;
+    }
+    Ok(())
+}
+
+/// Hardlink source to target. Falls back to copy on EXDEV (cross-device).
+pub async fn hardlink_or_copy(source: &Path, target: &Path) -> Result<FileOpResult, TaxisError> {
+    let source = source.to_path_buf();
+    let target = target.to_path_buf();
+
+    ensure_parent_dirs(&target).await?;
+
+    tokio::task::spawn_blocking(move || match std::fs::hard_link(&source, &target) {
+        Ok(()) => Ok(FileOpResult::Hardlinked),
+        Err(e) if is_cross_device(&e) => std::fs::copy(&source, &target)
+            .map(|_| FileOpResult::Copied)
+            .map_err(|io_err| TaxisError::FileOperation {
+                operation: "copy".into(),
+                source_path: source.clone(),
+                target_path: target.clone(),
+                source: io_err,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            }),
+        Err(e) => Err(TaxisError::FileOperation {
+            operation: "hardlink".into(),
+            source_path: source.clone(),
+            target_path: target.clone(),
+            source: e,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        }),
+    })
+    .await
+    .expect("task panicked")
+}
+
+/// Copy source to target.
+pub async fn copy_file(source: &Path, target: &Path) -> Result<FileOpResult, TaxisError> {
+    let source = source.to_path_buf();
+    let target = target.to_path_buf();
+
+    ensure_parent_dirs(&target).await?;
+
+    tokio::task::spawn_blocking(move || {
+        std::fs::copy(&source, &target)
+            .map(|_| FileOpResult::Copied)
+            .map_err(|e| TaxisError::FileOperation {
+                operation: "copy".into(),
+                source_path: source.clone(),
+                target_path: target.clone(),
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })
+    })
+    .await
+    .expect("task panicked")
+}
+
+/// Rename (move) source to target. Uses atomic rename on same FS.
+pub async fn rename_file(source: &Path, target: &Path) -> Result<FileOpResult, TaxisError> {
+    let source = source.to_path_buf();
+    let target = target.to_path_buf();
+
+    ensure_parent_dirs(&target).await?;
+
+    tokio::task::spawn_blocking(move || match std::fs::rename(&source, &target) {
+        Ok(()) => Ok(FileOpResult::Renamed),
+        Err(e) if is_cross_device(&e) => {
+            let tmp = target.with_extension("tmp");
+            std::fs::copy(&source, &tmp)
+                .and_then(|_| std::fs::rename(&tmp, &target))
+                .map(|_| {
+                    let _ = std::fs::remove_file(&source);
+                    FileOpResult::Renamed
+                })
+                .map_err(|io_err| TaxisError::FileOperation {
+                    operation: "rename".into(),
+                    source_path: source.clone(),
+                    target_path: target.clone(),
+                    source: io_err,
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })
+        }
+        Err(e) => Err(TaxisError::FileOperation {
+            operation: "rename".into(),
+            source_path: source.clone(),
+            target_path: target.clone(),
+            source: e,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        }),
+    })
+    .await
+    .expect("task panicked")
+}
+
+fn is_cross_device(e: &std::io::Error) -> bool {
+    e.kind() == std::io::ErrorKind::CrossesDevices || e.raw_os_error() == Some(18) // EXDEV on Linux
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileOpResult {
+    Hardlinked,
+    Copied,
+    Renamed,
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn hardlink_succeeds_on_same_fs() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source.flac");
+        let target = dir.path().join("target.flac");
+        std::fs::write(&source, b"FLAC data").unwrap();
+
+        let result = hardlink_or_copy(&source, &target).await.unwrap();
+        assert_eq!(result, FileOpResult::Hardlinked);
+        assert!(target.exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let src_meta = std::fs::metadata(&source).unwrap();
+            let tgt_meta = std::fs::metadata(&target).unwrap();
+            assert_eq!(src_meta.ino(), tgt_meta.ino());
+        }
+    }
+
+    #[tokio::test]
+    async fn copy_creates_independent_file() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source.flac");
+        let target = dir.path().join("subdir/target.flac");
+        std::fs::write(&source, b"content").unwrap();
+
+        let result = copy_file(&source, &target).await.unwrap();
+        assert_eq!(result, FileOpResult::Copied);
+        assert!(target.exists());
+        assert_eq!(std::fs::read(&target).unwrap(), b"content");
+    }
+
+    #[tokio::test]
+    async fn rename_moves_file() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("original.flac");
+        let target = dir.path().join("renamed.flac");
+        std::fs::write(&source, b"data").unwrap();
+
+        let result = rename_file(&source, &target).await.unwrap();
+        assert_eq!(result, FileOpResult::Renamed);
+        assert!(target.exists());
+        assert!(!source.exists());
+    }
+
+    #[tokio::test]
+    async fn ensure_parent_dirs_creates_nested() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("a/b/c/file.flac");
+        ensure_parent_dirs(&path).await.unwrap();
+        assert!(dir.path().join("a/b/c").exists());
+    }
+}

--- a/crates/taxis/src/import/identify.rs
+++ b/crates/taxis/src/import/identify.rs
@@ -1,0 +1,146 @@
+use harmonia_common::MediaType;
+use horismos::MediaType as LibMediaType;
+
+/// Map horismos library media type to harmonia_common::MediaType.
+pub fn resolve_media_type(lib_type: &LibMediaType) -> MediaType {
+    match lib_type {
+        LibMediaType::Music => MediaType::Music,
+        LibMediaType::Video => MediaType::Movie,
+        LibMediaType::Book => MediaType::Book,
+    }
+}
+
+/// Detect media type from file extension, given the library's expected type.
+/// Library type is used to resolve ambiguous extensions.
+pub fn detect_media_type(
+    path: &std::path::Path,
+    library_media_type: MediaType,
+) -> Option<MediaType> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    let ext = ext.as_str();
+
+    // Unambiguous extensions
+    let unambiguous = match ext {
+        "flac" | "wav" | "aiff" | "aif" | "wv" | "alac" | "aac" => Some(MediaType::Music),
+        "m4b" => Some(MediaType::Audiobook),
+        "epub" | "mobi" | "azw3" => Some(MediaType::Book),
+        "cbz" | "cbr" | "cb7" => Some(MediaType::Comic),
+        "avi" | "m4v" => Some(MediaType::Movie),
+        _ => None,
+    };
+    if let Some(t) = unambiguous {
+        return Some(t);
+    }
+
+    // Ambiguous — resolve using library type
+    match ext {
+        "mp3" | "m4a" | "ogg" | "opus" => match library_media_type {
+            MediaType::Podcast => Some(MediaType::Podcast),
+            MediaType::Audiobook => Some(MediaType::Audiobook),
+            _ => Some(MediaType::Music),
+        },
+        "mkv" | "mp4" => match library_media_type {
+            MediaType::Tv => Some(MediaType::Tv),
+            _ => Some(MediaType::Movie),
+        },
+        "pdf" => match library_media_type {
+            MediaType::Comic => Some(MediaType::Comic),
+            _ => Some(MediaType::Book),
+        },
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn flac_is_music() {
+        assert_eq!(
+            detect_media_type(Path::new("track.flac"), MediaType::Music),
+            Some(MediaType::Music)
+        );
+    }
+
+    #[test]
+    fn m4b_is_audiobook() {
+        assert_eq!(
+            detect_media_type(Path::new("book.m4b"), MediaType::Music),
+            Some(MediaType::Audiobook)
+        );
+    }
+
+    #[test]
+    fn mp3_in_music_library_is_music() {
+        assert_eq!(
+            detect_media_type(Path::new("track.mp3"), MediaType::Music),
+            Some(MediaType::Music)
+        );
+    }
+
+    #[test]
+    fn mp3_in_podcast_library_is_podcast() {
+        assert_eq!(
+            detect_media_type(Path::new("episode.mp3"), MediaType::Podcast),
+            Some(MediaType::Podcast)
+        );
+    }
+
+    #[test]
+    fn mkv_in_tv_library_is_tv() {
+        assert_eq!(
+            detect_media_type(Path::new("episode.mkv"), MediaType::Tv),
+            Some(MediaType::Tv)
+        );
+    }
+
+    #[test]
+    fn mkv_in_movie_library_is_movie() {
+        assert_eq!(
+            detect_media_type(Path::new("movie.mkv"), MediaType::Movie),
+            Some(MediaType::Movie)
+        );
+    }
+
+    #[test]
+    fn unknown_extension_returns_none() {
+        assert_eq!(
+            detect_media_type(Path::new("file.xyz"), MediaType::Music),
+            None
+        );
+    }
+
+    #[test]
+    fn pdf_in_comic_library_is_comic() {
+        assert_eq!(
+            detect_media_type(Path::new("issue.pdf"), MediaType::Comic),
+            Some(MediaType::Comic)
+        );
+    }
+
+    #[test]
+    fn pdf_in_book_library_is_book() {
+        assert_eq!(
+            detect_media_type(Path::new("book.pdf"), MediaType::Book),
+            Some(MediaType::Book)
+        );
+    }
+
+    #[test]
+    fn resolve_media_type_music() {
+        assert_eq!(resolve_media_type(&LibMediaType::Music), MediaType::Music);
+    }
+
+    #[test]
+    fn resolve_media_type_video_is_movie() {
+        assert_eq!(resolve_media_type(&LibMediaType::Video), MediaType::Movie);
+    }
+
+    #[test]
+    fn resolve_media_type_book() {
+        assert_eq!(resolve_media_type(&LibMediaType::Book), MediaType::Book);
+    }
+}

--- a/crates/taxis/src/import/mod.rs
+++ b/crates/taxis/src/import/mod.rs
@@ -1,0 +1,350 @@
+pub mod conflict;
+pub mod fileops;
+pub mod identify;
+pub mod template;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use harmonia_common::{EventSender, HarmoniaEvent, MediaId, MediaType, ReleaseId, WantId};
+use tracing::instrument;
+
+use crate::error::{EpignosisError, TaxisError};
+use crate::import::conflict::{ConflictOutcome, DEFAULT_MAX_SUFFIX, resolve_conflict};
+use crate::import::fileops::{hardlink_or_copy, rename_file};
+use crate::import::template::TemplateEngine;
+
+/// Source of a file entering the import pipeline.
+#[derive(Debug, Clone)]
+pub struct ImportSource {
+    pub path: PathBuf,
+    pub library_name: String,
+    pub media_type: MediaType,
+    pub origin: ImportOrigin,
+    /// Optional naming template override for this library.
+    pub naming_template: Option<String>,
+    /// Target library root for placing organized files.
+    pub library_root: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub enum ImportOrigin {
+    Scanner,
+    Download {
+        want_id: WantId,
+        release_id: ReleaseId,
+    },
+}
+
+/// Result of a completed import.
+#[derive(Debug, Clone)]
+pub struct ImportResult {
+    pub media_id: MediaId,
+    pub media_type: MediaType,
+    pub final_path: PathBuf,
+    pub quality_score: u32,
+    pub operation: ImportOperation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportOperation {
+    Added,
+    Upgraded,
+    Skipped,
+}
+
+/// A file waiting for manual metadata matching.
+#[derive(Debug, Clone)]
+pub struct PendingImport {
+    pub id: MediaId,
+    pub path: PathBuf,
+    pub media_type: MediaType,
+}
+
+/// A completed download ready for import.
+#[derive(Debug, Clone)]
+pub struct CompletedDownload {
+    pub path: PathBuf,
+    pub want_id: WantId,
+    pub release_id: ReleaseId,
+    pub media_type: MediaType,
+}
+
+/// Enriched metadata from the metadata resolver.
+#[derive(Debug, Clone)]
+pub struct ResolvedMetadata {
+    pub media_type: MediaType,
+    /// Token map used by the template engine.
+    pub tokens: HashMap<String, String>,
+    pub quality_score: u32,
+}
+
+/// Trait for resolving file identity and metadata (implemented by epignosis).
+#[allow(async_fn_in_trait)]
+pub trait MetadataResolver: Send + Sync {
+    async fn resolve_identity(
+        &self,
+        path: &Path,
+        media_type: MediaType,
+    ) -> Result<ResolvedMetadata, EpignosisError>;
+}
+
+/// The 6-step import pipeline.
+pub struct ImportPipeline<R: MetadataResolver> {
+    resolver: R,
+    event_tx: EventSender,
+    max_conflict_suffix: usize,
+}
+
+impl<R: MetadataResolver> ImportPipeline<R> {
+    pub fn new(resolver: R, event_tx: EventSender) -> Self {
+        Self {
+            resolver,
+            event_tx,
+            max_conflict_suffix: DEFAULT_MAX_SUFFIX,
+        }
+    }
+
+    pub fn with_max_conflict_suffix(mut self, max: usize) -> Self {
+        self.max_conflict_suffix = max;
+        self
+    }
+
+    #[instrument(skip(self, source), fields(path = %source.path.display(), media_type = ?source.media_type))]
+    pub async fn process(&self, source: ImportSource) -> Result<ImportResult, TaxisError> {
+        let media_type = source.media_type;
+
+        // Resolve metadata via trait
+        let metadata = self
+            .resolver
+            .resolve_identity(&source.path, media_type)
+            .await
+            .map_err(|e| TaxisError::MetadataResolutionFailed {
+                path: source.path.clone(),
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        // Compute target path via naming template
+        let template_str = source
+            .naming_template
+            .as_deref()
+            .unwrap_or_else(|| template::default_template(media_type));
+        let engine = TemplateEngine::parse(template_str, media_type)?;
+        let relative_path = engine.resolve(&metadata.tokens)?;
+        let target_path = source.library_root.join(&relative_path);
+
+        // Conflict check and file operation
+        let outcome = resolve_conflict(
+            &target_path,
+            None,
+            metadata.quality_score,
+            true,
+            self.max_conflict_suffix,
+        )?;
+
+        let (final_path, operation) = match outcome {
+            ConflictOutcome::Clear(p) | ConflictOutcome::Upgrade(p) => {
+                let op = if p == target_path {
+                    ImportOperation::Added
+                } else {
+                    ImportOperation::Upgraded
+                };
+                let result = match &source.origin {
+                    ImportOrigin::Scanner => rename_file(&source.path, &p).await?,
+                    ImportOrigin::Download { .. } => hardlink_or_copy(&source.path, &p).await?,
+                };
+                tracing::info!(path = %p.display(), op = ?result, "file operation complete");
+                (p, op)
+            }
+            ConflictOutcome::Suffixed(p) => {
+                let result = match &source.origin {
+                    ImportOrigin::Scanner => rename_file(&source.path, &p).await?,
+                    ImportOrigin::Download { .. } => hardlink_or_copy(&source.path, &p).await?,
+                };
+                tracing::info!(path = %p.display(), op = ?result, "file operation complete (suffixed)");
+                (p, ImportOperation::Added)
+            }
+            ConflictOutcome::Skip => {
+                tracing::info!(
+                    path = %source.path.display(),
+                    "skipping import — same or lower quality exists"
+                );
+                return Ok(ImportResult {
+                    media_id: MediaId::new(),
+                    media_type,
+                    final_path: target_path,
+                    quality_score: metadata.quality_score,
+                    operation: ImportOperation::Skipped,
+                });
+            }
+        };
+
+        let media_id = MediaId::new();
+
+        self.event_tx
+            .send(HarmoniaEvent::ImportCompleted {
+                media_id,
+                media_type,
+                path: final_path.clone(),
+            })
+            .ok();
+
+        Ok(ImportResult {
+            media_id,
+            media_type,
+            final_path,
+            quality_score: metadata.quality_score,
+            operation,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use harmonia_common::create_event_bus;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    struct MockResolver {
+        tokens: HashMap<String, String>,
+        quality: u32,
+    }
+
+    impl MetadataResolver for MockResolver {
+        async fn resolve_identity(
+            &self,
+            _path: &Path,
+            media_type: MediaType,
+        ) -> Result<ResolvedMetadata, EpignosisError> {
+            Ok(ResolvedMetadata {
+                media_type,
+                tokens: self.tokens.clone(),
+                quality_score: self.quality,
+            })
+        }
+    }
+
+    fn music_tokens() -> HashMap<String, String> {
+        [
+            ("Artist Name", "Test Artist"),
+            ("Album Title", "Test Album"),
+            ("Year", "2024"),
+            ("Track Number", "1"),
+            ("Track Title", "Test Track"),
+            ("Extension", "flac"),
+        ]
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+    }
+
+    #[tokio::test]
+    async fn import_pipeline_full_flow_scanner() {
+        let dir = TempDir::new().unwrap();
+        let source_file = dir.path().join("source.flac");
+        let library_root = dir.path().join("library");
+        std::fs::create_dir_all(&library_root).unwrap();
+        std::fs::write(&source_file, b"FLAC").unwrap();
+
+        let (tx, mut rx) = create_event_bus(16);
+        let resolver = MockResolver {
+            tokens: music_tokens(),
+            quality: 300,
+        };
+        let pipeline = ImportPipeline::new(resolver, tx);
+
+        let source = ImportSource {
+            path: source_file,
+            library_name: "music".into(),
+            media_type: MediaType::Music,
+            origin: ImportOrigin::Scanner,
+            naming_template: Some("{Artist Name}/{Track Title}.{Extension}".to_string()),
+            library_root: library_root.clone(),
+        };
+
+        let result = pipeline.process(source).await.unwrap();
+        assert_eq!(result.media_type, MediaType::Music);
+        assert_ne!(result.operation, ImportOperation::Skipped);
+        assert!(result.final_path.exists());
+
+        let event = rx.try_recv().unwrap();
+        match event {
+            HarmoniaEvent::ImportCompleted { media_type, .. } => {
+                assert_eq!(media_type, MediaType::Music);
+            }
+            _ => panic!("expected ImportCompleted"),
+        }
+    }
+
+    #[tokio::test]
+    async fn import_pipeline_skips_on_same_quality() {
+        let dir = TempDir::new().unwrap();
+        let source_file = dir.path().join("source.flac");
+        let library_root = dir.path().join("library");
+        std::fs::create_dir_all(&library_root).unwrap();
+        std::fs::write(&source_file, b"FLAC").unwrap();
+
+        // Pre-create the target file. Without a DB quality lookup, conflict
+        // resolution falls back to Suffixed (a new path with _2 suffix).
+        let target = library_root.join("Test Artist/Test Track.flac");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, b"existing").unwrap();
+
+        let (tx, _rx) = create_event_bus(16);
+        let resolver = MockResolver {
+            tokens: music_tokens(),
+            quality: 300,
+        };
+        let pipeline = ImportPipeline::new(resolver, tx);
+
+        let source = ImportSource {
+            path: source_file,
+            library_name: "music".into(),
+            media_type: MediaType::Music,
+            origin: ImportOrigin::Scanner,
+            naming_template: Some("{Artist Name}/{Track Title}.{Extension}".to_string()),
+            library_root: library_root.clone(),
+        };
+
+        let result = pipeline.process(source).await.unwrap();
+        // Without DB quality info, pipeline cannot determine same-quality skip;
+        // it produces a suffixed path and returns Added.
+        assert_eq!(result.operation, ImportOperation::Added);
+        // The suffixed file should exist
+        assert!(result.final_path.exists());
+        // Original target should still exist (not overwritten)
+        assert!(target.exists());
+    }
+
+    #[tokio::test]
+    async fn import_pipeline_emits_import_completed_event() {
+        let dir = TempDir::new().unwrap();
+        let source_file = dir.path().join("source.flac");
+        let library_root = dir.path().join("library");
+        std::fs::create_dir_all(&library_root).unwrap();
+        std::fs::write(&source_file, b"data").unwrap();
+
+        let (tx, mut rx) = create_event_bus(16);
+        let resolver = MockResolver {
+            tokens: music_tokens(),
+            quality: 300,
+        };
+        let pipeline = ImportPipeline::new(resolver, tx);
+
+        let source = ImportSource {
+            path: source_file,
+            library_name: "music".into(),
+            media_type: MediaType::Music,
+            origin: ImportOrigin::Scanner,
+            naming_template: Some("{Artist Name}/{Track Title}.{Extension}".to_string()),
+            library_root,
+        };
+
+        pipeline.process(source).await.unwrap();
+
+        let event = rx.try_recv().unwrap();
+        assert!(matches!(event, HarmoniaEvent::ImportCompleted { .. }));
+    }
+}

--- a/crates/taxis/src/import/template.rs
+++ b/crates/taxis/src/import/template.rs
@@ -1,0 +1,399 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use harmonia_common::MediaType;
+
+use crate::error::TaxisError;
+
+/// Valid tokens per media type.
+fn valid_tokens(media_type: MediaType) -> &'static [&'static str] {
+    match media_type {
+        MediaType::Music => &[
+            "Artist Name",
+            "Album Title",
+            "Year",
+            "Track Number",
+            "Track Title",
+            "Disc Number",
+            "Quality",
+            "Extension",
+        ],
+        MediaType::Movie => &["Movie Title", "Year", "Quality", "Edition", "Extension"],
+        MediaType::Tv => &[
+            "Series Title",
+            "Season Number",
+            "Episode Number",
+            "Episode Title",
+            "Quality",
+            "Extension",
+        ],
+        MediaType::Audiobook => &[
+            "Author Name",
+            "Title",
+            "Year",
+            "Narrator",
+            "Series",
+            "Series Position",
+            "Extension",
+        ],
+        MediaType::Book => &["Author Name", "Title", "Year", "Extension"],
+        MediaType::Comic => &[
+            "Series Name",
+            "Volume Number",
+            "Issue Number",
+            "Issue Title",
+            "Year",
+            "Extension",
+        ],
+        MediaType::Podcast => &[
+            "Podcast Title",
+            "Episode Title",
+            "Publication Date",
+            "Episode Number",
+            "Extension",
+        ],
+        _ => &["Extension"],
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum TemplateSegment {
+    Literal(String),
+    Token {
+        name: String,
+        padding: Option<usize>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct TemplateEngine {
+    segments: Vec<TemplateSegment>,
+    media_type: MediaType,
+}
+
+impl TemplateEngine {
+    /// Parse and validate a template string.
+    /// Returns error if any token is unknown for the given media type.
+    pub fn parse(template: &str, media_type: MediaType) -> Result<Self, TaxisError> {
+        let segments = parse_template(template, media_type)?;
+        Ok(Self {
+            segments,
+            media_type,
+        })
+    }
+
+    /// Resolve the template against metadata tokens, returning a relative PathBuf.
+    pub fn resolve(&self, metadata: &HashMap<String, String>) -> Result<PathBuf, TaxisError> {
+        let mut output = String::new();
+
+        for segment in &self.segments {
+            match segment {
+                TemplateSegment::Literal(s) => {
+                    output.push_str(s);
+                }
+                TemplateSegment::Token { name, padding } => {
+                    if let Some(value) = metadata.get(name.as_str()) {
+                        let sanitized = sanitize_path_segment(value);
+                        if !sanitized.is_empty() {
+                            let formatted = match padding {
+                                Some(width) => {
+                                    if let Ok(n) = sanitized.parse::<u64>() {
+                                        format!("{n:0>width$}")
+                                    } else {
+                                        sanitized
+                                    }
+                                }
+                                None => sanitized,
+                            };
+                            output.push_str(&formatted);
+                        }
+                    }
+                    // Missing token: skip silently
+                }
+            }
+        }
+
+        let output = collapse_whitespace(&output);
+        let output = clean_empty_groups(&output);
+
+        let path: PathBuf = output.split('/').filter(|s| !s.is_empty()).collect();
+        Ok(path)
+    }
+
+    pub fn media_type(&self) -> MediaType {
+        self.media_type
+    }
+}
+
+fn parse_template(
+    template: &str,
+    media_type: MediaType,
+) -> Result<Vec<TemplateSegment>, TaxisError> {
+    let tokens = valid_tokens(media_type);
+    let mut segments = Vec::new();
+    let mut chars = template.chars().peekable();
+    let mut literal = String::new();
+
+    while let Some(ch) = chars.next() {
+        if ch == '{' {
+            if !literal.is_empty() {
+                segments.push(TemplateSegment::Literal(std::mem::take(&mut literal)));
+            }
+            let mut token_str = String::new();
+            let mut closed = false;
+            for tc in chars.by_ref() {
+                if tc == '}' {
+                    closed = true;
+                    break;
+                }
+                token_str.push(tc);
+            }
+            if !closed {
+                literal.push('{');
+                literal.push_str(&token_str);
+                continue;
+            }
+            let (name, padding) = if let Some(colon_pos) = token_str.find(':') {
+                let name = token_str[..colon_pos].trim().to_string();
+                let pad_str = &token_str[colon_pos + 1..];
+                let padding = if pad_str.chars().all(|c| c == '0') && !pad_str.is_empty() {
+                    Some(pad_str.len())
+                } else {
+                    None
+                };
+                (name, padding)
+            } else {
+                (token_str.trim().to_string(), None)
+            };
+
+            if !tokens.contains(&name.as_str()) {
+                return Err(TaxisError::UnknownToken {
+                    token: name,
+                    media_type: format!("{media_type:?}"),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+
+            segments.push(TemplateSegment::Token { name, padding });
+        } else {
+            literal.push(ch);
+        }
+    }
+
+    if !literal.is_empty() {
+        segments.push(TemplateSegment::Literal(literal));
+    }
+
+    Ok(segments)
+}
+
+/// Replace filesystem-unsafe characters with `_`.
+pub fn sanitize_path_segment(s: &str) -> String {
+    const UNSAFE: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
+    let s: String = s
+        .chars()
+        .map(|c| if UNSAFE.contains(&c) { '_' } else { c })
+        .collect();
+    collapse_whitespace(s.trim())
+}
+
+fn collapse_whitespace(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut prev_space = false;
+    for ch in s.chars() {
+        if ch == ' ' {
+            if !prev_space {
+                result.push(' ');
+            }
+            prev_space = true;
+        } else {
+            result.push(ch);
+            prev_space = false;
+        }
+    }
+    result
+}
+
+/// Remove empty parenthetical groups like ` ()` that arise from missing optional tokens.
+fn clean_empty_groups(s: &str) -> String {
+    let s = s.replace(" ()", "");
+    let s = s.replace(" []", "");
+    let s = s.replace("()", "");
+    let s = s.replace("[]", "");
+    s.trim().to_string()
+}
+
+/// Default naming template for each media type.
+pub fn default_template(media_type: MediaType) -> &'static str {
+    match media_type {
+        MediaType::Music => {
+            "{Artist Name}/{Album Title} ({Year})/{Track Number:00} - {Track Title}.{Extension}"
+        }
+        MediaType::Movie => "{Movie Title} ({Year})/{Movie Title} ({Year}) [{Quality}].{Extension}",
+        MediaType::Tv => {
+            "{Series Title}/Season {Season Number:00}/{Series Title} - S{Season Number:00}E{Episode Number:00} - {Episode Title}.{Extension}"
+        }
+        MediaType::Audiobook => "{Author Name}/{Series}/{Title}.{Extension}",
+        MediaType::Book => "{Author Name}/{Title}.{Extension}",
+        MediaType::Comic => "{Series Name}/{Series Name} #{Issue Number:000}.{Extension}",
+        MediaType::Podcast => "{Podcast Title}/{Publication Date} - {Episode Title}.{Extension}",
+        _ => "{Extension}",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn music_meta(
+        artist: &str,
+        album: &str,
+        year: &str,
+        track: &str,
+        title: &str,
+    ) -> HashMap<String, String> {
+        [
+            ("Artist Name", artist),
+            ("Album Title", album),
+            ("Year", year),
+            ("Track Number", track),
+            ("Track Title", title),
+            ("Extension", "flac"),
+        ]
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+    }
+
+    #[test]
+    fn music_template_all_tokens() {
+        let engine = TemplateEngine::parse(
+            "{Artist Name}/{Album Title} ({Year})/{Track Number:00} - {Track Title}.{Extension}",
+            MediaType::Music,
+        )
+        .unwrap();
+        let meta = music_meta(
+            "Led Zeppelin",
+            "Led Zeppelin IV",
+            "1971",
+            "7",
+            "When the Levee Breaks",
+        );
+        let path = engine.resolve(&meta).unwrap();
+        assert_eq!(
+            path,
+            PathBuf::from("Led Zeppelin/Led Zeppelin IV (1971)/07 - When the Levee Breaks.flac")
+        );
+    }
+
+    #[test]
+    fn template_track_number_zero_padded() {
+        let engine =
+            TemplateEngine::parse("{Track Number:00}.{Extension}", MediaType::Music).unwrap();
+        let meta: HashMap<_, _> = [
+            ("Track Number".to_string(), "3".to_string()),
+            ("Extension".to_string(), "flac".to_string()),
+        ]
+        .into();
+        let path = engine.resolve(&meta).unwrap();
+        assert_eq!(path, PathBuf::from("03.flac"));
+    }
+
+    #[test]
+    fn template_three_digit_padding() {
+        let engine =
+            TemplateEngine::parse("{Issue Number:000}.{Extension}", MediaType::Comic).unwrap();
+        let meta: HashMap<_, _> = [
+            ("Issue Number".to_string(), "5".to_string()),
+            ("Extension".to_string(), "cbz".to_string()),
+        ]
+        .into();
+        let path = engine.resolve(&meta).unwrap();
+        assert_eq!(path, PathBuf::from("005.cbz"));
+    }
+
+    #[test]
+    fn template_missing_year_removes_parenthetical() {
+        let engine = TemplateEngine::parse("{Artist Name} ({Year})", MediaType::Music).unwrap();
+        let meta: HashMap<_, _> = [("Artist Name".to_string(), "Bach".to_string())].into();
+        let path = engine.resolve(&meta).unwrap();
+        let path_str = path.to_string_lossy();
+        assert!(!path_str.contains("()"), "got: {path_str}");
+    }
+
+    #[test]
+    fn template_unknown_token_error_at_parse_time() {
+        let err = TemplateEngine::parse("{Unknown Token}", MediaType::Music);
+        assert!(err.is_err());
+        let msg = err.unwrap_err().to_string();
+        assert!(msg.contains("Unknown Token"), "got: {msg}");
+    }
+
+    #[test]
+    fn path_sanitization_replaces_unsafe_chars() {
+        let result = sanitize_path_segment("AC/DC: Rock & Roll");
+        assert!(!result.contains('/'));
+        assert!(!result.contains(':'));
+    }
+
+    #[test]
+    fn path_sanitization_collapses_spaces() {
+        let result = sanitize_path_segment("  hello   world  ");
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn path_sanitization_replaces_all_unsafe() {
+        for ch in &['/', '\\', ':', '*', '?', '"', '<', '>', '|'] {
+            let input = format!("test{ch}file");
+            let result = sanitize_path_segment(&input);
+            assert!(
+                !result.contains(*ch),
+                "char {ch} should be replaced, got: {result}"
+            );
+        }
+    }
+
+    #[test]
+    fn tv_template_episode_format() {
+        let engine = TemplateEngine::parse(
+            "{Series Title}/Season {Season Number:00}/{Series Title} - S{Season Number:00}E{Episode Number:00} - {Episode Title}.{Extension}",
+            MediaType::Tv,
+        )
+        .unwrap();
+        let meta: HashMap<_, _> = [
+            ("Series Title", "Breaking Bad"),
+            ("Season Number", "5"),
+            ("Episode Number", "16"),
+            ("Episode Title", "Felina"),
+            ("Extension", "mkv"),
+        ]
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+        let path = engine.resolve(&meta).unwrap();
+        assert_eq!(
+            path,
+            PathBuf::from("Breaking Bad/Season 05/Breaking Bad - S05E16 - Felina.mkv")
+        );
+    }
+
+    #[test]
+    fn default_template_parseable_for_all_types() {
+        for mt in [
+            MediaType::Music,
+            MediaType::Movie,
+            MediaType::Book,
+            MediaType::Comic,
+            MediaType::Podcast,
+            MediaType::Audiobook,
+        ] {
+            let result = TemplateEngine::parse(default_template(mt), mt);
+            assert!(
+                result.is_ok(),
+                "default template for {mt:?} failed to parse: {:?}",
+                result.err()
+            );
+        }
+    }
+}

--- a/crates/taxis/src/lib.rs
+++ b/crates/taxis/src/lib.rs
@@ -1,1 +1,38 @@
-// Stub — implementation in P2-08
+pub mod error;
+pub mod event;
+pub mod import;
+pub mod scanner;
+
+use std::path::Path;
+
+use harmonia_common::{MediaId, MediaType};
+
+use crate::error::TaxisError;
+use crate::import::{CompletedDownload, ImportResult, PendingImport};
+
+pub use error::{EpignosisError, TaxisError as Error};
+pub use event::{Debouncer, WatchEvent, WatchEventKind};
+pub use import::{
+    ImportOperation, ImportOrigin, ImportPipeline, ImportResult as ImportResultPub, ImportSource,
+    MetadataResolver, PendingImport as PendingImportPub, ResolvedMetadata,
+};
+pub use scanner::ScannerManager;
+
+/// The primary service interface for Taxis.
+#[allow(async_fn_in_trait)]
+pub trait ImportService: Send + Sync {
+    async fn import_download(
+        &self,
+        download: CompletedDownload,
+    ) -> Result<ImportResult, TaxisError>;
+
+    async fn import_scan(&self, path: &Path, library: &str) -> Result<ImportResult, TaxisError>;
+
+    async fn get_import_queue(&self) -> Result<Vec<PendingImport>, TaxisError>;
+
+    async fn manual_match(
+        &self,
+        item_id: MediaId,
+        media_type: MediaType,
+    ) -> Result<ImportResult, TaxisError>;
+}

--- a/crates/taxis/src/scanner/filter.rs
+++ b/crates/taxis/src/scanner/filter.rs
@@ -1,0 +1,316 @@
+use std::path::{Path, PathBuf};
+
+use harmonia_common::MediaType;
+
+static MUSIC_EXTENSIONS: &[&str] = &[
+    "flac", "wav", "mp3", "m4a", "ogg", "opus", "aiff", "aif", "wv", "alac", "aac",
+];
+static AUDIOBOOK_EXTENSIONS: &[&str] = &["m4b", "mp3", "m4a", "flac"];
+static BOOK_EXTENSIONS: &[&str] = &["epub", "pdf", "mobi", "azw3", "cbz", "cbr"];
+static COMIC_EXTENSIONS: &[&str] = &["cbz", "cbr", "cb7", "pdf"];
+static MOVIE_EXTENSIONS: &[&str] = &["mkv", "mp4", "avi", "m4v"];
+static TV_EXTENSIONS: &[&str] = &["mkv", "mp4", "avi", "m4v"];
+static PODCAST_EXTENSIONS: &[&str] = &["mp3", "m4a", "ogg", "opus"];
+
+/// Returns true if this file extension is supported for the given media type.
+pub fn is_supported_extension(path: &Path, media_type: MediaType) -> bool {
+    let ext = match path.extension().and_then(|e| e.to_str()) {
+        Some(e) => e.to_ascii_lowercase(),
+        None => return false,
+    };
+    let exts: &[&str] = match media_type {
+        MediaType::Music => MUSIC_EXTENSIONS,
+        MediaType::Audiobook => AUDIOBOOK_EXTENSIONS,
+        MediaType::Book => BOOK_EXTENSIONS,
+        MediaType::Comic => COMIC_EXTENSIONS,
+        MediaType::Movie => MOVIE_EXTENSIONS,
+        MediaType::Tv => TV_EXTENSIONS,
+        MediaType::Podcast => PODCAST_EXTENSIONS,
+        MediaType::News => &[],
+        _ => &[],
+    };
+    exts.contains(&ext.as_str())
+}
+
+/// Returns all media types for which this extension is supported.
+pub fn extension_media_types(path: &Path) -> Vec<MediaType> {
+    if path.extension().is_none() {
+        return vec![];
+    }
+    let mut types = Vec::new();
+    for mt in [
+        MediaType::Music,
+        MediaType::Audiobook,
+        MediaType::Book,
+        MediaType::Comic,
+        MediaType::Movie,
+        MediaType::Tv,
+        MediaType::Podcast,
+    ] {
+        if is_supported_extension(path, mt) {
+            types.push(mt);
+        }
+    }
+    types
+}
+
+/// Represents loaded .harmoniaignore rules for a library root.
+pub struct HarmoniaIgnore {
+    rules: Vec<IgnoreRule>,
+    root: PathBuf,
+}
+
+#[derive(Debug)]
+struct IgnoreRule {
+    pattern: IgnorePattern,
+    negated: bool,
+}
+
+#[derive(Debug)]
+enum IgnorePattern {
+    Glob {
+        prefix: Option<String>,
+        suffix: Option<String>,
+        is_dir: bool,
+    },
+    Exact(String),
+    All,
+}
+
+impl HarmoniaIgnore {
+    /// Load .harmoniaignore from root directory only.
+    pub fn load(root: &Path) -> Self {
+        let rules = Self::load_file(&root.join(".harmoniaignore")).unwrap_or_default();
+        Self {
+            rules,
+            root: root.to_path_buf(),
+        }
+    }
+
+    fn load_file(path: &Path) -> Option<Vec<IgnoreRule>> {
+        let content = std::fs::read_to_string(path).ok()?;
+        let rules = content
+            .lines()
+            .filter(|l| !l.trim().is_empty() && !l.starts_with('#'))
+            .filter_map(|line| parse_rule(line.trim()))
+            .collect();
+        Some(rules)
+    }
+
+    pub fn is_ignored(&self, path: &Path) -> bool {
+        let rel = path.strip_prefix(&self.root).unwrap_or(path);
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        let is_dir = path.is_dir();
+
+        let mut ignored = false;
+        for rule in &self.rules {
+            if rule.negated {
+                if matches_rule(&rule.pattern, rel, name, is_dir) {
+                    ignored = false;
+                }
+            } else if matches_rule(&rule.pattern, rel, name, is_dir) {
+                ignored = true;
+            }
+        }
+        ignored
+    }
+}
+
+fn parse_rule(line: &str) -> Option<IgnoreRule> {
+    let (negated, line) = if let Some(rest) = line.strip_prefix('!') {
+        (true, rest)
+    } else {
+        (false, line)
+    };
+    let is_dir = line.ends_with('/');
+    let line = line.trim_end_matches('/');
+
+    if line.is_empty() {
+        return None;
+    }
+
+    let pattern = if line == "*" {
+        IgnorePattern::All
+    } else if let Some(suffix) = line.strip_prefix('*') {
+        IgnorePattern::Glob {
+            prefix: None,
+            suffix: Some(suffix.to_string()),
+            is_dir,
+        }
+    } else if let Some(prefix) = line.strip_suffix('*') {
+        IgnorePattern::Glob {
+            prefix: Some(prefix.to_string()),
+            suffix: None,
+            is_dir,
+        }
+    } else {
+        IgnorePattern::Exact(line.to_string())
+    };
+
+    Some(IgnoreRule { pattern, negated })
+}
+
+fn matches_rule(pattern: &IgnorePattern, rel_path: &Path, name: &str, is_dir: bool) -> bool {
+    match pattern {
+        IgnorePattern::All => true,
+        IgnorePattern::Exact(s) => {
+            name == s.as_str() || rel_path.to_str().is_some_and(|p| p == s.as_str())
+        }
+        IgnorePattern::Glob {
+            prefix,
+            suffix,
+            is_dir: pat_is_dir,
+        } => {
+            if *pat_is_dir && !is_dir {
+                return false;
+            }
+            match (prefix, suffix) {
+                (None, Some(suf)) => name.ends_with(suf.as_str()),
+                (Some(pre), None) => name.starts_with(pre.as_str()),
+                (Some(pre), Some(suf)) => {
+                    name.starts_with(pre.as_str()) && name.ends_with(suf.as_str())
+                }
+                (None, None) => true,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn make_path(name: &str) -> PathBuf {
+        PathBuf::from(name)
+    }
+
+    #[test]
+    fn music_extensions_accepted() {
+        for ext in &["flac", "mp3", "wav", "m4a", "ogg", "opus"] {
+            let path = make_path(&format!("track.{ext}"));
+            assert!(
+                is_supported_extension(&path, MediaType::Music),
+                "{ext} should be accepted for Music"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_extension_rejected_for_music() {
+        let path = make_path("track.xyz");
+        assert!(!is_supported_extension(&path, MediaType::Music));
+    }
+
+    #[test]
+    fn audiobook_extensions_accepted() {
+        for ext in &["m4b", "mp3", "m4a", "flac"] {
+            let path = make_path(&format!("book.{ext}"));
+            assert!(
+                is_supported_extension(&path, MediaType::Audiobook),
+                "{ext} should be accepted for Audiobook"
+            );
+        }
+    }
+
+    #[test]
+    fn book_extensions_accepted() {
+        for ext in &["epub", "pdf", "mobi", "azw3"] {
+            let path = make_path(&format!("book.{ext}"));
+            assert!(
+                is_supported_extension(&path, MediaType::Book),
+                "{ext} should be accepted for Book"
+            );
+        }
+    }
+
+    #[test]
+    fn comic_extensions_accepted() {
+        for ext in &["cbz", "cbr", "cb7"] {
+            let path = make_path(&format!("issue.{ext}"));
+            assert!(
+                is_supported_extension(&path, MediaType::Comic),
+                "{ext} should be accepted for Comic"
+            );
+        }
+    }
+
+    #[test]
+    fn video_extensions_accepted() {
+        for ext in &["mkv", "mp4", "avi", "m4v"] {
+            let path = make_path(&format!("movie.{ext}"));
+            assert!(
+                is_supported_extension(&path, MediaType::Movie),
+                "{ext} should be accepted for Movie"
+            );
+        }
+    }
+
+    #[test]
+    fn news_type_has_no_extensions() {
+        let path = make_path("article.mp3");
+        assert!(!is_supported_extension(&path, MediaType::News));
+    }
+
+    #[test]
+    fn extension_case_insensitive() {
+        let path = make_path("track.FLAC");
+        assert!(is_supported_extension(&path, MediaType::Music));
+        let path = make_path("track.Mp3");
+        assert!(is_supported_extension(&path, MediaType::Music));
+    }
+
+    #[test]
+    fn harmoniaignore_matches_glob_pattern() {
+        let dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(dir.path().join(".harmoniaignore")).unwrap();
+        writeln!(f, "*.part").unwrap();
+        writeln!(f, "*.tmp").unwrap();
+
+        let ignore = HarmoniaIgnore::load(dir.path());
+        assert!(ignore.is_ignored(&dir.path().join("download.part")));
+        assert!(ignore.is_ignored(&dir.path().join("file.tmp")));
+        assert!(!ignore.is_ignored(&dir.path().join("track.flac")));
+    }
+
+    #[test]
+    fn harmoniaignore_exact_match() {
+        let dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(dir.path().join(".harmoniaignore")).unwrap();
+        writeln!(f, "Thumbs.db").unwrap();
+
+        let ignore = HarmoniaIgnore::load(dir.path());
+        assert!(ignore.is_ignored(&dir.path().join("Thumbs.db")));
+        assert!(!ignore.is_ignored(&dir.path().join("track.flac")));
+    }
+
+    #[test]
+    fn harmoniaignore_comments_ignored() {
+        let dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(dir.path().join(".harmoniaignore")).unwrap();
+        writeln!(f, "# this is a comment").unwrap();
+        writeln!(f, "*.part").unwrap();
+
+        let ignore = HarmoniaIgnore::load(dir.path());
+        assert!(ignore.is_ignored(&dir.path().join("file.part")));
+        assert!(!ignore.is_ignored(&dir.path().join("# this is a comment")));
+    }
+
+    #[test]
+    fn harmoniaignore_missing_file_no_error() {
+        let dir = TempDir::new().unwrap();
+        let ignore = HarmoniaIgnore::load(dir.path());
+        assert!(!ignore.is_ignored(&dir.path().join("track.flac")));
+    }
+
+    #[test]
+    fn extension_media_types_returns_all_applicable() {
+        let path = make_path("episode.mp3");
+        let types = extension_media_types(&path);
+        assert!(types.contains(&MediaType::Music));
+        assert!(types.contains(&MediaType::Podcast));
+    }
+}

--- a/crates/taxis/src/scanner/mod.rs
+++ b/crates/taxis/src/scanner/mod.rs
@@ -1,0 +1,296 @@
+pub mod filter;
+pub mod walk;
+pub mod watcher;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use harmonia_common::{EventSender, HarmoniaEvent, MediaType};
+use horismos::TaxisConfig;
+use tokio::sync::{Semaphore, mpsc, watch};
+use tokio::task::JoinHandle;
+use tracing::{Instrument, instrument};
+
+use crate::error::TaxisError;
+use crate::event::Debouncer;
+use crate::import::identify::resolve_media_type;
+use crate::scanner::walk::walk_library;
+use crate::scanner::watcher::{AnyWatcher, create_watcher, normalize_event};
+
+const DEFAULT_DEBOUNCE_MS: u64 = 500;
+const DEFAULT_SCAN_CONCURRENCY: usize = 4;
+
+pub struct ScannerManager {
+    watcher_handles: Vec<JoinHandle<()>>,
+    scan_handles: Vec<JoinHandle<()>>,
+    shutdown_tx: watch::Sender<bool>,
+    scan_triggers: HashMap<String, mpsc::Sender<()>>,
+}
+
+impl ScannerManager {
+    #[instrument(skip(config, event_tx))]
+    pub async fn start(config: &TaxisConfig, event_tx: EventSender) -> Result<Self, TaxisError> {
+        let (shutdown_tx, _) = watch::channel(false);
+        let semaphore = Arc::new(Semaphore::new(DEFAULT_SCAN_CONCURRENCY));
+        let mut watcher_handles = Vec::new();
+        let mut scan_handles = Vec::new();
+        let mut scan_triggers = HashMap::new();
+
+        for (name, lib) in &config.libraries {
+            let (event_raw_tx, event_raw_rx) = mpsc::channel(256);
+
+            let lib_name = name.clone();
+            let lib_config = lib.clone();
+            let event_tx_clone = event_tx.clone();
+            let debounce_ms = DEFAULT_DEBOUNCE_MS;
+
+            match create_watcher(&lib_name, &lib_config, event_raw_tx) {
+                Ok(watcher) => {
+                    let handle = tokio::spawn(
+                        run_watcher_task(
+                            lib_name.clone(),
+                            watcher,
+                            event_raw_rx,
+                            debounce_ms,
+                            event_tx_clone.clone(),
+                            shutdown_tx.subscribe(),
+                        )
+                        .instrument(tracing::info_span!("watcher", library = %lib_name)),
+                    );
+                    watcher_handles.push(handle);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        library = %lib_name,
+                        error = %e,
+                        "watcher init failed, skipping library"
+                    );
+                }
+            }
+
+            let (scan_tx, scan_rx) = mpsc::channel(4);
+            scan_triggers.insert(name.clone(), scan_tx);
+
+            let lib_name2 = name.clone();
+            let lib_path = lib.path.clone();
+            let media_type = resolve_media_type(&lib.media_type);
+            let scan_interval = Duration::from_secs(lib.scan_interval_hours * 3600);
+            let event_tx_scan = event_tx.clone();
+            let sem_clone = Arc::clone(&semaphore);
+
+            let scan_handle = tokio::spawn(
+                run_scan_task(
+                    ScanTaskConfig {
+                        library_name: lib_name2.clone(),
+                        root: lib_path,
+                        media_type,
+                        interval: scan_interval,
+                    },
+                    scan_rx,
+                    event_tx_scan,
+                    sem_clone,
+                    shutdown_tx.subscribe(),
+                )
+                .instrument(tracing::info_span!("scanner", library = %lib_name2)),
+            );
+            scan_handles.push(scan_handle);
+        }
+
+        Ok(Self {
+            watcher_handles,
+            scan_handles,
+            shutdown_tx,
+            scan_triggers,
+        })
+    }
+
+    /// Trigger an immediate full scan of the named library.
+    pub async fn trigger_scan(&self, library: &str) -> Result<(), TaxisError> {
+        if let Some(tx) = self.scan_triggers.get(library) {
+            let _ = tx.send(()).await;
+        }
+        Ok(())
+    }
+
+    pub async fn shutdown(self) {
+        let _ = self.shutdown_tx.send(true);
+        for h in self.watcher_handles {
+            let _ = h.await;
+        }
+        for h in self.scan_handles {
+            let _ = h.await;
+        }
+    }
+}
+
+async fn run_watcher_task(
+    library_name: String,
+    _watcher: AnyWatcher,
+    mut rx: mpsc::Receiver<notify::Result<notify::Event>>,
+    debounce_ms: u64,
+    _event_tx: EventSender,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let mut debouncer = Debouncer::new(debounce_ms);
+
+    loop {
+        let deadline = debouncer.next_deadline();
+        let sleep_duration = deadline
+            .map(|d| d.saturating_duration_since(std::time::Instant::now()))
+            .unwrap_or(Duration::from_secs(3600));
+
+        tokio::select! {
+            biased;
+
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() { break; }
+            }
+
+            result = rx.recv() => {
+                match result {
+                    Some(Ok(event)) => {
+                        for watch_event in normalize_event(event, library_name.clone()) {
+                            debouncer.push(watch_event);
+                        }
+                    }
+                    Some(Err(e)) => {
+                        tracing::warn!(library = %library_name, error = %e, "watcher error");
+                    }
+                    None => break,
+                }
+            }
+
+            _ = tokio::time::sleep(sleep_duration) => {
+                // flush ready events
+            }
+        }
+
+        for event in debouncer.drain_ready() {
+            tracing::debug!(
+                library = %library_name,
+                path = %event.path.display(),
+                kind = ?event.kind,
+                "watcher event ready"
+            );
+        }
+    }
+    tracing::info!(library = %library_name, "watcher task stopped");
+}
+
+struct ScanTaskConfig {
+    library_name: String,
+    root: PathBuf,
+    media_type: MediaType,
+    interval: Duration,
+}
+
+async fn run_scan_task(
+    cfg: ScanTaskConfig,
+    mut trigger_rx: mpsc::Receiver<()>,
+    event_tx: EventSender,
+    semaphore: Arc<Semaphore>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let mut interval_timer = tokio::time::interval(cfg.interval);
+    interval_timer.tick().await; // skip the immediate first tick
+
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() { break; }
+            }
+
+            _ = trigger_rx.recv() => {
+                run_full_scan(&cfg.library_name, &cfg.root, cfg.media_type, &event_tx, &semaphore).await;
+            }
+
+            _ = interval_timer.tick() => {
+                run_full_scan(&cfg.library_name, &cfg.root, cfg.media_type, &event_tx, &semaphore).await;
+            }
+        }
+    }
+    tracing::info!(library = %cfg.library_name, "scan task stopped");
+}
+
+async fn run_full_scan(
+    library_name: &str,
+    root: &Path,
+    media_type: MediaType,
+    event_tx: &EventSender,
+    semaphore: &Arc<Semaphore>,
+) {
+    tracing::info!(library = %library_name, "starting full scan");
+    match walk_library(root, media_type, semaphore).await {
+        Ok((results, stats)) => {
+            tracing::info!(
+                library = %library_name,
+                found = results.len(),
+                scanned = stats.scanned,
+                skipped_ignored = stats.skipped_ignored,
+                skipped_unsupported = stats.skipped_unsupported,
+                "scan complete"
+            );
+            let items_added = results.len();
+            event_tx
+                .send(HarmoniaEvent::LibraryScanCompleted {
+                    items_scanned: stats.scanned,
+                    items_added,
+                    items_removed: 0,
+                })
+                .ok();
+        }
+        Err(e) => {
+            tracing::error!(library = %library_name, error = %e, "scan failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::time::Duration;
+
+    use harmonia_common::create_event_bus;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn scanner_detects_new_file_in_watched_directory() {
+        let dir = TempDir::new().unwrap();
+        let mut config = TaxisConfig::default();
+        let mut lib = horismos::LibraryConfig::default();
+        lib.path = dir.path().to_path_buf();
+        lib.watcher_mode = horismos::WatcherMode::Poll;
+        lib.poll_interval_seconds = 1;
+        lib.scan_interval_hours = 9999; // don't auto-scan
+        config.libraries.insert("test".to_string(), lib);
+
+        let (tx, mut rx) = create_event_bus(64);
+        let manager = ScannerManager::start(&config, tx).await.unwrap();
+
+        std::fs::write(dir.path().join("track.flac"), b"FLAC").unwrap();
+        manager.trigger_scan("test").await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        manager.shutdown().await;
+
+        let mut got_scan_completed = false;
+        while let Ok(event) = rx.try_recv() {
+            if let HarmoniaEvent::LibraryScanCompleted { items_added, .. } = event {
+                if items_added >= 1 {
+                    got_scan_completed = true;
+                }
+            }
+        }
+        assert!(
+            got_scan_completed,
+            "expected LibraryScanCompleted event with items_added >= 1"
+        );
+    }
+}

--- a/crates/taxis/src/scanner/walk.rs
+++ b/crates/taxis/src/scanner/walk.rs
@@ -1,0 +1,166 @@
+use std::path::{Path, PathBuf};
+
+use harmonia_common::MediaType;
+use tokio::sync::Semaphore;
+use tracing::instrument;
+use walkdir::WalkDir;
+
+use crate::error::TaxisError;
+use crate::scanner::filter::{HarmoniaIgnore, is_supported_extension};
+
+#[derive(Debug)]
+pub struct WalkResult {
+    pub path: PathBuf,
+    pub media_type: MediaType,
+}
+
+#[derive(Debug, Default)]
+pub struct WalkStats {
+    pub scanned: usize,
+    pub skipped_ignored: usize,
+    pub skipped_unsupported: usize,
+}
+
+/// Walk a library directory, yielding supported media files.
+/// Respects .harmoniaignore files and the expected media type.
+#[instrument(skip(semaphore))]
+pub async fn walk_library(
+    root: &Path,
+    media_type: MediaType,
+    semaphore: &Semaphore,
+) -> Result<(Vec<WalkResult>, WalkStats), TaxisError> {
+    let root = root.to_path_buf();
+    let ignore = HarmoniaIgnore::load(&root);
+    let _permit = semaphore.acquire().await.expect("semaphore closed");
+
+    let results =
+        tokio::task::spawn_blocking(move || walk_library_blocking(&root, media_type, &ignore))
+            .await
+            .expect("walk task panicked")?;
+
+    Ok(results)
+}
+
+fn walk_library_blocking(
+    root: &Path,
+    media_type: MediaType,
+    ignore: &HarmoniaIgnore,
+) -> Result<(Vec<WalkResult>, WalkStats), TaxisError> {
+    let mut results = Vec::new();
+    let mut stats = WalkStats::default();
+
+    for entry in WalkDir::new(root).follow_links(false).into_iter() {
+        let entry = entry.map_err(|e| {
+            let path = e.path().unwrap_or(root).to_path_buf();
+            TaxisError::ScanWalk {
+                path,
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            }
+        })?;
+
+        if entry.file_type().is_dir() {
+            continue;
+        }
+
+        let path = entry.into_path();
+        stats.scanned += 1;
+
+        if ignore.is_ignored(&path) {
+            stats.skipped_ignored += 1;
+            continue;
+        }
+
+        if !is_supported_extension(&path, media_type) {
+            stats.skipped_unsupported += 1;
+            continue;
+        }
+
+        results.push(WalkResult { path, media_type });
+    }
+
+    Ok((results, stats))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::TempDir;
+    use tokio::sync::Semaphore;
+
+    use super::*;
+
+    fn create_file(dir: &Path, name: &str) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, b"dummy").unwrap();
+        p
+    }
+
+    #[tokio::test]
+    async fn walk_finds_supported_files() {
+        let dir = TempDir::new().unwrap();
+        create_file(dir.path(), "track1.flac");
+        create_file(dir.path(), "track2.mp3");
+        create_file(dir.path(), "cover.jpg"); // unsupported
+
+        let sem = Semaphore::new(4);
+        let (results, stats) = walk_library(dir.path(), MediaType::Music, &sem)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(stats.skipped_unsupported, 1);
+    }
+
+    #[tokio::test]
+    async fn walk_respects_harmoniaignore() {
+        let dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(dir.path().join(".harmoniaignore")).unwrap();
+        writeln!(f, "*.part").unwrap();
+
+        create_file(dir.path(), "track.flac");
+        create_file(dir.path(), "download.part");
+
+        let sem = Semaphore::new(4);
+        let (results, stats) = walk_library(dir.path(), MediaType::Music, &sem)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path.file_name().unwrap(), "track.flac");
+        assert_eq!(stats.skipped_ignored, 1);
+    }
+
+    #[tokio::test]
+    async fn walk_recurses_subdirectories() {
+        let dir = TempDir::new().unwrap();
+        let sub = dir.path().join("Album");
+        std::fs::create_dir(&sub).unwrap();
+        create_file(&sub, "track.flac");
+        create_file(dir.path(), "other.mp3");
+
+        let sem = Semaphore::new(4);
+        let (results, _) = walk_library(dir.path(), MediaType::Music, &sem)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn walk_skips_unsupported_extensions() {
+        let dir = TempDir::new().unwrap();
+        create_file(dir.path(), "image.jpg");
+        create_file(dir.path(), "doc.txt");
+        create_file(dir.path(), "track.flac");
+
+        let sem = Semaphore::new(4);
+        let (results, stats) = walk_library(dir.path(), MediaType::Music, &sem)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(stats.skipped_unsupported, 2);
+    }
+}

--- a/crates/taxis/src/scanner/watcher.rs
+++ b/crates/taxis/src/scanner/watcher.rs
@@ -1,0 +1,264 @@
+use std::path::Path;
+use std::time::Duration;
+
+use notify::{Config, Event, EventKind, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher};
+use snafu::ResultExt;
+use tokio::sync::mpsc;
+use tracing::instrument;
+
+use crate::error::{TaxisError, WatcherInitSnafu};
+use crate::event::{WatchEvent, WatchEventKind};
+
+const NETWORK_FS_TYPES: &[&str] = &["nfs", "nfs4", "cifs", "smbfs", "smb", "fuse.sshfs"];
+
+/// Runtime watcher mode after auto-detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActiveWatcherMode {
+    Inotify,
+    Poll,
+}
+
+pub enum AnyWatcher {
+    Recommended(#[allow(dead_code)] RecommendedWatcher),
+    Poll(#[allow(dead_code)] PollWatcher),
+}
+
+/// Detect whether to use inotify or poll for a library path.
+pub fn detect_watcher_mode(watcher_mode: &horismos::WatcherMode, path: &Path) -> ActiveWatcherMode {
+    detect_watcher_mode_at(watcher_mode, path, Path::new("/proc/mounts"))
+}
+
+pub fn detect_watcher_mode_at(
+    watcher_mode: &horismos::WatcherMode,
+    path: &Path,
+    mounts_path: &Path,
+) -> ActiveWatcherMode {
+    match watcher_mode {
+        horismos::WatcherMode::Inotify => ActiveWatcherMode::Inotify,
+        horismos::WatcherMode::Poll => ActiveWatcherMode::Poll,
+        horismos::WatcherMode::Auto => {
+            if is_network_mount_at(path, mounts_path) {
+                tracing::info!(path = %path.display(), "NFS mount detected — using PollWatcher");
+                ActiveWatcherMode::Poll
+            } else {
+                ActiveWatcherMode::Inotify
+            }
+        }
+    }
+}
+
+pub fn is_network_mount(path: &Path) -> bool {
+    is_network_mount_at(path, Path::new("/proc/mounts"))
+}
+
+pub fn is_network_mount_at(path: &Path, mounts_path: &Path) -> bool {
+    let content = match std::fs::read_to_string(mounts_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, "NFS detection inconclusive — cannot read mounts");
+            return false;
+        }
+    };
+    let path_str = path.to_string_lossy();
+    let mut best_mount: Option<(usize, bool)> = None;
+
+    for line in content.lines() {
+        let mut parts = line.split_whitespace();
+        let _device = parts.next();
+        let mount_point = match parts.next() {
+            Some(m) => m,
+            None => continue,
+        };
+        let fs_type = match parts.next() {
+            Some(f) => f,
+            None => continue,
+        };
+
+        if path_str.starts_with(mount_point) {
+            let is_net = NETWORK_FS_TYPES.contains(&fs_type);
+            let len = mount_point.len();
+            match best_mount {
+                None => {
+                    best_mount = Some((len, is_net));
+                }
+                Some((prev_len, _)) if len > prev_len => {
+                    best_mount = Some((len, is_net));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    best_mount.is_some_and(|(_, is_net)| is_net)
+}
+
+#[instrument(skip(tx))]
+pub fn create_watcher(
+    library_name: &str,
+    lib: &horismos::LibraryConfig,
+    tx: mpsc::Sender<notify::Result<Event>>,
+) -> Result<AnyWatcher, TaxisError> {
+    let mode = detect_watcher_mode(&lib.watcher_mode, &lib.path);
+    let config =
+        Config::default().with_poll_interval(Duration::from_secs(lib.poll_interval_seconds));
+
+    match mode {
+        ActiveWatcherMode::Inotify => {
+            let tx2 = tx.clone();
+            let mut w = RecommendedWatcher::new(
+                move |result| {
+                    let _ = tx2.blocking_send(result);
+                },
+                config,
+            )
+            .context(WatcherInitSnafu {
+                library: library_name.to_string(),
+            })?;
+            w.watch(&lib.path, RecursiveMode::Recursive)
+                .context(WatcherInitSnafu {
+                    library: library_name.to_string(),
+                })?;
+            Ok(AnyWatcher::Recommended(w))
+        }
+        ActiveWatcherMode::Poll => {
+            let tx2 = tx.clone();
+            let mut w = PollWatcher::new(
+                move |result| {
+                    let _ = tx2.blocking_send(result);
+                },
+                config,
+            )
+            .context(WatcherInitSnafu {
+                library: library_name.to_string(),
+            })?;
+            w.watch(&lib.path, RecursiveMode::Recursive)
+                .context(WatcherInitSnafu {
+                    library: library_name.to_string(),
+                })?;
+            Ok(AnyWatcher::Poll(w))
+        }
+    }
+}
+
+pub fn normalize_event(event: Event, library_name: String) -> Vec<WatchEvent> {
+    let kind = match event.kind {
+        EventKind::Create(_) => WatchEventKind::Created,
+        EventKind::Modify(_) => WatchEventKind::Modified,
+        EventKind::Remove(_) => WatchEventKind::Removed,
+        EventKind::Access(_) => return vec![],
+        EventKind::Other => return vec![],
+        EventKind::Any => WatchEventKind::Modified,
+    };
+    event
+        .paths
+        .into_iter()
+        .filter(|p| p.is_file() || matches!(kind, WatchEventKind::Removed))
+        .map(|path| WatchEvent {
+            path,
+            kind: kind.clone(),
+            library_name: library_name.clone(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write_mounts(dir: &TempDir, content: &str) -> PathBuf {
+        let p = dir.path().join("mounts");
+        std::fs::write(&p, content).unwrap();
+        p
+    }
+
+    #[test]
+    fn nfs_detection_returns_poll_for_nfs_mount() {
+        let dir = TempDir::new().unwrap();
+        let mounts = write_mounts(&dir, "server:/export /mnt/nfs nfs rw,defaults 0 0\n");
+        let path = PathBuf::from("/mnt/nfs/library");
+        assert!(is_network_mount_at(&path, &mounts));
+    }
+
+    #[test]
+    fn nfs_detection_returns_false_for_local_mount() {
+        let dir = TempDir::new().unwrap();
+        let mounts = write_mounts(&dir, "/dev/sda1 /mnt/local ext4 rw,defaults 0 0\n");
+        let path = PathBuf::from("/mnt/local/library");
+        assert!(!is_network_mount_at(&path, &mounts));
+    }
+
+    #[test]
+    fn nfs_detection_picks_deepest_mount() {
+        let dir = TempDir::new().unwrap();
+        let mounts = write_mounts(
+            &dir,
+            "/dev/sda1 / ext4 rw 0 0\n\
+             server:/export /mnt/nfs nfs rw 0 0\n\
+             /dev/sda2 /mnt/nfs/local ext4 rw 0 0\n",
+        );
+        // /mnt/nfs/local is the deepest match and it's ext4 (not NFS)
+        let path = PathBuf::from("/mnt/nfs/local/library");
+        assert!(!is_network_mount_at(&path, &mounts));
+    }
+
+    #[test]
+    fn nfs_detection_cifs_is_network() {
+        let dir = TempDir::new().unwrap();
+        let mounts = write_mounts(&dir, "//server/share /mnt/smb cifs rw 0 0\n");
+        let path = PathBuf::from("/mnt/smb/files");
+        assert!(is_network_mount_at(&path, &mounts));
+    }
+
+    #[test]
+    fn nfs_detection_missing_file_returns_false() {
+        let path = PathBuf::from("/mnt/library");
+        let mounts_path = PathBuf::from("/nonexistent/proc/mounts");
+        assert!(!is_network_mount_at(&path, &mounts_path));
+    }
+
+    #[test]
+    fn detect_watcher_mode_explicit_poll_ignores_fs() {
+        let dir = TempDir::new().unwrap();
+        let mode = detect_watcher_mode_at(
+            &horismos::WatcherMode::Poll,
+            dir.path(),
+            Path::new("/nonexistent"),
+        );
+        assert_eq!(mode, ActiveWatcherMode::Poll);
+    }
+
+    #[test]
+    fn detect_watcher_mode_explicit_inotify_ignores_fs() {
+        let dir = TempDir::new().unwrap();
+        let mode = detect_watcher_mode_at(
+            &horismos::WatcherMode::Inotify,
+            dir.path(),
+            Path::new("/nonexistent"),
+        );
+        assert_eq!(mode, ActiveWatcherMode::Inotify);
+    }
+
+    #[test]
+    fn detect_watcher_mode_auto_nfs_selects_poll() {
+        let dir = TempDir::new().unwrap();
+        let mounts_path = dir.path().join("mounts");
+        std::fs::write(&mounts_path, "server:/export /mnt/nfs nfs rw 0 0\n").unwrap();
+        let lib_path = PathBuf::from("/mnt/nfs/music");
+        let mode = detect_watcher_mode_at(&horismos::WatcherMode::Auto, &lib_path, &mounts_path);
+        assert_eq!(mode, ActiveWatcherMode::Poll);
+    }
+
+    #[test]
+    fn detect_watcher_mode_auto_local_selects_inotify() {
+        let dir = TempDir::new().unwrap();
+        let mounts_path = dir.path().join("mounts");
+        std::fs::write(&mounts_path, "/dev/sda1 /mnt/local ext4 rw 0 0\n").unwrap();
+        let lib_path = PathBuf::from("/mnt/local/music");
+        let mode = detect_watcher_mode_at(&horismos::WatcherMode::Auto, &lib_path, &mounts_path);
+        assert_eq!(mode, ActiveWatcherMode::Inotify);
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `crates/taxis/` — library scanner and import pipeline
- `ScannerManager`: per-library watcher tasks (inotify/poll) + scheduled full scans
- `ImportPipeline<R: MetadataResolver>`: 6-step pipeline (identify → metadata → template → conflict → fileops → emit)
- `TemplateEngine`: `{Token}` syntax with parse-time validation, zero-padding, path sanitization
- `HarmoniaIgnore`: `.harmoniaignore` support (gitignore-style pattern matching)
- NFS detection via `/proc/mounts` with auto-fallback to `PollWatcher`
- Debouncer: collapses rapid watcher events per path with configurable window
- File ops: hardlink → copy fallback on EXDEV, atomic cross-FS rename, all via `spawn_blocking`
- Conflict resolution: skip on same/lower quality, upgrade on higher, `_N` suffix for different items

## Test plan

- [x] 68 tests pass across all modules
- [x] Scanner detects new file in watched directory (tempdir integration test)
- [x] Scanner ignores files matching `.harmoniaignore` patterns
- [x] Extension filter correct per media type, rejects unknown
- [x] NFS detection: mock `/proc/mounts`, verifies `PollWatcher` selected
- [x] Template resolution: all token types, zero-padding, missing tokens
- [x] Path sanitization: all unsafe chars replaced
- [x] Conflict resolution: skip/upgrade/suffix scenarios
- [x] Import pipeline: full flow with mock `MetadataResolver`
- [x] File operations: hardlink on same FS, copy fallback, rename
- [x] Debounce: rapid events collapsed to single entry per path
- [x] Scheduled scan: finds supported files, skips unsupported and ignored
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p taxis -- -D warnings` passes
- [x] `cargo test -p taxis` passes (68/68)