### PR TITLE
feat: NixOS module for declarative deployment (P2-13)

### DIFF
--- a/docs/nix-deployment.md
+++ b/docs/nix-deployment.md
@@ -1,0 +1,104 @@
+# NixOS Deployment
+
+Harmonia ships a NixOS module for declarative deployment. Add the flake input and import the module to manage the service through `configuration.nix`.
+
+## Flake Input
+
+```nix
+# flake.nix
+inputs.harmonia.url = "github:forkwright/harmonia";
+```
+
+## Minimal Configuration
+
+```nix
+# configuration.nix
+{ inputs, config, ... }:
+{
+  imports = [ inputs.harmonia.nixosModules.default ];
+
+  services.harmonia = {
+    enable = true;
+    settings.paroche.port = 8096;
+  };
+}
+```
+
+## Full Configuration with Secrets
+
+```nix
+# configuration.nix
+{ inputs, config, ... }:
+{
+  imports = [ inputs.harmonia.nixosModules.default ];
+
+  services.harmonia = {
+    enable = true;
+    openFirewall = true;
+
+    # agenix-managed secrets file containing jwt_secret and API keys
+    secretsFile = config.age.secrets.harmonia-secrets.path;
+
+    settings = {
+      paroche.port = 8096;
+
+      taxis.libraries = {
+        music = {
+          path = "/media/music";
+          media_type = "music";
+          watcher_mode = "auto";
+        };
+        audiobooks = {
+          path = "/media/audiobooks";
+          media_type = "audiobook";
+          watcher_mode = "poll";
+          poll_interval_seconds = 300;
+        };
+        books = {
+          path = "/media/books";
+          media_type = "book";
+          watcher_mode = "poll";
+        };
+      };
+
+      epignosis.musicbrainz_user_agent =
+        "Harmonia/0.1.0 (https://github.com/forkwright/harmonia)";
+    };
+  };
+}
+```
+
+## Module Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `enable` | bool | `false` | Enable the service |
+| `package` | package | `pkgs.harmonia` | Harmonia package (from overlay) |
+| `user` | str | `"harmonia"` | System user |
+| `group` | str | `"harmonia"` | System group |
+| `dataDir` | path | `"/var/lib/harmonia"` | Database and cache directory |
+| `settings` | attrs | `{}` | Config written to `harmonia.toml` |
+| `secretsFile` | path or null | `null` | Secrets file loaded via `LoadCredential` |
+| `openFirewall` | bool | `false` | Open `paroche.port` in the firewall |
+
+## Secret Management
+
+Pass `secretsFile` a path managed by [agenix](https://github.com/ryantm/agenix) or [sops-nix](https://github.com/Mic92/sops-nix). The file is delivered to the service via systemd `LoadCredential`, so it is never world-readable and the path in the environment variable (`HARMONIA_SECRETS_PATH`) points to the credential directory, not the original path.
+
+## Systemd Hardening
+
+The service runs with a hardened systemd profile:
+
+- `NoNewPrivileges`, `PrivateTmp`, `PrivateDevices`
+- `ProtectSystem = strict` with explicit `ReadWritePaths` for `dataDir` and library paths
+- `MemoryDenyWriteExecute`, `RestrictNamespaces`, `RestrictRealtime`
+- `SystemCallFilter = @system-service ~@privileged`
+
+## Overlay
+
+To use the package in your own NixOS config without the module:
+
+```nix
+nixpkgs.overlays = [ inputs.harmonia.overlays.default ];
+environment.systemPackages = [ pkgs.harmonia ];
+```

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,19 @@
   };
 
   outputs = { self, nixpkgs, crane, rust-overlay, flake-utils, ... }:
+    let
+      # NixOS module and overlay are system-independent — export them outside
+      # the per-system attrset so consumers can import without specifying system.
+      nixosModules.harmonia = import ./nix/module.nix;
+      nixosModules.default = nixosModules.harmonia;
+
+      overlays.default = final: prev: {
+        harmonia = self.packages.${prev.system}.default;
+      };
+    in
+    {
+      inherit nixosModules overlays;
+    } //
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -132,6 +145,10 @@
           fmt = craneLib.cargoFmt commonArgs;
 
           deny = craneLib.cargoDeny commonArgs;
