### PR TITLE
feat(paroche): OpenSubsonic API (P2-09)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "mediatype"
 version = "0.19.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1706,7 @@ dependencies = [
  "horismos",
  "http-body-util",
  "kritike",
+ "md5",
  "rand 0.9.2",
  "serde",
  "serde_json",

--- a/crates/harmonia-db/migrations/003_subsonic.sql
+++ b/crates/harmonia-db/migrations/003_subsonic.sql
@@ -1,0 +1,54 @@
+-- =============================================================================
+-- 003_subsonic.sql — Subsonic/OpenSubsonic API support tables
+-- =============================================================================
+
+-- Per-user plaintext password for Subsonic legacy token auth.
+-- Subsonic legacy auth is MD5-based and incompatible with Argon2id storage.
+-- Users who want legacy Subsonic client support set this separately.
+CREATE TABLE subsonic_passwords (
+    user_id  BLOB NOT NULL PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    password TEXT NOT NULL
+);
+
+-- Playlists
+CREATE TABLE subsonic_playlists (
+    id         BLOB NOT NULL PRIMARY KEY,
+    owner_id   BLOB NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name       TEXT NOT NULL,
+    comment    TEXT,
+    public     INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_sp_owner ON subsonic_playlists(owner_id);
+
+CREATE TABLE subsonic_playlist_tracks (
+    playlist_id BLOB    NOT NULL REFERENCES subsonic_playlists(id) ON DELETE CASCADE,
+    track_id    BLOB    NOT NULL REFERENCES music_tracks(id) ON DELETE CASCADE,
+    position    INTEGER NOT NULL,
+    PRIMARY KEY (playlist_id, position)
+);
+
+CREATE INDEX idx_spt_playlist ON subsonic_playlist_tracks(playlist_id);
+
+-- Stars (track, album/release-group, artist/registry)
+CREATE TABLE subsonic_stars (
+    user_id    BLOB NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    item_id    BLOB NOT NULL,
+    item_type  TEXT NOT NULL CHECK(item_type IN ('track', 'album', 'artist')),
+    starred_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    PRIMARY KEY (user_id, item_id)
+);
+
+CREATE INDEX idx_ss_user ON subsonic_stars(user_id);
+
+-- Ratings (1-5)
+CREATE TABLE subsonic_ratings (
+    user_id BLOB    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    item_id BLOB    NOT NULL,
+    rating  INTEGER NOT NULL CHECK(rating BETWEEN 1 AND 5),
+    PRIMARY KEY (user_id, item_id)
+);
+
+CREATE INDEX idx_sr_user ON subsonic_ratings(user_id);

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -25,6 +25,8 @@ uuid.workspace = true
 rand.workspace = true
 tokio-util = { version = "0.7", features = ["io"] }
 futures-util = "0.3"
+md5 = "0.7"
+sqlx.workspace = true
 
 [dev-dependencies]
 sqlx.workspace = true

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -3,6 +3,7 @@ pub mod middleware;
 pub mod response;
 pub mod routes;
 pub mod state;
+pub mod subsonic;
 pub mod ws;
 
 use std::time::Duration;
@@ -31,6 +32,7 @@ pub fn build_router(state: AppState) -> Router {
         .nest("/api/library", routes::library::library_routes())
         .nest("/api/system", routes::system::system_routes())
         .merge(routes::stream::stream_routes())
+        .nest("/rest", subsonic::subsonic_routes())
         .route("/api/ws", axum::routing::get(ws_handler))
         .layer(RequestIdLayer)
         .layer(TraceLayer::new_for_http())

--- a/crates/paroche/src/subsonic/auth.rs
+++ b/crates/paroche/src/subsonic/auth.rs
@@ -1,0 +1,151 @@
+use axum::response::Response;
+use exousia::AuthService;
+use exousia::user::UserRole;
+use harmonia_common::ids::UserId;
+
+use super::types::{
+    ERR_GENERIC, ERR_MISSING_PARAM, ERR_WRONG_CREDS, Format, SubsonicCommon, respond_error,
+};
+use crate::state::AppState;
+
+#[derive(Debug, Clone)]
+pub struct SubsonicUser {
+    pub user_id: UserId,
+    pub username: String,
+    pub role: UserRole,
+    pub format: Format,
+}
+
+/// Authenticate a Subsonic request from the common query params.
+/// Returns `Ok(SubsonicUser)` or an HTTP-200 Subsonic error Response.
+pub async fn authenticate(
+    common: &SubsonicCommon,
+    state: &AppState,
+) -> Result<SubsonicUser, Response> {
+    let fmt = common.format();
+
+    // OpenSubsonic API key mode
+    if let Some(api_key) = &common.api_key {
+        let authed = state
+            .auth
+            .validate_api_key(api_key)
+            .await
+            .map_err(|_| respond_error(fmt, ERR_WRONG_CREDS, "wrong username or password"))?;
+
+        let username = lookup_username(state, authed.user_id)
+            .await
+            .map_err(|_| respond_error(fmt, ERR_GENERIC, "internal error"))?;
+
+        return Ok(SubsonicUser {
+            user_id: authed.user_id,
+            username,
+            role: authed.role,
+            format: fmt,
+        });
+    }
+
+    // Legacy token auth: u + t + s
+    let username = common
+        .u
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| respond_error(fmt, ERR_MISSING_PARAM, "required parameter is missing: u"))?;
+    let token = common
+        .t
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| respond_error(fmt, ERR_MISSING_PARAM, "required parameter is missing: t"))?;
+    let salt = common
+        .s
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| respond_error(fmt, ERR_MISSING_PARAM, "required parameter is missing: s"))?;
+
+    let row = lookup_subsonic_user(state, username)
+        .await
+        .map_err(|_| respond_error(fmt, ERR_WRONG_CREDS, "wrong username or password"))?;
+
+    let expected = format!("{:x}", md5::compute(format!("{}{}", row.password, salt)));
+    if expected != token {
+        return Err(respond_error(
+            fmt,
+            ERR_WRONG_CREDS,
+            "wrong username or password",
+        ));
+    }
+
+    Ok(SubsonicUser {
+        user_id: row.user_id,
+        username: username.to_string(),
+        role: row.role,
+        format: fmt,
+    })
+}
+
+struct SubsonicUserRow {
+    user_id: UserId,
+    role: UserRole,
+    password: String,
+}
+
+async fn lookup_subsonic_user(
+    state: &AppState,
+    username: &str,
+) -> Result<SubsonicUserRow, sqlx::Error> {
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        id: Vec<u8>,
+        role: String,
+        password: String,
+    }
+
+    let row = sqlx::query_as::<_, Row>(
+        "SELECT u.id, u.role, sp.password
+         FROM users u
+         JOIN subsonic_passwords sp ON sp.user_id = u.id
+         WHERE u.username = ? AND u.is_active = 1",
+    )
+    .bind(username)
+    .fetch_one(&state.db.read)
+    .await?;
+
+    let uuid = uuid::Uuid::from_slice(&row.id)
+        .map_err(|_| sqlx::Error::Decode("invalid uuid bytes".into()))?;
+    let user_id = UserId::from_uuid(uuid);
+    let role = match row.role.as_str() {
+        "admin" => UserRole::Admin,
+        _ => UserRole::Member,
+    };
+
+    Ok(SubsonicUserRow {
+        user_id,
+        role,
+        password: row.password,
+    })
+}
+
+async fn lookup_username(state: &AppState, user_id: UserId) -> Result<String, sqlx::Error> {
+    let id_bytes = user_id.as_bytes().to_vec();
+    sqlx::query_scalar::<_, String>("SELECT username FROM users WHERE id = ?")
+        .bind(id_bytes)
+        .fetch_one(&state.db.read)
+        .await
+}
+
+/// Set a subsonic password for a user (used in tests and admin setup).
+pub async fn set_subsonic_password(
+    pool: &sqlx::SqlitePool,
+    user_id: UserId,
+    password: &str,
+) -> Result<(), sqlx::Error> {
+    let id_bytes = user_id.as_bytes().to_vec();
+    sqlx::query(
+        "INSERT INTO subsonic_passwords (user_id, password) VALUES (?, ?)
+         ON CONFLICT(user_id) DO UPDATE SET password = excluded.password",
+    )
+    .bind(id_bytes)
+    .bind(password)
+    .execute(pool)
+    .await?;
+    Ok(())
+}

