### PR TITLE
feat(paroche): core HTTP API (P2-08)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +54,18 @@ dependencies = [
  "blake2",
  "cpufeatures",
  "password-hash",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -172,6 +199,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +259,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -240,6 +290,26 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -849,6 +919,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1416,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,9 +1584,27 @@ dependencies = [
 name = "paroche"
 version = "0.1.0"
 dependencies = [
+ "axum",
+ "epignosis",
+ "exousia",
+ "futures-util",
  "harmonia-common",
+ "harmonia-db",
+ "horismos",
+ "http-body-util",
+ "kritike",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
  "snafu",
+ "sqlx",
+ "taxis",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2800,16 +2914,27 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2893,6 +3018,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -3629,3 +3760,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -3,9 +3,30 @@ name = "paroche"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Media serving — HTTP streaming and OPDS"
+description = "Paroche — Axum HTTP server, media streaming, and WebSocket events"
 
 [dependencies]
 harmonia-common.workspace = true
+harmonia-db.workspace = true
+horismos.workspace = true
+exousia.workspace = true
+taxis.workspace = true
+epignosis.workspace = true
+kritike.workspace = true
+axum.workspace = true
+tower.workspace = true
+tower-http = { version = "0.6", features = ["trace", "cors", "compression-full", "fs", "timeout"] }
+tokio.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 snafu.workspace = true
 tracing.workspace = true
+uuid.workspace = true
+rand.workspace = true
+tokio-util = { version = "0.7", features = ["io"] }
+futures-util = "0.3"
+
+[dev-dependencies]
+sqlx.workspace = true
+harmonia-db.workspace = true
+http-body-util = "0.1"

--- a/crates/paroche/src/error.rs
+++ b/crates/paroche/src/error.rs
@@ -1,0 +1,160 @@
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+use snafu::Snafu;
+
+fn new_correlation_id() -> String {
+    use rand::RngCore;
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 16];
+    rng.fill_bytes(&mut bytes);
+    bytes.iter().fold(String::with_capacity(32), |mut s, b| {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").unwrap();
+        s
+    })
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ParocheError {
+    #[snafu(display("resource not found"))]
+    NotFound,
+    #[snafu(display("authentication required"))]
+    Unauthorized,
+    #[snafu(display("access forbidden"))]
+    Forbidden,
+    #[snafu(display("validation error: {message}"))]
+    Validation { message: String },
+    #[snafu(display("rate limited"))]
+    RateLimited,
+    #[snafu(display("service temporarily unavailable"))]
+    Unavailable,
+    #[snafu(display("database error"))]
+    Database { source: harmonia_db::DbError },
+    #[snafu(display("internal error"))]
+    Internal,
+    #[snafu(display("invalid id format"))]
+    InvalidId,
+}
+
+impl IntoResponse for ParocheError {
+    fn into_response(self) -> Response {
+        let cid = new_correlation_id();
+        let (status, code, message) = match &self {
+            ParocheError::NotFound => (StatusCode::NOT_FOUND, "NOT_FOUND", self.to_string()),
+            ParocheError::Unauthorized => {
+                (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", self.to_string())
+            }
+            ParocheError::Forbidden => (StatusCode::FORBIDDEN, "FORBIDDEN", self.to_string()),
+            ParocheError::Validation { .. } => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "VALIDATION_ERROR",
+                self.to_string(),
+            ),
+            ParocheError::RateLimited => (
+                StatusCode::TOO_MANY_REQUESTS,
+                "RATE_LIMITED",
+                self.to_string(),
+            ),
+            ParocheError::Unavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "UNAVAILABLE",
+                self.to_string(),
+            ),
+            ParocheError::Database { .. } => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "DATABASE_ERROR",
+                self.to_string(),
+            ),
+            ParocheError::Internal => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                self.to_string(),
+            ),
+            ParocheError::InvalidId => (StatusCode::BAD_REQUEST, "INVALID_ID", self.to_string()),
+        };
+        (
+            status,
+            Json(json!({ "error": message, "code": code, "correlation_id": cid })),
+        )
+            .into_response()
+    }
+}
+
+impl From<harmonia_db::DbError> for ParocheError {
+    fn from(source: harmonia_db::DbError) -> Self {
+        ParocheError::Database { source }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    async fn status_and_body(err: ParocheError) -> (StatusCode, serde_json::Value) {
+        let resp = err.into_response();
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn not_found_returns_404() {
+        let (status, body) = status_and_body(ParocheError::NotFound).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["code"], "NOT_FOUND");
+        assert!(body["correlation_id"].is_string());
+    }
+
+    #[tokio::test]
+    async fn unauthorized_returns_401() {
+        let (status, body) = status_and_body(ParocheError::Unauthorized).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["code"], "UNAUTHORIZED");
+    }
+
+    #[tokio::test]
+    async fn forbidden_returns_403() {
+        let (status, body) = status_and_body(ParocheError::Forbidden).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["code"], "FORBIDDEN");
+    }
+
+    #[tokio::test]
+    async fn validation_returns_422() {
+        let (status, body) = status_and_body(ParocheError::Validation {
+            message: "bad input".to_string(),
+        })
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["code"], "VALIDATION_ERROR");
+    }
+
+    #[tokio::test]
+    async fn internal_returns_500() {
+        let (status, body) = status_and_body(ParocheError::Internal).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body["code"], "INTERNAL_ERROR");
+    }
+
+    #[tokio::test]
+    async fn invalid_id_returns_400() {
+        let (status, body) = status_and_body(ParocheError::InvalidId).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["code"], "INVALID_ID");
+    }
+
+    #[tokio::test]
+    async fn error_body_has_required_fields() {
+        let (_, body) = status_and_body(ParocheError::NotFound).await;
+        assert!(body.get("error").is_some());
+        assert!(body.get("code").is_some());
+        assert!(body.get("correlation_id").is_some());
+    }
+}

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -1,1 +1,105 @@
-// Stub — implementation in P2-07
+pub mod error;
+pub mod middleware;
+pub mod response;
+pub mod routes;
+pub mod state;
+pub mod ws;
+
+use std::time::Duration;
+
+use axum::Router;
+use tower_http::{
+    compression::CompressionLayer, cors::CorsLayer, timeout::TimeoutLayer, trace::TraceLayer,
+};
+
+use crate::{middleware::RequestIdLayer, state::AppState, ws::ws_handler};
+
+pub use error::ParocheError;
+
+pub fn build_router(state: AppState) -> Router {
+    Router::new()
+        .nest("/api/auth", routes::user::auth_routes())
+        .nest("/api/users", routes::user::user_routes())
+        .nest("/api/music", routes::music::music_routes())
+        .nest("/api/audiobooks", routes::audiobook::audiobook_routes())
+        .nest("/api/books", routes::book::book_routes())
+        .nest("/api/comics", routes::comic::comic_routes())
+        .nest("/api/podcasts", routes::podcast::podcast_routes())
+        .nest("/api/news", routes::news::news_routes())
+        .nest("/api/movies", routes::movie::movie_routes())
+        .nest("/api/tv", routes::tv::tv_routes())
+        .nest("/api/library", routes::library::library_routes())
+        .nest("/api/system", routes::system::system_routes())
+        .merge(routes::stream::stream_routes())
+        .route("/api/ws", axum::routing::get(ws_handler))
+        .layer(RequestIdLayer)
+        .layer(TraceLayer::new_for_http())
+        .layer(CompressionLayer::new())
+        .layer(TimeoutLayer::with_status_code(
+            axum::http::StatusCode::REQUEST_TIMEOUT,
+            Duration::from_secs(30),
+        ))
+        .layer(CorsLayer::permissive())
+        .with_state(state)
+}
+
+#[cfg(test)]
+pub mod test_helpers {
+    use std::sync::Arc;
+
+    use exousia::ExousiaServiceImpl;
+    use harmonia_common::create_event_bus;
+    use harmonia_db::{DbPools, migrate::MIGRATOR};
+    use horismos::{Config, ExousiaConfig};
+    use sqlx::SqlitePool;
+
+    use crate::state::AppState;
+
+    pub async fn test_state() -> (AppState, Arc<ExousiaServiceImpl>) {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let pools = Arc::new(DbPools {
+            read: pool.clone(),
+            write: pool,
+        });
+        let config = Arc::new(Config::default());
+        let (event_tx, _) = create_event_bus(64);
+
+        let exousia_config = ExousiaConfig {
+            access_token_ttl_secs: 900,
+            refresh_token_ttl_days: 30,
+            jwt_secret: "test-secret-that-is-long-enough-for-hs256".to_string(),
+        };
+        let auth = Arc::new(ExousiaServiceImpl::new(pools.clone(), exousia_config));
+
+        let import = crate::state::make_import_service(|| async { Ok(vec![]) });
+
+        let state = AppState::with_stubs(pools, config, event_tx, auth.clone(), import);
+
+        (state, auth)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_helpers::test_state;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn build_router_serves_health() {
+        let (state, _) = test_state().await;
+        let app = super::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/system/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/crates/paroche/src/middleware.rs
+++ b/crates/paroche/src/middleware.rs
@@ -1,0 +1,121 @@
+use axum::{
+    body::Body,
+    http::{Request, Response, header::HeaderValue},
+};
+use rand::RngCore;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{Layer, Service};
+
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
+
+fn generate_request_id() -> String {
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 16];
+    rng.fill_bytes(&mut bytes);
+    bytes.iter().fold(String::with_capacity(32), |mut s, b| {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").unwrap();
+        s
+    })
+}
+
+#[derive(Clone)]
+pub struct RequestIdLayer;
+
+impl<S> Layer<S> for RequestIdLayer {
+    type Service = RequestIdMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestIdMiddleware { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct RequestIdMiddleware<S> {
+    inner: S,
+}
+
+impl<S> Service<Request<Body>> for RequestIdMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        let request_id = req
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+            .unwrap_or_else(generate_request_id);
+
+        if let Ok(val) = HeaderValue::from_str(&request_id) {
+            req.headers_mut().insert(REQUEST_ID_HEADER, val);
+        }
+
+        let mut inner = self.inner.clone();
+        let fut = inner.call(req);
+
+        Box::pin(async move {
+            let mut resp = fut.await?;
+            if let Ok(val) = HeaderValue::from_str(&request_id) {
+                resp.headers_mut().insert(REQUEST_ID_HEADER, val);
+            }
+            Ok(resp)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{Request, StatusCode};
+    use axum::{Router, body::Body, routing::get};
+    use tower::ServiceExt;
+
+    async fn ok_handler() -> StatusCode {
+        StatusCode::OK
+    }
+
+    fn app() -> Router {
+        Router::new()
+            .route("/", get(ok_handler))
+            .layer(RequestIdLayer)
+    }
+
+    #[tokio::test]
+    async fn response_contains_request_id_when_not_provided() {
+        let response = app()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert!(response.headers().contains_key(REQUEST_ID_HEADER));
+    }
+
+    #[tokio::test]
+    async fn propagates_provided_request_id() {
+        let id = "test-request-id-12345";
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header(REQUEST_ID_HEADER, id)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.headers().get(REQUEST_ID_HEADER).unwrap(), id);
+    }
+}

--- a/crates/paroche/src/response.rs
+++ b/crates/paroche/src/response.rs
@@ -1,0 +1,72 @@
+use axum::{Json, http::StatusCode, response::IntoResponse};
+use rand::RngCore;
+use serde::Serialize;
+
+pub fn new_correlation_id() -> String {
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 16];
+    rng.fill_bytes(&mut bytes);
+    bytes.iter().fold(String::with_capacity(32), |mut s, b| {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").unwrap();
+        s
+    })
+}
+
+#[derive(Serialize)]
+pub struct Meta {
+    pub page: u64,
+    pub per_page: u64,
+    pub total: u64,
+}
+
+#[derive(Serialize)]
+pub struct ApiResponse<T: Serialize> {
+    pub data: T,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+    pub correlation_id: String,
+}
+
+impl<T: Serialize> ApiResponse<T> {
+    pub fn ok(data: T) -> (StatusCode, Json<Self>) {
+        (
+            StatusCode::OK,
+            Json(Self {
+                data,
+                meta: None,
+                correlation_id: new_correlation_id(),
+            }),
+        )
+    }
+
+    pub fn created(data: T) -> (StatusCode, Json<Self>) {
+        (
+            StatusCode::CREATED,
+            Json(Self {
+                data,
+                meta: None,
+                correlation_id: new_correlation_id(),
+            }),
+        )
+    }
+
+    pub fn paginated(data: T, page: u64, per_page: u64, total: u64) -> (StatusCode, Json<Self>) {
+        (
+            StatusCode::OK,
+            Json(Self {
+                data,
+                meta: Some(Meta {
+                    page,
+                    per_page,
+                    total,
+                }),
+                correlation_id: new_correlation_id(),
+            }),
+        )
+    }
+}
+
+pub fn deleted() -> impl IntoResponse {
+    StatusCode::NO_CONTENT
+}

--- a/crates/paroche/src/routes/audiobook.rs
+++ b/crates/paroche/src/routes/audiobook.rs
@@ -1,0 +1,210 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use exousia::{AuthenticatedUser, RequireAdmin};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::ParocheError,
+    response::{ApiResponse, deleted},
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct PaginationQuery {
+    #[serde(default = "default_page")]
+    pub page: u64,
+    #[serde(default = "default_per_page")]
+    pub per_page: u64,
+}
+
+fn default_page() -> u64 {
+    1
+}
+fn default_per_page() -> u64 {
+    20
+}
+
+fn bytes_to_uuid_str(bytes: &[u8]) -> String {
+    Uuid::from_slice(bytes)
+        .map(|u| u.to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+pub struct AudiobookResponse {
+    pub id: String,
+    pub title: String,
+    pub series_name: Option<String>,
+    pub series_position: Option<f64>,
+    pub duration_ms: Option<i64>,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::audiobook::Audiobook> for AudiobookResponse {
+    fn from(b: harmonia_db::repo::audiobook::Audiobook) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&b.id),
+            title: b.title,
+            series_name: b.series_name,
+            series_position: b.series_position,
+            duration_ms: b.duration_ms,
+            added_at: b.added_at,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateAudiobookRequest {
+    pub title: String,
+    pub series_name: Option<String>,
+    pub series_position: Option<f64>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateAudiobookRequest {
+    pub title: String,
+    pub quality_score: Option<i64>,
+    pub file_path: Option<String>,
+}
+
+pub async fn list_audiobooks(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let per_page = pagination.per_page.clamp(1, 100);
+    let page = pagination.page.max(1);
+    let offset = (page - 1) * per_page;
+
+    let books = harmonia_db::repo::audiobook::list_audiobooks(
+        &state.db.read,
+        per_page as i64,
+        offset as i64,
+    )
+    .await?;
+
+    let total = books.len() as u64;
+    let data: Vec<AudiobookResponse> = books.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::paginated(data, page, per_page, total))
+}
+
+pub async fn get_audiobook(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let book = harmonia_db::repo::audiobook::get_audiobook(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok(ApiResponse::ok(AudiobookResponse::from(book)))
+}
+
+pub async fn create_audiobook(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<CreateAudiobookRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.title.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "title is required".to_string(),
+        });
+    }
+
+    let id = Uuid::now_v7().as_bytes().to_vec();
+    let now = crate::routes::music::chrono_now_pub();
+
+    let book = harmonia_db::repo::audiobook::Audiobook {
+        id: id.clone(),
+        registry_id: None,
+        title: body.title,
+        subtitle: None,
+        publisher: None,
+        isbn: None,
+        asin: None,
+        duration_ms: None,
+        release_date: None,
+        language: None,
+        series_name: body.series_name,
+        series_position: body.series_position,
+        file_path: None,
+        file_format: None,
+        file_size_bytes: None,
+        quality_score: None,
+        quality_profile_id: None,
+        source_type: "manual".to_string(),
+        added_at: now,
+    };
+
+    harmonia_db::repo::audiobook::insert_audiobook(&state.db.write, &book).await?;
+
+    let created = harmonia_db::repo::audiobook::get_audiobook(&state.db.read, &id)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::created(AudiobookResponse::from(created)))
+}
+
+pub async fn update_audiobook(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateAudiobookRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::audiobook::get_audiobook(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::audiobook::update_audiobook(
+        &state.db.write,
+        &id_bytes,
+        &body.title,
+        body.quality_score,
+        body.file_path.as_deref(),
+    )
+    .await?;
+
+    let updated = harmonia_db::repo::audiobook::get_audiobook(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::ok(AudiobookResponse::from(updated)))
+}
+
+pub async fn delete_audiobook(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::audiobook::get_audiobook(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::audiobook::delete_audiobook(&state.db.write, &id_bytes).await?;
+
+    Ok(deleted())
+}
+
+pub fn audiobook_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route("/", get(list_audiobooks).post(create_audiobook))
+        .route(
+            "/{id}",
+            get(get_audiobook)
+                .put(update_audiobook)
+                .delete(delete_audiobook),
+        )
+}

--- a/crates/paroche/src/routes/book.rs
+++ b/crates/paroche/src/routes/book.rs
@@ -1,0 +1,205 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use exousia::{AuthenticatedUser, RequireAdmin};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::ParocheError,
+    response::{ApiResponse, deleted},
+    routes::music::chrono_now_pub,
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct PaginationQuery {
+    #[serde(default = "default_page")]
+    pub page: u64,
+    #[serde(default = "default_per_page")]
+    pub per_page: u64,
+}
+
+fn default_page() -> u64 {
+    1
+}
+fn default_per_page() -> u64 {
+    20
+}
+
+fn bytes_to_uuid_str(bytes: &[u8]) -> String {
+    Uuid::from_slice(bytes)
+        .map(|u| u.to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+pub struct BookResponse {
+    pub id: String,
+    pub title: String,
+    pub isbn: Option<String>,
+    pub publisher: Option<String>,
+    pub page_count: Option<i64>,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::book::Book> for BookResponse {
+    fn from(b: harmonia_db::repo::book::Book) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&b.id),
+            title: b.title,
+            isbn: b.isbn,
+            publisher: b.publisher,
+            page_count: b.page_count,
+            added_at: b.added_at,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateBookRequest {
+    pub title: String,
+    pub isbn: Option<String>,
+    pub publisher: Option<String>,
+    pub page_count: Option<i64>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateBookRequest {
+    pub title: String,
+    pub quality_score: Option<i64>,
+    pub file_path: Option<String>,
+}
+
+pub async fn list_books(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let per_page = pagination.per_page.clamp(1, 100);
+    let page = pagination.page.max(1);
+    let offset = (page - 1) * per_page;
+
+    let books =
+        harmonia_db::repo::book::list_books(&state.db.read, per_page as i64, offset as i64).await?;
+
+    let total = books.len() as u64;
+    let data: Vec<BookResponse> = books.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::paginated(data, page, per_page, total))
+}
+
+pub async fn get_book(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let book = harmonia_db::repo::book::get_book(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok(ApiResponse::ok(BookResponse::from(book)))
+}
+
+pub async fn create_book(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<CreateBookRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.title.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "title is required".to_string(),
+        });
+    }
+
+    let id = Uuid::now_v7().as_bytes().to_vec();
+    let now = chrono_now_pub();
+
+    let book = harmonia_db::repo::book::Book {
+        id: id.clone(),
+        registry_id: None,
+        title: body.title,
+        subtitle: None,
+        isbn: body.isbn,
+        isbn13: None,
+        openlibrary_id: None,
+        goodreads_id: None,
+        publisher: body.publisher,
+        publish_date: None,
+        language: None,
+        page_count: body.page_count,
+        description: None,
+        file_path: None,
+        file_format: None,
+        file_size_bytes: None,
+        quality_score: None,
+        quality_profile_id: None,
+        source_type: "manual".to_string(),
+        added_at: now,
+    };
+
+    harmonia_db::repo::book::insert_book(&state.db.write, &book).await?;
+
+    let created = harmonia_db::repo::book::get_book(&state.db.read, &id)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::created(BookResponse::from(created)))
+}
+
+pub async fn update_book(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateBookRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::book::get_book(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::book::update_book(
+        &state.db.write,
+        &id_bytes,
+        &body.title,
+        body.quality_score,
+        body.file_path.as_deref(),
+        None,
+    )
+    .await?;
+
+    let updated = harmonia_db::repo::book::get_book(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::ok(BookResponse::from(updated)))
+}
+
+pub async fn delete_book(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::book::get_book(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::book::delete_book(&state.db.write, &id_bytes).await?;
+
+    Ok(deleted())
+}
+
+pub fn book_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route("/", get(list_books).post(create_book))
+        .route("/{id}", get(get_book).put(update_book).delete(delete_book))
+}

--- a/crates/paroche/src/routes/comic.rs
+++ b/crates/paroche/src/routes/comic.rs
@@ -1,0 +1,213 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use exousia::{AuthenticatedUser, RequireAdmin};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::ParocheError,
+    response::{ApiResponse, deleted},
+    routes::music::chrono_now_pub,
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct PaginationQuery {
+    #[serde(default = "default_page")]
+    pub page: u64,
+    #[serde(default = "default_per_page")]
+    pub per_page: u64,
+}
+
+fn default_page() -> u64 {
+    1
+}
+fn default_per_page() -> u64 {
+    20
+}
+
+fn bytes_to_uuid_str(bytes: &[u8]) -> String {
+    Uuid::from_slice(bytes)
+        .map(|u| u.to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+pub struct ComicResponse {
+    pub id: String,
+    pub series_name: String,
+    pub volume: Option<i64>,
+    pub issue_number: Option<f64>,
+    pub title: Option<String>,
+    pub publisher: Option<String>,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::comic::Comic> for ComicResponse {
+    fn from(c: harmonia_db::repo::comic::Comic) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&c.id),
+            series_name: c.series_name,
+            volume: c.volume,
+            issue_number: c.issue_number,
+            title: c.title,
+            publisher: c.publisher,
+            added_at: c.added_at,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateComicRequest {
+    pub series_name: String,
+    pub volume: Option<i64>,
+    pub issue_number: Option<f64>,
+    pub title: Option<String>,
+    pub publisher: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateComicRequest {
+    pub title: Option<String>,
+    pub quality_score: Option<i64>,
+    pub file_path: Option<String>,
+}
+
+pub async fn list_comics(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let per_page = pagination.per_page.clamp(1, 100);
+    let page = pagination.page.max(1);
+    let offset = (page - 1) * per_page;
+
+    let comics =
+        harmonia_db::repo::comic::list_comics(&state.db.read, per_page as i64, offset as i64)
+            .await?;
+
+    let total = comics.len() as u64;
+    let data: Vec<ComicResponse> = comics.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::paginated(data, page, per_page, total))
+}
+
+pub async fn get_comic(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let comic = harmonia_db::repo::comic::get_comic(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok(ApiResponse::ok(ComicResponse::from(comic)))
+}
+
+pub async fn create_comic(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<CreateComicRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.series_name.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "series_name is required".to_string(),
+        });
+    }
+
+    let id = Uuid::now_v7().as_bytes().to_vec();
+    let now = chrono_now_pub();
+
+    let comic = harmonia_db::repo::comic::Comic {
+        id: id.clone(),
+        registry_id: None,
+        series_name: body.series_name,
+        volume: body.volume,
+        issue_number: body.issue_number,
+        title: body.title,
+        publisher: body.publisher,
+        release_date: None,
+        page_count: None,
+        summary: None,
+        language: None,
+        comicinfo_writer: None,
+        comicinfo_penciller: None,
+        comicinfo_inker: None,
+        comicinfo_colorist: None,
+        file_path: None,
+        file_format: None,
+        file_size_bytes: None,
+        quality_score: None,
+        quality_profile_id: None,
+        source_type: "manual".to_string(),
+        added_at: now,
+    };
+
+    harmonia_db::repo::comic::insert_comic(&state.db.write, &comic).await?;
+
+    let created = harmonia_db::repo::comic::get_comic(&state.db.read, &id)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::created(ComicResponse::from(created)))
+}
+
+pub async fn update_comic(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateComicRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::comic::get_comic(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::comic::update_comic(
+        &state.db.write,
+        &id_bytes,
+        body.title.as_deref(),
+        body.quality_score,
+        body.file_path.as_deref(),
+    )
+    .await?;
+
+    let updated = harmonia_db::repo::comic::get_comic(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::ok(ComicResponse::from(updated)))
+}
+
+pub async fn delete_comic(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::comic::get_comic(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::comic::delete_comic(&state.db.write, &id_bytes).await?;
+
+    Ok(deleted())
+}
+
+pub fn comic_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route("/", get(list_comics).post(create_comic))
+        .route(
+            "/{id}",
+            get(get_comic).put(update_comic).delete(delete_comic),
+        )
+}

--- a/crates/paroche/src/routes/library.rs
+++ b/crates/paroche/src/routes/library.rs
@@ -1,0 +1,47 @@
+use axum::{Json, extract::State, http::StatusCode};
+use exousia::RequireAdmin;
+use serde_json::json;
+
+use crate::{error::ParocheError, state::AppState};
+
+pub async fn health(State(_state): State<AppState>) -> impl axum::response::IntoResponse {
+    (StatusCode::OK, Json(json!({"status": "ok"})))
+}
+
+pub async fn get_import_queue(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let queue = state
+        .get_import_queue()
+        .await
+        .map_err(|_| ParocheError::Unavailable)?;
+
+    let items: Vec<serde_json::Value> = queue
+        .iter()
+        .map(|item| {
+            json!({
+                "id": item.id.to_string(),
+                "path": item.path.to_string_lossy(),
+                "media_type": format!("{:?}", item.media_type),
+            })
+        })
+        .collect();
+
+    Ok((StatusCode::OK, Json(json!({"data": items}))))
+}
+
+pub async fn trigger_scan(
+    State(_state): State<AppState>,
+    _admin: RequireAdmin,
+) -> impl axum::response::IntoResponse {
+    StatusCode::ACCEPTED
+}
+
+pub fn library_routes() -> axum::Router<AppState> {
+    use axum::routing::{get, post};
+    axum::Router::new()
+        .route("/health", get(health))
+        .route("/import-queue", get(get_import_queue))
+        .route("/scan", post(trigger_scan))
+}

--- a/crates/paroche/src/routes/mod.rs
+++ b/crates/paroche/src/routes/mod.rs
@@ -1,0 +1,12 @@
+pub mod audiobook;
+pub mod book;
+pub mod comic;
+pub mod library;
+pub mod movie;
+pub mod music;
+pub mod news;
+pub mod podcast;
+pub mod stream;
+pub mod system;
+pub mod tv;
+pub mod user;

--- a/crates/paroche/src/routes/movie.rs
+++ b/crates/paroche/src/routes/movie.rs
@@ -1,0 +1,208 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use exousia::{AuthenticatedUser, RequireAdmin};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::ParocheError,
+    response::{ApiResponse, deleted},
+    routes::music::chrono_now_pub,
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct PaginationQuery {
+    #[serde(default = "default_page")]
+    pub page: u64,
+    #[serde(default = "default_per_page")]
+    pub per_page: u64,
+}
+
+fn default_page() -> u64 {
+    1
+}
+fn default_per_page() -> u64 {
+    20
+}
+
+fn bytes_to_uuid_str(bytes: &[u8]) -> String {
+    Uuid::from_slice(bytes)
+        .map(|u| u.to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+pub struct MovieResponse {
+    pub id: String,
+    pub title: String,
+    pub year: Option<i64>,
+    pub runtime_min: Option<i64>,
+    pub overview: Option<String>,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::movie::Movie> for MovieResponse {
+    fn from(m: harmonia_db::repo::movie::Movie) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&m.id),
+            title: m.title,
+            year: m.year,
+            runtime_min: m.runtime_min,
+            overview: m.overview,
+            added_at: m.added_at,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateMovieRequest {
+    pub title: String,
+    pub year: Option<i64>,
+    pub runtime_min: Option<i64>,
+    pub overview: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateMovieRequest {
+    pub title: String,
+    pub quality_score: Option<i64>,
+    pub file_path: Option<String>,
+}
+
+pub async fn list_movies(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let per_page = pagination.per_page.clamp(1, 100);
+    let page = pagination.page.max(1);
+    let offset = (page - 1) * per_page;
+
+    let movies =
+        harmonia_db::repo::movie::list_movies(&state.db.read, per_page as i64, offset as i64)
+            .await?;
+
+    let total = movies.len() as u64;
+    let data: Vec<MovieResponse> = movies.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::paginated(data, page, per_page, total))
+}
+
+pub async fn get_movie(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let movie = harmonia_db::repo::movie::get_movie(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok(ApiResponse::ok(MovieResponse::from(movie)))
+}
+
+pub async fn create_movie(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<CreateMovieRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.title.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "title is required".to_string(),
+        });
+    }
+
+    let id = Uuid::now_v7().as_bytes().to_vec();
+    let now = chrono_now_pub();
+
+    let movie = harmonia_db::repo::movie::Movie {
+        id: id.clone(),
+        registry_id: None,
+        title: body.title,
+        original_title: None,
+        year: body.year,
+        tmdb_id: None,
+        imdb_id: None,
+        runtime_min: body.runtime_min,
+        overview: body.overview,
+        certification: None,
+        file_path: None,
+        file_format: None,
+        file_size_bytes: None,
+        resolution: None,
+        codec: None,
+        hdr_type: None,
+        quality_score: None,
+        quality_profile_id: None,
+        source_type: "manual".to_string(),
+        added_at: now,
+    };
+
+    harmonia_db::repo::movie::insert_movie(&state.db.write, &movie).await?;
+
+    let created = harmonia_db::repo::movie::get_movie(&state.db.read, &id)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::created(MovieResponse::from(created)))
+}
+
+pub async fn update_movie(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateMovieRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::movie::get_movie(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::movie::update_movie(
+        &state.db.write,
+        &id_bytes,
+        &body.title,
+        body.quality_score,
+        body.file_path.as_deref(),
+    )
+    .await?;
+
+    let updated = harmonia_db::repo::movie::get_movie(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::ok(MovieResponse::from(updated)))
+}
+
+pub async fn delete_movie(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::movie::get_movie(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::movie::delete_movie(&state.db.write, &id_bytes).await?;
+
+    Ok(deleted())
+}
+
+pub fn movie_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route("/", get(list_movies).post(create_movie))
+        .route(
+            "/{id}",
+            get(get_movie).put(update_movie).delete(delete_movie),
+        )
+}

--- a/crates/paroche/src/routes/music.rs
+++ b/crates/paroche/src/routes/music.rs
@@ -1,0 +1,497 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use exousia::{AuthenticatedUser, RequireAdmin};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::ParocheError,
+    response::{ApiResponse, deleted},
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct PaginationQuery {
+    #[serde(default = "default_page")]
+    pub page: u64,
+    #[serde(default = "default_per_page")]
+    pub per_page: u64,
+}
+
+fn default_page() -> u64 {
+    1
+}
+
+fn default_per_page() -> u64 {
+    20
+}
+
+fn bytes_to_uuid_str(bytes: &[u8]) -> String {
+    Uuid::from_slice(bytes)
+        .map(|u| u.to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+pub struct ReleaseGroupResponse {
+    pub id: String,
+    pub title: String,
+    pub rg_type: String,
+    pub year: Option<i64>,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::music::MusicReleaseGroup> for ReleaseGroupResponse {
+    fn from(rg: harmonia_db::repo::music::MusicReleaseGroup) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&rg.id),
+            title: rg.title,
+            rg_type: rg.rg_type,
+            year: rg.year,
+            added_at: rg.added_at,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct TrackResponse {
+    pub id: String,
+    pub title: String,
+    pub position: i64,
+    pub duration_ms: Option<i64>,
+    pub codec: Option<String>,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::music::MusicTrack> for TrackResponse {
+    fn from(t: harmonia_db::repo::music::MusicTrack) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&t.id),
+            title: t.title,
+            position: t.position,
+            duration_ms: t.duration_ms,
+            codec: t.codec,
+            added_at: t.added_at,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateReleaseGroupRequest {
+    pub title: String,
+    pub rg_type: String,
+    pub year: Option<i64>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateReleaseGroupRequest {
+    pub title: String,
+    pub rg_type: String,
+    pub quality_profile_id: Option<i64>,
+}
+
+pub async fn list_release_groups(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let per_page = pagination.per_page.clamp(1, 100);
+    let page = pagination.page.max(1);
+    let offset = (page - 1) * per_page;
+
+    let groups = harmonia_db::repo::music::list_release_groups(
+        &state.db.read,
+        per_page as i64,
+        offset as i64,
+    )
+    .await?;
+
+    let total = groups.len() as u64;
+    let data: Vec<ReleaseGroupResponse> = groups.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::paginated(data, page, per_page, total))
+}
+
+pub async fn get_release_group(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let group = harmonia_db::repo::music::get_release_group(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok(ApiResponse::ok(ReleaseGroupResponse::from(group)))
+}
+
+pub async fn create_release_group(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<CreateReleaseGroupRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.title.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "title is required".to_string(),
+        });
+    }
+
+    let id = Uuid::now_v7().as_bytes().to_vec();
+    let now = chrono_now();
+
+    let group = harmonia_db::repo::music::MusicReleaseGroup {
+        id: id.clone(),
+        registry_id: None,
+        title: body.title,
+        rg_type: body.rg_type,
+        mb_release_group_id: None,
+        year: body.year,
+        quality_profile_id: None,
+        added_at: now,
+    };
+
+    harmonia_db::repo::music::insert_release_group(&state.db.write, &group).await?;
+
+    let created = harmonia_db::repo::music::get_release_group(&state.db.read, &id)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::created(ReleaseGroupResponse::from(created)))
+}
+
+pub async fn update_release_group(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateReleaseGroupRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::music::get_release_group(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::music::update_release_group(
+        &state.db.write,
+        &id_bytes,
+        &body.title,
+        &body.rg_type,
+        body.quality_profile_id,
+    )
+    .await?;
+
+    let updated = harmonia_db::repo::music::get_release_group(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::ok(ReleaseGroupResponse::from(updated)))
+}
+
+pub async fn delete_release_group(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::music::get_release_group(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::music::delete_release_group(&state.db.write, &id_bytes).await?;
+
+    Ok(deleted())
+}
+
+pub async fn list_tracks(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let per_page = pagination.per_page.clamp(1, 100);
+    let page = pagination.page.max(1);
+    let offset = (page - 1) * per_page;
+
+    let tracks =
+        harmonia_db::repo::music::search_tracks(&state.db.read, "", per_page as i64).await?;
+
+    let _ = offset;
+    let total = tracks.len() as u64;
+    let data: Vec<TrackResponse> = tracks.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::paginated(data, page, per_page, total))
+}
+
+pub async fn get_track(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let track = harmonia_db::repo::music::get_track(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok(ApiResponse::ok(TrackResponse::from(track)))
+}
+
+pub fn chrono_now_pub() -> String {
+    chrono_now()
+}
+
+fn chrono_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format_unix_ts(secs)
+}
+
+fn format_unix_ts(secs: u64) -> String {
+    let s = secs as i64;
+    let (year, month, day, hour, min, sec) = unix_to_parts(s);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
+}
+
+fn unix_to_parts(secs: i64) -> (i64, i64, i64, i64, i64, i64) {
+    let sec = secs % 60;
+    let mins = secs / 60;
+    let min = mins % 60;
+    let hours = mins / 60;
+    let hour = hours % 24;
+    let days = hours / 24;
+
+    let mut year = 1970i64;
+    let mut remaining = days;
+    loop {
+        let days_in_year = if is_leap(year) { 366 } else { 365 };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        year += 1;
+    }
+
+    let month_days = [
+        31i64,
+        if is_leap(year) { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut month = 1i64;
+    for &md in &month_days {
+        if remaining < md {
+            break;
+        }
+        remaining -= md;
+        month += 1;
+    }
+    let day = remaining + 1;
+
+    (year, month, day, hour, min, sec)
+}
+
+fn is_leap(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+pub fn music_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route(
+            "/release-groups",
+            get(list_release_groups).post(create_release_group),
+        )
+        .route(
+            "/release-groups/{id}",
+            get(get_release_group)
+                .put(update_release_group)
+                .delete(delete_release_group),
+        )
+        .route("/tracks", get(list_tracks))
+        .route("/tracks/{id}", get(get_track))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_state;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use exousia::{
+        AuthService,
+        user::{CreateUserRequest, UserRole},
+    };
+    use tower::ServiceExt;
+
+    async fn admin_token(auth: &std::sync::Arc<exousia::ExousiaServiceImpl>) -> String {
+        auth.create_user(CreateUserRequest {
+            username: "admin".to_string(),
+            display_name: "Admin".to_string(),
+            password: "password123".to_string(),
+            role: UserRole::Admin,
+        })
+        .await
+        .unwrap();
+        auth.login("admin", "password123")
+            .await
+            .unwrap()
+            .access_token
+    }
+
+    async fn member_token(auth: &std::sync::Arc<exousia::ExousiaServiceImpl>) -> String {
+        auth.create_user(CreateUserRequest {
+            username: "member".to_string(),
+            display_name: "Member".to_string(),
+            password: "password123".to_string(),
+            role: UserRole::Member,
+        })
+        .await
+        .unwrap();
+        auth.login("member", "password123")
+            .await
+            .unwrap()
+            .access_token
+    }
+
+    #[tokio::test]
+    async fn list_release_groups_unauthenticated_returns_401() {
+        let (state, _auth) = test_state().await;
+        let app = music_routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/release-groups")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn create_release_group_requires_admin() {
+        let (state, auth) = test_state().await;
+        let token = member_token(&auth).await;
+        let app = music_routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/release-groups")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"title":"Test","rg_type":"album"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn crud_release_group_happy_path() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+        let app = music_routes().with_state(state);
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/release-groups")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        r#"{"title":"Led Zeppelin IV","rg_type":"album","year":1971}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let id = json["data"]["id"].as_str().unwrap().to_string();
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/release-groups/{id}"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/release-groups")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json.get("meta").is_some());
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/release-groups/{id}"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn get_nonexistent_release_group_returns_404() {
+        let (state, auth) = test_state().await;
+        let token = member_token(&auth).await;
+        let app = music_routes().with_state(state);
+        let id = Uuid::now_v7();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/release-groups/{id}"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/paroche/src/routes/news.rs
+++ b/crates/paroche/src/routes/news.rs
@@ -1,0 +1,201 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use exousia::{AuthenticatedUser, RequireAdmin};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::ParocheError,
+    response::{ApiResponse, deleted},
+    routes::music::chrono_now_pub,
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct PaginationQuery {
+    #[serde(default = "default_page")]
+    pub page: u64,
+    #[serde(default = "default_per_page")]
+    pub per_page: u64,
+}
+
+fn default_page() -> u64 {
+    1
+}
+fn default_per_page() -> u64 {
+    20
+}
+
+fn bytes_to_uuid_str(bytes: &[u8]) -> String {
+    Uuid::from_slice(bytes)
+        .map(|u| u.to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+pub struct FeedResponse {
+    pub id: String,
+    pub title: String,
+    pub url: String,
+    pub category: Option<String>,
+    pub is_active: bool,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::news::NewsFeed> for FeedResponse {
+    fn from(f: harmonia_db::repo::news::NewsFeed) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&f.id),
+            title: f.title,
+            url: f.url,
+            category: f.category,
+            is_active: f.is_active != 0,
+            added_at: f.added_at,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateFeedRequest {
+    pub title: String,
+    pub url: String,
+    pub category: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateFeedRequest {
+    pub title: String,
+    pub is_active: bool,
+}
+
+pub async fn list_feeds(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let per_page = pagination.per_page.clamp(1, 100);
+    let page = pagination.page.max(1);
+    let offset = (page - 1) * per_page;
+
+    let feeds =
+        harmonia_db::repo::news::list_feeds(&state.db.read, per_page as i64, offset as i64).await?;
+
+    let total = feeds.len() as u64;
+    let data: Vec<FeedResponse> = feeds.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::paginated(data, page, per_page, total))
+}
+
+pub async fn get_feed(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let feed = harmonia_db::repo::news::get_feed(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok(ApiResponse::ok(FeedResponse::from(feed)))
+}
+
+pub async fn create_feed(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<CreateFeedRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.title.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "title is required".to_string(),
+        });
+    }
+    if body.url.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "url is required".to_string(),
+        });
+    }
+
+    let id = Uuid::now_v7().as_bytes().to_vec();
+    let now = chrono_now_pub();
+
+    let feed = harmonia_db::repo::news::NewsFeed {
+        id: id.clone(),
+        title: body.title,
+        url: body.url,
+        site_url: None,
+        description: None,
+        category: body.category,
+        icon_url: None,
+        last_fetched_at: None,
+        fetch_interval_minutes: 60,
+        is_active: 1,
+        added_at: now.clone(),
+        updated_at: now,
+    };
+
+    harmonia_db::repo::news::insert_feed(&state.db.write, &feed).await?;
+
+    let created = harmonia_db::repo::news::get_feed(&state.db.read, &id)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::created(FeedResponse::from(created)))
+}
+
+pub async fn update_feed(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateFeedRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::news::get_feed(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    let now = chrono_now_pub();
+    harmonia_db::repo::news::update_feed(
+        &state.db.write,
+        &id_bytes,
+        &body.title,
+        if body.is_active { 1 } else { 0 },
+        None,
+        &now,
+    )
+    .await?;
+
+    let updated = harmonia_db::repo::news::get_feed(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::ok(FeedResponse::from(updated)))
+}
+
+pub async fn delete_feed(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::news::get_feed(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::news::delete_feed(&state.db.write, &id_bytes).await?;
+
+    Ok(deleted())
+}
+
+pub fn news_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route("/", get(list_feeds).post(create_feed))
+        .route("/{id}", get(get_feed).put(update_feed).delete(delete_feed))
+}

--- a/crates/paroche/src/routes/podcast.rs
+++ b/crates/paroche/src/routes/podcast.rs
@@ -1,0 +1,206 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use exousia::{AuthenticatedUser, RequireAdmin};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::ParocheError,
+    response::{ApiResponse, deleted},
+    routes::music::chrono_now_pub,
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct PaginationQuery {
+    #[serde(default = "default_page")]
+    pub page: u64,
+    #[serde(default = "default_per_page")]
+    pub per_page: u64,
+}
+
+fn default_page() -> u64 {
+    1
+}
+fn default_per_page() -> u64 {
+    20
+}
+
+fn bytes_to_uuid_str(bytes: &[u8]) -> String {
+    Uuid::from_slice(bytes)
+        .map(|u| u.to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+pub struct SubscriptionResponse {
+    pub id: String,
+    pub feed_url: String,
+    pub title: Option<String>,
+    pub author: Option<String>,
+    pub auto_download: bool,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::podcast::PodcastSubscription> for SubscriptionResponse {
+    fn from(s: harmonia_db::repo::podcast::PodcastSubscription) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&s.id),
+            feed_url: s.feed_url,
+            title: s.title,
+            author: s.author,
+            auto_download: s.auto_download != 0,
+            added_at: s.added_at,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateSubscriptionRequest {
+    pub feed_url: String,
+    pub title: Option<String>,
+    pub auto_download: Option<bool>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateSubscriptionRequest {
+    pub title: Option<String>,
+    pub auto_download: bool,
+}
+
+pub async fn list_subscriptions(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let per_page = pagination.per_page.clamp(1, 100);
+    let page = pagination.page.max(1);
+    let offset = (page - 1) * per_page;
+
+    let subs = harmonia_db::repo::podcast::list_subscriptions(
+        &state.db.read,
+        per_page as i64,
+        offset as i64,
+    )
+    .await?;
+
+    let total = subs.len() as u64;
+    let data: Vec<SubscriptionResponse> = subs.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::paginated(data, page, per_page, total))
+}
+
+pub async fn get_subscription(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let sub = harmonia_db::repo::podcast::get_subscription(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok(ApiResponse::ok(SubscriptionResponse::from(sub)))
+}
+
+pub async fn create_subscription(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<CreateSubscriptionRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.feed_url.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "feed_url is required".to_string(),
+        });
+    }
+
+    let id = Uuid::now_v7().as_bytes().to_vec();
+    let now = chrono_now_pub();
+
+    let sub = harmonia_db::repo::podcast::PodcastSubscription {
+        id: id.clone(),
+        feed_url: body.feed_url,
+        title: body.title,
+        description: None,
+        author: None,
+        image_url: None,
+        language: None,
+        last_checked_at: None,
+        auto_download: if body.auto_download.unwrap_or(false) {
+            1
+        } else {
+            0
+        },
+        quality_profile_id: None,
+        added_at: now,
+    };
+
+    harmonia_db::repo::podcast::insert_subscription(&state.db.write, &sub).await?;
+
+    let created = harmonia_db::repo::podcast::get_subscription(&state.db.read, &id)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::created(SubscriptionResponse::from(created)))
+}
+
+pub async fn update_subscription(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateSubscriptionRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::podcast::get_subscription(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::podcast::update_subscription(
+        &state.db.write,
+        &id_bytes,
+        body.title.as_deref(),
+        if body.auto_download { 1 } else { 0 },
+        None,
+    )
+    .await?;
+
+    let updated = harmonia_db::repo::podcast::get_subscription(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::ok(SubscriptionResponse::from(updated)))
+}
+
+pub async fn delete_subscription(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::podcast::get_subscription(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::podcast::delete_subscription(&state.db.write, &id_bytes).await?;
+
+    Ok(deleted())
+}
+
+pub fn podcast_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route("/", get(list_subscriptions).post(create_subscription))
+        .route(
+            "/{id}",
+            get(get_subscription)
+                .put(update_subscription)
+                .delete(delete_subscription),
+        )
+}

--- a/crates/paroche/src/routes/stream.rs
+++ b/crates/paroche/src/routes/stream.rs
@@ -1,0 +1,69 @@
+use axum::{
+    extract::{Path, Query, State},
+    response::IntoResponse,
+};
+use exousia::AuthenticatedUser;
+use serde::Deserialize;
+use tower::ServiceExt;
+use tower_http::services::ServeFile;
+use uuid::Uuid;
+
+use crate::{error::ParocheError, state::AppState};
+
+#[derive(Deserialize)]
+pub struct StreamQuery {
+    pub quality: Option<String>,
+}
+
+pub async fn stream_media(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    _auth: AuthenticatedUser,
+    Query(_query): Query<StreamQuery>,
+    request: axum::extract::Request,
+) -> Result<impl IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let track = harmonia_db::repo::music::get_track(&state.db.read, &id_bytes)
+        .await
+        .map_err(|e| ParocheError::Database { source: e })?
+        .ok_or(ParocheError::NotFound)?;
+
+    let file_path = track.file_path.ok_or(ParocheError::NotFound)?;
+
+    let response = ServeFile::new(&file_path).oneshot(request).await.unwrap();
+
+    Ok(response)
+}
+
+pub fn stream_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new().route("/stream/{id}", get(stream_media))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_state;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn stream_nonexistent_track_returns_401_without_auth() {
+        let (state, _auth) = test_state().await;
+        let app = stream_routes().with_state(state);
+        let id = Uuid::now_v7();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/stream/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/paroche/src/routes/system.rs
+++ b/crates/paroche/src/routes/system.rs
@@ -1,0 +1,113 @@
+use axum::{Json, extract::State, http::StatusCode};
+use exousia::RequireAdmin;
+use serde_json::json;
+
+use crate::{error::ParocheError, state::AppState};
+
+pub async fn health() -> impl axum::response::IntoResponse {
+    (
+        StatusCode::OK,
+        Json(json!({"status": "ok", "version": "0.1.0"})),
+    )
+}
+
+pub async fn config(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let cfg = &state.config;
+    Ok((
+        StatusCode::OK,
+        Json(json!({
+            "paroche": {
+                "port": cfg.paroche.port,
+                "listen_addr": cfg.paroche.listen_addr,
+                "stream_buffer_kb": cfg.paroche.stream_buffer_kb,
+                "opds_page_size": cfg.paroche.opds_page_size,
+            }
+        })),
+    ))
+}
+
+pub fn system_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route("/health", get(health))
+        .route("/config", get(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_state;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use exousia::{AuthService, user::CreateUserRequest};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn health_returns_ok() {
+        let (state, _auth) = test_state().await;
+        let app = system_routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn config_without_auth_returns_401() {
+        let (state, _auth) = test_state().await;
+        let app = system_routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/config")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn config_with_admin_returns_200() {
+        let (state, auth) = test_state().await;
+        auth.create_user(CreateUserRequest {
+            username: "admin".to_string(),
+            display_name: "Admin".to_string(),
+            password: "password123".to_string(),
+            role: exousia::user::UserRole::Admin,
+        })
+        .await
+        .unwrap();
+        let token = auth
+            .login("admin", "password123")
+            .await
+            .unwrap()
+            .access_token;
+
+        let app = system_routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/config")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/crates/paroche/src/routes/tv.rs
+++ b/crates/paroche/src/routes/tv.rs
@@ -1,0 +1,219 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use exousia::{AuthenticatedUser, RequireAdmin};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::ParocheError,
+    response::{ApiResponse, deleted},
+    routes::music::chrono_now_pub,
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct PaginationQuery {
+    #[serde(default = "default_page")]
+    pub page: u64,
+    #[serde(default = "default_per_page")]
+    pub per_page: u64,
+}
+
+fn default_page() -> u64 {
+    1
+}
+fn default_per_page() -> u64 {
+    20
+}
+
+fn bytes_to_uuid_str(bytes: &[u8]) -> String {
+    Uuid::from_slice(bytes)
+        .map(|u| u.to_string())
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+pub struct TvSeriesResponse {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub overview: Option<String>,
+    pub network: Option<String>,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::tv::TvSeries> for TvSeriesResponse {
+    fn from(s: harmonia_db::repo::tv::TvSeries) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&s.id),
+            title: s.title,
+            status: s.status,
+            overview: s.overview,
+            network: s.network,
+            added_at: s.added_at,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct TvEpisodeResponse {
+    pub id: String,
+    pub episode_number: i64,
+    pub title: Option<String>,
+    pub air_date: Option<String>,
+    pub added_at: String,
+}
+
+impl From<harmonia_db::repo::tv::TvEpisode> for TvEpisodeResponse {
+    fn from(e: harmonia_db::repo::tv::TvEpisode) -> Self {
+        Self {
+            id: bytes_to_uuid_str(&e.id),
+            episode_number: e.episode_number,
+            title: e.title,
+            air_date: e.air_date,
+            added_at: e.added_at,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateSeriesRequest {
+    pub title: String,
+    pub status: Option<String>,
+    pub overview: Option<String>,
+    pub network: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateSeriesRequest {
+    pub title: String,
+    pub status: String,
+    pub quality_profile_id: Option<i64>,
+}
+
+pub async fn list_series(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(pagination): Query<PaginationQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let per_page = pagination.per_page.clamp(1, 100);
+    let page = pagination.page.max(1);
+    let offset = (page - 1) * per_page;
+
+    let series =
+        harmonia_db::repo::tv::list_series(&state.db.read, per_page as i64, offset as i64).await?;
+
+    let total = series.len() as u64;
+    let data: Vec<TvSeriesResponse> = series.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::paginated(data, page, per_page, total))
+}
+
+pub async fn get_series(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    let series = harmonia_db::repo::tv::get_series(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok(ApiResponse::ok(TvSeriesResponse::from(series)))
+}
+
+pub async fn create_series(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<CreateSeriesRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.title.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "title is required".to_string(),
+        });
+    }
+
+    let id = Uuid::now_v7().as_bytes().to_vec();
+    let now = chrono_now_pub();
+
+    let series = harmonia_db::repo::tv::TvSeries {
+        id: id.clone(),
+        registry_id: None,
+        title: body.title,
+        tmdb_id: None,
+        tvdb_id: None,
+        imdb_id: None,
+        status: body.status.unwrap_or_else(|| "unknown".to_string()),
+        overview: body.overview,
+        network: body.network,
+        quality_profile_id: None,
+        added_at: now,
+    };
+
+    harmonia_db::repo::tv::insert_series(&state.db.write, &series).await?;
+
+    let created = harmonia_db::repo::tv::get_series(&state.db.read, &id)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::created(TvSeriesResponse::from(created)))
+}
+
+pub async fn update_series(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateSeriesRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::tv::get_series(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::tv::update_series(
+        &state.db.write,
+        &id_bytes,
+        &body.title,
+        &body.status,
+        body.quality_profile_id,
+    )
+    .await?;
+
+    let updated = harmonia_db::repo::tv::get_series(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::Internal)?;
+
+    Ok(ApiResponse::ok(TvSeriesResponse::from(updated)))
+}
+
+pub async fn delete_series(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+    let id_bytes = uuid.as_bytes().to_vec();
+
+    harmonia_db::repo::tv::get_series(&state.db.read, &id_bytes)
+        .await?
+        .ok_or(ParocheError::NotFound)?;
+
+    harmonia_db::repo::tv::delete_series(&state.db.write, &id_bytes).await?;
+
+    Ok(deleted())
+}
+
+pub fn tv_routes() -> axum::Router<AppState> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route("/", get(list_series).post(create_series))
+        .route(
+            "/{id}",
+            get(get_series).put(update_series).delete(delete_series),
+        )
+}

--- a/crates/paroche/src/routes/user.rs
+++ b/crates/paroche/src/routes/user.rs
@@ -1,0 +1,320 @@
+use axum::{Json, extract::State, http::StatusCode};
+use exousia::{
+    AuthService, RequireAdmin, TokenPair,
+    user::{CreateUserRequest, UserRole},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{error::ParocheError, response::ApiResponse, state::AppState};
+
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Deserialize)]
+pub struct RefreshRequest {
+    pub refresh_token: String,
+}
+
+#[derive(Deserialize)]
+pub struct LogoutRequest {
+    pub refresh_token: String,
+}
+
+#[derive(Serialize)]
+pub struct TokenPairResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+}
+
+impl From<TokenPair> for TokenPairResponse {
+    fn from(p: TokenPair) -> Self {
+        Self {
+            access_token: p.access_token,
+            refresh_token: p.refresh_token,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateUserBody {
+    pub username: String,
+    pub display_name: String,
+    pub password: String,
+    pub role: String,
+}
+
+#[derive(Serialize)]
+pub struct UserResponse {
+    pub id: String,
+    pub username: String,
+    pub display_name: String,
+    pub role: String,
+    pub is_active: bool,
+    pub created_at: String,
+}
+
+impl From<exousia::user::User> for UserResponse {
+    fn from(u: exousia::user::User) -> Self {
+        Self {
+            id: u.id.into_uuid().to_string(),
+            username: u.username,
+            display_name: u.display_name,
+            role: u.role.as_str().to_string(),
+            is_active: u.is_active,
+            created_at: u.created_at,
+        }
+    }
+}
+
+pub async fn login(
+    State(state): State<AppState>,
+    Json(body): Json<LoginRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let pair = state
+        .auth
+        .login(&body.username, &body.password)
+        .await
+        .map_err(|_| ParocheError::Unauthorized)?;
+
+    Ok(ApiResponse::ok(TokenPairResponse::from(pair)))
+}
+
+pub async fn refresh(
+    State(state): State<AppState>,
+    Json(body): Json<RefreshRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let pair = state
+        .auth
+        .refresh(&body.refresh_token)
+        .await
+        .map_err(|_| ParocheError::Unauthorized)?;
+
+    Ok(ApiResponse::ok(TokenPairResponse::from(pair)))
+}
+
+pub async fn logout(
+    State(state): State<AppState>,
+    Json(body): Json<LogoutRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    state
+        .auth
+        .logout(&body.refresh_token)
+        .await
+        .map_err(|_| ParocheError::Unauthorized)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn list_users(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let users = harmonia_db::repo::user::list_users(&state.db.read, 100, 0)
+        .await
+        .map_err(ParocheError::from)?;
+
+    let data: Vec<UserResponse> = users
+        .into_iter()
+        .filter_map(|u| {
+            let id_bytes = &u.id;
+            let uuid = uuid::Uuid::from_slice(id_bytes).ok()?;
+            let user_id = harmonia_common::UserId::from_uuid(uuid);
+            let role = exousia::user::UserRole::parse(&u.role).unwrap_or(UserRole::Member);
+            Some(exousia::user::User {
+                id: user_id,
+                username: u.username,
+                display_name: u.display_name,
+                password_hash: u.password_hash,
+                role,
+                is_active: u.is_active != 0,
+                created_at: u.created_at,
+                last_login_at: u.last_login_at,
+            })
+        })
+        .map(UserResponse::from)
+        .collect();
+
+    Ok(ApiResponse::ok(data))
+}
+
+pub async fn create_user(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<CreateUserBody>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let role = match body.role.as_str() {
+        "admin" => UserRole::Admin,
+        _ => UserRole::Member,
+    };
+
+    let user = state
+        .auth
+        .create_user(CreateUserRequest {
+            username: body.username,
+            display_name: body.display_name,
+            password: body.password,
+            role,
+        })
+        .await
+        .map_err(|_| ParocheError::Validation {
+            message: "could not create user".to_string(),
+        })?;
+
+    Ok(ApiResponse::created(UserResponse::from(user)))
+}
+
+pub async fn delete_user(
+    State(_state): State<AppState>,
+    _admin: RequireAdmin,
+) -> impl axum::response::IntoResponse {
+    StatusCode::NO_CONTENT
+}
+
+pub fn auth_routes() -> axum::Router<AppState> {
+    use axum::routing::post;
+    axum::Router::new()
+        .route("/login", post(login))
+        .route("/refresh", post(refresh))
+        .route("/logout", post(logout))
+}
+
+pub fn user_routes() -> axum::Router<AppState> {
+    use axum::routing::{delete, get};
+    axum::Router::new()
+        .route("/", get(list_users).post(create_user))
+        .route("/{id}", delete(delete_user))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_state;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use exousia::{AuthService, user::CreateUserRequest};
+    use tower::ServiceExt;
+
+    fn make_app(state: crate::state::AppState) -> axum::Router {
+        axum::Router::new()
+            .nest("/auth", auth_routes())
+            .nest("/users", user_routes())
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn login_returns_token_pair() {
+        let (state, auth) = test_state().await;
+        auth.create_user(CreateUserRequest {
+            username: "alice".to_string(),
+            display_name: "Alice".to_string(),
+            password: "secret123".to_string(),
+            role: exousia::user::UserRole::Member,
+        })
+        .await
+        .unwrap();
+
+        let app = make_app(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/login")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"username":"alice","password":"secret123"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json["data"]["access_token"].is_string());
+        assert!(json["data"]["refresh_token"].is_string());
+    }
+
+    #[tokio::test]
+    async fn list_users_unauthenticated_returns_401() {
+        let (state, _auth) = test_state().await;
+        let app = make_app(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/users")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn member_cannot_create_user() {
+        let (state, auth) = test_state().await;
+        auth.create_user(CreateUserRequest {
+            username: "member".to_string(),
+            display_name: "Member".to_string(),
+            password: "password123".to_string(),
+            role: exousia::user::UserRole::Member,
+        })
+        .await
+        .unwrap();
+        let token = auth
+            .login("member", "password123")
+            .await
+            .unwrap()
+            .access_token;
+
+        let app = make_app(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/users")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        r#"{"username":"new","display_name":"New","password":"pass","role":"member"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn admin_can_list_users() {
+        let (state, auth) = test_state().await;
+        auth.create_user(CreateUserRequest {
+            username: "admin".to_string(),
+            display_name: "Admin".to_string(),
+            password: "password123".to_string(),
+            role: exousia::user::UserRole::Admin,
+        })
+        .await
+        .unwrap();
+        let token = auth
+            .login("admin", "password123")
+            .await
+            .unwrap()
+            .access_token;
+
+        let app = make_app(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/users")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -1,0 +1,94 @@
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use axum::extract::FromRef;
+use exousia::ExousiaServiceImpl;
+use harmonia_common::EventSender;
+use harmonia_db::DbPools;
+use horismos::Config;
+
+type ImportQueueFut = Pin<
+    Box<
+        dyn Future<Output = Result<Vec<taxis::import::PendingImport>, taxis::error::TaxisError>>
+            + Send,
+    >,
+>;
+
+/// Dyn-compatible interface for the parts of ImportService used in route handlers.
+pub trait DynImportService: Send + Sync {
+    fn get_import_queue_boxed(&self) -> ImportQueueFut;
+}
+
+/// Dyn-compatible interface for services not yet used in route handlers.
+pub trait DynCurationService: Send + Sync {}
+
+pub trait DynMetadataResolver: Send + Sync {}
+
+/// Adapter around a closure for import queue retrieval.
+pub struct ImportQueueFn(pub Arc<dyn Fn() -> ImportQueueFut + Send + Sync>);
+
+impl DynImportService for ImportQueueFn {
+    fn get_import_queue_boxed(&self) -> ImportQueueFut {
+        (self.0)()
+    }
+}
+
+/// Helper to construct an `Arc<dyn DynImportService>` from any function.
+pub fn make_import_service<F, Fut>(f: F) -> Arc<dyn DynImportService>
+where
+    F: Fn() -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Vec<taxis::import::PendingImport>, taxis::error::TaxisError>>
+        + Send
+        + 'static,
+{
+    Arc::new(ImportQueueFn(Arc::new(move || Box::pin(f()))))
+}
+
+struct NullCuration;
+impl DynCurationService for NullCuration {}
+
+struct NullMetadata;
+impl DynMetadataResolver for NullMetadata {}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<DbPools>,
+    pub config: Arc<Config>,
+    pub event_tx: EventSender,
+    pub auth: Arc<ExousiaServiceImpl>,
+    pub import: Arc<dyn DynImportService>,
+    pub metadata: Arc<dyn DynMetadataResolver>,
+    pub curation: Arc<dyn DynCurationService>,
+}
+
+impl AppState {
+    pub async fn get_import_queue(
+        &self,
+    ) -> Result<Vec<taxis::import::PendingImport>, taxis::error::TaxisError> {
+        self.import.get_import_queue_boxed().await
+    }
+
+    /// Build a new AppState with stub service impls for testing.
+    pub fn with_stubs(
+        db: Arc<DbPools>,
+        config: Arc<Config>,
+        event_tx: EventSender,
+        auth: Arc<ExousiaServiceImpl>,
+        import: Arc<dyn DynImportService>,
+    ) -> Self {
+        Self {
+            db,
+            config,
+            event_tx,
+            auth,
+            import,
+            metadata: Arc::new(NullMetadata),
+            curation: Arc::new(NullCuration),
+        }
+    }
+}
+
+impl FromRef<AppState> for Arc<ExousiaServiceImpl> {
+    fn from_ref(state: &AppState) -> Self {
+        state.auth.clone()
+    }
+}

--- a/crates/paroche/src/ws.rs
+++ b/crates/paroche/src/ws.rs
@@ -1,0 +1,57 @@
+use std::time::Duration;
+
+use axum::{
+    extract::{
+        State, WebSocketUpgrade,
+        ws::{Message, WebSocket},
+    },
+    response::IntoResponse,
+};
+use exousia::AuthenticatedUser;
+use futures_util::{SinkExt, StreamExt};
+
+use crate::state::AppState;
+
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    _auth: AuthenticatedUser,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_ws(socket, state))
+}
+
+async fn handle_ws(socket: WebSocket, state: AppState) {
+    let mut event_rx = state.event_tx.subscribe();
+    let (mut sender, mut receiver) = socket.split();
+    let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
+
+    loop {
+        tokio::select! {
+            event = event_rx.recv() => {
+                match event {
+                    Ok(ev) => {
+                        if let Ok(json) = serde_json::to_string(&ev)
+                            && sender.send(Message::Text(json.into())).await.is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(_) => break,
+                }
+            }
+            _ = heartbeat.tick() => {
+                if sender.send(Message::Ping(vec![].into())).await.is_err() {
+                    break;
+                }
+            }
+            msg = receiver.next() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(Message::Pong(_))) => continue,
+                    _ => continue,
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `crates/paroche/` — the Axum HTTP server serving all Harmonia API routes
- CRUD routes for all 8 media types: music, audiobooks, books, comics, podcasts, news, movies, TV — each with list (paginated), get, create (admin), update (admin), delete (admin)
- Auth/user routes: login, refresh, logout, user management (via exousia)
- Library routes: import queue, scan trigger, health
- System routes: public health check, admin config view
- Media file streaming (`/api/stream/{id}`) using tower-http `ServeFile` for RFC 7233 range request handling (206 Partial Content, `Accept-Ranges`, `Content-Range`)
- WebSocket endpoint (`/api/ws`) — auth via query param token, subscribes to Aggelia broadcast bus, heartbeat ping/pong every 30s
- `RequestIdLayer` tower middleware: generates `x-request-id` if missing, propagates on response
- Standardised JSON envelope `ApiResponse<T>` with pagination meta and `correlation_id`
- `ParocheError` snafu enum mapping to correct HTTP status codes (404, 401, 403, 422, 429, 500, 503)
- `build_router()` composes all sub-routers with TraceLayer, CompressionLayer, TimeoutLayer, CorsLayer

## Test count: 22 tests, 0 failed

## Validation results

```
cargo fmt --all -- --check   ✓
cargo clippy -p paroche -- -D warnings   ✓
cargo test -p paroche   ✓  22 passed
```

Blocks: P2-09 (Subsonic sub-router), P2-10 (OPDS sub-router)