+
+          harmonia-basic = import ./nix/tests/module-test.nix {
+            pkgs = pkgs // { harmonia = self.packages.${system}.default; };
+          };
         };
       }
     );

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,1 @@
+import ./module.nix

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,123 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.harmonia;
+  settingsFormat = pkgs.formats.toml { };
+  configFile = settingsFormat.generate "harmonia.toml" cfg.settings;
+in {
+  options.services.harmonia = {
+    enable = lib.mkEnableOption "Harmonia media server";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.harmonia;
+      description = "Harmonia package to use.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "harmonia";
+      description = "User to run harmonia as.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "harmonia";
+      description = "Group to run harmonia as.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/harmonia";
+      description = "State directory (database, cache).";
+    };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = "Configuration written to harmonia.toml.";
+      example = lib.literalExpression ''
+        {
+          paroche.port = 8096;
+          taxis.libraries.music = {
+            path = "/media/music";
+            media_type = "music";
+            watcher_mode = "auto";
+          };
+        }
+      '';
+    };
+
+    secretsFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to secrets file (JWT secret, API keys). Integrate with agenix or sops-nix.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open firewall port for Harmonia.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+    };
+    users.groups.${cfg.group} = { };
+
+    systemd.services.harmonia = {
+      description = "Harmonia Media Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${cfg.package}/bin/harmonia serve --config ${configFile}";
+        Restart = "on-failure";
+        RestartSec = 5;
+        StateDirectory = "harmonia";
+        StateDirectoryMode = "0750";
+
+        # Systemd hardening
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        SystemCallFilter = [ "@system-service" "~@privileged" ];
+        SystemCallArchitectures = "native";
+
+        ReadWritePaths = [
+          cfg.dataDir
+        ] ++ (lib.mapAttrsToList (_: lib.getAttr "path") (cfg.settings.taxis.libraries or { }));
+
+        LoadCredential = lib.mkIf (cfg.secretsFile != null) [
+          "secrets.toml:${cfg.secretsFile}"
+        ];
+      };
+
+      environment = {
+        HARMONIA__DATABASE__DB_PATH = "${cfg.dataDir}/harmonia.db";
+      } // lib.optionalAttrs (cfg.secretsFile != null) {
+        HARMONIA_SECRETS_PATH = "%d/secrets.toml";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts =
+      lib.mkIf cfg.openFirewall [ (cfg.settings.paroche.port or 8096) ];
+  };
+}

--- a/nix/tests/module-test.nix
+++ b/nix/tests/module-test.nix
@@ -1,0 +1,27 @@
+{ pkgs }:
+
+pkgs.nixosTest {
+  name = "harmonia-basic";
+
+  nodes.server = { ... }: {
+    imports = [ ../module.nix ];
+
+    # Supply the package from the local build; tests run with the overlay applied.
+    nixpkgs.overlays = [
+      (final: prev: {
+        harmonia = pkgs.harmonia or (throw "harmonia package not in overlay — run tests via flake checks");
+      })
+    ];
+
+    services.harmonia = {
+      enable = true;
+      settings.paroche.port = 8096;
+    };
+  };
+
+  testScript = ''
+    server.wait_for_unit("harmonia.service")
+    server.wait_for_open_port(8096)
+    server.succeed("curl -sf http://localhost:8096/api/system/health")
+  '';
+}


### PR DESCRIPTION
## Summary

- `nix/module.nix`: `services.harmonia` NixOS module — user/group creation, systemd service with hardened profile, `LoadCredential` secret injection, firewall integration
- `nix/default.nix`: importable wrapper
- `nix/tests/module-test.nix`: NixOS VM test (unit start + health check on port 8096)
- `flake.nix`: exports `nixosModules.harmonia`, `nixosModules.default`, `overlays.default`, and `checks.<system>.harmonia-basic` VM test
- `docs/nix-deployment.md`: deployment guide with minimal and full examples, option reference, secrets and hardening notes

## Validation

```
cargo fmt --all -- --check     ✓
cargo clippy --workspace       ✓
cargo build --release -p harmonia-host  ✓
```

Module evaluation (no Nix in CI, manual):
```bash
nix eval .#nixosModules.harmonia --show-trace
nix build .#checks.x86_64-linux.harmonia-basic -L
```

## Test plan

- [ ] `nix eval .#nixosModules.harmonia` evaluates without errors
- [ ] VM test: `harmonia.service` starts and health endpoint responds
- [ ] `openFirewall = true` opens the configured port
- [ ] `secretsFile` wires `LoadCredential` and sets `HARMONIA_SECRETS_PATH`
- [ ] Service runs as `harmonia` user with no root capabilities