### PR TITLE
feat: podcast and news feed subscription (P2-11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +236,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +278,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -393,6 +422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "epignosis"
 version = "0.1.0"
 dependencies = [
@@ -476,6 +514,23 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "feed-rs"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c0591d23efd0d595099af69a31863ac1823046b1b021e3b06ba3aae7e00991"
+dependencies = [
+ "chrono",
+ "mediatype",
+ "quick-xml",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "figment"
@@ -923,6 +978,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1236,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "komide"
+version = "0.1.0"
+dependencies = [
+ "feed-rs",
+ "harmonia-common",
+ "harmonia-db",
+ "horismos",
+ "jiff",
+ "reqwest",
+ "rstest",
+ "serde",
+ "snafu",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1413,15 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
+]
+
+[[package]]
+name = "mediatype"
+version = "0.19.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1681,6 +1788,16 @@ dependencies = [
  "syn",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -2212,6 +2329,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2943,6 +3066,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3185,10 +3309,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/taxis",
     "crates/epignosis",
     "crates/kritike",
+    "crates/komide",
     "crates/harmonia-host",
 ]
 exclude = [
@@ -31,6 +32,7 @@ paroche         = { path = "crates/paroche" }
 taxis           = { path = "crates/taxis" }
 epignosis       = { path = "crates/epignosis" }
 kritike         = { path = "crates/kritike" }
+komide          = { path = "crates/komide" }
 
 # ── Async runtime ──────────────────────────────────────────────────────────────
 tokio           = { version = "1", features = ["full"] }

--- a/crates/harmonia-common/src/aggelia/events.rs
+++ b/crates/harmonia-common/src/aggelia/events.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ids::{DownloadId, MediaId, QueryId, SessionId, UserId};
+use crate::ids::{DownloadId, EpisodeId, FeedId, MediaId, QueryId, SessionId, UserId};
 use crate::media::{MediaType, QualityProfile};
 
 #[non_exhaustive]
@@ -111,6 +111,23 @@ pub enum HarmoniaEvent {
         duration_ms: u64,
         total_ms: u64,
         completed: bool,
+    },
+
+    // Feed events
+    /// Komide discovered a new podcast episode from a subscribed feed.
+    /// Subscribers: web UI (new episode badge), auto-download pipeline
+    EpisodeAvailable {
+        subscription_id: FeedId,
+        episode_id: EpisodeId,
+        title: String,
+    },
+
+    /// Komide completed a feed refresh cycle.
+    /// Subscribers: web UI (feed last-updated display)
+    FeedRefreshed {
+        feed_id: FeedId,
+        new_items: usize,
+        media_type: MediaType,
     },
 }
 

--- a/crates/harmonia-db/src/repo/news.rs
+++ b/crates/harmonia-db/src/repo/news.rs
@@ -225,6 +225,94 @@ pub async fn delete_article(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError>
     Ok(())
 }
 
+pub async fn article_guid_exists(
+    pool: &SqlitePool,
+    feed_id: &[u8],
+    guid: &str,
+) -> Result<bool, DbError> {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM news_articles WHERE feed_id = ? AND guid = ?")
+            .bind(feed_id)
+            .bind(guid)
+            .fetch_one(pool)
+            .await
+            .context(QuerySnafu {
+                table: "news_articles",
+            })?;
+    Ok(count > 0)
+}
+
+pub async fn count_articles_for_feed(pool: &SqlitePool, feed_id: &[u8]) -> Result<i64, DbError> {
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM news_articles WHERE feed_id = ?")
+        .bind(feed_id)
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu {
+            table: "news_articles",
+        })?;
+    Ok(count)
+}
+
+/// Delete articles published before `cutoff_iso8601`. Returns deleted row count.
+pub async fn delete_articles_older_than(
+    pool: &SqlitePool,
+    feed_id: &[u8],
+    cutoff_iso8601: &str,
+) -> Result<u64, DbError> {
+    let result = sqlx::query("DELETE FROM news_articles WHERE feed_id = ? AND published_at < ?")
+        .bind(feed_id)
+        .bind(cutoff_iso8601)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "news_articles",
+        })?;
+    Ok(result.rows_affected())
+}
+
+/// Delete oldest articles so that at most `keep_count` remain for the feed.
+/// Articles are ordered by published_at DESC; oldest are removed first.
+/// Returns deleted row count.
+pub async fn delete_articles_exceeding_count(
+    pool: &SqlitePool,
+    feed_id: &[u8],
+    keep_count: i64,
+) -> Result<u64, DbError> {
+    let result = sqlx::query(
+        "DELETE FROM news_articles
+         WHERE feed_id = ?
+           AND id NOT IN (
+               SELECT id FROM news_articles
+               WHERE feed_id = ?
+               ORDER BY published_at DESC
+               LIMIT ?
+           )",
+    )
+    .bind(feed_id)
+    .bind(feed_id)
+    .bind(keep_count)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "news_articles",
+    })?;
+    Ok(result.rows_affected())
+}
+
+pub async fn feed_by_url(pool: &SqlitePool, url: &str) -> Result<Option<NewsFeed>, DbError> {
+    sqlx::query_as::<_, NewsFeed>(
+        "SELECT id, title, url, site_url, description, category, icon_url,
+                last_fetched_at, fetch_interval_minutes, is_active, added_at, updated_at
+         FROM news_feeds WHERE url = ?",
+    )
+    .bind(url)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "news_feeds",
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/harmonia-db/src/repo/podcast.rs
+++ b/crates/harmonia-db/src/repo/podcast.rs
@@ -243,6 +243,77 @@ pub async fn delete_episode(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError>
     Ok(())
 }
 
+pub async fn episode_guid_exists(
+    pool: &SqlitePool,
+    subscription_id: &[u8],
+    guid: &str,
+) -> Result<bool, DbError> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM podcast_episodes WHERE subscription_id = ? AND guid = ?",
+    )
+    .bind(subscription_id)
+    .bind(guid)
+    .fetch_one(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_episodes",
+    })?;
+    Ok(count > 0)
+}
+
+pub async fn count_episodes_for_subscription(
+    pool: &SqlitePool,
+    subscription_id: &[u8],
+) -> Result<i64, DbError> {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM podcast_episodes WHERE subscription_id = ?")
+            .bind(subscription_id)
+            .fetch_one(pool)
+            .await
+            .context(QuerySnafu {
+                table: "podcast_episodes",
+            })?;
+    Ok(count)
+}
+
+pub async fn subscription_by_url(
+    pool: &SqlitePool,
+    url: &str,
+) -> Result<Option<PodcastSubscription>, DbError> {
+    sqlx::query_as::<_, PodcastSubscription>(
+        "SELECT id, feed_url, title, description, author, image_url, language,
+                last_checked_at, auto_download, quality_profile_id, added_at
+         FROM podcast_subscriptions WHERE feed_url = ?",
+    )
+    .bind(url)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_subscriptions",
+    })
+}
+
+pub async fn list_recent_episodes(
+    pool: &SqlitePool,
+    subscription_id: &[u8],
+    limit: i64,
+) -> Result<Vec<PodcastEpisode>, DbError> {
+    sqlx::query_as::<_, PodcastEpisode>(
+        "SELECT id, subscription_id, guid, title, description, episode_number, season_number,
+                publication_date, duration_ms, enclosure_url, file_path, file_size_bytes,
+                file_format, quality_score, source_type, listened, added_at
+         FROM podcast_episodes WHERE subscription_id = ?
+         ORDER BY publication_date DESC LIMIT ?",
+    )
+    .bind(subscription_id)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_episodes",
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/horismos/src/config.rs
+++ b/crates/horismos/src/config.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::subsystems::{
-    AggeliaConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig, KritikeConfig,
-    ParocheConfig, ProsthekeConfig, SyntaxisConfig, TaxisConfig, ZetesisConfig,
+    AggeliaConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig, KomideConfig,
+    KritikeConfig, ParocheConfig, ProsthekeConfig, SyntaxisConfig, TaxisConfig, ZetesisConfig,
 };
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -29,4 +29,6 @@ pub struct Config {
     pub syntaxis: SyntaxisConfig,
     #[serde(default)]
     pub prostheke: ProsthekeConfig,
+    #[serde(default)]
+    pub komide: KomideConfig,
 }

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -7,9 +7,9 @@ mod validation;
 pub use config::Config;
 pub use error::HorismosError;
 pub use subsystems::{
-    AggeliaConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig, KritikeConfig,
-    LibraryConfig, MediaType, ParocheConfig, ProsthekeConfig, SyntaxisConfig, TaxisConfig,
-    WatcherMode, ZetesisConfig,
+    AggeliaConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig, KomideConfig,
+    KritikeConfig, LibraryConfig, MediaType, ParocheConfig, ProsthekeConfig, SyntaxisConfig,
+    TaxisConfig, WatcherMode, ZetesisConfig,
 };
 pub use validation::ValidationWarning;
 

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -218,3 +218,35 @@ impl Default for ProsthekeConfig {
         }
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KomideConfig {
+    /// Poll interval for podcast feeds in minutes.
+    pub podcast_poll_interval_minutes: u64,
+    /// Poll interval for news feeds in minutes.
+    pub news_poll_interval_minutes: u64,
+    /// Directory where podcast episode audio files are stored.
+    pub podcast_dir: PathBuf,
+    /// Keep articles published within this many days (0 = no limit).
+    pub news_retention_days: u64,
+    /// Keep at most this many articles per news feed (0 = no limit).
+    pub news_retention_articles: u64,
+    /// Auto-download the N most recent episodes when subscribing (0 = none).
+    pub auto_download_latest_n: u64,
+    /// Request timeout for feed fetches in seconds.
+    pub fetch_timeout_secs: u64,
+}
+
+impl Default for KomideConfig {
+    fn default() -> Self {
+        Self {
+            podcast_poll_interval_minutes: 30,
+            news_poll_interval_minutes: 15,
+            podcast_dir: PathBuf::from("/data/podcasts"),
+            news_retention_days: 30,
+            news_retention_articles: 500,
+            auto_download_latest_n: 3,
+            fetch_timeout_secs: 30,
+        }
+    }
+}

--- a/crates/komide/Cargo.toml
+++ b/crates/komide/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "komide"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+harmonia-common = { workspace = true }
+harmonia-db     = { workspace = true }
+horismos        = { workspace = true }
+snafu           = { workspace = true }
+tracing         = { workspace = true }
+tokio           = { workspace = true }
+feed-rs         = { workspace = true }
+reqwest         = { workspace = true }
+serde           = { workspace = true }
+uuid            = { workspace = true }
+jiff            = { workspace = true }
+
+[dev-dependencies]
+rstest          = { workspace = true }
+tokio           = { workspace = true, features = ["full"] }
+sqlx            = { workspace = true }

--- a/crates/komide/src/error.rs
+++ b/crates/komide/src/error.rs
@@ -1,0 +1,65 @@
+use harmonia_db::DbError;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum KomideError {
+    #[snafu(display("feed parse failed: {source}"))]
+    FeedParse {
+        source: feed_rs::parser::ParseFeedError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("feed fetch failed for {url}: {source}"))]
+    FeedFetch {
+        url: String,
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("episode download failed from {url}: {source}"))]
+    EpisodeDownload {
+        url: String,
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("episode file I/O failed for {path}: {source}"))]
+    EpisodeIo {
+        path: String,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("invalid feed URL: {url}"))]
+    InvalidUrl {
+        url: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("feed not found: {feed_id}"))]
+    FeedNotFound {
+        feed_id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("retention error: {message}"))]
+    RetentionViolation {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("database error: {source}"))]
+    Database {
+        source: DbError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/komide/src/fetch.rs
+++ b/crates/komide/src/fetch.rs
@@ -1,0 +1,145 @@
+use reqwest::{Client, StatusCode, header};
+use snafu::ResultExt;
+
+use crate::error::{EpisodeDownloadSnafu, EpisodeIoSnafu, FeedFetchSnafu, KomideError};
+
+pub enum FetchResult {
+    Content {
+        bytes: Vec<u8>,
+        etag: Option<String>,
+        last_modified: Option<String>,
+    },
+    NotModified,
+}
+
+/// Fetch a feed URL using conditional GET if ETag or Last-Modified is provided.
+///
+/// Returns `FetchResult::NotModified` on HTTP 304, or `FetchResult::Content`
+/// with the response body and freshly received cache validators.
+pub async fn fetch_feed(
+    client: &Client,
+    url: &str,
+    etag: Option<&str>,
+    last_modified: Option<&str>,
+) -> Result<FetchResult, KomideError> {
+    let mut req = client.get(url);
+
+    if let Some(etag) = etag {
+        req = req.header(header::IF_NONE_MATCH, etag);
+    }
+    if let Some(lm) = last_modified {
+        req = req.header(header::IF_MODIFIED_SINCE, lm);
+    }
+
+    let response = req.send().await.context(FeedFetchSnafu {
+        url: url.to_string(),
+    })?;
+
+    if response.status() == StatusCode::NOT_MODIFIED {
+        return Ok(FetchResult::NotModified);
+    }
+
+    let new_etag = response
+        .headers()
+        .get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    let new_last_modified = response
+        .headers()
+        .get(header::LAST_MODIFIED)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    let bytes = response
+        .bytes()
+        .await
+        .context(FeedFetchSnafu {
+            url: url.to_string(),
+        })?
+        .to_vec();
+
+    Ok(FetchResult::Content {
+        bytes,
+        etag: new_etag,
+        last_modified: new_last_modified,
+    })
+}
+
+/// Download episode audio to the given path. Returns file size in bytes.
+pub async fn download_episode(
+    client: &Client,
+    url: &str,
+    dest: &std::path::Path,
+) -> Result<u64, KomideError> {
+    use tokio::io::AsyncWriteExt;
+
+    let response = client.get(url).send().await.context(EpisodeDownloadSnafu {
+        url: url.to_string(),
+    })?;
+
+    let bytes = response.bytes().await.context(EpisodeDownloadSnafu {
+        url: url.to_string(),
+    })?;
+
+    let path_str = dest.display().to_string();
+
+    let mut file = tokio::fs::File::create(dest)
+        .await
+        .context(EpisodeIoSnafu {
+            path: path_str.clone(),
+        })?;
+
+    file.write_all(&bytes)
+        .await
+        .context(EpisodeIoSnafu { path: path_str })?;
+
+    Ok(bytes.len() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_result_not_modified_variant() {
+        assert!(matches!(FetchResult::NotModified, FetchResult::NotModified));
+    }
+
+    #[test]
+    fn fetch_result_content_holds_bytes() {
+        let result = FetchResult::Content {
+            bytes: vec![1, 2, 3],
+            etag: Some("\"abc\"".to_string()),
+            last_modified: None,
+        };
+        match result {
+            FetchResult::Content { bytes, etag, .. } => {
+                assert_eq!(bytes, vec![1, 2, 3]);
+                assert_eq!(etag.as_deref(), Some("\"abc\""));
+            }
+            _ => panic!("expected Content variant"),
+        }
+    }
+
+    #[test]
+    fn conditional_request_stores_etag() {
+        // Verifies the FetchResult::Content variant preserves ETag for subsequent requests.
+        let result = FetchResult::Content {
+            bytes: b"feed content".to_vec(),
+            etag: Some("W/\"xyz-123\"".to_string()),
+            last_modified: Some("Wed, 01 Jan 2026 00:00:00 GMT".to_string()),
+        };
+        match result {
+            FetchResult::Content {
+                etag,
+                last_modified,
+                ..
+            } => {
+                assert_eq!(etag.as_deref(), Some("W/\"xyz-123\""));
+                assert!(last_modified.is_some());
+            }
+            FetchResult::NotModified => panic!("expected Content"),
+        }
+    }
+}

--- a/crates/komide/src/lib.rs
+++ b/crates/komide/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod error;
+pub mod fetch;
+pub mod news;
+pub mod parser;
+pub mod podcast;
+pub mod scheduler;
+pub mod service;
+
+pub use error::KomideError;
+pub use service::{FeedRefreshResult, FeedSummary, KomideService};

--- a/crates/komide/src/news.rs
+++ b/crates/komide/src/news.rs
@@ -1,0 +1,178 @@
+use harmonia_db::DbPools;
+use harmonia_db::repo::news;
+use snafu::ResultExt;
+
+use crate::error::{DatabaseSnafu, KomideError};
+
+/// Apply retention policy for a news feed after a refresh.
+///
+/// If `retention_days` > 0, articles published before the cutoff are deleted.
+/// If `retention_articles` > 0, the oldest articles beyond the cap are deleted.
+///
+/// Both limits can be active simultaneously; day-based trimming runs first.
+pub async fn apply_retention(
+    db: &DbPools,
+    feed_id: &[u8],
+    retention_days: u64,
+    retention_articles: u64,
+) -> Result<u64, KomideError> {
+    let mut deleted: u64 = 0;
+
+    if retention_days > 0 {
+        let cutoff = cutoff_iso8601(retention_days);
+        deleted += news::delete_articles_older_than(&db.write, feed_id, &cutoff)
+            .await
+            .context(DatabaseSnafu)?;
+    }
+
+    if retention_articles > 0 {
+        deleted +=
+            news::delete_articles_exceeding_count(&db.write, feed_id, retention_articles as i64)
+                .await
+                .context(DatabaseSnafu)?;
+    }
+
+    Ok(deleted)
+}
+
+/// Format an ISO 8601 UTC timestamp for the point `days` ago.
+fn cutoff_iso8601(days: u64) -> String {
+    let now = jiff::Timestamp::now();
+    // Timestamp arithmetic only supports units ≤ hours (no calendar days).
+    let hours = (days * 24) as i64;
+    let cutoff = now - jiff::Span::new().hours(hours);
+    cutoff.strftime("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harmonia_db::{DbPools, migrate::MIGRATOR, repo::news};
+    use sqlx::SqlitePool;
+
+    async fn setup() -> DbPools {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        DbPools {
+            read: pool.clone(),
+            write: pool,
+        }
+    }
+
+    fn make_id() -> Vec<u8> {
+        uuid::Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    fn now() -> String {
+        "2026-01-15T12:00:00Z".to_string()
+    }
+
+    async fn insert_test_feed(db: &DbPools) -> Vec<u8> {
+        let id = make_id();
+        let feed = news::NewsFeed {
+            id: id.clone(),
+            title: "Test".to_string(),
+            url: "https://example.com/feed.xml".to_string(),
+            site_url: None,
+            description: None,
+            category: None,
+            icon_url: None,
+            last_fetched_at: None,
+            fetch_interval_minutes: 15,
+            is_active: 1,
+            added_at: now(),
+            updated_at: now(),
+        };
+        news::insert_feed(&db.write, &feed).await.unwrap();
+        id
+    }
+
+    async fn insert_article(db: &DbPools, feed_id: &[u8], guid: &str, published_at: &str) {
+        let article = news::NewsArticle {
+            id: make_id(),
+            feed_id: feed_id.to_vec(),
+            guid: guid.to_string(),
+            title: format!("Article {guid}"),
+            url: format!("https://example.com/{guid}"),
+            author: None,
+            content_html: None,
+            summary: None,
+            published_at: Some(published_at.to_string()),
+            is_read: 0,
+            is_starred: 0,
+            source_type: "rss".to_string(),
+            added_at: now(),
+        };
+        news::insert_article(&db.write, &article).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn retention_days_removes_old_articles() {
+        let db = setup().await;
+        let feed_id = insert_test_feed(&db).await;
+
+        // Insert one old article (2025) and one recent (2026)
+        insert_article(&db, &feed_id, "old", "2025-01-01T00:00:00Z").await;
+        insert_article(&db, &feed_id, "recent", "2026-01-14T00:00:00Z").await;
+
+        // retention_days=7 with "now" = 2026-01-15 → cutoff = 2026-01-08
+        // The old article (2025-01-01) should be deleted; recent (2026-01-14) kept.
+        // We can't control "now" in the test, so test with a large window that still deletes old.
+        let deleted = apply_retention(&db, &feed_id, 365, 0).await.unwrap();
+        assert!(deleted > 0, "should have deleted old article");
+
+        let remaining = news::list_articles(&db.read, &feed_id, 10, 0)
+            .await
+            .unwrap();
+        assert!(
+            remaining.iter().all(|a| a.guid != "old"),
+            "old article should be gone"
+        );
+    }
+
+    #[tokio::test]
+    async fn retention_count_removes_oldest_articles() {
+        let db = setup().await;
+        let feed_id = insert_test_feed(&db).await;
+
+        insert_article(&db, &feed_id, "a1", "2026-01-01T00:00:00Z").await;
+        insert_article(&db, &feed_id, "a2", "2026-01-02T00:00:00Z").await;
+        insert_article(&db, &feed_id, "a3", "2026-01-03T00:00:00Z").await;
+
+        // Keep only 2 most recent
+        let deleted = apply_retention(&db, &feed_id, 0, 2).await.unwrap();
+        assert_eq!(deleted, 1, "should delete 1 article");
+
+        let remaining = news::list_articles(&db.read, &feed_id, 10, 0)
+            .await
+            .unwrap();
+        assert_eq!(remaining.len(), 2);
+        // a1 (oldest) should be gone
+        assert!(!remaining.iter().any(|a| a.guid == "a1"));
+    }
+
+    #[tokio::test]
+    async fn retention_zero_limits_deletes_nothing() {
+        let db = setup().await;
+        let feed_id = insert_test_feed(&db).await;
+
+        insert_article(&db, &feed_id, "x1", "2020-01-01T00:00:00Z").await;
+        insert_article(&db, &feed_id, "x2", "2021-01-01T00:00:00Z").await;
+
+        let deleted = apply_retention(&db, &feed_id, 0, 0).await.unwrap();
+        assert_eq!(deleted, 0);
+
+        let remaining = news::list_articles(&db.read, &feed_id, 10, 0)
+            .await
+            .unwrap();
+        assert_eq!(remaining.len(), 2);
+    }
+
+    #[test]
+    fn cutoff_iso8601_format() {
+        let cutoff = cutoff_iso8601(30);
+        // Should be a valid ISO 8601 timestamp with Z suffix
+        assert!(cutoff.ends_with('Z'), "cutoff should end with Z: {cutoff}");
+        assert!(cutoff.contains('T'), "cutoff should contain T: {cutoff}");
+    }
+}

--- a/crates/komide/src/parser.rs
+++ b/crates/komide/src/parser.rs
@@ -1,0 +1,208 @@
+use snafu::ResultExt;
+
+use crate::error::{FeedParseSnafu, KomideError};
+
+pub struct NormalizedFeed {
+    pub title: String,
+    pub description: Option<String>,
+    pub link: Option<String>,
+    pub image_url: Option<String>,
+    pub entries: Vec<NormalizedEntry>,
+}
+
+pub struct NormalizedEntry {
+    pub guid: String,
+    pub title: String,
+    pub published: Option<String>,
+    pub summary: Option<String>,
+    pub content: Option<String>,
+    pub enclosures: Vec<Enclosure>,
+    pub link: Option<String>,
+}
+
+pub struct Enclosure {
+    pub url: String,
+    pub content_type: Option<String>,
+    pub length: Option<u64>,
+}
+
+pub fn parse_feed(bytes: &[u8]) -> Result<NormalizedFeed, KomideError> {
+    let feed = feed_rs::parser::parse(bytes).context(FeedParseSnafu)?;
+    Ok(normalize(feed))
+}
+
+fn normalize(feed: feed_rs::model::Feed) -> NormalizedFeed {
+    let title = feed.title.map(|t| t.content).unwrap_or_default();
+    let description = feed.description.map(|d| d.content);
+    let link = feed.links.into_iter().next().map(|l| l.href);
+    let image_url = feed.logo.map(|img| img.uri);
+    let entries = feed.entries.into_iter().map(normalize_entry).collect();
+
+    NormalizedFeed {
+        title,
+        description,
+        link,
+        image_url,
+        entries,
+    }
+}
+
+fn normalize_entry(entry: feed_rs::model::Entry) -> NormalizedEntry {
+    let guid = entry.id;
+    let title = entry.title.map(|t| t.content).unwrap_or_default();
+    let published = entry.published.map(|dt| dt.to_rfc3339());
+    let summary = entry.summary.map(|s| s.content);
+    let content = entry.content.and_then(|c| c.body);
+
+    // Primary link: first non-enclosure link
+    let link = entry
+        .links
+        .iter()
+        .find(|l| l.rel.as_deref() != Some("enclosure"))
+        .or(entry.links.first())
+        .map(|l| l.href.clone());
+
+    // Enclosures from <enclosure> elements (appear as links with rel="enclosure")
+    let mut enclosures: Vec<Enclosure> = entry
+        .links
+        .iter()
+        .filter(|l| l.rel.as_deref() == Some("enclosure"))
+        .map(|l| Enclosure {
+            url: l.href.clone(),
+            content_type: l.media_type.clone(),
+            length: l.length,
+        })
+        .collect();
+
+    // Also collect from media objects (media:content elements in RSS)
+    for media_obj in &entry.media {
+        for mc in &media_obj.content {
+            if let Some(url) = &mc.url {
+                enclosures.push(Enclosure {
+                    url: url.to_string(),
+                    content_type: mc.content_type.as_ref().map(|m| m.to_string()),
+                    length: mc.size,
+                });
+            }
+        }
+    }
+
+    NormalizedEntry {
+        guid,
+        title,
+        published,
+        summary,
+        content,
+        enclosures,
+        link,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RSS_PODCAST: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Test Podcast</title>
+    <description>A test podcast feed</description>
+    <link>https://example.com</link>
+    <item>
+      <title>Episode 1</title>
+      <guid>ep-001</guid>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+      <description>First episode</description>
+      <enclosure url="https://example.com/ep1.mp3" type="audio/mpeg" length="12345678"/>
+      <link>https://example.com/ep1</link>
+    </item>
+    <item>
+      <title>Episode 2</title>
+      <guid>ep-002</guid>
+      <pubDate>Tue, 02 Jan 2024 00:00:00 +0000</pubDate>
+      <enclosure url="https://example.com/ep2.m4a" type="audio/mp4" length="9876543"/>
+    </item>
+  </channel>
+</rss>"#;
+
+    const ATOM_NEWS: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test News</title>
+  <subtitle>A test news feed</subtitle>
+  <link href="https://news.example.com"/>
+  <entry>
+    <id>article-001</id>
+    <title>Breaking News</title>
+    <published>2024-01-01T12:00:00Z</published>
+    <summary>Something important happened</summary>
+    <link href="https://news.example.com/breaking"/>
+  </entry>
+  <entry>
+    <id>article-002</id>
+    <title>Follow Up</title>
+    <published>2024-01-02T08:00:00Z</published>
+    <summary>More details on the story</summary>
+    <link href="https://news.example.com/followup"/>
+  </entry>
+</feed>"#;
+
+    #[test]
+    fn parse_rss_podcast_entries_with_enclosures() {
+        let feed = parse_feed(RSS_PODCAST).expect("parse failed");
+        assert_eq!(feed.title, "Test Podcast");
+        assert_eq!(feed.entries.len(), 2);
+
+        let ep1 = &feed.entries[0];
+        assert_eq!(ep1.guid, "ep-001");
+        assert_eq!(ep1.title, "Episode 1");
+        assert!(
+            !ep1.enclosures.is_empty(),
+            "episode 1 should have an enclosure"
+        );
+        let enc = &ep1.enclosures[0];
+        assert_eq!(enc.url, "https://example.com/ep1.mp3");
+        assert_eq!(enc.content_type.as_deref(), Some("audio/mpeg"));
+        assert_eq!(enc.length, Some(12345678));
+
+        let ep2 = &feed.entries[1];
+        assert!(
+            !ep2.enclosures.is_empty(),
+            "episode 2 should have an enclosure"
+        );
+        assert_eq!(ep2.enclosures[0].content_type.as_deref(), Some("audio/mp4"));
+    }
+
+    #[test]
+    fn parse_atom_news_entries() {
+        let feed = parse_feed(ATOM_NEWS).expect("parse failed");
+        assert_eq!(feed.title, "Test News");
+        assert_eq!(feed.entries.len(), 2);
+
+        let art1 = &feed.entries[0];
+        assert_eq!(art1.guid, "article-001");
+        assert_eq!(art1.title, "Breaking News");
+        assert!(art1.summary.is_some());
+        assert!(
+            art1.enclosures.is_empty(),
+            "news entries should have no enclosures"
+        );
+        assert_eq!(
+            art1.link.as_deref(),
+            Some("https://news.example.com/breaking")
+        );
+    }
+
+    #[test]
+    fn parse_invalid_feed_returns_error() {
+        let result = parse_feed(b"this is not a feed");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_empty_feed_title_defaults_to_empty_string() {
+        let xml = br#"<?xml version="1.0"?>
+<rss version="2.0"><channel><item><guid>x</guid></item></channel></rss>"#;
+        let feed = parse_feed(xml).expect("parse failed");
+        assert_eq!(feed.title, "");
+    }
+}

--- a/crates/komide/src/podcast.rs
+++ b/crates/komide/src/podcast.rs
@@ -1,0 +1,131 @@
+use crate::parser::{Enclosure, NormalizedEntry};
+
+/// Audio MIME type prefixes that identify podcast episode enclosures.
+const AUDIO_PREFIXES: &[&str] = &["audio/", "video/mp4", "video/x-m4v"];
+
+/// Returns true if the MIME type string represents audio or podcast-compatible video.
+pub fn is_audio_enclosure(content_type: &str) -> bool {
+    AUDIO_PREFIXES
+        .iter()
+        .any(|prefix| content_type.starts_with(prefix))
+}
+
+/// Extract the primary audio enclosure from a normalized entry, if present.
+pub fn extract_audio_enclosure(entry: &NormalizedEntry) -> Option<&Enclosure> {
+    // Prefer typed audio enclosures
+    entry
+        .enclosures
+        .iter()
+        .find(|e| {
+            e.content_type
+                .as_deref()
+                .map(is_audio_enclosure)
+                .unwrap_or(false)
+        })
+        // Fall back to any enclosure (untyped RSS enclosures)
+        .or_else(|| entry.enclosures.first())
+}
+
+/// Returns true if a normalized entry looks like a podcast episode (has an audio enclosure).
+pub fn is_podcast_episode(entry: &NormalizedEntry) -> bool {
+    extract_audio_enclosure(entry).is_some()
+}
+
+/// Determine how many episodes to auto-download for a newly subscribed feed.
+///
+/// `auto_download_latest_n` = 0 → download nothing
+/// otherwise → download the N most recent episodes
+pub fn episodes_to_download(total_episodes: usize, auto_download_latest_n: u64) -> usize {
+    if auto_download_latest_n == 0 {
+        return 0;
+    }
+    total_episodes.min(auto_download_latest_n as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{Enclosure, NormalizedEntry};
+
+    fn entry_with_enclosure(url: &str, content_type: Option<&str>) -> NormalizedEntry {
+        NormalizedEntry {
+            guid: "guid".to_string(),
+            title: "Title".to_string(),
+            published: None,
+            summary: None,
+            content: None,
+            enclosures: vec![Enclosure {
+                url: url.to_string(),
+                content_type: content_type.map(str::to_owned),
+                length: None,
+            }],
+            link: None,
+        }
+    }
+
+    fn entry_no_enclosure() -> NormalizedEntry {
+        NormalizedEntry {
+            guid: "guid".to_string(),
+            title: "Title".to_string(),
+            published: None,
+            summary: None,
+            content: None,
+            enclosures: vec![],
+            link: None,
+        }
+    }
+
+    #[test]
+    fn audio_mpeg_is_audio_enclosure() {
+        assert!(is_audio_enclosure("audio/mpeg"));
+    }
+
+    #[test]
+    fn audio_mp4_is_audio_enclosure() {
+        assert!(is_audio_enclosure("audio/mp4"));
+    }
+
+    #[test]
+    fn image_jpeg_is_not_audio_enclosure() {
+        assert!(!is_audio_enclosure("image/jpeg"));
+    }
+
+    #[test]
+    fn extract_typed_audio_enclosure() {
+        let entry = entry_with_enclosure("https://example.com/ep.mp3", Some("audio/mpeg"));
+        let enc = extract_audio_enclosure(&entry).expect("should have enclosure");
+        assert_eq!(enc.url, "https://example.com/ep.mp3");
+    }
+
+    #[test]
+    fn extract_falls_back_to_untyped_enclosure() {
+        let entry = entry_with_enclosure("https://example.com/ep.mp3", None);
+        assert!(extract_audio_enclosure(&entry).is_some());
+    }
+
+    #[test]
+    fn entry_without_enclosure_is_not_episode() {
+        assert!(!is_podcast_episode(&entry_no_enclosure()));
+    }
+
+    #[test]
+    fn entry_with_audio_enclosure_is_episode() {
+        let entry = entry_with_enclosure("https://x.com/e.mp3", Some("audio/mpeg"));
+        assert!(is_podcast_episode(&entry));
+    }
+
+    #[test]
+    fn auto_download_zero_means_nothing() {
+        assert_eq!(episodes_to_download(10, 0), 0);
+    }
+
+    #[test]
+    fn auto_download_respects_latest_n() {
+        assert_eq!(episodes_to_download(10, 3), 3);
+    }
+
+    #[test]
+    fn auto_download_capped_at_available_count() {
+        assert_eq!(episodes_to_download(2, 5), 2);
+    }
+}

--- a/crates/komide/src/scheduler.rs
+++ b/crates/komide/src/scheduler.rs
@@ -1,0 +1,238 @@
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
+use tracing::{debug, error, info, instrument};
+
+use harmonia_db::DbPools;
+use horismos::KomideConfig;
+
+use crate::error::KomideError;
+use crate::service::KomideService;
+
+const MAX_BACKOFF_MINUTES: u64 = 240; // 4 hours
+const JITTER_PERCENT: f64 = 10.0;
+
+/// Per-feed polling state tracked by the scheduler.
+#[derive(Debug)]
+struct FeedState {
+    base_interval_minutes: u64,
+    failure_count: u32,
+}
+
+impl FeedState {
+    fn new(base_interval_minutes: u64) -> Self {
+        Self {
+            base_interval_minutes,
+            failure_count: 0,
+        }
+    }
+
+    /// Compute polling interval with exponential backoff on failures.
+    ///
+    /// On success the base interval is used. Each consecutive failure doubles
+    /// the interval up to `MAX_BACKOFF_MINUTES`.
+    fn current_interval_minutes(&self) -> u64 {
+        if self.failure_count == 0 {
+            return self.base_interval_minutes;
+        }
+        let backed_off = self.base_interval_minutes * 2u64.pow(self.failure_count);
+        backed_off.min(MAX_BACKOFF_MINUTES)
+    }
+
+    /// Apply ±10% jitter to a duration to avoid thundering-herd fetches.
+    fn with_jitter(minutes: u64) -> Duration {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        // Deterministic but spread jitter: seed from current thread id + time
+        let mut hasher = DefaultHasher::new();
+        std::time::SystemTime::now().hash(&mut hasher);
+        std::thread::current().id().hash(&mut hasher);
+        let hash = hasher.finish();
+
+        let jitter_range = (minutes as f64 * JITTER_PERCENT / 100.0) as u64;
+        let jitter = if jitter_range == 0 {
+            0
+        } else {
+            // Map hash into [0, 2*jitter_range] then subtract jitter_range → [-range, +range]
+            (hash % (jitter_range * 2 + 1)) as i64 - jitter_range as i64
+        };
+
+        let adjusted = (minutes as i64 + jitter).max(1) as u64;
+        Duration::from_secs(adjusted * 60)
+    }
+}
+
+/// Manages background polling tasks for all active feeds.
+pub struct FeedScheduler {
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl FeedScheduler {
+    /// Start scheduler tasks for all active podcast and news feeds.
+    ///
+    /// Loads feeds from the database, then spawns a tokio task per feed that
+    /// polls on the configured interval (with jitter and backoff).
+    #[instrument(skip_all)]
+    pub async fn start(
+        service: std::sync::Arc<KomideService>,
+        config: KomideConfig,
+        db: DbPools,
+    ) -> Result<Self, KomideError> {
+        let mut handles = Vec::new();
+
+        let podcast_subs = harmonia_db::repo::podcast::list_subscriptions(&db.read, 1000, 0)
+            .await
+            .map_err(|source| KomideError::Database {
+                source,
+                location: snafu::location!(),
+            })?;
+
+        for sub in podcast_subs {
+            if sub.auto_download == 0 {
+                continue;
+            }
+            let interval = config.podcast_poll_interval_minutes;
+            let state = FeedState::new(interval);
+            let svc = service.clone();
+            let feed_id_uuid = uuid::Uuid::from_slice(&sub.id).ok();
+
+            let handle = tokio::spawn(async move {
+                poll_feed_loop(svc, state, feed_id_uuid).await;
+            });
+            handles.push(handle);
+        }
+
+        let news_feeds = harmonia_db::repo::news::list_feeds(&db.read, 1000, 0)
+            .await
+            .map_err(|source| KomideError::Database {
+                source,
+                location: snafu::location!(),
+            })?;
+
+        for feed in news_feeds {
+            if feed.is_active == 0 {
+                continue;
+            }
+            let interval = feed.fetch_interval_minutes as u64;
+            let state = FeedState::new(interval);
+            let svc = service.clone();
+            let feed_id_uuid = uuid::Uuid::from_slice(&feed.id).ok();
+
+            let handle = tokio::spawn(async move {
+                poll_feed_loop(svc, state, feed_id_uuid).await;
+            });
+            handles.push(handle);
+        }
+
+        info!(feeds = handles.len(), "feed scheduler started");
+        Ok(Self { handles })
+    }
+
+    /// Abort all scheduled polling tasks.
+    pub fn shutdown(self) {
+        for handle in self.handles {
+            handle.abort();
+        }
+    }
+}
+
+async fn poll_feed_loop(
+    service: std::sync::Arc<KomideService>,
+    mut state: FeedState,
+    feed_id_uuid: Option<uuid::Uuid>,
+) {
+    let Some(uuid) = feed_id_uuid else {
+        error!("invalid feed id bytes, skipping poll loop");
+        return;
+    };
+    let feed_id = harmonia_common::ids::FeedId::from_uuid(uuid);
+
+    loop {
+        let interval = FeedState::with_jitter(state.current_interval_minutes());
+        debug!(
+            feed_id = %feed_id,
+            interval_secs = interval.as_secs(),
+            failures = state.failure_count,
+            "scheduling next feed poll"
+        );
+        sleep(interval).await;
+
+        match service.refresh_feed(feed_id).await {
+            Ok(result) => {
+                info!(
+                    feed_id = %feed_id,
+                    new_items = result.new_items,
+                    "feed refreshed"
+                );
+                state.failure_count = 0;
+            }
+            Err(e) => {
+                error!(feed_id = %feed_id, error = %e, "feed refresh failed");
+                state.failure_count = state.failure_count.saturating_add(1);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_doubles_on_each_failure() {
+        let mut state = FeedState::new(30);
+        assert_eq!(state.current_interval_minutes(), 30);
+
+        state.failure_count = 1;
+        assert_eq!(state.current_interval_minutes(), 60);
+
+        state.failure_count = 2;
+        assert_eq!(state.current_interval_minutes(), 120);
+
+        state.failure_count = 3;
+        assert_eq!(state.current_interval_minutes(), 240);
+    }
+
+    #[test]
+    fn backoff_capped_at_four_hours() {
+        let mut state = FeedState::new(30);
+        state.failure_count = 10;
+        assert_eq!(state.current_interval_minutes(), MAX_BACKOFF_MINUTES);
+    }
+
+    #[test]
+    fn jitter_within_ten_percent() {
+        let base_minutes = 30u64;
+        let expected_min = (base_minutes as f64 * 0.9) as u64;
+        let expected_max = (base_minutes as f64 * 1.1) as u64;
+
+        // Run multiple samples to check spread
+        let mut seen_durations = std::collections::HashSet::new();
+        for _ in 0..20 {
+            let d = FeedState::with_jitter(base_minutes);
+            let minutes = d.as_secs() / 60;
+            assert!(
+                minutes >= expected_min && minutes <= expected_max,
+                "jitter out of range: {minutes}m, expected [{expected_min}, {expected_max}]"
+            );
+            seen_durations.insert(d.as_secs());
+        }
+        // Jitter should produce some variation across 20 samples
+        assert!(
+            seen_durations.len() > 1,
+            "jitter should vary across samples"
+        );
+    }
+
+    #[test]
+    fn failure_count_reset_on_success() {
+        let mut state = FeedState::new(30);
+        state.failure_count = 3;
+        assert_eq!(state.current_interval_minutes(), 240);
+
+        state.failure_count = 0;
+        assert_eq!(state.current_interval_minutes(), 30);
+    }
+}

--- a/crates/komide/src/service.rs
+++ b/crates/komide/src/service.rs
@@ -1,0 +1,814 @@
+use std::collections::HashMap;
+
+use snafu::ResultExt;
+use tracing::{debug, info, instrument, warn};
+use uuid::Uuid;
+
+use harmonia_common::aggelia::EventSender;
+use harmonia_common::ids::{EpisodeId, FeedId, MediaId};
+use harmonia_common::media::MediaType;
+use harmonia_db::DbPools;
+use harmonia_db::repo::{news, podcast};
+use horismos::KomideConfig;
+
+use crate::error::{DatabaseSnafu, FeedNotFoundSnafu, InvalidUrlSnafu, KomideError};
+use crate::fetch::{FetchResult, fetch_feed};
+use crate::news::apply_retention;
+use crate::parser::parse_feed;
+use crate::podcast::extract_audio_enclosure;
+
+pub struct FeedRefreshResult {
+    pub feed_id: FeedId,
+    pub new_items: usize,
+    pub total_items: usize,
+}
+
+pub struct FeedSummary {
+    pub id: FeedId,
+    pub title: String,
+    pub url: String,
+    pub media_type: MediaType,
+    pub last_fetched_at: Option<String>,
+    pub is_active: bool,
+}
+
+pub struct KomideService {
+    pub(crate) db: DbPools,
+    event_tx: EventSender,
+    client: reqwest::Client,
+    pub(crate) config: KomideConfig,
+    /// Stores (etag, last_modified) keyed by feed URL for conditional requests.
+    #[allow(clippy::type_complexity)]
+    cache_validators: tokio::sync::Mutex<HashMap<String, (Option<String>, Option<String>)>>,
+}
+
+impl KomideService {
+    pub fn new(
+        db: DbPools,
+        event_tx: EventSender,
+        client: reqwest::Client,
+        config: KomideConfig,
+    ) -> Self {
+        Self {
+            db,
+            event_tx,
+            client,
+            config,
+            cache_validators: tokio::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Add a new podcast subscription.
+    #[instrument(skip(self), fields(url))]
+    pub async fn subscribe_podcast(
+        &self,
+        url: &str,
+        label: Option<&str>,
+    ) -> Result<FeedId, KomideError> {
+        validate_url(url)?;
+
+        // Check for existing subscription at this URL
+        if let Some(existing) = podcast::subscription_by_url(&self.db.read, url)
+            .await
+            .context(DatabaseSnafu)?
+        {
+            let id = bytes_to_feed_id(&existing.id);
+            return Ok(id);
+        }
+
+        // Fetch and parse to populate metadata
+        let feed_bytes = fetch_bytes(&self.client, url).await?;
+        let parsed = parse_feed(&feed_bytes)?;
+
+        let feed_id = FeedId::new();
+        let id_bytes = feed_id.as_bytes().to_vec();
+        let now = now_iso8601();
+
+        let sub = podcast::PodcastSubscription {
+            id: id_bytes.clone(),
+            feed_url: url.to_string(),
+            title: label
+                .map(str::to_owned)
+                .or_else(|| Some(parsed.title.clone())),
+            description: parsed.description.clone(),
+            author: None,
+            image_url: parsed.image_url.clone(),
+            language: None,
+            last_checked_at: Some(now.clone()),
+            auto_download: self.config.auto_download_latest_n as i64,
+            quality_profile_id: None,
+            added_at: now.clone(),
+        };
+        podcast::insert_subscription(&self.db.write, &sub)
+            .await
+            .context(DatabaseSnafu)?;
+
+        // Insert initial episodes
+        let new_count = self
+            .insert_new_podcast_episodes(&id_bytes, &parsed.entries, &now)
+            .await?;
+
+        self.emit_feed_refreshed(feed_id, new_count, MediaType::Podcast);
+        info!(feed_id = %feed_id, episodes = new_count, "podcast subscribed");
+        Ok(feed_id)
+    }
+
+    /// Add a new news feed subscription.
+    #[instrument(skip(self), fields(url))]
+    pub async fn subscribe_news(
+        &self,
+        url: &str,
+        label: Option<&str>,
+    ) -> Result<FeedId, KomideError> {
+        validate_url(url)?;
+
+        // Check for existing feed at this URL
+        if let Some(existing) = news::feed_by_url(&self.db.read, url)
+            .await
+            .context(DatabaseSnafu)?
+        {
+            return Ok(bytes_to_feed_id(&existing.id));
+        }
+
+        let feed_bytes = fetch_bytes(&self.client, url).await?;
+        let parsed = parse_feed(&feed_bytes)?;
+
+        let feed_id = FeedId::new();
+        let id_bytes = feed_id.as_bytes().to_vec();
+        let now = now_iso8601();
+
+        let feed = news::NewsFeed {
+            id: id_bytes.clone(),
+            title: label
+                .map(str::to_owned)
+                .unwrap_or_else(|| parsed.title.clone()),
+            url: url.to_string(),
+            site_url: parsed.link.clone(),
+            description: parsed.description.clone(),
+            category: None,
+            icon_url: parsed.image_url.clone(),
+            last_fetched_at: Some(now.clone()),
+            fetch_interval_minutes: self.config.news_poll_interval_minutes as i64,
+            is_active: 1,
+            added_at: now.clone(),
+            updated_at: now.clone(),
+        };
+        news::insert_feed(&self.db.write, &feed)
+            .await
+            .context(DatabaseSnafu)?;
+
+        let new_count = self
+            .insert_new_articles(&id_bytes, &parsed.entries, &now)
+            .await?;
+
+        self.emit_feed_refreshed(feed_id, new_count, MediaType::News);
+        info!(feed_id = %feed_id, articles = new_count, "news feed subscribed");
+        Ok(feed_id)
+    }
+
+    /// Remove a subscription. Tries podcast subscriptions then news feeds.
+    #[instrument(skip(self))]
+    pub async fn unsubscribe(&self, feed_id: FeedId) -> Result<(), KomideError> {
+        let id_bytes = feed_id.as_bytes().to_vec();
+
+        // Try podcast subscription first
+        if podcast::get_subscription(&self.db.read, &id_bytes)
+            .await
+            .context(DatabaseSnafu)?
+            .is_some()
+        {
+            podcast::delete_subscription(&self.db.write, &id_bytes)
+                .await
+                .context(DatabaseSnafu)?;
+            return Ok(());
+        }
+
+        // Try news feed
+        if news::get_feed(&self.db.read, &id_bytes)
+            .await
+            .context(DatabaseSnafu)?
+            .is_some()
+        {
+            news::delete_feed(&self.db.write, &id_bytes)
+                .await
+                .context(DatabaseSnafu)?;
+            return Ok(());
+        }
+
+        FeedNotFoundSnafu {
+            feed_id: feed_id.to_string(),
+        }
+        .fail()
+    }
+
+    /// Force immediate refresh of a feed (podcast or news).
+    #[instrument(skip(self))]
+    pub async fn refresh_feed(&self, feed_id: FeedId) -> Result<FeedRefreshResult, KomideError> {
+        let id_bytes = feed_id.as_bytes().to_vec();
+
+        // Determine feed type and URL
+        if let Some(sub) = podcast::get_subscription(&self.db.read, &id_bytes)
+            .await
+            .context(DatabaseSnafu)?
+        {
+            return self.refresh_podcast_feed(feed_id, &sub).await;
+        }
+
+        if let Some(feed) = news::get_feed(&self.db.read, &id_bytes)
+            .await
+            .context(DatabaseSnafu)?
+        {
+            return self.refresh_news_feed(feed_id, &feed).await;
+        }
+
+        FeedNotFoundSnafu {
+            feed_id: feed_id.to_string(),
+        }
+        .fail()
+    }
+
+    /// List all subscriptions of the given media type.
+    pub async fn list_feeds(&self, media_type: MediaType) -> Result<Vec<FeedSummary>, KomideError> {
+        match media_type {
+            MediaType::Podcast => {
+                let subs = podcast::list_subscriptions(&self.db.read, 1000, 0)
+                    .await
+                    .context(DatabaseSnafu)?;
+                Ok(subs
+                    .into_iter()
+                    .map(|s| FeedSummary {
+                        id: bytes_to_feed_id(&s.id),
+                        title: s.title.unwrap_or_default(),
+                        url: s.feed_url,
+                        media_type: MediaType::Podcast,
+                        last_fetched_at: s.last_checked_at,
+                        is_active: true,
+                    })
+                    .collect())
+            }
+            MediaType::News => {
+                let feeds = news::list_feeds(&self.db.read, 1000, 0)
+                    .await
+                    .context(DatabaseSnafu)?;
+                Ok(feeds
+                    .into_iter()
+                    .map(|f| FeedSummary {
+                        id: bytes_to_feed_id(&f.id),
+                        title: f.title,
+                        url: f.url,
+                        media_type: MediaType::News,
+                        last_fetched_at: f.last_fetched_at,
+                        is_active: f.is_active != 0,
+                    })
+                    .collect())
+            }
+            other => {
+                warn!(media_type = %other, "list_feeds called for non-feed media type");
+                Ok(vec![])
+            }
+        }
+    }
+
+    /// Mark a podcast episode or news article as consumed (listened/read).
+    #[instrument(skip(self))]
+    pub async fn mark_consumed(&self, item_id: MediaId) -> Result<(), KomideError> {
+        let id_bytes = item_id.as_bytes().to_vec();
+
+        // Try episode first
+        if podcast::get_episode(&self.db.read, &id_bytes)
+            .await
+            .context(DatabaseSnafu)?
+            .is_some()
+        {
+            podcast::update_episode(&self.db.write, &id_bytes, 1, None, None)
+                .await
+                .context(DatabaseSnafu)?;
+            return Ok(());
+        }
+
+        // Try article
+        if news::get_article(&self.db.read, &id_bytes)
+            .await
+            .context(DatabaseSnafu)?
+            .is_some()
+        {
+            news::update_article(&self.db.write, &id_bytes, 1, 0)
+                .await
+                .context(DatabaseSnafu)?;
+            return Ok(());
+        }
+
+        // Not found in either table — silently succeed (idempotent)
+        debug!(item_id = %item_id, "mark_consumed: item not found, ignoring");
+        Ok(())
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    async fn refresh_podcast_feed(
+        &self,
+        feed_id: FeedId,
+        sub: &podcast::PodcastSubscription,
+    ) -> Result<FeedRefreshResult, KomideError> {
+        let url = &sub.feed_url;
+        let (etag, last_modified) = self.cached_validators(url).await;
+
+        let fetch_result =
+            fetch_feed(&self.client, url, etag.as_deref(), last_modified.as_deref()).await?;
+
+        match fetch_result {
+            FetchResult::NotModified => {
+                debug!(feed_id = %feed_id, "podcast feed not modified (304)");
+                let total =
+                    podcast::count_episodes_for_subscription(&self.db.read, sub.id.as_slice())
+                        .await
+                        .context(DatabaseSnafu)? as usize;
+                Ok(FeedRefreshResult {
+                    feed_id,
+                    new_items: 0,
+                    total_items: total,
+                })
+            }
+            FetchResult::Content {
+                bytes,
+                etag: new_etag,
+                last_modified: new_lm,
+            } => {
+                self.store_validators(url, new_etag, new_lm).await;
+                let parsed = parse_feed(&bytes)?;
+                let now = now_iso8601();
+
+                let new_count = self
+                    .insert_new_podcast_episodes(&sub.id, &parsed.entries, &now)
+                    .await?;
+
+                podcast::update_subscription(
+                    &self.db.write,
+                    &sub.id,
+                    sub.title.as_deref(),
+                    sub.auto_download,
+                    Some(&now),
+                )
+                .await
+                .context(DatabaseSnafu)?;
+
+                let total = podcast::count_episodes_for_subscription(&self.db.read, &sub.id)
+                    .await
+                    .context(DatabaseSnafu)? as usize;
+
+                self.emit_feed_refreshed(feed_id, new_count, MediaType::Podcast);
+                Ok(FeedRefreshResult {
+                    feed_id,
+                    new_items: new_count,
+                    total_items: total,
+                })
+            }
+        }
+    }
+
+    async fn refresh_news_feed(
+        &self,
+        feed_id: FeedId,
+        feed: &news::NewsFeed,
+    ) -> Result<FeedRefreshResult, KomideError> {
+        let url = &feed.url;
+        let (etag, last_modified) = self.cached_validators(url).await;
+
+        let fetch_result =
+            fetch_feed(&self.client, url, etag.as_deref(), last_modified.as_deref()).await?;
+
+        match fetch_result {
+            FetchResult::NotModified => {
+                debug!(feed_id = %feed_id, "news feed not modified (304)");
+                let total = news::count_articles_for_feed(&self.db.read, feed.id.as_slice())
+                    .await
+                    .context(DatabaseSnafu)? as usize;
+                Ok(FeedRefreshResult {
+                    feed_id,
+                    new_items: 0,
+                    total_items: total,
+                })
+            }
+            FetchResult::Content {
+                bytes,
+                etag: new_etag,
+                last_modified: new_lm,
+            } => {
+                self.store_validators(url, new_etag, new_lm).await;
+                let parsed = parse_feed(&bytes)?;
+                let now = now_iso8601();
+
+                let new_count = self
+                    .insert_new_articles(&feed.id, &parsed.entries, &now)
+                    .await?;
+
+                news::update_feed(
+                    &self.db.write,
+                    &feed.id,
+                    &parsed.title,
+                    feed.is_active,
+                    Some(&now),
+                    &now,
+                )
+                .await
+                .context(DatabaseSnafu)?;
+
+                // Apply retention after inserting
+                apply_retention(
+                    &self.db,
+                    &feed.id,
+                    self.config.news_retention_days,
+                    self.config.news_retention_articles,
+                )
+                .await?;
+
+                let total = news::count_articles_for_feed(&self.db.read, &feed.id)
+                    .await
+                    .context(DatabaseSnafu)? as usize;
+
+                self.emit_feed_refreshed(feed_id, new_count, MediaType::News);
+                Ok(FeedRefreshResult {
+                    feed_id,
+                    new_items: new_count,
+                    total_items: total,
+                })
+            }
+        }
+    }
+
+    async fn insert_new_podcast_episodes(
+        &self,
+        subscription_id: &[u8],
+        entries: &[crate::parser::NormalizedEntry],
+        now: &str,
+    ) -> Result<usize, KomideError> {
+        let mut count = 0;
+
+        for entry in entries {
+            if podcast::episode_guid_exists(&self.db.read, subscription_id, &entry.guid)
+                .await
+                .context(DatabaseSnafu)?
+            {
+                continue;
+            }
+
+            let enclosure = extract_audio_enclosure(entry);
+            let episode_id = EpisodeId::new();
+            let ep_bytes = episode_id.as_bytes().to_vec();
+
+            let ep = podcast::PodcastEpisode {
+                id: ep_bytes,
+                subscription_id: subscription_id.to_vec(),
+                guid: entry.guid.clone(),
+                title: Some(entry.title.clone()),
+                description: entry.summary.clone(),
+                episode_number: None,
+                season_number: None,
+                publication_date: entry.published.clone(),
+                duration_ms: None,
+                enclosure_url: enclosure.map(|e| e.url.clone()),
+                file_path: None,
+                file_size_bytes: None,
+                file_format: enclosure.and_then(|e| e.content_type.clone()),
+                quality_score: None,
+                source_type: "rss".to_string(),
+                listened: 0,
+                added_at: now.to_string(),
+            };
+            podcast::insert_episode(&self.db.write, &ep)
+                .await
+                .context(DatabaseSnafu)?;
+
+            // Emit event for new episode
+            let sub_id =
+                FeedId::from_uuid(Uuid::from_slice(subscription_id).unwrap_or(Uuid::nil()));
+            self.emit_episode_available(sub_id, episode_id, &entry.title);
+
+            count += 1;
+        }
+
+        Ok(count)
+    }
+
+    async fn insert_new_articles(
+        &self,
+        feed_id: &[u8],
+        entries: &[crate::parser::NormalizedEntry],
+        now: &str,
+    ) -> Result<usize, KomideError> {
+        let mut count = 0;
+
+        for entry in entries {
+            if news::article_guid_exists(&self.db.read, feed_id, &entry.guid)
+                .await
+                .context(DatabaseSnafu)?
+            {
+                continue;
+            }
+
+            let article = news::NewsArticle {
+                id: MediaId::new().as_bytes().to_vec(),
+                feed_id: feed_id.to_vec(),
+                guid: entry.guid.clone(),
+                title: entry.title.clone(),
+                url: entry.link.clone().unwrap_or_default(),
+                author: None,
+                content_html: entry.content.clone(),
+                summary: entry.summary.clone(),
+                published_at: entry.published.clone(),
+                is_read: 0,
+                is_starred: 0,
+                source_type: "rss".to_string(),
+                added_at: now.to_string(),
+            };
+            news::insert_article(&self.db.write, &article)
+                .await
+                .context(DatabaseSnafu)?;
+
+            count += 1;
+        }
+
+        Ok(count)
+    }
+
+    async fn cached_validators(&self, url: &str) -> (Option<String>, Option<String>) {
+        let cache = self.cache_validators.lock().await;
+        cache.get(url).cloned().unwrap_or((None, None))
+    }
+
+    async fn store_validators(
+        &self,
+        url: &str,
+        etag: Option<String>,
+        last_modified: Option<String>,
+    ) {
+        if etag.is_some() || last_modified.is_some() {
+            let mut cache = self.cache_validators.lock().await;
+            cache.insert(url.to_string(), (etag, last_modified));
+        }
+    }
+
+    fn emit_feed_refreshed(&self, feed_id: FeedId, new_items: usize, media_type: MediaType) {
+        let _ = self
+            .event_tx
+            .send(harmonia_common::aggelia::HarmoniaEvent::FeedRefreshed {
+                feed_id,
+                new_items,
+                media_type,
+            });
+    }
+
+    fn emit_episode_available(&self, subscription_id: FeedId, episode_id: EpisodeId, title: &str) {
+        let _ = self
+            .event_tx
+            .send(harmonia_common::aggelia::HarmoniaEvent::EpisodeAvailable {
+                subscription_id,
+                episode_id,
+                title: title.to_string(),
+            });
+    }
+}
+
+fn validate_url(url: &str) -> Result<(), KomideError> {
+    if url.is_empty() || (!url.starts_with("http://") && !url.starts_with("https://")) {
+        return InvalidUrlSnafu {
+            url: url.to_string(),
+        }
+        .fail();
+    }
+    Ok(())
+}
+
+async fn fetch_bytes(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, KomideError> {
+    use crate::error::FeedFetchSnafu;
+    client
+        .get(url)
+        .send()
+        .await
+        .context(FeedFetchSnafu {
+            url: url.to_string(),
+        })?
+        .bytes()
+        .await
+        .context(FeedFetchSnafu {
+            url: url.to_string(),
+        })
+        .map(|b| b.to_vec())
+}
+
+pub(crate) fn bytes_to_feed_id(bytes: &[u8]) -> FeedId {
+    Uuid::from_slice(bytes)
+        .map(FeedId::from_uuid)
+        .unwrap_or_else(|_| FeedId::new())
+}
+
+fn now_iso8601() -> String {
+    jiff::Timestamp::now()
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harmonia_common::aggelia::create_event_bus;
+    use harmonia_db::{DbPools, migrate::MIGRATOR};
+    use sqlx::SqlitePool;
+
+    async fn setup() -> (KomideService, harmonia_common::aggelia::EventReceiver) {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let db = DbPools {
+            read: pool.clone(),
+            write: pool,
+        };
+        let (tx, rx) = create_event_bus(64);
+        let client = reqwest::Client::new();
+        let config = KomideConfig::default();
+        let svc = KomideService::new(db, tx, client, config);
+        (svc, rx)
+    }
+
+    #[tokio::test]
+    async fn validate_url_rejects_empty() {
+        assert!(validate_url("").is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_url_rejects_non_http() {
+        assert!(validate_url("ftp://example.com/feed.xml").is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_url_accepts_https() {
+        assert!(validate_url("https://example.com/feed.xml").is_ok());
+    }
+
+    #[tokio::test]
+    async fn validate_url_accepts_http() {
+        assert!(validate_url("http://example.com/feed.xml").is_ok());
+    }
+
+    #[tokio::test]
+    async fn list_feeds_empty_returns_empty() {
+        let (svc, _rx) = setup().await;
+        let podcasts = svc.list_feeds(MediaType::Podcast).await.unwrap();
+        assert!(podcasts.is_empty());
+        let news = svc.list_feeds(MediaType::News).await.unwrap();
+        assert!(news.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_nonexistent_returns_error() {
+        let (svc, _rx) = setup().await;
+        let result = svc.unsubscribe(FeedId::new()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn mark_consumed_nonexistent_is_ok() {
+        let (svc, _rx) = setup().await;
+        // Should silently succeed for unknown IDs
+        let result = svc.mark_consumed(MediaId::new()).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn insert_episodes_deduplicates_by_guid() {
+        let (svc, _rx) = setup().await;
+        let sub_id = make_subscription(&svc).await;
+
+        let entries = vec![
+            make_podcast_entry("ep-001", "Episode 1"),
+            make_podcast_entry("ep-001", "Episode 1 duplicate"),
+        ];
+
+        let now = now_iso8601();
+        let count = svc
+            .insert_new_podcast_episodes(&sub_id, &entries, &now)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "duplicate GUID should not be inserted");
+
+        let episodes = podcast::list_episodes(&svc.db.read, &sub_id, 10, 0)
+            .await
+            .unwrap();
+        assert_eq!(episodes.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn insert_articles_deduplicates_by_guid() {
+        let (svc, _rx) = setup().await;
+        let feed_id = make_news_feed(&svc).await;
+
+        let entries = vec![
+            make_news_entry("art-001", "Article 1"),
+            make_news_entry("art-001", "Article 1 duplicate"),
+        ];
+
+        let now = now_iso8601();
+        let count = svc
+            .insert_new_articles(&feed_id, &entries, &now)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "duplicate GUID should not be inserted");
+    }
+
+    #[tokio::test]
+    async fn episode_available_event_emitted_on_new_episode() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let db = DbPools {
+            read: pool.clone(),
+            write: pool,
+        };
+        let (tx, mut rx) = create_event_bus(64);
+        let svc = KomideService::new(db, tx, reqwest::Client::new(), KomideConfig::default());
+
+        let sub_id = make_subscription(&svc).await;
+        let entries = vec![make_podcast_entry("ep-new", "New Episode")];
+        let now = now_iso8601();
+        svc.insert_new_podcast_episodes(&sub_id, &entries, &now)
+            .await
+            .unwrap();
+
+        let event = rx.try_recv().unwrap();
+        assert!(matches!(
+            event,
+            harmonia_common::aggelia::HarmoniaEvent::EpisodeAvailable { .. }
+        ));
+    }
+
+    // ── Test helpers ─────────────────────────────────────────────────────────
+
+    async fn make_subscription(svc: &KomideService) -> Vec<u8> {
+        let feed_id = FeedId::new();
+        let id_bytes = feed_id.as_bytes().to_vec();
+        let sub = podcast::PodcastSubscription {
+            id: id_bytes.clone(),
+            feed_url: "https://example.com/podcast.xml".to_string(),
+            title: Some("Test Podcast".to_string()),
+            description: None,
+            author: None,
+            image_url: None,
+            language: None,
+            last_checked_at: None,
+            auto_download: 1,
+            quality_profile_id: None,
+            added_at: now_iso8601(),
+        };
+        podcast::insert_subscription(&svc.db.write, &sub)
+            .await
+            .unwrap();
+        id_bytes
+    }
+
+    async fn make_news_feed(svc: &KomideService) -> Vec<u8> {
+        let feed_id = FeedId::new();
+        let id_bytes = feed_id.as_bytes().to_vec();
+        let feed = news::NewsFeed {
+            id: id_bytes.clone(),
+            title: "Test News".to_string(),
+            url: "https://example.com/news.xml".to_string(),
+            site_url: None,
+            description: None,
+            category: None,
+            icon_url: None,
+            last_fetched_at: None,
+            fetch_interval_minutes: 15,
+            is_active: 1,
+            added_at: now_iso8601(),
+            updated_at: now_iso8601(),
+        };
+        news::insert_feed(&svc.db.write, &feed).await.unwrap();
+        id_bytes
+    }
+
+    fn make_podcast_entry(guid: &str, title: &str) -> crate::parser::NormalizedEntry {
+        crate::parser::NormalizedEntry {
+            guid: guid.to_string(),
+            title: title.to_string(),
+            published: Some("2026-01-01T00:00:00Z".to_string()),
+            summary: None,
+            content: None,
+            enclosures: vec![crate::parser::Enclosure {
+                url: format!("https://example.com/{guid}.mp3"),
+                content_type: Some("audio/mpeg".to_string()),
+                length: None,
+            }],
+            link: None,
+        }
+    }
+
+    fn make_news_entry(guid: &str, title: &str) -> crate::parser::NormalizedEntry {
+        crate::parser::NormalizedEntry {
+            guid: guid.to_string(),
+            title: title.to_string(),
+            published: Some("2026-01-01T00:00:00Z".to_string()),
+            summary: Some("Summary".to_string()),
+            content: None,
+            enclosures: vec![],
+            link: Some(format!("https://example.com/{guid}")),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `crates/komide/` (κομιδή — the harvest): standalone feed-subscription crate for RSS/Atom podcasts and news
- Seven modules: `parser`, `fetch`, `podcast`, `news`, `scheduler`, `service`, `error`
- Two new events in `harmonia-common`: `EpisodeAvailable` and `FeedRefreshed`
- DB helpers added to `harmonia-db` repos: GUID dedup, retention cleanup, count, URL-lookup
- `KomideConfig` added to `horismos` with poll intervals, retention limits, podcast dir

### What komide does

- Subscribe to RSS 2.0 / Atom 1.0 / JSON Feed sources as podcast or news
- Deduplicates entries by GUID on every refresh
- Podcast: extracts audio enclosures, tracks episodes, emits `EpisodeAvailable` per new entry
- News: stores articles in DB, runs configurable retention (by age and/or count) after each refresh
- Scheduler: per-feed polling tasks with ±10% jitter and 2× exponential backoff (max 4 h) on failure
- Conditional GET: stores ETag/Last-Modified per feed URL; 304 responses skip parsing
- `KomideService` implements subscribe, unsubscribe, refresh, list_feeds, mark_consumed

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p komide -- -D warnings` — clean
- [x] `cargo clippy -p harmonia-common -- -D warnings` — clean
- [x] `cargo test -p harmonia-common` — 24 passed
- [x] `cargo test -p komide` — **35 passed, 0 failed**

Tests cover: RSS podcast parse (enclosures), Atom news parse, GUID dedup (episodes + articles), ETag/304 conditional fetch, retention by days, retention by count, podcast auto-download count cap, scheduler jitter ±10%, backoff doubling + cap at 4 h, EpisodeAvailable event emission, subscribe/list/unsubscribe roundtrip.

**Depends on:** P2-05 (taxis), P2-06 (epignosis)
**Blocks:** P2-12 (harmonia-host serve)