--- a/crates/paroche/src/subsonic/browsing.rs
+++ b/crates/paroche/src/subsonic/browsing.rs
@@ -1,0 +1,751 @@
+use axum::{
+    extract::{Query, State},
+    response::Response,
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{
+    auth::authenticate,
+    types::{
+        ERR_NOT_FOUND, SubsonicCommon, album_json, album_xml_elem, artist_xml, codec_content_type,
+        codec_suffix, index_letter, respond_error, respond_ok, song_json, song_xml_elem,
+        uuid_bytes, uuid_str,
+    },
+};
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// DB row types
+// ---------------------------------------------------------------------------
+
+#[derive(sqlx::FromRow)]
+struct ArtistRow {
+    id: Vec<u8>,
+    name: String,
+    album_count: i64,
+}
+
+#[derive(sqlx::FromRow)]
+struct AlbumRow {
+    id: Vec<u8>,
+    name: String,
+    year: Option<i64>,
+    artist_id: Option<Vec<u8>>,
+    artist_name: Option<String>,
+}
+
+#[derive(sqlx::FromRow)]
+struct SongRow {
+    id: Vec<u8>,
+    title: String,
+    position: i64,
+    duration_ms: Option<i64>,
+    codec: Option<String>,
+    album_id: Vec<u8>,
+    album_title: String,
+    year: Option<i64>,
+    artist_id: Option<Vec<u8>>,
+    artist_name: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Query params
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Default)]
+pub struct FolderQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    #[serde(rename = "musicFolderId")]
+    pub music_folder_id: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct IdQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// getMusicFolders
+// ---------------------------------------------------------------------------
+
+pub async fn get_music_folders(
+    State(state): State<AppState>,
+    Query(q): Query<FolderQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let xml = r#"<musicFolders><musicFolder id="1" name="Music" /></musicFolders>"#;
+    let json_val = json!({
+        "musicFolder": [{ "id": 1, "name": "Music" }]
+    });
+    respond_ok(user.format, xml, Some(("musicFolders", json_val)))
+}
+
+// ---------------------------------------------------------------------------
+// getIndexes — same data as getArtists but different wrapper element
+// ---------------------------------------------------------------------------
+
+pub async fn get_indexes(State(state): State<AppState>, Query(q): Query<FolderQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    match fetch_artist_index(&state).await {
+        Ok((xml_inner, json_val)) => respond_ok(
+            user.format,
+            &format!(
+                r#"<indexes lastModified="0" ignoredArticles="The El La Los Las Le Les">{xml_inner}</indexes>"#
+            ),
+            Some((
+                "indexes",
+                json!({
+                    "lastModified": 0,
+                    "ignoredArticles": "The El La Los Las Le Les",
+                    "index": json_val
+                }),
+            )),
+        ),
+        Err(_) => respond_error(user.format, 0, "database error"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// getArtists
+// ---------------------------------------------------------------------------
+
+pub async fn get_artists(State(state): State<AppState>, Query(q): Query<FolderQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    match fetch_artist_index(&state).await {
+        Ok((xml_inner, json_val)) => respond_ok(
+            user.format,
+            &format!(
+                r#"<artists lastModified="0" ignoredArticles="The El La Los Las Le Les">{xml_inner}</artists>"#
+            ),
+            Some((
+                "artists",
+                json!({
+                    "lastModified": 0,
+                    "ignoredArticles": "The El La Los Las Le Les",
+                    "index": json_val
+                }),
+            )),
+        ),
+        Err(_) => respond_error(user.format, 0, "database error"),
+    }
+}
+
+async fn fetch_artist_index(state: &AppState) -> Result<(String, Value), sqlx::Error> {
+    let rows = sqlx::query_as::<_, ArtistRow>(
+        "SELECT mr.id, mr.display_name as name,
+                COUNT(DISTINCT mrga.release_group_id) as album_count
+         FROM media_registry mr
+         LEFT JOIN music_release_group_artists mrga ON mrga.artist_id = mr.id AND mrga.role = 'primary'
+         WHERE mr.entity_type = 'person'
+         GROUP BY mr.id
+         ORDER BY UPPER(mr.display_name)",
+    )
+    .fetch_all(&state.db.read)
+    .await?;
+
+    // Group by first letter
+    let mut groups: std::collections::BTreeMap<String, Vec<&ArtistRow>> =
+        std::collections::BTreeMap::new();
+    for row in &rows {
+        let letter = index_letter(&row.name);
+        groups.entry(letter).or_default().push(row);
+    }
+
+    let mut xml_parts = String::new();
+    let mut json_indexes: Vec<Value> = Vec::new();
+
+    for (letter, artists) in &groups {
+        let mut xml_artists = String::new();
+        let mut json_artists: Vec<Value> = Vec::new();
+
+        for artist in artists {
+            let id = uuid_str(&artist.id);
+            xml_artists.push_str(&artist_xml(&id, &artist.name, artist.album_count));
+            json_artists.push(json!({
+                "id": id,
+                "name": artist.name,
+                "albumCount": artist.album_count
+            }));
+        }
+
+        xml_parts.push_str(&format!(r#"<index name="{letter}">{xml_artists}</index>"#));
+        json_indexes.push(json!({ "name": letter, "artist": json_artists }));
+    }
+
+    Ok((xml_parts, Value::Array(json_indexes)))
+}
+
+// ---------------------------------------------------------------------------
+// getMusicDirectory
+// ---------------------------------------------------------------------------
+
+pub async fn get_music_directory(
+    State(state): State<AppState>,
+    Query(q): Query<IdQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let id = match &q.id {
+        Some(id) => id.clone(),
+        None => return respond_error(user.format, 10, "required parameter is missing: id"),
+    };
+
+    // Music folder virtual root
+    if id == "1" {
+        return match fetch_artist_index(&state).await {
+            Ok((xml_artists_inner, _)) => {
+                // Flatten all artists as directory children
+                let children =
+                    format!("<directory id=\"1\" name=\"Music\">{xml_artists_inner}</directory>");
+                respond_ok(
+                    user.format,
+                    &children,
+                    Some(("directory", json!({ "id": "1", "name": "Music" }))),
+                )
+            }
+            Err(_) => respond_error(user.format, 0, "database error"),
+        };
+    }
+
+    let id_bytes = match uuid_bytes(&id) {
+        Some(b) => b,
+        None => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    // Try as artist → list albums
+    let albums = sqlx::query_as::<_, AlbumRow>(
+        "SELECT mrg.id, mrg.title as name, mrg.year,
+                mr.id as artist_id, mr.display_name as artist_name
+         FROM music_release_groups mrg
+         JOIN music_release_group_artists mrga ON mrga.release_group_id = mrg.id AND mrga.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mrga.artist_id
+         WHERE mrga.artist_id = ?
+         ORDER BY mrg.year, mrg.title",
+    )
+    .bind(&id_bytes)
+    .fetch_all(&state.db.read)
+    .await
+    .unwrap_or_default();
+
+    if !albums.is_empty() {
+        let mut xml_children = String::new();
+        for a in &albums {
+            let album_id = uuid_str(&a.id);
+            let artist_id = a.artist_id.as_deref().map(uuid_str).unwrap_or_default();
+            let artist_name = a.artist_name.as_deref().unwrap_or("");
+            xml_children.push_str(&format!(
+                r#"<child id="{}" parent="{id}" isDir="true" title="{}" artist="{}" artistId="{}" />"#,
+                super::types::xml_escape(&album_id),
+                super::types::xml_escape(&a.name),
+                super::types::xml_escape(artist_name),
+                super::types::xml_escape(&artist_id),
+            ));
+        }
+        let xml = format!(r#"<directory id="{id}" name="">{xml_children}</directory>"#);
+        return respond_ok(user.format, &xml, Some(("directory", json!({ "id": id }))));
+    }
+
+    // Try as album → list tracks
+    match fetch_songs_for_album(&state, &id_bytes).await {
+        Ok(songs) if !songs.is_empty() => {
+            let album_name = songs[0].album_title.clone();
+            let mut xml_songs = String::new();
+            let mut json_songs: Vec<Value> = Vec::new();
+            for s in &songs {
+                let (xml_s, json_s) = song_tuple(s, &uuid_str(&s.album_id));
+                xml_songs.push_str(&xml_s);
+                json_songs.push(json_s);
+            }
+            let xml = format!(
+                r#"<directory id="{id}" name="{}">{xml_songs}</directory>"#,
+                super::types::xml_escape(&album_name)
+            );
+            respond_ok(user.format, &xml, Some(("directory", json!({ "id": id }))))
+        }
+        _ => respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// getArtist
+// ---------------------------------------------------------------------------
+
+pub async fn get_artist(State(state): State<AppState>, Query(q): Query<IdQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let id = match &q.id {
+        Some(id) => id.clone(),
+        None => return respond_error(user.format, 10, "required parameter is missing: id"),
+    };
+    let id_bytes = match uuid_bytes(&id) {
+        Some(b) => b,
+        None => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    #[derive(sqlx::FromRow)]
+    struct ArtistInfo {
+        name: String,
+    }
+    let artist = match sqlx::query_as::<_, ArtistInfo>(
+        "SELECT display_name as name FROM media_registry WHERE id = ? AND entity_type = 'person'",
+    )
+    .bind(&id_bytes)
+    .fetch_optional(&state.db.read)
+    .await
+    {
+        Ok(Some(a)) => a,
+        _ => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    let albums = sqlx::query_as::<_, AlbumRow>(
+        "SELECT mrg.id, mrg.title as name, mrg.year,
+                mr.id as artist_id, mr.display_name as artist_name
+         FROM music_release_groups mrg
+         JOIN music_release_group_artists mrga ON mrga.release_group_id = mrg.id AND mrga.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mrga.artist_id
+         WHERE mrga.artist_id = ?
+         ORDER BY mrg.year, mrg.title",
+    )
+    .bind(&id_bytes)
+    .fetch_all(&state.db.read)
+    .await
+    .unwrap_or_default();
+
+    let album_count = albums.len() as i64;
+    let mut xml_albums = String::new();
+    let mut json_albums: Vec<Value> = Vec::new();
+
+    for a in &albums {
+        let album_id = uuid_str(&a.id);
+        let (song_count, duration) = fetch_album_stats(&state, &a.id).await;
+        let a_artist_id = a.artist_id.as_deref().map(uuid_str).unwrap_or_default();
+        let a_artist = a.artist_name.as_deref().unwrap_or("");
+        xml_albums.push_str(&album_xml_elem(
+            &album_id,
+            &a.name,
+            a_artist,
+            &a_artist_id,
+            a.year,
+            song_count,
+            duration,
+        ));
+        json_albums.push(album_json(
+            &album_id,
+            &a.name,
+            a_artist,
+            &a_artist_id,
+            a.year,
+            song_count,
+            duration,
+        ));
+    }
+
+    let xml = format!(
+        r#"<artist id="{id}" name="{}" albumCount="{album_count}">{xml_albums}</artist>"#,
+        super::types::xml_escape(&artist.name)
+    );
+    let json_val = json!({
+        "id": id,
+        "name": artist.name,
+        "albumCount": album_count,
+        "album": json_albums
+    });
+    respond_ok(user.format, &xml, Some(("artist", json_val)))
+}
+
+// ---------------------------------------------------------------------------
+// getAlbum
+// ---------------------------------------------------------------------------
+
+pub async fn get_album(State(state): State<AppState>, Query(q): Query<IdQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let id = match &q.id {
+        Some(id) => id.clone(),
+        None => return respond_error(user.format, 10, "required parameter is missing: id"),
+    };
+    let id_bytes = match uuid_bytes(&id) {
+        Some(b) => b,
+        None => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    #[derive(sqlx::FromRow)]
+    struct AlbumInfo {
+        title: String,
+        year: Option<i64>,
+    }
+    let album = match sqlx::query_as::<_, AlbumInfo>(
+        "SELECT title, year FROM music_release_groups WHERE id = ?",
+    )
+    .bind(&id_bytes)
+    .fetch_optional(&state.db.read)
+    .await
+    {
+        Ok(Some(a)) => a,
+        _ => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    let artist_row = sqlx::query_as::<_, ArtistRow>(
+        "SELECT mr.id, mr.display_name as name, 0 as album_count
+         FROM media_registry mr
+         JOIN music_release_group_artists mrga ON mrga.artist_id = mr.id
+         WHERE mrga.release_group_id = ? AND mrga.role = 'primary'
+         LIMIT 1",
+    )
+    .bind(&id_bytes)
+    .fetch_optional(&state.db.read)
+    .await
+    .unwrap_or(None);
+
+    let artist_id = artist_row
+        .as_ref()
+        .map(|r| uuid_str(&r.id))
+        .unwrap_or_default();
+    let artist_name = artist_row.as_ref().map(|r| r.name.as_str()).unwrap_or("");
+
+    let songs = fetch_songs_for_album(&state, &id_bytes)
+        .await
+        .unwrap_or_default();
+
+    let song_count = songs.len() as i64;
+    let duration: i64 = songs
+        .iter()
+        .map(|s| s.duration_ms.unwrap_or(0) / 1000)
+        .sum();
+
+    let mut xml_songs = String::new();
+    let mut json_songs: Vec<Value> = Vec::new();
+    for s in &songs {
+        let (xml_s, json_s) = song_tuple(s, &id);
+        xml_songs.push_str(&xml_s);
+        json_songs.push(json_s);
+    }
+
+    let year_attr = album
+        .year
+        .map(|y| format!(r#" year="{y}""#))
+        .unwrap_or_default();
+    let xml = format!(
+        r#"<album id="{id}" name="{}" artist="{}" artistId="{}" songCount="{song_count}" duration="{duration}"{year_attr}>{xml_songs}</album>"#,
+        super::types::xml_escape(&album.title),
+        super::types::xml_escape(artist_name),
+        super::types::xml_escape(&artist_id),
+    );
+    let json_val = json!({
+        "id": id,
+        "name": album.title,
+        "artist": artist_name,
+        "artistId": artist_id,
+        "year": album.year,
+        "songCount": song_count,
+        "duration": duration,
+        "song": json_songs
+    });
+    respond_ok(user.format, &xml, Some(("album", json_val)))
+}
+
+// ---------------------------------------------------------------------------
+// getSong
+// ---------------------------------------------------------------------------
+
+pub async fn get_song(State(state): State<AppState>, Query(q): Query<IdQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let id = match &q.id {
+        Some(id) => id.clone(),
+        None => return respond_error(user.format, 10, "required parameter is missing: id"),
+    };
+    let id_bytes = match uuid_bytes(&id) {
+        Some(b) => b,
+        None => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    let song = match sqlx::query_as::<_, SongRow>(
+        "SELECT t.id, t.title, t.position, t.duration_ms, t.codec,
+                mrg.id as album_id, mrg.title as album_title, mrg.year,
+                mr.id as artist_id, mr.display_name as artist_name
+         FROM music_tracks t
+         JOIN music_media mm ON mm.id = t.medium_id
+         JOIN music_releases r ON r.id = mm.release_id
+         JOIN music_release_groups mrg ON mrg.id = r.release_group_id
+         LEFT JOIN music_track_artists mta ON mta.track_id = t.id AND mta.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mta.artist_id
+         WHERE t.id = ?",
+    )
+    .bind(&id_bytes)
+    .fetch_optional(&state.db.read)
+    .await
+    {
+        Ok(Some(s)) => s,
+        _ => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    let album_id = uuid_str(&song.album_id);
+    let (xml_s, json_s) = song_tuple(&song, &album_id);
+    respond_ok(user.format, &xml_s, Some(("song", json_s)))
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+async fn fetch_songs_for_album(
+    state: &AppState,
+    group_id: &[u8],
+) -> Result<Vec<SongRow>, sqlx::Error> {
+    sqlx::query_as::<_, SongRow>(
+        "SELECT t.id, t.title, t.position, t.duration_ms, t.codec,
+                mrg.id as album_id, mrg.title as album_title, mrg.year,
+                mr.id as artist_id, mr.display_name as artist_name
+         FROM music_tracks t
+         JOIN music_media mm ON mm.id = t.medium_id
+         JOIN music_releases r ON r.id = mm.release_id
+         JOIN music_release_groups mrg ON mrg.id = r.release_group_id
+         LEFT JOIN music_track_artists mta ON mta.track_id = t.id AND mta.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mta.artist_id
+         WHERE r.release_group_id = ?
+         ORDER BY r.release_date, mm.position, t.position",
+    )
+    .bind(group_id)
+    .fetch_all(&state.db.read)
+    .await
+}
+
+async fn fetch_album_stats(state: &AppState, group_id: &[u8]) -> (i64, i64) {
+    #[derive(sqlx::FromRow)]
+    struct Stats {
+        count: i64,
+        total_ms: i64,
+    }
+    let stats = sqlx::query_as::<_, Stats>(
+        "SELECT COUNT(*) as count, COALESCE(SUM(t.duration_ms), 0) as total_ms
+         FROM music_tracks t
+         JOIN music_media mm ON mm.id = t.medium_id
+         JOIN music_releases r ON r.id = mm.release_id
+         WHERE r.release_group_id = ?",
+    )
+    .bind(group_id)
+    .fetch_one(&state.db.read)
+    .await
+    .unwrap_or(Stats {
+        count: 0,
+        total_ms: 0,
+    });
+    (stats.count, stats.total_ms / 1000)
+}
+
+fn song_tuple(s: &SongRow, album_id: &str) -> (String, Value) {
+    let id = uuid_str(&s.id);
+    let artist_id = s.artist_id.as_deref().map(uuid_str).unwrap_or_default();
+    let artist_name = s.artist_name.as_deref().unwrap_or("");
+    let duration_secs = s.duration_ms.map(|d| d / 1000);
+    let ct = codec_content_type(s.codec.as_deref());
+    let suffix = codec_suffix(s.codec.as_deref());
+
+    let xml = song_xml_elem(
+        &id,
+        &s.title,
+        &s.album_title,
+        album_id,
+        artist_name,
+        &artist_id,
+        Some(s.position),
+        s.year,
+        duration_secs,
+        None,
+        ct,
+        suffix,
+        false,
+    );
+    let json = song_json(
+        &id,
+        &s.title,
+        &s.album_title,
+        album_id,
+        artist_name,
+        &artist_id,
+        Some(s.position),
+        s.year,
+        duration_secs,
+        None,
+        ct,
+        suffix,
+    );
+    (xml, json)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
+    use axum::{body::Body, body::to_bytes, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn get_music_folders_returns_one_folder() {
+        let (app, _state, key) = subsonic_app().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getMusicFolders.view?apiKey={key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("musicFolder"));
+        assert!(body.contains("id=\"1\""));
+    }
+
+    #[tokio::test]
+    async fn get_artists_empty_library() {
+        let (app, _state, key) = subsonic_app().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getArtists.view?apiKey={key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("artists"));
+    }
+
+    #[tokio::test]
+    async fn get_artists_alphabetical_index() {
+        let (app, state, key) = subsonic_app().await;
+        seed_music_data(&state).await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getArtists.view?apiKey={key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        // Should have the seeded artist
+        assert!(body.contains("Test Artist"));
+    }
+
+    #[tokio::test]
+    async fn get_album_returns_correct_song_children() {
+        let (app, state, key) = subsonic_app().await;
+        let (group_id, _) = seed_music_data(&state).await;
+        let id = uuid_str(&group_id);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getAlbum.view?apiKey={key}&id={id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("<song"));
+        assert!(body.contains("Test Track"));
+    }
+
+    #[tokio::test]
+    async fn get_song_returns_single_song() {
+        let (app, state, key) = subsonic_app().await;
+        let (_, track_id) = seed_music_data(&state).await;
+        let id = uuid_str(&track_id);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getSong.view?apiKey={key}&id={id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("Test Track"));
+    }
+
+    #[tokio::test]
+    async fn get_album_not_found_returns_error_70() {
+        let (app, _state, key) = subsonic_app().await;
+        let fake_id = uuid::Uuid::now_v7();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getAlbum.view?apiKey={key}&id={fake_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"failed\""));
+        assert!(body.contains("code=\"70\""));
+    }
+
+    #[tokio::test]
+    async fn folder_simulation_artists_appear_as_directories() {
+        let (app, state, key) = subsonic_app().await;
+        seed_music_data(&state).await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getMusicDirectory.view?apiKey={key}&id=1"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+    }
+}

--- a/crates/paroche/src/subsonic/lists.rs
+++ b/crates/paroche/src/subsonic/lists.rs
@@ -1,0 +1,476 @@
+use axum::{
+    extract::{Query, State},
+    response::Response,
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{
+    auth::authenticate,
+    types::{
+        SubsonicCommon, album_json, album_xml_elem, codec_content_type, codec_suffix, respond_ok,
+        song_json, song_xml_elem, uuid_str,
+    },
+};
+use crate::state::AppState;
+
+#[derive(Deserialize, Default)]
+pub struct AlbumListQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    #[serde(rename = "type")]
+    pub list_type: Option<String>,
+    pub size: Option<i64>,
+    pub offset: Option<i64>,
+    #[serde(rename = "fromYear")]
+    pub from_year: Option<i64>,
+    #[serde(rename = "toYear")]
+    pub to_year: Option<i64>,
+    pub genre: Option<String>,
+    #[serde(rename = "musicFolderId")]
+    pub music_folder_id: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct RandomSongsQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub size: Option<i64>,
+    #[serde(rename = "fromYear")]
+    pub from_year: Option<i64>,
+    #[serde(rename = "toYear")]
+    pub to_year: Option<i64>,
+    pub genre: Option<String>,
+    #[serde(rename = "musicFolderId")]
+    pub music_folder_id: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct CommonQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+}
+
+#[derive(sqlx::FromRow)]
+struct AlbumRow {
+    id: Vec<u8>,
+    name: String,
+    year: Option<i64>,
+    artist_name: Option<String>,
+    artist_id: Option<Vec<u8>>,
+    song_count: i64,
+    duration: i64,
+}
+
+#[derive(sqlx::FromRow)]
+struct SongRow {
+    id: Vec<u8>,
+    title: String,
+    position: i64,
+    duration_ms: Option<i64>,
+    codec: Option<String>,
+    album_id: Vec<u8>,
+    album_title: String,
+    year: Option<i64>,
+    artist_id: Option<Vec<u8>>,
+    artist_name: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// getAlbumList2
+// ---------------------------------------------------------------------------
+
+pub async fn get_album_list2(
+    State(state): State<AppState>,
+    Query(q): Query<AlbumListQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let list_type = q.list_type.as_deref().unwrap_or("alphabeticalByName");
+    let limit = q.size.unwrap_or(10).clamp(1, 500);
+    let offset = q.offset.unwrap_or(0).max(0);
+
+    let order_clause = match list_type {
+        "newest" | "recent" => "ORDER BY mrg.added_at DESC",
+        "frequent" => "ORDER BY mrg.title",
+        "alphabeticalByName" | "alphabeticalByArtist" => "ORDER BY UPPER(mrg.title)",
+        "byYear" => "ORDER BY mrg.year",
+        "random" => "ORDER BY RANDOM()",
+        "starred" => "ORDER BY mrg.added_at DESC", // stub — real starred needs join
+        _ => "ORDER BY UPPER(mrg.title)",
+    };
+
+    let mut year_filter = String::new();
+    if list_type == "byYear" {
+        if let Some(from) = q.from_year {
+            year_filter.push_str(&format!(" AND mrg.year >= {from}"));
+        }
+        if let Some(to) = q.to_year {
+            year_filter.push_str(&format!(" AND mrg.year <= {to}"));
+        }
+    }
+
+    let sql = format!(
+        "SELECT mrg.id, mrg.title as name, mrg.year,
+                mr.display_name as artist_name, mr.id as artist_id,
+                COUNT(DISTINCT t.id) as song_count,
+                COALESCE(SUM(t.duration_ms), 0) / 1000 as duration
+         FROM music_release_groups mrg
+         LEFT JOIN music_release_group_artists mrga ON mrga.release_group_id = mrg.id AND mrga.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mrga.artist_id
+         LEFT JOIN music_releases r ON r.release_group_id = mrg.id
+         LEFT JOIN music_media mm ON mm.release_id = r.id
+         LEFT JOIN music_tracks t ON t.medium_id = mm.id
+         WHERE 1=1{year_filter}
+         GROUP BY mrg.id
+         {order_clause}
+         LIMIT ? OFFSET ?"
+    );
+
+    let albums = sqlx::query_as::<_, AlbumRow>(&sql)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&state.db.read)
+        .await
+        .unwrap_or_default();
+
+    let mut xml_albums = String::new();
+    let mut json_albums: Vec<Value> = Vec::new();
+    for a in &albums {
+        let id = uuid_str(&a.id);
+        let artist_id = a.artist_id.as_deref().map(uuid_str).unwrap_or_default();
+        let artist_name = a.artist_name.as_deref().unwrap_or("");
+        xml_albums.push_str(&album_xml_elem(
+            &id,
+            &a.name,
+            artist_name,
+            &artist_id,
+            a.year,
+            a.song_count,
+            a.duration,
+        ));
+        json_albums.push(album_json(
+            &id,
+            &a.name,
+            artist_name,
+            &artist_id,
+            a.year,
+            a.song_count,
+            a.duration,
+        ));
+    }
+
+    let xml = format!("<albumList2>{xml_albums}</albumList2>");
+    respond_ok(
+        user.format,
+        &xml,
+        Some(("albumList2", json!({ "album": json_albums }))),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// getRandomSongs
+// ---------------------------------------------------------------------------
+
+pub async fn get_random_songs(
+    State(state): State<AppState>,
+    Query(q): Query<RandomSongsQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let limit = q.size.unwrap_or(10).clamp(1, 500);
+
+    let mut year_filter = String::new();
+    if let Some(from) = q.from_year {
+        year_filter.push_str(&format!(" AND mrg.year >= {from}"));
+    }
+    if let Some(to) = q.to_year {
+        year_filter.push_str(&format!(" AND mrg.year <= {to}"));
+    }
+
+    let sql = format!(
+        "SELECT t.id, t.title, t.position, t.duration_ms, t.codec,
+                mrg.id as album_id, mrg.title as album_title, mrg.year,
+                mr.id as artist_id, mr.display_name as artist_name
+         FROM music_tracks t
+         JOIN music_media mm ON mm.id = t.medium_id
+         JOIN music_releases r ON r.id = mm.release_id
+         JOIN music_release_groups mrg ON mrg.id = r.release_group_id
+         LEFT JOIN music_track_artists mta ON mta.track_id = t.id AND mta.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mta.artist_id
+         WHERE 1=1{year_filter}
+         ORDER BY RANDOM()
+         LIMIT ?"
+    );
+
+    let songs = sqlx::query_as::<_, SongRow>(&sql)
+        .bind(limit)
+        .fetch_all(&state.db.read)
+        .await
+        .unwrap_or_default();
+
+    let (xml_songs, json_songs) = build_song_lists(&songs);
+    let xml = format!("<randomSongs>{xml_songs}</randomSongs>");
+    respond_ok(
+        user.format,
+        &xml,
+        Some(("randomSongs", json!({ "song": json_songs }))),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// getStarred2
+// ---------------------------------------------------------------------------
+
+pub async fn get_starred2(State(state): State<AppState>, Query(q): Query<CommonQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let user_id_bytes = user.user_id.as_bytes().to_vec();
+
+    // Starred tracks
+    let songs = sqlx::query_as::<_, SongRow>(
+        "SELECT t.id, t.title, t.position, t.duration_ms, t.codec,
+                mrg.id as album_id, mrg.title as album_title, mrg.year,
+                mr.id as artist_id, mr.display_name as artist_name
+         FROM subsonic_stars ss
+         JOIN music_tracks t ON t.id = ss.item_id
+         JOIN music_media mm ON mm.id = t.medium_id
+         JOIN music_releases r ON r.id = mm.release_id
+         JOIN music_release_groups mrg ON mrg.id = r.release_group_id
+         LEFT JOIN music_track_artists mta ON mta.track_id = t.id AND mta.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mta.artist_id
+         WHERE ss.user_id = ? AND ss.item_type = 'track'
+         ORDER BY ss.starred_at DESC",
+    )
+    .bind(&user_id_bytes)
+    .fetch_all(&state.db.read)
+    .await
+    .unwrap_or_default();
+
+    // Starred albums
+    let albums = sqlx::query_as::<_, AlbumRow>(
+        "SELECT mrg.id, mrg.title as name, mrg.year,
+                mr.display_name as artist_name, mr.id as artist_id,
+                COUNT(DISTINCT t.id) as song_count,
+                COALESCE(SUM(t.duration_ms), 0) / 1000 as duration
+         FROM subsonic_stars ss
+         JOIN music_release_groups mrg ON mrg.id = ss.item_id
+         LEFT JOIN music_release_group_artists mrga ON mrga.release_group_id = mrg.id AND mrga.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mrga.artist_id
+         LEFT JOIN music_releases r ON r.release_group_id = mrg.id
+         LEFT JOIN music_media mm ON mm.release_id = r.id
+         LEFT JOIN music_tracks t ON t.medium_id = mm.id
+         WHERE ss.user_id = ? AND ss.item_type = 'album'
+         GROUP BY mrg.id
+         ORDER BY ss.starred_at DESC",
+    )
+    .bind(&user_id_bytes)
+    .fetch_all(&state.db.read)
+    .await
+    .unwrap_or_default();
+
+    let (xml_songs, json_songs) = build_song_lists(&songs);
+    let mut xml_albums = String::new();
+    let mut json_albums: Vec<Value> = Vec::new();
+    for a in &albums {
+        let id = uuid_str(&a.id);
+        let artist_id = a.artist_id.as_deref().map(uuid_str).unwrap_or_default();
+        let artist_name = a.artist_name.as_deref().unwrap_or("");
+        xml_albums.push_str(&album_xml_elem(
+            &id,
+            &a.name,
+            artist_name,
+            &artist_id,
+            a.year,
+            a.song_count,
+            a.duration,
+        ));
+        json_albums.push(album_json(
+            &id,
+            &a.name,
+            artist_name,
+            &artist_id,
+            a.year,
+            a.song_count,
+            a.duration,
+        ));
+    }
+
+    let xml = format!("<starred2>{xml_albums}{xml_songs}</starred2>");
+    respond_ok(
+        user.format,
+        &xml,
+        Some((
+            "starred2",
+            json!({ "album": json_albums, "song": json_songs }),
+        )),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// getNowPlaying
+// ---------------------------------------------------------------------------
+
+pub async fn get_now_playing(
+    State(state): State<AppState>,
+    Query(q): Query<CommonQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    // No real-time play state tracking yet — return empty
+    respond_ok(
+        user.format,
+        "<nowPlaying />",
+        Some(("nowPlaying", json!({}))),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_song_lists(songs: &[SongRow]) -> (String, Vec<Value>) {
+    let mut xml = String::new();
+    let mut json: Vec<Value> = Vec::new();
+    for s in songs {
+        let id = uuid_str(&s.id);
+        let album_id = uuid_str(&s.album_id);
+        let artist_id = s.artist_id.as_deref().map(uuid_str).unwrap_or_default();
+        let artist_name = s.artist_name.as_deref().unwrap_or("");
+        let duration_secs = s.duration_ms.map(|d| d / 1000);
+        let ct = codec_content_type(s.codec.as_deref());
+        let sfx = codec_suffix(s.codec.as_deref());
+        xml.push_str(&song_xml_elem(
+            &id,
+            &s.title,
+            &s.album_title,
+            &album_id,
+            artist_name,
+            &artist_id,
+            Some(s.position),
+            s.year,
+            duration_secs,
+            None,
+            ct,
+            sfx,
+            false,
+        ));
+        json.push(song_json(
+            &id,
+            &s.title,
+            &s.album_title,
+            &album_id,
+            artist_name,
+            &artist_id,
+            Some(s.position),
+            s.year,
+            duration_secs,
+            None,
+            ct,
+            sfx,
+        ));
+    }
+    (xml, json)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+
+    use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
+    use axum::{body::Body, body::to_bytes, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn get_album_list2_alphabetical() {
+        let (app, state, key) = subsonic_app().await;
+        seed_music_data(&state).await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/rest/getAlbumList2.view?apiKey={key}&type=alphabeticalByName"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("albumList2"));
+    }
+
+    #[tokio::test]
+    async fn get_album_list2_by_year() {
+        let (app, state, key) = subsonic_app().await;
+        seed_music_data(&state).await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/rest/getAlbumList2.view?apiKey={key}&type=byYear&fromYear=2020&toYear=2026"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+    }
+
+    #[tokio::test]
+    async fn get_random_songs_returns_songs() {
+        let (app, state, key) = subsonic_app().await;
+        seed_music_data(&state).await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getRandomSongs.view?apiKey={key}&size=5"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("randomSongs"));
+    }
+
+    #[tokio::test]
+    async fn get_starred2_empty() {
+        let (app, _state, key) = subsonic_app().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getStarred2.view?apiKey={key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("starred2"));
+    }
+}

--- a/crates/paroche/src/subsonic/media.rs
+++ b/crates/paroche/src/subsonic/media.rs
@@ -1,0 +1,284 @@
+use axum::{
+    extract::{Query, State},
+    response::Response,
+};
+use serde::Deserialize;
+
+use super::{
+    auth::authenticate,
+    types::{ERR_MISSING_PARAM, SubsonicCommon, respond_error, respond_ok, uuid_bytes},
+};
+use crate::state::AppState;
+
+#[derive(Deserialize, Default)]
+pub struct StarQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub id: Option<String>,
+    #[serde(rename = "albumId")]
+    pub album_id: Option<String>,
+    #[serde(rename = "artistId")]
+    pub artist_id: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct RatingQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub id: Option<String>,
+    pub rating: Option<i64>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct ScrobbleQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub id: Option<String>,
+    pub time: Option<i64>,
+    pub submission: Option<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// star.view
+// ---------------------------------------------------------------------------
+
+pub async fn star(State(state): State<AppState>, Query(q): Query<StarQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let user_id_bytes = user.user_id.as_bytes().to_vec();
+
+    if let Some(id) = &q.id
+        && let Some(bytes) = uuid_bytes(id)
+    {
+        let _ = sqlx::query(
+            "INSERT OR IGNORE INTO subsonic_stars (user_id, item_id, item_type) VALUES (?, ?, 'track')",
+        )
+        .bind(&user_id_bytes)
+        .bind(bytes)
+        .execute(&state.db.write)
+        .await;
+    }
+    if let Some(id) = &q.album_id
+        && let Some(bytes) = uuid_bytes(id)
+    {
+        let _ = sqlx::query(
+            "INSERT OR IGNORE INTO subsonic_stars (user_id, item_id, item_type) VALUES (?, ?, 'album')",
+        )
+        .bind(&user_id_bytes)
+        .bind(bytes)
+        .execute(&state.db.write)
+        .await;
+    }
+    if let Some(id) = &q.artist_id
+        && let Some(bytes) = uuid_bytes(id)
+    {
+        let _ = sqlx::query(
+            "INSERT OR IGNORE INTO subsonic_stars (user_id, item_id, item_type) VALUES (?, ?, 'artist')",
+        )
+        .bind(&user_id_bytes)
+        .bind(bytes)
+        .execute(&state.db.write)
+        .await;
+    }
+
+    respond_ok(user.format, "", None)
+}
+
+// ---------------------------------------------------------------------------
+// unstar.view
+// ---------------------------------------------------------------------------
+
+pub async fn unstar(State(state): State<AppState>, Query(q): Query<StarQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let user_id_bytes = user.user_id.as_bytes().to_vec();
+
+    for id in [&q.id, &q.album_id, &q.artist_id].into_iter().flatten() {
+        if let Some(bytes) = uuid_bytes(id) {
+            let _ = sqlx::query("DELETE FROM subsonic_stars WHERE user_id = ? AND item_id = ?")
+                .bind(&user_id_bytes)
+                .bind(bytes)
+                .execute(&state.db.write)
+                .await;
+        }
+    }
+
+    respond_ok(user.format, "", None)
+}
+
+// ---------------------------------------------------------------------------
+// setRating.view
+// ---------------------------------------------------------------------------
+
+pub async fn set_rating(State(state): State<AppState>, Query(q): Query<RatingQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let id = match &q.id {
+        Some(id) => id.clone(),
+        None => {
+            return respond_error(
+                user.format,
+                ERR_MISSING_PARAM,
+                "required parameter is missing: id",
+            );
+        }
+    };
+    let rating = match q.rating {
+        Some(r) if (1..=5).contains(&r) => r,
+        Some(0) => {
+            // rating=0 means remove rating
+            if let Some(bytes) = uuid_bytes(&id) {
+                let user_id_bytes = user.user_id.as_bytes().to_vec();
+                let _ =
+                    sqlx::query("DELETE FROM subsonic_ratings WHERE user_id = ? AND item_id = ?")
+                        .bind(user_id_bytes)
+                        .bind(bytes)
+                        .execute(&state.db.write)
+                        .await;
+            }
+            return respond_ok(user.format, "", None);
+        }
+        None => {
+            return respond_error(
+                user.format,
+                ERR_MISSING_PARAM,
+                "required parameter is missing: rating",
+            );
+        }
+        _ => return respond_error(user.format, 0, "invalid rating: must be 1-5"),
+    };
+
+    let id_bytes = match uuid_bytes(&id) {
+        Some(b) => b,
+        None => return respond_error(user.format, 0, "invalid id"),
+    };
+
+    let user_id_bytes = user.user_id.as_bytes().to_vec();
+    let _ = sqlx::query(
+        "INSERT INTO subsonic_ratings (user_id, item_id, rating) VALUES (?, ?, ?)
+         ON CONFLICT(user_id, item_id) DO UPDATE SET rating = excluded.rating",
+    )
+    .bind(user_id_bytes)
+    .bind(id_bytes)
+    .bind(rating)
+    .execute(&state.db.write)
+    .await;
+
+    respond_ok(user.format, "", None)
+}
+
+// ---------------------------------------------------------------------------
+// scrobble.view
+// ---------------------------------------------------------------------------
+
+pub async fn scrobble(State(state): State<AppState>, Query(q): Query<ScrobbleQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    // Emit event for scrobbling — acknowledged but no external scrobbler yet
+    let _ = &q.id;
+    let _ = &q.time;
+    respond_ok(user.format, "", None)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+
+    use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
+    use crate::subsonic::types::uuid_str;
+    use axum::{body::Body, body::to_bytes, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn star_and_unstar_track() {
+        let (app, state, key) = subsonic_app().await;
+        let (_, track_id) = seed_music_data(&state).await;
+        let id = uuid_str(&track_id);
+
+        // Star
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/star.view?apiKey={key}&id={id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+
+        // Unstar
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/unstar.view?apiKey={key}&id={id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+    }
+
+    #[tokio::test]
+    async fn set_rating_persisted() {
+        let (app, state, key) = subsonic_app().await;
+        let (_, track_id) = seed_music_data(&state).await;
+        let id = uuid_str(&track_id);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/rest/setRating.view?apiKey={key}&id={id}&rating=4"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+    }
+
+    #[tokio::test]
+    async fn scrobble_returns_ok() {
+        let (app, state, key) = subsonic_app().await;
+        let (_, track_id) = seed_music_data(&state).await;
+        let id = uuid_str(&track_id);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/rest/scrobble.view?apiKey={key}&id={id}&submission=true"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+    }
+}

--- a/crates/paroche/src/subsonic/mod.rs
+++ b/crates/paroche/src/subsonic/mod.rs
@@ -1,0 +1,293 @@
+pub mod auth;
+pub mod browsing;
+pub mod lists;
+pub mod media;
+pub mod playlists;
+pub mod retrieval;
+pub mod search;
+pub mod system;
+pub mod types;
+
+use axum::{Router, routing::get};
+
+use crate::state::AppState;
+
+pub fn subsonic_routes() -> Router<AppState> {
+    Router::new()
+        // System
+        .route("/ping.view", get(system::ping).post(system::ping))
+        .route(
+            "/getLicense.view",
+            get(system::get_license).post(system::get_license),
+        )
+        .route(
+            "/getOpenSubsonicExtensions.view",
+            get(system::get_open_subsonic_extensions).post(system::get_open_subsonic_extensions),
+        )
+        // Browsing
+        .route(
+            "/getMusicFolders.view",
+            get(browsing::get_music_folders).post(browsing::get_music_folders),
+        )
+        .route(
+            "/getIndexes.view",
+            get(browsing::get_indexes).post(browsing::get_indexes),
+        )
+        .route(
+            "/getArtists.view",
+            get(browsing::get_artists).post(browsing::get_artists),
+        )
+        .route(
+            "/getArtist.view",
+            get(browsing::get_artist).post(browsing::get_artist),
+        )
+        .route(
+            "/getAlbum.view",
+            get(browsing::get_album).post(browsing::get_album),
+        )
+        .route(
+            "/getSong.view",
+            get(browsing::get_song).post(browsing::get_song),
+        )
+        .route(
+            "/getMusicDirectory.view",
+            get(browsing::get_music_directory).post(browsing::get_music_directory),
+        )
+        // Retrieval
+        .route(
+            "/stream.view",
+            get(retrieval::stream).post(retrieval::stream),
+        )
+        .route(
+            "/getCoverArt.view",
+            get(retrieval::get_cover_art).post(retrieval::get_cover_art),
+        )
+        .route(
+            "/getAvatar.view",
+            get(retrieval::get_avatar).post(retrieval::get_avatar),
+        )
+        // Search
+        .route("/search3.view", get(search::search3).post(search::search3))
+        // Lists
+        .route(
+            "/getAlbumList2.view",
+            get(lists::get_album_list2).post(lists::get_album_list2),
+        )
+        .route(
+            "/getRandomSongs.view",
+            get(lists::get_random_songs).post(lists::get_random_songs),
+        )
+        .route(
+            "/getStarred2.view",
+            get(lists::get_starred2).post(lists::get_starred2),
+        )
+        .route(
+            "/getNowPlaying.view",
+            get(lists::get_now_playing).post(lists::get_now_playing),
+        )
+        // Media annotation
+        .route("/star.view", get(media::star).post(media::star))
+        .route("/unstar.view", get(media::unstar).post(media::unstar))
+        .route(
+            "/setRating.view",
+            get(media::set_rating).post(media::set_rating),
+        )
+        .route("/scrobble.view", get(media::scrobble).post(media::scrobble))
+        // Playlists
+        .route(
+            "/getPlaylists.view",
+            get(playlists::get_playlists).post(playlists::get_playlists),
+        )
+        .route(
+            "/getPlaylist.view",
+            get(playlists::get_playlist).post(playlists::get_playlist),
+        )
+        .route(
+            "/createPlaylist.view",
+            get(playlists::create_playlist).post(playlists::create_playlist),
+        )
+        .route(
+            "/updatePlaylist.view",
+            get(playlists::update_playlist).post(playlists::update_playlist),
+        )
+        .route(
+            "/deletePlaylist.view",
+            get(playlists::delete_playlist).post(playlists::delete_playlist),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers shared across subsonic test modules
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+pub mod test_helpers {
+
+    use axum::Router;
+    use exousia::AuthService;
+    use harmonia_common::ids::UserId;
+    use uuid::Uuid;
+
+    use crate::{state::AppState, subsonic::subsonic_routes, test_helpers::test_state};
+
+    /// Build the subsonic sub-router wired with a fresh in-memory state.
+    /// Returns (router, state, api_key_string)
+    pub async fn subsonic_app() -> (Router, AppState, String) {
+        let (state, auth) = test_state().await;
+
+        // Create a test user and API key
+        auth.create_user(exousia::user::CreateUserRequest {
+            username: "subsonic_test".to_string(),
+            display_name: "Subsonic Test".to_string(),
+            password: "testpass".to_string(),
+            role: exousia::user::UserRole::Admin,
+        })
+        .await
+        .unwrap();
+
+        let api_key = auth
+            .create_api_key(get_user_id(&state, "subsonic_test").await, "test key")
+            .await
+            .unwrap();
+
+        let router = Router::new()
+            .nest("/rest", subsonic_routes())
+            .with_state(state.clone());
+        (router, state, api_key)
+    }
+
+    async fn get_user_id(state: &AppState, username: &str) -> UserId {
+        let id_bytes: Vec<u8> = sqlx::query_scalar("SELECT id FROM users WHERE username = ?")
+            .bind(username)
+            .fetch_one(&state.db.read)
+            .await
+            .unwrap();
+        let uuid = Uuid::from_slice(&id_bytes).unwrap();
+        UserId::from_uuid(uuid)
+    }
+
+    /// Seed a minimal music hierarchy: one artist, one album, one track.
+    /// Returns (release_group_id_bytes, track_id_bytes).
+    pub async fn seed_music_data(state: &AppState) -> (Vec<u8>, Vec<u8>) {
+        let now = "2026-01-01T00:00:00Z";
+
+        // Artist in media_registry
+        let artist_id = Uuid::now_v7().as_bytes().to_vec();
+        sqlx::query(
+            "INSERT INTO media_registry (id, entity_type, display_name, created_at, updated_at)
+             VALUES (?, 'person', 'Test Artist', ?, ?)",
+        )
+        .bind(&artist_id)
+        .bind(now)
+        .bind(now)
+        .execute(&state.db.write)
+        .await
+        .unwrap();
+
+        // Release group (album)
+        let group_id = Uuid::now_v7().as_bytes().to_vec();
+        sqlx::query(
+            "INSERT INTO music_release_groups (id, title, rg_type, year, added_at)
+             VALUES (?, 'Test Album', 'album', 2024, ?)",
+        )
+        .bind(&group_id)
+        .bind(now)
+        .execute(&state.db.write)
+        .await
+        .unwrap();
+
+        // Link artist → album
+        sqlx::query(
+            "INSERT INTO music_release_group_artists (release_group_id, artist_id, role)
+             VALUES (?, ?, 'primary')",
+        )
+        .bind(&group_id)
+        .bind(&artist_id)
+        .execute(&state.db.write)
+        .await
+        .unwrap();
+
+        // Release
+        let release_id = Uuid::now_v7().as_bytes().to_vec();
+        sqlx::query(
+            "INSERT INTO music_releases (id, release_group_id, title, release_date, added_at)
+             VALUES (?, ?, 'Test Album', '2024-01-01', ?)",
+        )
+        .bind(&release_id)
+        .bind(&group_id)
+        .bind(now)
+        .execute(&state.db.write)
+        .await
+        .unwrap();
+
+        // Medium
+        let medium_id = Uuid::now_v7().as_bytes().to_vec();
+        sqlx::query(
+            "INSERT INTO music_media (id, release_id, position, format) VALUES (?, ?, 1, 'Digital')",
+        )
+        .bind(&medium_id)
+        .bind(&release_id)
+        .execute(&state.db.write)
+        .await
+        .unwrap();
+
+        // Track
+        let track_id = Uuid::now_v7().as_bytes().to_vec();
+        sqlx::query(
+            "INSERT INTO music_tracks
+             (id, medium_id, position, title, duration_ms, codec, source_type, added_at)
+             VALUES (?, ?, 1, 'Test Track', 240000, 'FLAC', 'local', ?)",
+        )
+        .bind(&track_id)
+        .bind(&medium_id)
+        .bind(now)
+        .execute(&state.db.write)
+        .await
+        .unwrap();
+
+        // Link track → artist
+        sqlx::query(
+            "INSERT INTO music_track_artists (track_id, artist_id, role) VALUES (?, ?, 'primary')",
+        )
+        .bind(&track_id)
+        .bind(&artist_id)
+        .execute(&state.db.write)
+        .await
+        .unwrap();
+
+        (group_id, track_id)
+    }
+
+    /// Helpers for legacy MD5 token auth tests.
+    pub mod make_api_key {
+        use super::*;
+        use crate::subsonic::auth::set_subsonic_password;
+
+        /// Create a user with a subsonic password and return (username, token, salt).
+        pub async fn legacy_params(
+            state: &AppState,
+            username: &str,
+            password: &str,
+        ) -> (String, String, String) {
+            // Create user if doesn't exist
+            let _ = state
+                .auth
+                .create_user(exousia::user::CreateUserRequest {
+                    username: username.to_string(),
+                    display_name: username.to_string(),
+                    password: "any_argon2_password".to_string(),
+                    role: exousia::user::UserRole::Member,
+                })
+                .await;
+
+            let user_id = get_user_id(state, username).await;
+            set_subsonic_password(&state.db.write, user_id, password)
+                .await
+                .unwrap();
+
+            let salt = "randomsalt";
+            let token = format!("{:x}", md5::compute(format!("{password}{salt}")));
+            (username.to_string(), token, salt.to_string())
+        }
+    }
+}

--- a/crates/paroche/src/subsonic/playlists.rs
+++ b/crates/paroche/src/subsonic/playlists.rs
@@ -1,0 +1,602 @@
+use axum::{
+    extract::{Query, State},
+    response::Response,
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use super::{
+    auth::authenticate,
+    types::{
+        ERR_MISSING_PARAM, ERR_NOT_FOUND, SubsonicCommon, codec_content_type, codec_suffix,
+        respond_error, respond_ok, song_json, song_xml_elem, uuid_bytes, uuid_str,
+    },
+};
+use crate::state::AppState;
+
+#[derive(Deserialize, Default)]
+pub struct PlaylistsQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub username: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct GetPlaylistQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub id: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct CreatePlaylistQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    #[serde(rename = "playlistId")]
+    pub playlist_id: Option<String>,
+    pub name: Option<String>,
+    #[serde(rename = "songId")]
+    pub song_ids: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct UpdatePlaylistQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    #[serde(rename = "playlistId")]
+    pub playlist_id: Option<String>,
+    pub name: Option<String>,
+    pub comment: Option<String>,
+    pub public: Option<bool>,
+    #[serde(rename = "songIndexToRemove")]
+    pub song_indexes_to_remove: Option<Vec<i64>>,
+    #[serde(rename = "songIdToAdd")]
+    pub song_ids_to_add: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct DeletePlaylistQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub id: Option<String>,
+}
+
+#[derive(sqlx::FromRow)]
+struct PlaylistRow {
+    id: Vec<u8>,
+    name: String,
+    comment: Option<String>,
+    public: i64,
+    owner: String,
+    song_count: i64,
+    duration: i64,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(sqlx::FromRow)]
+struct SongRow {
+    id: Vec<u8>,
+    title: String,
+    position: i64,
+    duration_ms: Option<i64>,
+    codec: Option<String>,
+    album_id: Vec<u8>,
+    album_title: String,
+    year: Option<i64>,
+    artist_id: Option<Vec<u8>>,
+    artist_name: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// getPlaylists
+// ---------------------------------------------------------------------------
+
+pub async fn get_playlists(
+    State(state): State<AppState>,
+    Query(q): Query<PlaylistsQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let user_id_bytes = user.user_id.as_bytes().to_vec();
+
+    let playlists = sqlx::query_as::<_, PlaylistRow>(
+        "SELECT sp.id, sp.name, sp.comment, sp.public, u.username as owner,
+                COUNT(spt.track_id) as song_count,
+                COALESCE(SUM(t.duration_ms), 0) / 1000 as duration,
+                sp.created_at, sp.updated_at
+         FROM subsonic_playlists sp
+         JOIN users u ON u.id = sp.owner_id
+         LEFT JOIN subsonic_playlist_tracks spt ON spt.playlist_id = sp.id
+         LEFT JOIN music_tracks t ON t.id = spt.track_id
+         WHERE sp.owner_id = ? OR sp.public = 1
+         GROUP BY sp.id
+         ORDER BY sp.name",
+    )
+    .bind(&user_id_bytes)
+    .fetch_all(&state.db.read)
+    .await
+    .unwrap_or_default();
+
+    let (xml_items, json_items) = build_playlist_list(&playlists);
+    let xml = format!("<playlists>{xml_items}</playlists>");
+    respond_ok(
+        user.format,
+        &xml,
+        Some(("playlists", json!({ "playlist": json_items }))),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// getPlaylist
+// ---------------------------------------------------------------------------
+
+pub async fn get_playlist(
+    State(state): State<AppState>,
+    Query(q): Query<GetPlaylistQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let id = match &q.id {
+        Some(id) => id.clone(),
+        None => {
+            return respond_error(
+                user.format,
+                ERR_MISSING_PARAM,
+                "required parameter is missing: id",
+            );
+        }
+    };
+    let id_bytes = match uuid_bytes(&id) {
+        Some(b) => b,
+        None => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+    let user_id_bytes = user.user_id.as_bytes().to_vec();
+
+    let playlist = match sqlx::query_as::<_, PlaylistRow>(
+        "SELECT sp.id, sp.name, sp.comment, sp.public, u.username as owner,
+                COUNT(spt.track_id) as song_count,
+                COALESCE(SUM(t.duration_ms), 0) / 1000 as duration,
+                sp.created_at, sp.updated_at
+         FROM subsonic_playlists sp
+         JOIN users u ON u.id = sp.owner_id
+         LEFT JOIN subsonic_playlist_tracks spt ON spt.playlist_id = sp.id
+         LEFT JOIN music_tracks t ON t.id = spt.track_id
+         WHERE sp.id = ? AND (sp.owner_id = ? OR sp.public = 1)
+         GROUP BY sp.id",
+    )
+    .bind(&id_bytes)
+    .bind(&user_id_bytes)
+    .fetch_optional(&state.db.read)
+    .await
+    {
+        Ok(Some(p)) => p,
+        _ => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    let songs = sqlx::query_as::<_, SongRow>(
+        "SELECT t.id, t.title, t.position, t.duration_ms, t.codec,
+                mrg.id as album_id, mrg.title as album_title, mrg.year,
+                mr.id as artist_id, mr.display_name as artist_name
+         FROM subsonic_playlist_tracks spt
+         JOIN music_tracks t ON t.id = spt.track_id
+         JOIN music_media mm ON mm.id = t.medium_id
+         JOIN music_releases r ON r.id = mm.release_id
+         JOIN music_release_groups mrg ON mrg.id = r.release_group_id
+         LEFT JOIN music_track_artists mta ON mta.track_id = t.id AND mta.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mta.artist_id
+         WHERE spt.playlist_id = ?
+         ORDER BY spt.position",
+    )
+    .bind(&id_bytes)
+    .fetch_all(&state.db.read)
+    .await
+    .unwrap_or_default();
+
+    let (xml_songs, json_songs) = build_songs(&songs);
+    let playlist_id = uuid_str(&playlist.id);
+    let xml = format!(
+        r#"<playlist id="{}" name="{}" comment="{}" owner="{}" public="{}" songCount="{}" duration="{}" created="{}" changed="{}">{xml_songs}</playlist>"#,
+        super::types::xml_escape(&playlist_id),
+        super::types::xml_escape(&playlist.name),
+        super::types::xml_escape(playlist.comment.as_deref().unwrap_or("")),
+        super::types::xml_escape(&playlist.owner),
+        if playlist.public != 0 {
+            "true"
+        } else {
+            "false"
+        },
+        playlist.song_count,
+        playlist.duration,
+        playlist.created_at,
+        playlist.updated_at,
+    );
+    let json_val = json!({
+        "id": playlist_id,
+        "name": playlist.name,
+        "comment": playlist.comment,
+        "owner": playlist.owner,
+        "public": playlist.public != 0,
+        "songCount": playlist.song_count,
+        "duration": playlist.duration,
+        "created": playlist.created_at,
+        "changed": playlist.updated_at,
+        "entry": json_songs
+    });
+    respond_ok(user.format, &xml, Some(("playlist", json_val)))
+}
+
+// ---------------------------------------------------------------------------
+// createPlaylist
+// ---------------------------------------------------------------------------
+
+pub async fn create_playlist(
+    State(state): State<AppState>,
+    Query(q): Query<CreatePlaylistQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let name = match &q.name {
+        Some(n) if !n.trim().is_empty() => n.clone(),
+        _ => {
+            return respond_error(
+                user.format,
+                ERR_MISSING_PARAM,
+                "required parameter is missing: name",
+            );
+        }
+    };
+
+    let playlist_id = Uuid::now_v7().as_bytes().to_vec();
+    let user_id_bytes = user.user_id.as_bytes().to_vec();
+
+    let _ = sqlx::query("INSERT INTO subsonic_playlists (id, owner_id, name) VALUES (?, ?, ?)")
+        .bind(&playlist_id)
+        .bind(&user_id_bytes)
+        .bind(&name)
+        .execute(&state.db.write)
+        .await;
+
+    if let Some(song_ids) = &q.song_ids {
+        for (pos, sid) in song_ids.iter().enumerate() {
+            if let Some(track_bytes) = uuid_bytes(sid) {
+                let _ = sqlx::query(
+                    "INSERT OR IGNORE INTO subsonic_playlist_tracks (playlist_id, track_id, position) VALUES (?, ?, ?)",
+                )
+                .bind(&playlist_id)
+                .bind(track_bytes)
+                .bind(pos as i64)
+                .execute(&state.db.write)
+                .await;
+            }
+        }
+    }
+
+    let pl_id_str = uuid_str(&playlist_id);
+    let xml = format!(
+        r#"<playlist id="{}" name="{}" owner="{}" public="false" songCount="0" duration="0" />"#,
+        super::types::xml_escape(&pl_id_str),
+        super::types::xml_escape(&name),
+        super::types::xml_escape(&user.username),
+    );
+    let json_val = json!({
+        "id": pl_id_str,
+        "name": name,
+        "owner": user.username,
+        "public": false,
+        "songCount": 0,
+        "duration": 0
+    });
+    respond_ok(user.format, &xml, Some(("playlist", json_val)))
+}
+
+// ---------------------------------------------------------------------------
+// updatePlaylist
+// ---------------------------------------------------------------------------
+
+pub async fn update_playlist(
+    State(state): State<AppState>,
+    Query(q): Query<UpdatePlaylistQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let id = match &q.playlist_id {
+        Some(id) => id.clone(),
+        None => {
+            return respond_error(
+                user.format,
+                ERR_MISSING_PARAM,
+                "required parameter is missing: playlistId",
+            );
+        }
+    };
+    let id_bytes = match uuid_bytes(&id) {
+        Some(b) => b,
+        None => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+    let user_id_bytes = user.user_id.as_bytes().to_vec();
+
+    // Verify ownership
+    let owned: Option<i64> =
+        sqlx::query_scalar("SELECT 1 FROM subsonic_playlists WHERE id = ? AND owner_id = ?")
+            .bind(&id_bytes)
+            .bind(&user_id_bytes)
+            .fetch_optional(&state.db.read)
+            .await
+            .unwrap_or(None);
+
+    if owned.is_none() {
+        return respond_error(user.format, ERR_NOT_FOUND, "not found");
+    }
+
+    if let Some(name) = &q.name {
+        let _ = sqlx::query(
+            "UPDATE subsonic_playlists SET name = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+        )
+        .bind(name)
+        .bind(&id_bytes)
+        .execute(&state.db.write)
+        .await;
+    }
+
+    if let Some(comment) = &q.comment {
+        let _ = sqlx::query(
+            "UPDATE subsonic_playlists SET comment = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+        )
+        .bind(comment)
+        .bind(&id_bytes)
+        .execute(&state.db.write)
+        .await;
+    }
+
+    if let Some(public) = q.public {
+        let _ = sqlx::query(
+            "UPDATE subsonic_playlists SET public = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+        )
+        .bind(if public { 1i64 } else { 0i64 })
+        .bind(&id_bytes)
+        .execute(&state.db.write)
+        .await;
+    }
+
+    // Append songs
+    if let Some(song_ids) = &q.song_ids_to_add {
+        // Get current max position
+        let max_pos: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(MAX(position), -1) FROM subsonic_playlist_tracks WHERE playlist_id = ?",
+        )
+        .bind(&id_bytes)
+        .fetch_one(&state.db.read)
+        .await
+        .unwrap_or(-1);
+
+        for (i, sid) in song_ids.iter().enumerate() {
+            if let Some(track_bytes) = uuid_bytes(sid) {
+                let _ = sqlx::query(
+                    "INSERT OR IGNORE INTO subsonic_playlist_tracks (playlist_id, track_id, position) VALUES (?, ?, ?)",
+                )
+                .bind(&id_bytes)
+                .bind(track_bytes)
+                .bind(max_pos + 1 + i as i64)
+                .execute(&state.db.write)
+                .await;
+            }
+        }
+    }
+
+    respond_ok(user.format, "", None)
+}
+
+// ---------------------------------------------------------------------------
+// deletePlaylist
+// ---------------------------------------------------------------------------
+
+pub async fn delete_playlist(
+    State(state): State<AppState>,
+    Query(q): Query<DeletePlaylistQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let id = match &q.id {
+        Some(id) => id.clone(),
+        None => {
+            return respond_error(
+                user.format,
+                ERR_MISSING_PARAM,
+                "required parameter is missing: id",
+            );
+        }
+    };
+    let id_bytes = match uuid_bytes(&id) {
+        Some(b) => b,
+        None => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+    let user_id_bytes = user.user_id.as_bytes().to_vec();
+
+    let _ = sqlx::query("DELETE FROM subsonic_playlists WHERE id = ? AND owner_id = ?")
+        .bind(&id_bytes)
+        .bind(user_id_bytes)
+        .execute(&state.db.write)
+        .await;
+
+    respond_ok(user.format, "", None)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_playlist_list(playlists: &[PlaylistRow]) -> (String, Vec<Value>) {
+    let mut xml = String::new();
+    let mut json: Vec<Value> = Vec::new();
+    for p in playlists {
+        let id = uuid_str(&p.id);
+        xml.push_str(&format!(
+            r#"<playlist id="{}" name="{}" owner="{}" public="{}" songCount="{}" duration="{}" created="{}" changed="{}" />"#,
+            super::types::xml_escape(&id),
+            super::types::xml_escape(&p.name),
+            super::types::xml_escape(&p.owner),
+            if p.public != 0 { "true" } else { "false" },
+            p.song_count,
+            p.duration,
+            p.created_at,
+            p.updated_at,
+        ));
+        json.push(json!({
+            "id": id,
+            "name": p.name,
+            "owner": p.owner,
+            "public": p.public != 0,
+            "songCount": p.song_count,
+            "duration": p.duration,
+            "created": p.created_at,
+            "changed": p.updated_at
+        }));
+    }
+    (xml, json)
+}
+
+fn build_songs(songs: &[SongRow]) -> (String, Vec<Value>) {
+    let mut xml = String::new();
+    let mut json: Vec<Value> = Vec::new();
+    for s in songs {
+        let id = uuid_str(&s.id);
+        let album_id = uuid_str(&s.album_id);
+        let artist_id = s.artist_id.as_deref().map(uuid_str).unwrap_or_default();
+        let artist_name = s.artist_name.as_deref().unwrap_or("");
+        let duration_secs = s.duration_ms.map(|d| d / 1000);
+        let ct = codec_content_type(s.codec.as_deref());
+        let sfx = codec_suffix(s.codec.as_deref());
+        xml.push_str(&song_xml_elem(
+            &id,
+            &s.title,
+            &s.album_title,
+            &album_id,
+            artist_name,
+            &artist_id,
+            Some(s.position),
+            s.year,
+            duration_secs,
+            None,
+            ct,
+            sfx,
+            false,
+        ));
+        json.push(song_json(
+            &id,
+            &s.title,
+            &s.album_title,
+            &album_id,
+            artist_name,
+            &artist_id,
+            Some(s.position),
+            s.year,
+            duration_secs,
+            None,
+            ct,
+            sfx,
+        ));
+    }
+    (xml, json)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+
+    use crate::subsonic::test_helpers::subsonic_app;
+    use axum::{body::Body, body::to_bytes, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn playlist_crud() {
+        let (app, _state, key) = subsonic_app().await;
+
+        // Create
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/rest/createPlaylist.view?apiKey={key}&name=MyList"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("MyList"));
+
+        // Get playlists
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getPlaylists.view?apiKey={key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("MyList"));
+
+        // Extract playlist id
+        let id_start = body.find("id=\"").unwrap() + 4;
+        let id_end = body[id_start..].find('"').unwrap() + id_start;
+        let pl_id = &body[id_start..id_end];
+
+        // Get single playlist
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/getPlaylist.view?apiKey={key}&id={pl_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+
+        // Delete
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/deletePlaylist.view?apiKey={key}&id={pl_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+    }
+}

--- a/crates/paroche/src/subsonic/retrieval.rs
+++ b/crates/paroche/src/subsonic/retrieval.rs
@@ -1,0 +1,156 @@
+use axum::{
+    extract::{Query, State},
+    response::{IntoResponse, Response},
+};
+use serde::Deserialize;
+use tower::ServiceExt;
+use tower_http::services::ServeFile;
+
+use super::{
+    auth::authenticate,
+    types::{ERR_NOT_FOUND, SubsonicCommon, respond_error, uuid_bytes},
+};
+use crate::state::AppState;
+
+#[derive(Deserialize, Default)]
+pub struct StreamQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub id: Option<String>,
+    pub format: Option<String>,
+    #[serde(rename = "maxBitRate")]
+    pub max_bit_rate: Option<u32>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct CoverArtQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub id: Option<String>,
+    pub size: Option<u32>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct AvatarQuery {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub username: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// stream.view — proxy to the track file
+// ---------------------------------------------------------------------------
+
+pub async fn stream(
+    State(state): State<AppState>,
+    Query(q): Query<StreamQuery>,
+    request: axum::extract::Request,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let id = match &q.id {
+        Some(id) => id.clone(),
+        None => return respond_error(user.format, 10, "required parameter is missing: id"),
+    };
+
+    let id_bytes = match uuid_bytes(&id) {
+        Some(b) => b,
+        None => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    let track = match harmonia_db::repo::music::get_track(&state.db.read, &id_bytes).await {
+        Ok(Some(t)) => t,
+        _ => return respond_error(user.format, ERR_NOT_FOUND, "not found"),
+    };
+
+    let file_path = match track.file_path {
+        Some(p) => p,
+        None => return respond_error(user.format, ERR_NOT_FOUND, "media file not available"),
+    };
+
+    ServeFile::new(&file_path)
+        .oneshot(request)
+        .await
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// getCoverArt.view
+// ---------------------------------------------------------------------------
+
+pub async fn get_cover_art(
+    State(state): State<AppState>,
+    Query(q): Query<CoverArtQuery>,
+) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    // No cover art storage yet — return not found
+    respond_error(user.format, ERR_NOT_FOUND, "cover art not found")
+}
+
+// ---------------------------------------------------------------------------
+// getAvatar.view
+// ---------------------------------------------------------------------------
+
+pub async fn get_avatar(State(state): State<AppState>, Query(q): Query<AvatarQuery>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    // No avatar support — return not found
+    respond_error(user.format, ERR_NOT_FOUND, "avatar not found")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::subsonic::test_helpers::subsonic_app;
+    use axum::{body::Body, body::to_bytes, http::Request};
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn stream_missing_id_returns_error() {
+        let (app, _state, key) = subsonic_app().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/stream.view?apiKey={key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"failed\""));
+    }
+
+    #[tokio::test]
+    async fn stream_nonexistent_track_returns_error_70() {
+        let (app, _state, key) = subsonic_app().await;
+        let fake_id = Uuid::now_v7();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/stream.view?apiKey={key}&id={fake_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("code=\"70\""));
+    }
+}

--- a/crates/paroche/src/subsonic/search.rs
+++ b/crates/paroche/src/subsonic/search.rs
@@ -1,0 +1,286 @@
+use axum::{
+    extract::{Query, State},
+    response::Response,
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{
+    auth::authenticate,
+    types::{
+        SubsonicCommon, codec_content_type, codec_suffix, respond_ok, song_json, song_xml_elem,
+        uuid_str,
+    },
+};
+use crate::state::AppState;
+
+#[derive(Deserialize, Default)]
+pub struct Search3Query {
+    #[serde(flatten)]
+    pub common: SubsonicCommon,
+    pub query: Option<String>,
+    #[serde(rename = "artistCount")]
+    pub artist_count: Option<i64>,
+    #[serde(rename = "artistOffset")]
+    pub artist_offset: Option<i64>,
+    #[serde(rename = "albumCount")]
+    pub album_count: Option<i64>,
+    #[serde(rename = "albumOffset")]
+    pub album_offset: Option<i64>,
+    #[serde(rename = "songCount")]
+    pub song_count: Option<i64>,
+    #[serde(rename = "songOffset")]
+    pub song_offset: Option<i64>,
+    #[serde(rename = "musicFolderId")]
+    pub music_folder_id: Option<String>,
+}
+
+#[derive(sqlx::FromRow)]
+struct ArtistRow {
+    id: Vec<u8>,
+    name: String,
+    album_count: i64,
+}
+
+#[derive(sqlx::FromRow)]
+struct AlbumRow {
+    id: Vec<u8>,
+    name: String,
+    year: Option<i64>,
+    artist_name: Option<String>,
+    artist_id: Option<Vec<u8>>,
+}
+
+#[derive(sqlx::FromRow)]
+struct SongRow {
+    id: Vec<u8>,
+    title: String,
+    position: i64,
+    duration_ms: Option<i64>,
+    codec: Option<String>,
+    album_id: Vec<u8>,
+    album_title: String,
+    year: Option<i64>,
+    artist_id: Option<Vec<u8>>,
+    artist_name: Option<String>,
+}
+
+pub async fn search3(State(state): State<AppState>, Query(q): Query<Search3Query>) -> Response {
+    let user = match authenticate(&q.common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let query = q.query.as_deref().unwrap_or("").trim().to_string();
+    if query.is_empty() {
+        // Empty query — return empty results
+        return respond_ok(
+            user.format,
+            r#"<searchResult3 />"#,
+            Some((
+                "searchResult3",
+                json!({ "artist": [], "album": [], "song": [] }),
+            )),
+        );
+    }
+
+    let pattern = format!("%{query}%");
+    let artist_limit = q.artist_count.unwrap_or(20).min(500);
+    let artist_offset = q.artist_offset.unwrap_or(0);
+    let album_limit = q.album_count.unwrap_or(20).min(500);
+    let album_offset = q.album_offset.unwrap_or(0);
+    let song_limit = q.song_count.unwrap_or(20).min(500);
+    let song_offset = q.song_offset.unwrap_or(0);
+
+    let artists = sqlx::query_as::<_, ArtistRow>(
+        "SELECT mr.id, mr.display_name as name,
+                COUNT(DISTINCT mrga.release_group_id) as album_count
+         FROM media_registry mr
+         LEFT JOIN music_release_group_artists mrga ON mrga.artist_id = mr.id AND mrga.role = 'primary'
+         WHERE mr.entity_type = 'person' AND mr.display_name LIKE ?
+         GROUP BY mr.id
+         ORDER BY UPPER(mr.display_name)
+         LIMIT ? OFFSET ?",
+    )
+    .bind(&pattern)
+    .bind(artist_limit)
+    .bind(artist_offset)
+    .fetch_all(&state.db.read)
+    .await
+    .unwrap_or_default();
+
+    let albums = sqlx::query_as::<_, AlbumRow>(
+        "SELECT mrg.id, mrg.title as name, mrg.year,
+                mr.display_name as artist_name, mr.id as artist_id
+         FROM music_release_groups mrg
+         LEFT JOIN music_release_group_artists mrga ON mrga.release_group_id = mrg.id AND mrga.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mrga.artist_id
+         WHERE mrg.title LIKE ?
+         ORDER BY UPPER(mrg.title)
+         LIMIT ? OFFSET ?",
+    )
+    .bind(&pattern)
+    .bind(album_limit)
+    .bind(album_offset)
+    .fetch_all(&state.db.read)
+    .await
+    .unwrap_or_default();
+
+    let songs = sqlx::query_as::<_, SongRow>(
+        "SELECT t.id, t.title, t.position, t.duration_ms, t.codec,
+                mrg.id as album_id, mrg.title as album_title, mrg.year,
+                mr.id as artist_id, mr.display_name as artist_name
+         FROM music_tracks t
+         JOIN music_media mm ON mm.id = t.medium_id
+         JOIN music_releases r ON r.id = mm.release_id
+         JOIN music_release_groups mrg ON mrg.id = r.release_group_id
+         LEFT JOIN music_track_artists mta ON mta.track_id = t.id AND mta.role = 'primary'
+         LEFT JOIN media_registry mr ON mr.id = mta.artist_id
+         WHERE t.title LIKE ?
+         ORDER BY UPPER(t.title)
+         LIMIT ? OFFSET ?",
+    )
+    .bind(&pattern)
+    .bind(song_limit)
+    .bind(song_offset)
+    .fetch_all(&state.db.read)
+    .await
+    .unwrap_or_default();
+
+    // Build XML
+    let mut xml_artists = String::new();
+    let mut json_artists: Vec<Value> = Vec::new();
+    for a in &artists {
+        let id = uuid_str(&a.id);
+        xml_artists.push_str(&format!(
+            r#"<artist id="{}" name="{}" albumCount="{}" />"#,
+            super::types::xml_escape(&id),
+            super::types::xml_escape(&a.name),
+            a.album_count
+        ));
+        json_artists.push(json!({ "id": id, "name": a.name, "albumCount": a.album_count }));
+    }
+
+    let mut xml_albums = String::new();
+    let mut json_albums: Vec<Value> = Vec::new();
+    for a in &albums {
+        let id = uuid_str(&a.id);
+        let artist_id = a.artist_id.as_deref().map(uuid_str).unwrap_or_default();
+        let artist_name = a.artist_name.as_deref().unwrap_or("");
+        let year_attr = a
+            .year
+            .map(|y| format!(r#" year="{y}""#))
+            .unwrap_or_default();
+        xml_albums.push_str(&format!(
+            r#"<album id="{}" name="{}" artist="{}" artistId="{}"{year_attr} />"#,
+            super::types::xml_escape(&id),
+            super::types::xml_escape(&a.name),
+            super::types::xml_escape(artist_name),
+            super::types::xml_escape(&artist_id),
+        ));
+        json_albums.push(json!({
+            "id": id, "name": a.name,
+            "artist": artist_name, "artistId": artist_id,
+            "year": a.year
+        }));
+    }
+
+    let mut xml_songs = String::new();
+    let mut json_songs: Vec<Value> = Vec::new();
+    for s in &songs {
+        let id = uuid_str(&s.id);
+        let album_id = uuid_str(&s.album_id);
+        let artist_id = s.artist_id.as_deref().map(uuid_str).unwrap_or_default();
+        let artist_name = s.artist_name.as_deref().unwrap_or("");
+        let duration_secs = s.duration_ms.map(|d| d / 1000);
+        let ct = codec_content_type(s.codec.as_deref());
+        let sfx = codec_suffix(s.codec.as_deref());
+        xml_songs.push_str(&song_xml_elem(
+            &id,
+            &s.title,
+            &s.album_title,
+            &album_id,
+            artist_name,
+            &artist_id,
+            Some(s.position),
+            s.year,
+            duration_secs,
+            None,
+            ct,
+            sfx,
+            false,
+        ));
+        json_songs.push(song_json(
+            &id,
+            &s.title,
+            &s.album_title,
+            &album_id,
+            artist_name,
+            &artist_id,
+            Some(s.position),
+            s.year,
+            duration_secs,
+            None,
+            ct,
+            sfx,
+        ));
+    }
+
+    let xml = format!("<searchResult3>{xml_artists}{xml_albums}{xml_songs}</searchResult3>");
+    let json_val = json!({
+        "artist": json_artists,
+        "album": json_albums,
+        "song": json_songs
+    });
+    respond_ok(user.format, &xml, Some(("searchResult3", json_val)))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+
+    use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
+    use axum::{body::Body, body::to_bytes, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn search3_finds_artists_albums_songs() {
+        let (app, state, key) = subsonic_app().await;
+        seed_music_data(&state).await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/search3.view?apiKey={key}&query=Test"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("searchResult3"));
+        // Should find our seeded "Test Artist", "Test Album", "Test Track"
+        assert!(body.contains("Test"));
+    }
+
+    #[tokio::test]
+    async fn search3_empty_query_returns_empty_results() {
+        let (app, _state, key) = subsonic_app().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/search3.view?apiKey={key}&query="))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+    }
+}

--- a/crates/paroche/src/subsonic/system.rs
+++ b/crates/paroche/src/subsonic/system.rs
@@ -1,0 +1,161 @@
+use axum::{
+    extract::{Query, State},
+    response::Response,
+};
+use serde_json::json;
+
+use super::{
+    auth::authenticate,
+    types::{SubsonicCommon, respond_ok},
+};
+use crate::state::AppState;
+
+pub async fn ping(State(state): State<AppState>, Query(common): Query<SubsonicCommon>) -> Response {
+    let user = match authenticate(&common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+    respond_ok(user.format, "<ping />", Some(("ping", json!({}))))
+}
+
+pub async fn get_license(
+    State(state): State<AppState>,
+    Query(common): Query<SubsonicCommon>,
+) -> Response {
+    let user = match authenticate(&common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+    let xml = r#"<license valid="true" email="" licenseExpires="2099-12-31T00:00:00Z" />"#;
+    let json_val = json!({
+        "valid": true,
+        "email": "",
+        "licenseExpires": "2099-12-31T00:00:00Z"
+    });
+    respond_ok(user.format, xml, Some(("license", json_val)))
+}
+
+pub async fn get_open_subsonic_extensions(
+    State(state): State<AppState>,
+    Query(common): Query<SubsonicCommon>,
+) -> Response {
+    let user = match authenticate(&common, &state).await {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+    let xml = r#"<openSubsonicExtensions><openSubsonicExtension name="formPost" versions="1" /><openSubsonicExtension name="apiKeyAuthentication" versions="1" /></openSubsonicExtensions>"#;
+    let json_val = json!([
+        { "name": "formPost", "versions": [1] },
+        { "name": "apiKeyAuthentication", "versions": [1] }
+    ]);
+    respond_ok(user.format, xml, Some(("openSubsonicExtensions", json_val)))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::subsonic::test_helpers::{make_api_key, subsonic_app};
+    use axum::{body::Body, body::to_bytes, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn ping_returns_ok_xml_with_correct_version() {
+        let (app, _state, key) = subsonic_app().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/ping.view?apiKey={key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+        assert!(body.contains("version=\"1.16.1\""));
+        assert!(body.contains("openSubsonic=\"true\""));
+    }
+
+    #[tokio::test]
+    async fn ping_returns_json_when_requested() {
+        let (app, _state, key) = subsonic_app().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/ping.view?apiKey={key}&f=json"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["subsonic-response"]["status"], "ok");
+        assert_eq!(json["subsonic-response"]["version"], "1.16.1");
+        assert_eq!(json["subsonic-response"]["openSubsonic"], true);
+    }
+
+    #[tokio::test]
+    async fn ping_wrong_api_key_returns_error_40() {
+        let (app, _state, _key) = subsonic_app().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/rest/ping.view?apiKey=hmn_bad_key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"failed\""));
+        assert!(body.contains("code=\"40\""));
+    }
+
+    #[tokio::test]
+    async fn ping_legacy_token_valid_accepted() {
+        let (app, state, _key) = subsonic_app().await;
+        let (u, t, s) = make_api_key::legacy_params(&state, "testuser", "secret123").await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rest/ping.view?u={u}&t={t}&s={s}&v=1.16.1&c=test"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"ok\""));
+    }
+
+    #[tokio::test]
+    async fn ping_legacy_token_wrong_rejected_with_40() {
+        let (app, state, _key) = subsonic_app().await;
+        let (u, _t, s) = make_api_key::legacy_params(&state, "testuser2", "correct_pass").await;
+        // send wrong token
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/rest/ping.view?u={u}&t=wronghash&s={s}&v=1.16.1&c=test"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = std::str::from_utf8(&bytes).unwrap();
+        assert!(body.contains("status=\"failed\""));
+        assert!(body.contains("code=\"40\""));
+    }
+}

--- a/crates/paroche/src/subsonic/types.rs
+++ b/crates/paroche/src/subsonic/types.rs
@@ -1,0 +1,312 @@
+use axum::{body::Body, response::Response};
+use serde_json::{Value, json};
+
+pub const API_VERSION: &str = "1.16.1";
+pub const SERVER_TYPE: &str = "harmonia";
+pub const SERVER_VERSION: &str = "0.1.0";
+
+// Subsonic error codes
+pub const ERR_GENERIC: u32 = 0;
+pub const ERR_MISSING_PARAM: u32 = 10;
+pub const ERR_WRONG_CREDS: u32 = 40;
+pub const ERR_NOT_FOUND: u32 = 70;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    Xml,
+    Json,
+}
+
+impl Format {
+    pub fn parse(s: &str) -> Self {
+        if s == "json" { Self::Json } else { Self::Xml }
+    }
+}
+
+pub fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn xml_wrapper(status: &str, inner: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?><subsonic-response xmlns="http://subsonic.org/restapi" status="{status}" version="{API_VERSION}" type="{SERVER_TYPE}" serverVersion="{SERVER_VERSION}" openSubsonic="true">{inner}</subsonic-response>"#
+    )
+}
+
+fn json_base(status: &str) -> serde_json::Map<String, Value> {
+    let mut m = serde_json::Map::new();
+    m.insert("status".into(), json!(status));
+    m.insert("version".into(), json!(API_VERSION));
+    m.insert("type".into(), json!(SERVER_TYPE));
+    m.insert("serverVersion".into(), json!(SERVER_VERSION));
+    m.insert("openSubsonic".into(), json!(true));
+    m
+}
+
+pub fn respond_ok(format: Format, xml_inner: &str, json_key: Option<(&str, Value)>) -> Response {
+    match format {
+        Format::Xml => {
+            let body = xml_wrapper("ok", xml_inner);
+            Response::builder()
+                .status(200)
+                .header("Content-Type", "text/xml; charset=UTF-8")
+                .body(Body::from(body))
+                .unwrap()
+        }
+        Format::Json => {
+            let mut obj = json_base("ok");
+            if let Some((key, val)) = json_key {
+                obj.insert(key.to_string(), val);
+            }
+            let body =
+                serde_json::to_string(&json!({ "subsonic-response": Value::Object(obj) })).unwrap();
+            Response::builder()
+                .status(200)
+                .header("Content-Type", "application/json")
+                .body(Body::from(body))
+                .unwrap()
+        }
+    }
+}
+
+pub fn respond_error(format: Format, code: u32, message: &str) -> Response {
+    match format {
+        Format::Xml => {
+            let inner = format!(
+                r#"<error code="{code}" message="{}" />"#,
+                xml_escape(message)
+            );
+            let body = xml_wrapper("failed", &inner);
+            Response::builder()
+                .status(200)
+                .header("Content-Type", "text/xml; charset=UTF-8")
+                .body(Body::from(body))
+                .unwrap()
+        }
+        Format::Json => {
+            let mut obj = json_base("failed");
+            obj.insert("error".into(), json!({ "code": code, "message": message }));
+            let body =
+                serde_json::to_string(&json!({ "subsonic-response": Value::Object(obj) })).unwrap();
+            Response::builder()
+                .status(200)
+                .header("Content-Type", "application/json")
+                .body(Body::from(body))
+                .unwrap()
+        }
+    }
+}
+
+pub fn uuid_str(bytes: &[u8]) -> String {
+    uuid::Uuid::from_slice(bytes)
+        .map(|u| u.to_string())
+        .unwrap_or_default()
+}
+
+pub fn uuid_bytes(id: &str) -> Option<Vec<u8>> {
+    uuid::Uuid::parse_str(id)
+        .map(|u| u.as_bytes().to_vec())
+        .ok()
+}
+
+pub fn codec_content_type(codec: Option<&str>) -> &'static str {
+    match codec.map(|s| s.to_uppercase()).as_deref() {
+        Some("FLAC") => "audio/flac",
+        Some("MP3") => "audio/mpeg",
+        Some("AAC") | Some("M4A") | Some("ALAC") => "audio/mp4",
+        Some("OGG") => "audio/ogg",
+        Some("OPUS") => "audio/ogg; codecs=opus",
+        _ => "audio/mpeg",
+    }
+}
+
+pub fn codec_suffix(codec: Option<&str>) -> &'static str {
+    match codec.map(|s| s.to_uppercase()).as_deref() {
+        Some("FLAC") => "flac",
+        Some("MP3") => "mp3",
+        Some("AAC") => "aac",
+        Some("M4A") => "m4a",
+        Some("ALAC") => "m4a",
+        Some("OGG") => "ogg",
+        Some("OPUS") => "opus",
+        _ => "mp3",
+    }
+}
+
+/// Artist index grouping — returns uppercase first letter, stripping common articles.
+pub fn index_letter(name: &str) -> String {
+    let lower = name.to_lowercase();
+    let stripped = [
+        "the ", "a ", "an ", "el ", "la ", "los ", "las ", "le ", "les ",
+    ]
+    .iter()
+    .find_map(|prefix| lower.strip_prefix(prefix))
+    .unwrap_or(name);
+
+    stripped
+        .chars()
+        .next()
+        .map(|c| {
+            if c.is_ascii_alphabetic() {
+                c.to_ascii_uppercase().to_string()
+            } else {
+                "#".to_string()
+            }
+        })
+        .unwrap_or_else(|| "#".to_string())
+}
+
+/// Build Subsonic artist XML element.
+pub fn artist_xml(id: &str, name: &str, album_count: i64) -> String {
+    format!(
+        r#"<artist id="{}" name="{}" albumCount="{album_count}" />"#,
+        xml_escape(id),
+        xml_escape(name)
+    )
+}
+
+/// Build Subsonic AlbumID3 XML element (without children).
+pub fn album_xml_elem(
+    id: &str,
+    name: &str,
+    artist: &str,
+    artist_id: &str,
+    year: Option<i64>,
+    song_count: i64,
+    duration: i64,
+) -> String {
+    let year_attr = year.map(|y| format!(r#" year="{y}""#)).unwrap_or_default();
+    format!(
+        r#"<album id="{}" name="{}" artist="{}" artistId="{}" songCount="{song_count}" duration="{duration}"{year_attr} />"#,
+        xml_escape(id),
+        xml_escape(name),
+        xml_escape(artist),
+        xml_escape(artist_id),
+    )
+}
+
+/// Build Subsonic song/Child XML element.
+#[allow(clippy::too_many_arguments)]
+pub fn song_xml_elem(
+    id: &str,
+    title: &str,
+    album: &str,
+    album_id: &str,
+    artist: &str,
+    artist_id: &str,
+    track: Option<i64>,
+    year: Option<i64>,
+    duration_secs: Option<i64>,
+    bit_rate: Option<i64>,
+    content_type: &str,
+    suffix: &str,
+    is_dir: bool,
+) -> String {
+    let track_attr = track
+        .map(|t| format!(r#" track="{t}""#))
+        .unwrap_or_default();
+    let year_attr = year.map(|y| format!(r#" year="{y}""#)).unwrap_or_default();
+    let dur_attr = duration_secs
+        .map(|d| format!(r#" duration="{d}""#))
+        .unwrap_or_default();
+    let br_attr = bit_rate
+        .map(|b| format!(r#" bitRate="{b}""#))
+        .unwrap_or_default();
+    format!(
+        r#"<song id="{}" parent="{}" isDir="{is_dir}" title="{}" album="{}" albumId="{}" artist="{}" artistId="{}"{track_attr}{year_attr}{dur_attr}{br_attr} contentType="{content_type}" suffix="{suffix}" />"#,
+        xml_escape(id),
+        xml_escape(album_id),
+        xml_escape(title),
+        xml_escape(album),
+        xml_escape(album_id),
+        xml_escape(artist),
+        xml_escape(artist_id),
+    )
+}
+
+/// Build JSON object for an AlbumID3.
+pub fn album_json(
+    id: &str,
+    name: &str,
+    artist: &str,
+    artist_id: &str,
+    year: Option<i64>,
+    song_count: i64,
+    duration: i64,
+) -> Value {
+    let mut m = serde_json::Map::new();
+    m.insert("id".into(), json!(id));
+    m.insert("name".into(), json!(name));
+    m.insert("artist".into(), json!(artist));
+    m.insert("artistId".into(), json!(artist_id));
+    if let Some(y) = year {
+        m.insert("year".into(), json!(y));
+    }
+    m.insert("songCount".into(), json!(song_count));
+    m.insert("duration".into(), json!(duration));
+    Value::Object(m)
+}
+
+/// Build JSON object for a song/Child.
+#[allow(clippy::too_many_arguments)]
+pub fn song_json(
+    id: &str,
+    title: &str,
+    album: &str,
+    album_id: &str,
+    artist: &str,
+    artist_id: &str,
+    track: Option<i64>,
+    year: Option<i64>,
+    duration_secs: Option<i64>,
+    bit_rate: Option<i64>,
+    content_type: &str,
+    suffix: &str,
+) -> Value {
+    let mut m = serde_json::Map::new();
+    m.insert("id".into(), json!(id));
+    m.insert("parent".into(), json!(album_id));
+    m.insert("isDir".into(), json!(false));
+    m.insert("title".into(), json!(title));
+    m.insert("album".into(), json!(album));
+    m.insert("albumId".into(), json!(album_id));
+    m.insert("artist".into(), json!(artist));
+    m.insert("artistId".into(), json!(artist_id));
+    if let Some(t) = track {
+        m.insert("track".into(), json!(t));
+    }
+    if let Some(y) = year {
+        m.insert("year".into(), json!(y));
+    }
+    if let Some(d) = duration_secs {
+        m.insert("duration".into(), json!(d));
+    }
+    if let Some(b) = bit_rate {
+        m.insert("bitRate".into(), json!(b));
+    }
+    m.insert("contentType".into(), json!(content_type));
+    m.insert("suffix".into(), json!(suffix));
+    Value::Object(m)
+}
+
+/// Shared query params present on every Subsonic request.
+#[derive(serde::Deserialize, Default, Clone)]
+pub struct SubsonicCommon {
+    pub u: Option<String>,
+    pub t: Option<String>,
+    pub s: Option<String>,
+    #[serde(rename = "apiKey")]
+    pub api_key: Option<String>,
+    pub f: Option<String>,
+    pub v: Option<String>,
+    pub c: Option<String>,
+}
+
+impl SubsonicCommon {
+    pub fn format(&self) -> Format {
+        self.f.as_deref().map(Format::parse).unwrap_or(Format::Xml)
+    }
+}


### PR DESCRIPTION
## Summary

- Implements the OpenSubsonic REST API at `/rest/*` enabling Symfonium and other Subsonic-compatible clients to work with Harmonia
- ~25 endpoints covering system, browsing, retrieval, search, lists, media annotation, and playlists
- Supports both OpenSubsonic `apiKey` auth and legacy MD5 token auth; DB migration adds 5 new tables

## Endpoints

| Group | Endpoints |
|-------|-----------|
| System | `ping`, `getLicense`, `getOpenSubsonicExtensions` |
| Browsing | `getMusicFolders`, `getIndexes`, `getArtists`, `getArtist`, `getAlbum`, `getSong`, `getMusicDirectory` |
| Retrieval | `stream`, `getCoverArt` (stub), `getAvatar` (stub) |
| Search | `search3` |
| Lists | `getAlbumList2`, `getRandomSongs`, `getStarred2`, `getNowPlaying` |
| Media annotation | `star`, `unstar`, `setRating`, `scrobble` |
| Playlists | `getPlaylists`, `getPlaylist`, `createPlaylist`, `updatePlaylist`, `deletePlaylist` |

## Technical notes

- Response format: XML (default) and JSON (`f=json`) — manual XML string building, no extra dependency
- Legacy auth stores a separate subsonic password to avoid reversing Argon2id hashes
- Artists are grouped by first letter for `getIndexes`/`getArtists`; virtual folder id=1 simulates folder browsing

## Test plan

- [ ] `cargo test -p paroche` — 46 tests pass (25 subsonic + 21 existing HTTP API)
- [ ] `cargo clippy -p paroche -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean