### PR TITLE
feat(zetesis): indexer protocol and search routing (P3-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +859,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2060,6 +2076,7 @@ checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "encoding_rs",
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -4157,6 +4174,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zetesis"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "dashmap",
+ "futures",
+ "harmonia-common",
+ "harmonia-db",
+ "horismos",
+ "jiff",
+ "quick-xml",
+ "reqwest",
+ "rstest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "sqlx",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/epignosis",
     "crates/kritike",
     "crates/komide",
+    "crates/zetesis",
     "crates/harmonia-host",
 ]
 exclude = [
@@ -33,6 +34,7 @@ taxis           = { path = "crates/taxis" }
 epignosis       = { path = "crates/epignosis" }
 kritike         = { path = "crates/kritike" }
 komide          = { path = "crates/komide" }
+zetesis         = { path = "crates/zetesis" }
 
 # ── Async runtime ──────────────────────────────────────────────────────────────
 tokio           = { version = "1", features = ["full"] }
@@ -114,6 +116,20 @@ feed-rs         = "2.3"
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
 clap            = { version = "4", features = ["derive"] }
+
+# ── XML ───────────────────────────────────────────────────────────────────────
+quick-xml       = { version = "0.37", features = ["serialize"] }
+
+# ── Concurrency ──────────────────────────────────────────────────────────────
+dashmap         = "6"
+tokio-util      = { version = "0.7", features = ["rt"] }
+futures         = "0.3"
+
+# ── Bytes ────────────────────────────────────────────────────────────────────
+bytes           = "1"
+
+# ── Regex ────────────────────────────────────────────────────────────────────
+regex           = "1"
 
 # ── Test ───────────────────────────────────────────────────────────────────────
 rstest          = "0.25"

--- a/crates/harmonia-db/migrations/004_indexers.sql
+++ b/crates/harmonia-db/migrations/004_indexers.sql
@@ -1,0 +1,28 @@
+-- Indexer registry tables for Zetesis
+-- Stores configured indexer endpoints and their cached capabilities.
+
+CREATE TABLE indexers (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL,
+    url         TEXT NOT NULL,
+    protocol    TEXT NOT NULL CHECK (protocol IN ('torznab', 'newznab')),
+    api_key     TEXT,
+    enabled     BOOLEAN NOT NULL DEFAULT TRUE,
+    cf_bypass   BOOLEAN NOT NULL DEFAULT FALSE,
+    status      TEXT NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active', 'degraded', 'failed')),
+    last_tested TEXT,
+    caps_json   TEXT,
+    priority    INTEGER NOT NULL DEFAULT 50,
+    added_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE TABLE indexer_categories (
+    indexer_id  INTEGER NOT NULL REFERENCES indexers(id) ON DELETE CASCADE,
+    category_id INTEGER NOT NULL,
+    name        TEXT NOT NULL,
+    PRIMARY KEY (indexer_id, category_id)
+);
+
+CREATE INDEX idx_indexers_enabled_status ON indexers(enabled, status);
+CREATE INDEX idx_indexer_categories_indexer ON indexer_categories(indexer_id);

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -155,6 +155,17 @@ impl Default for AggeliaConfig {
 pub struct ZetesisConfig {
     pub request_timeout_secs: u64,
     pub max_results_per_indexer: usize,
+    pub cloudflare_bypass_enabled: bool,
+    pub max_concurrent_searches: usize,
+    pub per_indexer_rate_limit_requests: u32,
+    pub per_indexer_rate_limit_window_seconds: u64,
+    pub caps_refresh_hours: u64,
+    pub search_timeout_seconds: u64,
+    pub cardigann_definitions_dir: Option<PathBuf>,
+    pub cf_proxy_url: Option<String>,
+    pub cf_proxy_timeout_seconds: u64,
+    pub cf_cookie_refresh_minutes: u64,
+    pub cf_health_check_interval_minutes: u64,
 }
 
 impl Default for ZetesisConfig {
@@ -162,6 +173,17 @@ impl Default for ZetesisConfig {
         Self {
             request_timeout_secs: 30,
             max_results_per_indexer: 100,
+            cloudflare_bypass_enabled: false,
+            max_concurrent_searches: 10,
+            per_indexer_rate_limit_requests: 5,
+            per_indexer_rate_limit_window_seconds: 10,
+            caps_refresh_hours: 24,
+            search_timeout_seconds: 30,
+            cardigann_definitions_dir: None,
+            cf_proxy_url: None,
+            cf_proxy_timeout_seconds: 60,
+            cf_cookie_refresh_minutes: 30,
+            cf_health_check_interval_minutes: 5,
         }
     }
 }

--- a/crates/zetesis/Cargo.toml
+++ b/crates/zetesis/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "zetesis"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Indexer protocol and search routing for Harmonia"
+
+[dependencies]
+harmonia-common.workspace = true
+horismos.workspace = true
+harmonia-db.workspace = true
+snafu.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+quick-xml.workspace = true
+dashmap.workspace = true
+tokio-util.workspace = true
+futures.workspace = true
+bytes.workspace = true
+uuid.workspace = true
+jiff.workspace = true
+sqlx.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/zetesis/src/cf_bypass/byparr.rs
+++ b/crates/zetesis/src/cf_bypass/byparr.rs
@@ -1,0 +1,232 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+
+use crate::cf_bypass::{CloudflareProxy, Cookie, ProxyResponse};
+use crate::error::{self, ZetesisError};
+
+pub struct ByparrProxy {
+    client: reqwest::Client,
+    endpoint: String,
+    timeout: Duration,
+}
+
+#[derive(Debug, Serialize)]
+struct ByparrRequest {
+    cmd: &'static str,
+    url: String,
+    #[serde(rename = "maxTimeout")]
+    max_timeout: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct ByparrResponse {
+    status: String,
+    message: String,
+    solution: Option<ByparrSolution>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ByparrSolution {
+    #[expect(dead_code)]
+    url: String,
+    status: u16,
+    response: String,
+    cookies: Vec<ByparrCookie>,
+    #[serde(rename = "userAgent")]
+    user_agent: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ByparrCookie {
+    name: String,
+    value: String,
+    domain: String,
+    path: String,
+    expires: f64,
+    #[serde(rename = "httpOnly")]
+    http_only: bool,
+    secure: bool,
+}
+
+impl ByparrProxy {
+    pub fn new(endpoint: String, timeout: Duration) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(timeout + Duration::from_secs(5))
+            .build()
+            .unwrap_or_default();
+
+        Self {
+            client,
+            endpoint,
+            timeout,
+        }
+    }
+
+    pub async fn health_check(&self) -> bool {
+        let req = ByparrRequest {
+            cmd: "request.get",
+            url: "http://localhost".to_string(),
+            max_timeout: 5000,
+        };
+
+        let url = format!("{}/v1", self.endpoint.trim_end_matches('/'));
+        matches!(
+            self.client.post(&url).json(&req).send().await,
+            Ok(resp) if resp.status().is_success() || resp.status().is_client_error()
+        )
+    }
+}
+
+impl CloudflareProxy for ByparrProxy {
+    fn get(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> Pin<Box<dyn Future<Output = Result<ProxyResponse, ZetesisError>> + Send + '_>> {
+        let url = url.to_string();
+        Box::pin(async move { self.get_inner(&url, ct).await })
+    }
+}
+
+impl ByparrProxy {
+    #[instrument(skip(self, ct), fields(endpoint = %self.endpoint))]
+    async fn get_inner(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> Result<ProxyResponse, ZetesisError> {
+        let req = ByparrRequest {
+            cmd: "request.get",
+            url: url.to_string(),
+            max_timeout: self.timeout.as_millis() as u32,
+        };
+
+        let endpoint_url = format!("{}/v1", self.endpoint.trim_end_matches('/'));
+
+        let response = tokio::select! {
+            result = self.client.post(&endpoint_url).json(&req).send() => {
+                result.context(error::HttpRequestSnafu { url })?
+            }
+            () = ct.cancelled() => {
+                return Err(ZetesisError::CfProxyTimeout {
+                    url: url.to_string(),
+                    timeout: self.timeout.as_secs() as u32,
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+        };
+
+        let byparr_resp: ByparrResponse = response
+            .json()
+            .await
+            .context(error::HttpRequestSnafu { url })?;
+
+        if byparr_resp.status != "ok" {
+            return Err(ZetesisError::CfProxyError {
+                url: url.to_string(),
+                status: byparr_resp.status,
+                message: byparr_resp.message,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+
+        let solution = byparr_resp
+            .solution
+            .ok_or_else(|| ZetesisError::CfProxyError {
+                url: url.to_string(),
+                status: "ok".to_string(),
+                message: "no solution in response".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        let cookies = solution
+            .cookies
+            .into_iter()
+            .map(|c| Cookie {
+                name: c.name,
+                value: c.value,
+                domain: c.domain,
+                path: c.path,
+                expires: c.expires,
+                http_only: c.http_only,
+                secure: c.secure,
+            })
+            .collect();
+
+        Ok(ProxyResponse {
+            status: solution.status,
+            body: solution.response,
+            cookies,
+            user_agent: solution.user_agent,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byparr_request_serialization() {
+        let req = ByparrRequest {
+            cmd: "request.get",
+            url: "https://example.com".to_string(),
+            max_timeout: 60000,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["cmd"], "request.get");
+        assert_eq!(json["maxTimeout"], 60000);
+    }
+
+    #[test]
+    fn byparr_response_deserialization() {
+        let json = r#"{
+            "status": "ok",
+            "message": "Challenge solved!",
+            "solution": {
+                "url": "https://example.com",
+                "status": 200,
+                "response": "<html>test</html>",
+                "cookies": [
+                    {
+                        "name": "cf_clearance",
+                        "value": "abc123",
+                        "domain": ".example.com",
+                        "path": "/",
+                        "expires": 1709500000.0,
+                        "httpOnly": false,
+                        "secure": true
+                    }
+                ],
+                "userAgent": "Mozilla/5.0 Test"
+            }
+        }"#;
+
+        let resp: ByparrResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "ok");
+        let solution = resp.solution.unwrap();
+        assert_eq!(solution.status, 200);
+        assert_eq!(solution.cookies.len(), 1);
+        assert_eq!(solution.cookies[0].name, "cf_clearance");
+        assert_eq!(solution.user_agent, "Mozilla/5.0 Test");
+    }
+
+    #[test]
+    fn byparr_error_response_deserialization() {
+        let json = r#"{
+            "status": "error",
+            "message": "Error: Unable to solve the challenge. Timeout.",
+            "solution": null
+        }"#;
+
+        let resp: ByparrResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "error");
+        assert!(resp.solution.is_none());
+    }
+}

--- a/crates/zetesis/src/cf_bypass/cookies.rs
+++ b/crates/zetesis/src/cf_bypass/cookies.rs
@@ -1,0 +1,247 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use dashmap::DashMap;
+use tokio::time::Instant;
+
+use crate::cf_bypass::Cookie;
+
+pub struct CookieStore {
+    jars: DashMap<i64, IndexerCookieJar>,
+}
+
+pub struct IndexerCookieJar {
+    pub cookies: Vec<StoredCookie>,
+    pub user_agent: String,
+    pub last_refreshed: Instant,
+}
+
+pub struct StoredCookie {
+    pub name: String,
+    pub value: String,
+    pub domain: String,
+    pub path: String,
+    pub expires_at: Option<SystemTime>,
+}
+
+impl CookieStore {
+    pub fn new() -> Self {
+        Self {
+            jars: DashMap::new(),
+        }
+    }
+
+    pub fn store(&self, indexer_id: i64, cookies: Vec<Cookie>, user_agent: String) {
+        let stored: Vec<StoredCookie> = cookies
+            .into_iter()
+            .map(|c| {
+                let expires_at = if c.expires < 0.0 {
+                    None
+                } else {
+                    Some(UNIX_EPOCH + Duration::from_secs_f64(c.expires))
+                };
+                StoredCookie {
+                    name: c.name,
+                    value: c.value,
+                    domain: c.domain,
+                    path: c.path,
+                    expires_at,
+                }
+            })
+            .collect();
+
+        self.jars.insert(
+            indexer_id,
+            IndexerCookieJar {
+                cookies: stored,
+                user_agent,
+                last_refreshed: Instant::now(),
+            },
+        );
+    }
+
+    pub fn get_cookie_header(&self, indexer_id: i64) -> Option<String> {
+        let jar = self.jars.get(&indexer_id)?;
+        let now = SystemTime::now();
+
+        let valid_cookies: Vec<String> = jar
+            .cookies
+            .iter()
+            .filter(|c| c.expires_at.map(|exp| exp > now).unwrap_or(true))
+            .map(|c| format!("{}={}", c.name, c.value))
+            .collect();
+
+        if valid_cookies.is_empty() {
+            return None;
+        }
+        Some(valid_cookies.join("; "))
+    }
+
+    pub fn get_user_agent(&self, indexer_id: i64) -> Option<String> {
+        self.jars.get(&indexer_id).map(|j| j.user_agent.clone())
+    }
+
+    pub fn needs_refresh(&self, indexer_id: i64, refresh_before_expiry: Duration) -> bool {
+        let Some(jar) = self.jars.get(&indexer_id) else {
+            return true;
+        };
+
+        let now = SystemTime::now();
+        jar.cookies.iter().any(|c| {
+            c.expires_at
+                .map(|exp| {
+                    let threshold = exp.checked_sub(refresh_before_expiry).unwrap_or(UNIX_EPOCH);
+                    now >= threshold
+                })
+                .unwrap_or(false)
+        })
+    }
+
+    pub fn remove(&self, indexer_id: i64) {
+        self.jars.remove(&indexer_id);
+    }
+
+    pub fn has_cookies(&self, indexer_id: i64) -> bool {
+        self.get_cookie_header(indexer_id).is_some()
+    }
+}
+
+impl Default for CookieStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cookie(name: &str, value: &str, expires: f64) -> Cookie {
+        Cookie {
+            name: name.to_string(),
+            value: value.to_string(),
+            domain: ".example.com".to_string(),
+            path: "/".to_string(),
+            expires,
+            http_only: false,
+            secure: true,
+        }
+    }
+
+    #[test]
+    fn store_and_retrieve_cookies() {
+        let store = CookieStore::new();
+        let future_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            + 3600.0;
+
+        store.store(
+            1,
+            vec![make_cookie("cf_clearance", "abc123", future_ts)],
+            "Mozilla/5.0".to_string(),
+        );
+
+        let header = store.get_cookie_header(1);
+        assert_eq!(header, Some("cf_clearance=abc123".to_string()));
+        assert_eq!(store.get_user_agent(1), Some("Mozilla/5.0".to_string()));
+    }
+
+    #[test]
+    fn expired_cookies_filtered() {
+        let store = CookieStore::new();
+        let past_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            - 3600.0;
+
+        store.store(
+            1,
+            vec![make_cookie("cf_clearance", "expired", past_ts)],
+            "Mozilla/5.0".to_string(),
+        );
+
+        assert!(store.get_cookie_header(1).is_none());
+    }
+
+    #[test]
+    fn session_cookies_always_valid() {
+        let store = CookieStore::new();
+        store.store(
+            1,
+            vec![make_cookie("session", "val", -1.0)],
+            "Agent".to_string(),
+        );
+
+        assert!(store.get_cookie_header(1).is_some());
+    }
+
+    #[test]
+    fn needs_refresh_when_absent() {
+        let store = CookieStore::new();
+        assert!(store.needs_refresh(1, Duration::from_secs(1800)));
+    }
+
+    #[test]
+    fn needs_refresh_before_expiry() {
+        let store = CookieStore::new();
+        let near_expiry = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            + 900.0; // 15 minutes from now
+
+        store.store(
+            1,
+            vec![make_cookie("cf_clearance", "val", near_expiry)],
+            "Agent".to_string(),
+        );
+
+        assert!(store.needs_refresh(1, Duration::from_secs(1800)));
+    }
+
+    #[test]
+    fn remove_cookies() {
+        let store = CookieStore::new();
+        let future_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            + 3600.0;
+
+        store.store(
+            1,
+            vec![make_cookie("cf_clearance", "val", future_ts)],
+            "Agent".to_string(),
+        );
+        assert!(store.has_cookies(1));
+
+        store.remove(1);
+        assert!(!store.has_cookies(1));
+    }
+
+    #[test]
+    fn multiple_cookies_joined() {
+        let store = CookieStore::new();
+        let future_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            + 3600.0;
+
+        store.store(
+            1,
+            vec![
+                make_cookie("cf_clearance", "abc", future_ts),
+                make_cookie("session", "xyz", future_ts),
+            ],
+            "Agent".to_string(),
+        );
+
+        let header = store.get_cookie_header(1).unwrap();
+        assert!(header.contains("cf_clearance=abc"));
+        assert!(header.contains("session=xyz"));
+        assert!(header.contains("; "));
+    }
+}

--- a/crates/zetesis/src/cf_bypass/mod.rs
+++ b/crates/zetesis/src/cf_bypass/mod.rs
@@ -1,0 +1,37 @@
+pub mod byparr;
+pub mod cookies;
+pub mod noop;
+
+use std::future::Future;
+use std::pin::Pin;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::error::ZetesisError;
+
+#[derive(Debug)]
+pub struct ProxyResponse {
+    pub status: u16,
+    pub body: String,
+    pub cookies: Vec<Cookie>,
+    pub user_agent: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Cookie {
+    pub name: String,
+    pub value: String,
+    pub domain: String,
+    pub path: String,
+    pub expires: f64,
+    pub http_only: bool,
+    pub secure: bool,
+}
+
+pub trait CloudflareProxy: Send + Sync {
+    fn get(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> Pin<Box<dyn Future<Output = Result<ProxyResponse, ZetesisError>> + Send + '_>>;
+}

--- a/crates/zetesis/src/cf_bypass/noop.rs
+++ b/crates/zetesis/src/cf_bypass/noop.rs
@@ -1,0 +1,43 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::cf_bypass::{CloudflareProxy, ProxyResponse};
+use crate::error::ZetesisError;
+
+pub struct NoProxy;
+
+impl CloudflareProxy for NoProxy {
+    fn get(
+        &self,
+        url: &str,
+        _ct: CancellationToken,
+    ) -> Pin<Box<dyn Future<Output = Result<ProxyResponse, ZetesisError>> + Send + '_>> {
+        let url = url.to_string();
+        Box::pin(async move {
+            Err(ZetesisError::NoCfBypass {
+                url,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn no_proxy_returns_error() {
+        let proxy = NoProxy;
+        let ct = CancellationToken::new();
+        let result = proxy.get("https://example.com", ct).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ZetesisError::NoCfBypass { .. }),
+            "expected NoCfBypass, got {err:?}"
+        );
+    }
+}

--- a/crates/zetesis/src/client/mod.rs
+++ b/crates/zetesis/src/client/mod.rs
@@ -1,0 +1,215 @@
+pub mod newznab;
+pub mod torznab;
+pub mod xml;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::error::ZetesisError;
+use crate::types::{DownloadResponse, IndexerCaps, IndexerStatus, SearchQuery, SearchResult};
+
+pub trait IndexerClient: Send + Sync {
+    fn search(
+        &self,
+        query: &SearchQuery,
+        ct: CancellationToken,
+    ) -> impl Future<Output = Result<Vec<SearchResult>, ZetesisError>> + Send;
+
+    fn caps(
+        &self,
+        ct: CancellationToken,
+    ) -> impl Future<Output = Result<IndexerCaps, ZetesisError>> + Send;
+
+    fn test(
+        &self,
+        ct: CancellationToken,
+    ) -> impl Future<Output = Result<IndexerStatus, ZetesisError>> + Send;
+
+    fn download(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> impl Future<Output = Result<DownloadResponse, ZetesisError>> + Send;
+}
+
+use std::future::Future;
+use std::pin::Pin;
+
+pub trait DynIndexerClient: Send + Sync {
+    fn search_boxed<'a>(
+        &'a self,
+        query: &'a SearchQuery,
+        ct: CancellationToken,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<SearchResult>, ZetesisError>> + Send + 'a>>;
+}
+
+impl<T: IndexerClient> DynIndexerClient for T {
+    fn search_boxed<'a>(
+        &'a self,
+        query: &'a SearchQuery,
+        ct: CancellationToken,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<SearchResult>, ZetesisError>> + Send + 'a>> {
+        Box::pin(self.search(query, ct))
+    }
+}
+
+pub struct IndexerConfig {
+    pub id: i64,
+    pub name: String,
+    pub url: String,
+    pub api_key: Option<String>,
+    pub cf_bypass: bool,
+}
+
+pub(crate) fn build_search_url(config: &IndexerConfig, query: &SearchQuery) -> String {
+    let mut url = format!(
+        "{}?t={}",
+        config.url.trim_end_matches('/'),
+        query.search_function()
+    );
+
+    if let Some(ref q) = query.query_text {
+        url.push_str(&format!("&q={}", urlencoding(q)));
+    }
+
+    if !query.category_ids.is_empty() {
+        let cats: Vec<String> = query.category_ids.iter().map(|c| c.to_string()).collect();
+        url.push_str(&format!("&cat={}", cats.join(",")));
+    }
+
+    if let Some(ref imdb) = query.imdb_id {
+        url.push_str(&format!("&imdbid={imdb}"));
+    }
+    if let Some(tvdb) = query.tvdb_id {
+        url.push_str(&format!("&tvdbid={tvdb}"));
+    }
+    if let Some(tmdb) = query.tmdb_id {
+        url.push_str(&format!("&tmdbid={tmdb}"));
+    }
+    if let Some(ref artist) = query.artist {
+        url.push_str(&format!("&artist={}", urlencoding(artist)));
+    }
+    if let Some(ref album) = query.album {
+        url.push_str(&format!("&album={}", urlencoding(album)));
+    }
+    if let Some(ref author) = query.author {
+        url.push_str(&format!("&author={}", urlencoding(author)));
+    }
+    if let Some(season) = query.season {
+        url.push_str(&format!("&season={season}"));
+    }
+    if let Some(episode) = query.episode {
+        url.push_str(&format!("&ep={episode}"));
+    }
+
+    url.push_str(&format!("&limit={}", query.limit));
+    if query.offset > 0 {
+        url.push_str(&format!("&offset={}", query.offset));
+    }
+
+    if let Some(ref key) = config.api_key {
+        url.push_str(&format!("&apikey={key}"));
+    }
+
+    url
+}
+
+pub(crate) fn build_caps_url(config: &IndexerConfig) -> String {
+    let mut url = format!("{}?t=caps", config.url.trim_end_matches('/'));
+    if let Some(ref key) = config.api_key {
+        url.push_str(&format!("&apikey={key}"));
+    }
+    url
+}
+
+fn urlencoding(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(b as char);
+            }
+            b' ' => result.push('+'),
+            _ => {
+                result.push('%');
+                result.push_str(&format!("{b:02X}"));
+            }
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::SearchMediaType;
+
+    #[test]
+    fn build_search_url_basic() {
+        let config = IndexerConfig {
+            id: 1,
+            name: "Test".to_string(),
+            url: "https://example.com/api".to_string(),
+            api_key: Some("abc123".to_string()),
+            cf_bypass: false,
+        };
+        let query = SearchQuery {
+            query_text: Some("test query".to_string()),
+            media_type: SearchMediaType::Any,
+            limit: 100,
+            ..Default::default()
+        };
+
+        let url = build_search_url(&config, &query);
+        assert!(url.starts_with("https://example.com/api?t=search"));
+        assert!(url.contains("q=test+query"));
+        assert!(url.contains("apikey=abc123"));
+        assert!(url.contains("limit=100"));
+    }
+
+    #[test]
+    fn build_search_url_tv() {
+        let config = IndexerConfig {
+            id: 1,
+            name: "Test".to_string(),
+            url: "https://example.com/api/".to_string(),
+            api_key: None,
+            cf_bypass: false,
+        };
+        let query = SearchQuery {
+            media_type: SearchMediaType::Tv,
+            tvdb_id: Some(12345),
+            season: Some(3),
+            episode: Some(5),
+            limit: 50,
+            ..Default::default()
+        };
+
+        let url = build_search_url(&config, &query);
+        assert!(url.starts_with("https://example.com/api?t=tvsearch"));
+        assert!(url.contains("tvdbid=12345"));
+        assert!(url.contains("season=3"));
+        assert!(url.contains("ep=5"));
+        assert!(!url.contains("apikey="));
+    }
+
+    #[test]
+    fn build_caps_url_with_key() {
+        let config = IndexerConfig {
+            id: 1,
+            name: "Test".to_string(),
+            url: "https://example.com/api".to_string(),
+            api_key: Some("key123".to_string()),
+            cf_bypass: false,
+        };
+
+        let url = build_caps_url(&config);
+        assert_eq!(url, "https://example.com/api?t=caps&apikey=key123");
+    }
+
+    #[test]
+    fn urlencoding_special_chars() {
+        assert_eq!(urlencoding("hello world"), "hello+world");
+        assert_eq!(urlencoding("test&value"), "test%26value");
+        assert_eq!(urlencoding("normal"), "normal");
+    }
+}

--- a/crates/zetesis/src/client/newznab.rs
+++ b/crates/zetesis/src/client/newznab.rs
@@ -1,0 +1,181 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use snafu::ResultExt;
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+
+use crate::cf_bypass::CloudflareProxy;
+use crate::client::xml::{get_attr_f64, get_attr_u32, parse_caps_xml, parse_feed_xml};
+use crate::client::{IndexerClient, IndexerConfig, build_caps_url, build_search_url};
+use crate::error::{self, ZetesisError};
+use crate::types::{
+    DownloadResponse, IndexerCaps, IndexerStatus, ReleaseProtocol, SearchQuery, SearchResult,
+};
+
+pub struct NewznabClient {
+    pub config: IndexerConfig,
+    http: reqwest::Client,
+    cf_proxy: Arc<dyn CloudflareProxy>,
+    timeout: Duration,
+}
+
+impl NewznabClient {
+    pub fn new(
+        config: IndexerConfig,
+        http: reqwest::Client,
+        cf_proxy: Arc<dyn CloudflareProxy>,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            config,
+            http,
+            cf_proxy,
+            timeout,
+        }
+    }
+
+    async fn fetch_xml(&self, url: &str, ct: CancellationToken) -> Result<String, ZetesisError> {
+        if self.config.cf_bypass {
+            let response = self.cf_proxy.get(url, ct).await?;
+            return Ok(response.body);
+        }
+
+        let fut = self.http.get(url).timeout(self.timeout).send();
+        let response = tokio::select! {
+            result = fut => result.context(error::HttpRequestSnafu { url })?,
+            () = ct.cancelled() => {
+                return Err(ZetesisError::ParseResponse {
+                    url: url.to_string(),
+                    error: "request cancelled".to_string(),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+        };
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(ZetesisError::AuthFailed {
+                indexer_id: self.config.id,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse().ok());
+            return Err(ZetesisError::RateLimited {
+                indexer_id: self.config.id,
+                retry_after_seconds: retry_after,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+
+        let body = response
+            .text()
+            .await
+            .context(error::HttpRequestSnafu { url })?;
+        Ok(body)
+    }
+}
+
+impl IndexerClient for NewznabClient {
+    #[instrument(skip(self, ct), fields(indexer_id = self.config.id, indexer_name = %self.config.name))]
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        ct: CancellationToken,
+    ) -> Result<Vec<SearchResult>, ZetesisError> {
+        let url = build_search_url(&self.config, query);
+        let xml = self.fetch_xml(&url, ct).await?;
+        let feed = parse_feed_xml(&xml).map_err(|e| ZetesisError::ParseResponse {
+            url: url.clone(),
+            error: e.to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
+
+        let results = feed
+            .channel
+            .items
+            .into_iter()
+            .map(|item| {
+                let download_url = item.link.unwrap_or_default();
+                let category_id = get_attr_u32(&item.attrs, "category");
+                let download_volume_factor =
+                    get_attr_f64(&item.attrs, "downloadvolumefactor").unwrap_or(1.0);
+                let upload_volume_factor =
+                    get_attr_f64(&item.attrs, "uploadvolumefactor").unwrap_or(1.0);
+
+                let mut custom_attrs = HashMap::new();
+                for attr in &item.attrs {
+                    match attr.name.as_str() {
+                        "category" | "downloadvolumefactor" | "uploadvolumefactor" | "size" => {}
+                        _ => {
+                            custom_attrs.insert(attr.name.clone(), attr.value.clone());
+                        }
+                    }
+                }
+
+                SearchResult {
+                    title: item.title,
+                    guid: item.guid,
+                    download_url,
+                    size_bytes: item.size,
+                    seeders: None,
+                    leechers: None,
+                    info_hash: None,
+                    category_id,
+                    publication_date: item.pub_date,
+                    indexer_id: self.config.id,
+                    protocol: ReleaseProtocol::Nzb,
+                    download_volume_factor,
+                    upload_volume_factor,
+                    custom_attrs,
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self, ct), fields(indexer_id = self.config.id))]
+    async fn caps(&self, ct: CancellationToken) -> Result<IndexerCaps, ZetesisError> {
+        let url = build_caps_url(&self.config);
+        let xml = self.fetch_xml(&url, ct).await?;
+        parse_caps_xml(&xml).map_err(|e| ZetesisError::ParseResponse {
+            url,
+            error: e.to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })
+    }
+
+    #[instrument(skip(self, ct), fields(indexer_id = self.config.id))]
+    async fn test(&self, ct: CancellationToken) -> Result<IndexerStatus, ZetesisError> {
+        match self.caps(ct).await {
+            Ok(caps) => Ok(IndexerStatus {
+                healthy: true,
+                caps: Some(caps),
+                error: None,
+            }),
+            Err(e) => Ok(IndexerStatus {
+                healthy: false,
+                caps: None,
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+
+    #[instrument(skip(self, ct), fields(indexer_id = self.config.id))]
+    async fn download(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> Result<DownloadResponse, ZetesisError> {
+        let body = self.fetch_xml(url, ct).await?;
+        Ok(DownloadResponse::NzbFile(Bytes::from(body)))
+    }
+}

--- a/crates/zetesis/src/client/torznab.rs
+++ b/crates/zetesis/src/client/torznab.rs
@@ -1,0 +1,194 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use snafu::ResultExt;
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+
+use crate::cf_bypass::CloudflareProxy;
+use crate::client::xml::{get_attr, get_attr_f64, get_attr_u32, parse_caps_xml, parse_feed_xml};
+use crate::client::{IndexerClient, IndexerConfig, build_caps_url, build_search_url};
+use crate::error::{self, ZetesisError};
+use crate::types::{
+    DownloadResponse, IndexerCaps, IndexerStatus, ReleaseProtocol, SearchQuery, SearchResult,
+};
+
+pub struct TorznabClient {
+    pub config: IndexerConfig,
+    http: reqwest::Client,
+    cf_proxy: Arc<dyn CloudflareProxy>,
+    timeout: Duration,
+}
+
+impl TorznabClient {
+    pub fn new(
+        config: IndexerConfig,
+        http: reqwest::Client,
+        cf_proxy: Arc<dyn CloudflareProxy>,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            config,
+            http,
+            cf_proxy,
+            timeout,
+        }
+    }
+
+    async fn fetch_xml(&self, url: &str, ct: CancellationToken) -> Result<String, ZetesisError> {
+        if self.config.cf_bypass {
+            let response = self.cf_proxy.get(url, ct).await?;
+            return Ok(response.body);
+        }
+
+        let fut = self.http.get(url).timeout(self.timeout).send();
+        let response = tokio::select! {
+            result = fut => result.context(error::HttpRequestSnafu { url })?,
+            () = ct.cancelled() => {
+                return Err(ZetesisError::ParseResponse {
+                    url: url.to_string(),
+                    error: "request cancelled".to_string(),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+        };
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(ZetesisError::AuthFailed {
+                indexer_id: self.config.id,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse().ok());
+            return Err(ZetesisError::RateLimited {
+                indexer_id: self.config.id,
+                retry_after_seconds: retry_after,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+
+        let body = response
+            .text()
+            .await
+            .context(error::HttpRequestSnafu { url })?;
+        Ok(body)
+    }
+}
+
+impl IndexerClient for TorznabClient {
+    #[instrument(skip(self, ct), fields(indexer_id = self.config.id, indexer_name = %self.config.name))]
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        ct: CancellationToken,
+    ) -> Result<Vec<SearchResult>, ZetesisError> {
+        let url = build_search_url(&self.config, query);
+        let xml = self.fetch_xml(&url, ct).await?;
+        let feed = parse_feed_xml(&xml).map_err(|e| ZetesisError::ParseResponse {
+            url: url.clone(),
+            error: e.to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
+
+        let results = feed
+            .channel
+            .items
+            .into_iter()
+            .map(|item| {
+                let download_url = item.link.unwrap_or_default();
+                let info_hash = get_attr(&item.attrs, "infohash").map(str::to_string);
+                let seeders = get_attr_u32(&item.attrs, "seeders");
+                let leechers = get_attr_u32(&item.attrs, "leechers");
+                let category_id = get_attr_u32(&item.attrs, "category");
+                let download_volume_factor =
+                    get_attr_f64(&item.attrs, "downloadvolumefactor").unwrap_or(1.0);
+                let upload_volume_factor =
+                    get_attr_f64(&item.attrs, "uploadvolumefactor").unwrap_or(1.0);
+
+                let mut custom_attrs = HashMap::new();
+                for attr in &item.attrs {
+                    match attr.name.as_str() {
+                        "seeders"
+                        | "leechers"
+                        | "infohash"
+                        | "category"
+                        | "downloadvolumefactor"
+                        | "uploadvolumefactor"
+                        | "size" => {}
+                        _ => {
+                            custom_attrs.insert(attr.name.clone(), attr.value.clone());
+                        }
+                    }
+                }
+
+                SearchResult {
+                    title: item.title,
+                    guid: item.guid,
+                    download_url,
+                    size_bytes: item.size,
+                    seeders,
+                    leechers,
+                    info_hash,
+                    category_id,
+                    publication_date: item.pub_date,
+                    indexer_id: self.config.id,
+                    protocol: ReleaseProtocol::Torrent,
+                    download_volume_factor,
+                    upload_volume_factor,
+                    custom_attrs,
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self, ct), fields(indexer_id = self.config.id))]
+    async fn caps(&self, ct: CancellationToken) -> Result<IndexerCaps, ZetesisError> {
+        let url = build_caps_url(&self.config);
+        let xml = self.fetch_xml(&url, ct).await?;
+        parse_caps_xml(&xml).map_err(|e| ZetesisError::ParseResponse {
+            url,
+            error: e.to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })
+    }
+
+    #[instrument(skip(self, ct), fields(indexer_id = self.config.id))]
+    async fn test(&self, ct: CancellationToken) -> Result<IndexerStatus, ZetesisError> {
+        match self.caps(ct).await {
+            Ok(caps) => Ok(IndexerStatus {
+                healthy: true,
+                caps: Some(caps),
+                error: None,
+            }),
+            Err(e) => Ok(IndexerStatus {
+                healthy: false,
+                caps: None,
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+
+    #[instrument(skip(self, ct), fields(indexer_id = self.config.id))]
+    async fn download(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> Result<DownloadResponse, ZetesisError> {
+        if url.starts_with("magnet:") {
+            return Ok(DownloadResponse::MagnetUri(url.to_string()));
+        }
+
+        let body = self.fetch_xml(url, ct).await?;
+        Ok(DownloadResponse::TorrentFile(Bytes::from(body)))
+    }
+}

--- a/crates/zetesis/src/client/xml.rs
+++ b/crates/zetesis/src/client/xml.rs
@@ -1,0 +1,378 @@
+use serde::Deserialize;
+
+use crate::types::{IndexerCaps, IndexerCategory, SearchFunction, SearchLimits, ServerInfo};
+
+#[derive(Debug, Deserialize)]
+pub struct TorznabFeed {
+    pub channel: TorznabChannel,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TorznabChannel {
+    pub title: Option<String>,
+    #[serde(rename = "item", default)]
+    pub items: Vec<TorznabItem>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TorznabItem {
+    pub title: String,
+    pub guid: Option<String>,
+    #[serde(rename = "pubDate")]
+    pub pub_date: Option<String>,
+    pub size: Option<u64>,
+    pub link: Option<String>,
+    #[serde(rename = "attr", default)]
+    pub attrs: Vec<TorznabAttr>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TorznabAttr {
+    #[serde(rename = "@name")]
+    pub name: String,
+    #[serde(rename = "@value")]
+    pub value: String,
+}
+
+pub fn get_attr<'a>(attrs: &'a [TorznabAttr], name: &str) -> Option<&'a str> {
+    attrs
+        .iter()
+        .find(|a| a.name == name)
+        .map(|a| a.value.as_str())
+}
+
+pub fn get_attr_u64(attrs: &[TorznabAttr], name: &str) -> Option<u64> {
+    get_attr(attrs, name)?.parse().ok()
+}
+
+pub fn get_attr_f64(attrs: &[TorznabAttr], name: &str) -> Option<f64> {
+    get_attr(attrs, name)?.parse().ok()
+}
+
+pub fn get_attr_u32(attrs: &[TorznabAttr], name: &str) -> Option<u32> {
+    get_attr(attrs, name)?.parse().ok()
+}
+
+// --- Caps XML parsing ---
+
+#[derive(Debug, Deserialize)]
+pub struct CapsRoot {
+    pub server: Option<CapsServer>,
+    pub limits: Option<CapsLimits>,
+    pub searching: Option<CapsSearching>,
+    pub categories: Option<CapsCategories>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CapsServer {
+    #[serde(rename = "@title")]
+    pub title: Option<String>,
+    #[serde(rename = "@version")]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CapsLimits {
+    #[serde(rename = "@default")]
+    pub default: Option<String>,
+    #[serde(rename = "@max")]
+    pub max: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CapsSearching {
+    pub search: Option<CapsSearchFunc>,
+    #[serde(rename = "tv-search")]
+    pub tv_search: Option<CapsSearchFunc>,
+    #[serde(rename = "movie-search")]
+    pub movie_search: Option<CapsSearchFunc>,
+    #[serde(rename = "music-search")]
+    pub music_search: Option<CapsSearchFunc>,
+    #[serde(rename = "book-search")]
+    pub book_search: Option<CapsSearchFunc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CapsSearchFunc {
+    #[serde(rename = "@available")]
+    pub available: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CapsCategories {
+    #[serde(rename = "category", default)]
+    pub categories: Vec<CapsCategory>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CapsCategory {
+    #[serde(rename = "@id")]
+    pub id: Option<String>,
+    #[serde(rename = "@name")]
+    pub name: Option<String>,
+    #[serde(rename = "subcat", default)]
+    pub subcategories: Vec<CapsCategory>,
+}
+
+impl CapsRoot {
+    pub fn into_indexer_caps(self) -> IndexerCaps {
+        let server = self.server.map_or_else(
+            || ServerInfo {
+                title: None,
+                version: None,
+            },
+            |s| ServerInfo {
+                title: s.title,
+                version: s.version,
+            },
+        );
+
+        let limits = self
+            .limits
+            .map_or_else(SearchLimits::default, |l| SearchLimits {
+                default: l.default.and_then(|v| v.parse().ok()).unwrap_or(100),
+                max: l.max.and_then(|v| v.parse().ok()).unwrap_or(100),
+            });
+
+        let search_functions = self
+            .searching
+            .map(|s| {
+                let mut funcs = Vec::new();
+                if let Some(f) = s.search {
+                    funcs.push(SearchFunction {
+                        function_type: "search".to_string(),
+                        available: f.available.as_deref() == Some("yes"),
+                    });
+                }
+                if let Some(f) = s.tv_search {
+                    funcs.push(SearchFunction {
+                        function_type: "tvsearch".to_string(),
+                        available: f.available.as_deref() == Some("yes"),
+                    });
+                }
+                if let Some(f) = s.movie_search {
+                    funcs.push(SearchFunction {
+                        function_type: "movie".to_string(),
+                        available: f.available.as_deref() == Some("yes"),
+                    });
+                }
+                if let Some(f) = s.music_search {
+                    funcs.push(SearchFunction {
+                        function_type: "music".to_string(),
+                        available: f.available.as_deref() == Some("yes"),
+                    });
+                }
+                if let Some(f) = s.book_search {
+                    funcs.push(SearchFunction {
+                        function_type: "book".to_string(),
+                        available: f.available.as_deref() == Some("yes"),
+                    });
+                }
+                funcs
+            })
+            .unwrap_or_default();
+
+        let categories = self
+            .categories
+            .map(|c| c.categories.into_iter().map(convert_category).collect())
+            .unwrap_or_default();
+
+        IndexerCaps {
+            server,
+            limits,
+            search_functions,
+            categories,
+        }
+    }
+}
+
+fn convert_category(c: CapsCategory) -> IndexerCategory {
+    IndexerCategory {
+        id: c.id.and_then(|v| v.parse().ok()).unwrap_or(0),
+        name: c.name.unwrap_or_default(),
+        subcategories: c.subcategories.into_iter().map(convert_category).collect(),
+    }
+}
+
+pub fn parse_feed_xml(xml: &str) -> Result<TorznabFeed, quick_xml::DeError> {
+    quick_xml::de::from_str(xml)
+}
+
+pub fn parse_caps_xml(xml: &str) -> Result<IndexerCaps, quick_xml::DeError> {
+    let caps_root: CapsRoot = quick_xml::de::from_str(xml)?;
+    Ok(caps_root.into_indexer_caps())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_torznab_feed() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <title>Test Indexer</title>
+    <item>
+      <title>Test.Release.2024.FLAC</title>
+      <guid>abc123</guid>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+      <size>734003200</size>
+      <link>https://example.com/download/abc123</link>
+      <torznab:attr name="seeders" value="42"/>
+      <torznab:attr name="leechers" value="5"/>
+      <torznab:attr name="infohash" value="deadbeef1234567890abcdef1234567890abcdef"/>
+      <torznab:attr name="category" value="3000"/>
+      <torznab:attr name="downloadvolumefactor" value="0.0"/>
+      <torznab:attr name="uploadvolumefactor" value="2.0"/>
+    </item>
+  </channel>
+</rss>"#;
+
+        let feed = parse_feed_xml(xml).unwrap();
+        assert_eq!(feed.channel.title.as_deref(), Some("Test Indexer"));
+        assert_eq!(feed.channel.items.len(), 1);
+
+        let item = &feed.channel.items[0];
+        assert_eq!(item.title, "Test.Release.2024.FLAC");
+        assert_eq!(item.guid.as_deref(), Some("abc123"));
+        assert_eq!(item.size, Some(734003200));
+
+        assert_eq!(get_attr_u32(&item.attrs, "seeders"), Some(42));
+        assert_eq!(get_attr_u32(&item.attrs, "leechers"), Some(5));
+        assert_eq!(
+            get_attr(&item.attrs, "infohash"),
+            Some("deadbeef1234567890abcdef1234567890abcdef")
+        );
+        assert_eq!(get_attr_f64(&item.attrs, "downloadvolumefactor"), Some(0.0));
+        assert_eq!(get_attr_f64(&item.attrs, "uploadvolumefactor"), Some(2.0));
+    }
+
+    #[test]
+    fn parse_newznab_feed() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+  <channel>
+    <title>Usenet Indexer</title>
+    <item>
+      <title>Test.Release.2024.NZB</title>
+      <guid>nzb-guid-456</guid>
+      <size>524288000</size>
+      <link>https://example.com/getnzb/nzb-guid-456</link>
+      <newznab:attr name="category" value="2000"/>
+      <newznab:attr name="grabs" value="150"/>
+    </item>
+  </channel>
+</rss>"#;
+
+        let feed = parse_feed_xml(xml).unwrap();
+        assert_eq!(feed.channel.items.len(), 1);
+
+        let item = &feed.channel.items[0];
+        assert_eq!(item.title, "Test.Release.2024.NZB");
+        assert_eq!(get_attr_u32(&item.attrs, "grabs"), Some(150));
+        assert!(get_attr(&item.attrs, "infohash").is_none());
+        assert!(get_attr(&item.attrs, "seeders").is_none());
+    }
+
+    #[test]
+    fn parse_empty_feed() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Empty</title>
+  </channel>
+</rss>"#;
+
+        let feed = parse_feed_xml(xml).unwrap();
+        assert!(feed.channel.items.is_empty());
+    }
+
+    #[test]
+    fn parse_caps_response() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+  <server title="Test Indexer" version="1.0"/>
+  <limits default="100" max="500"/>
+  <searching>
+    <search available="yes"/>
+    <tv-search available="yes"/>
+    <movie-search available="yes"/>
+    <music-search available="no"/>
+    <book-search available="no"/>
+  </searching>
+  <categories>
+    <category id="2000" name="Movies">
+      <subcat id="2010" name="Movies/Foreign"/>
+      <subcat id="2020" name="Movies/Other"/>
+    </category>
+    <category id="5000" name="TV">
+      <subcat id="5010" name="TV/WEB-DL"/>
+    </category>
+  </categories>
+</caps>"#;
+
+        let caps = parse_caps_xml(xml).unwrap();
+        assert_eq!(caps.server.title.as_deref(), Some("Test Indexer"));
+        assert_eq!(caps.limits.default, 100);
+        assert_eq!(caps.limits.max, 500);
+
+        assert_eq!(caps.search_functions.len(), 5);
+        let search = caps
+            .search_functions
+            .iter()
+            .find(|f| f.function_type == "search")
+            .unwrap();
+        assert!(search.available);
+        let music = caps
+            .search_functions
+            .iter()
+            .find(|f| f.function_type == "music")
+            .unwrap();
+        assert!(!music.available);
+
+        assert_eq!(caps.categories.len(), 2);
+        assert_eq!(caps.categories[0].id, 2000);
+        assert_eq!(caps.categories[0].name, "Movies");
+        assert_eq!(caps.categories[0].subcategories.len(), 2);
+    }
+
+    #[test]
+    fn parse_minimal_caps() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+  <server title="Minimal"/>
+</caps>"#;
+
+        let caps = parse_caps_xml(xml).unwrap();
+        assert_eq!(caps.server.title.as_deref(), Some("Minimal"));
+        assert_eq!(caps.limits.default, 100);
+        assert!(caps.search_functions.is_empty());
+        assert!(caps.categories.is_empty());
+    }
+
+    #[test]
+    fn attr_helpers() {
+        let attrs = vec![
+            TorznabAttr {
+                name: "seeders".to_string(),
+                value: "42".to_string(),
+            },
+            TorznabAttr {
+                name: "size".to_string(),
+                value: "1234567890".to_string(),
+            },
+            TorznabAttr {
+                name: "ratio".to_string(),
+                value: "1.5".to_string(),
+            },
+        ];
+
+        assert_eq!(get_attr(&attrs, "seeders"), Some("42"));
+        assert_eq!(get_attr(&attrs, "missing"), None);
+        assert_eq!(get_attr_u64(&attrs, "size"), Some(1234567890));
+        assert_eq!(get_attr_u64(&attrs, "seeders"), Some(42));
+        assert_eq!(get_attr_f64(&attrs, "ratio"), Some(1.5));
+        assert_eq!(get_attr_u32(&attrs, "seeders"), Some(42));
+    }
+}

--- a/crates/zetesis/src/error.rs
+++ b/crates/zetesis/src/error.rs
@@ -1,0 +1,84 @@
+use snafu::Snafu;
+
+use harmonia_db::DbError;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ZetesisError {
+    #[snafu(display("HTTP request to indexer {url} failed"))]
+    HttpRequest {
+        url: String,
+        source: reqwest::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("failed to parse Torznab/Newznab XML response from {url}"))]
+    ParseResponse {
+        url: String,
+        error: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("indexer {indexer_id} returned auth failure (bad API key)"))]
+    AuthFailed {
+        indexer_id: i64,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("indexer {indexer_id} rate limited — retry after {retry_after_seconds:?}s"))]
+    RateLimited {
+        indexer_id: i64,
+        retry_after_seconds: Option<u64>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("CF bypass proxy not available for {url}"))]
+    NoCfBypass {
+        url: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("caps negotiation failed for indexer {indexer_id}"))]
+    CapsUnavailable {
+        indexer_id: i64,
+        source: Box<ZetesisError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("Byparr did not respond within {timeout}s for {url}"))]
+    CfProxyTimeout {
+        url: String,
+        timeout: u32,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("Byparr returned error for {url}: [{status}] {message}"))]
+    CfProxyError {
+        url: String,
+        status: String,
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("CF cookies expired for indexer {indexer_name}"))]
+    CfCookieExpired {
+        indexer_name: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("database error: {source}"))]
+    Database {
+        source: DbError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/zetesis/src/lib.rs
+++ b/crates/zetesis/src/lib.rs
@@ -1,0 +1,27 @@
+pub mod cf_bypass;
+pub mod client;
+pub mod error;
+pub mod rate_limit;
+pub mod repo;
+pub mod search;
+pub mod types;
+
+pub use cf_bypass::CloudflareProxy;
+pub use client::IndexerClient;
+pub use error::ZetesisError;
+pub use search::ZetesisService;
+pub use types::{
+    DownloadResponse, IndexerCaps, IndexerStatus, ReleaseProtocol, SearchMediaType, SearchQuery,
+    SearchResult,
+};
+
+use std::sync::Arc;
+
+use horismos::ZetesisConfig;
+
+pub struct CardigannClient {
+    #[expect(dead_code)]
+    config: Arc<ZetesisConfig>,
+    #[expect(dead_code)]
+    http_client: reqwest::Client,
+}

--- a/crates/zetesis/src/rate_limit.rs
+++ b/crates/zetesis/src/rate_limit.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+
+pub struct RateLimiter {
+    buckets: Arc<DashMap<i64, Mutex<TokenBucket>>>,
+    max_tokens: u32,
+    window: Duration,
+}
+
+struct TokenBucket {
+    tokens: f64,
+    max_tokens: f64,
+    last_refill: Instant,
+    refill_rate: f64,
+    retry_after: Option<Instant>,
+}
+
+impl TokenBucket {
+    fn new(max_tokens: u32, window: Duration) -> Self {
+        let max = f64::from(max_tokens);
+        Self {
+            tokens: max,
+            max_tokens: max,
+            last_refill: Instant::now(),
+            refill_rate: max / window.as_secs_f64(),
+            retry_after: None,
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.refill_rate).min(self.max_tokens);
+        self.last_refill = now;
+    }
+
+    fn try_acquire(&mut self) -> Option<Duration> {
+        self.refill();
+
+        if let Some(retry_until) = self.retry_after {
+            let now = Instant::now();
+            if now < retry_until {
+                return Some(retry_until - now);
+            }
+            self.retry_after = None;
+        }
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            None
+        } else {
+            let wait = (1.0 - self.tokens) / self.refill_rate;
+            Some(Duration::from_secs_f64(wait))
+        }
+    }
+
+    fn set_retry_after(&mut self, duration: Duration) {
+        self.retry_after = Some(Instant::now() + duration);
+        self.tokens = 0.0;
+    }
+}
+
+impl RateLimiter {
+    pub fn new(max_tokens: u32, window: Duration) -> Self {
+        Self {
+            buckets: Arc::new(DashMap::new()),
+            max_tokens,
+            window,
+        }
+    }
+
+    pub async fn acquire(&self, indexer_id: i64) {
+        loop {
+            let wait = {
+                let entry = self
+                    .buckets
+                    .entry(indexer_id)
+                    .or_insert_with(|| Mutex::new(TokenBucket::new(self.max_tokens, self.window)));
+                let mut bucket = entry.value().lock().await;
+                bucket.try_acquire()
+            };
+
+            match wait {
+                None => return,
+                Some(duration) => tokio::time::sleep(duration).await,
+            }
+        }
+    }
+
+    pub async fn set_retry_after(&self, indexer_id: i64, duration: Duration) {
+        let entry = self
+            .buckets
+            .entry(indexer_id)
+            .or_insert_with(|| Mutex::new(TokenBucket::new(self.max_tokens, self.window)));
+        let mut bucket = entry.value().lock().await;
+        bucket.set_retry_after(duration);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn acquire_within_limit() {
+        let limiter = RateLimiter::new(5, Duration::from_secs(10));
+        for _ in 0..5 {
+            limiter.acquire(1).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn acquire_exceeding_limit_delays() {
+        let limiter = RateLimiter::new(2, Duration::from_millis(200));
+        let start = Instant::now();
+
+        limiter.acquire(1).await;
+        limiter.acquire(1).await;
+        limiter.acquire(1).await;
+
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(50),
+            "expected delay for 3rd token, got {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn separate_indexers_independent() {
+        let limiter = RateLimiter::new(1, Duration::from_secs(10));
+        limiter.acquire(1).await;
+        limiter.acquire(2).await;
+    }
+
+    #[tokio::test]
+    async fn retry_after_respected() {
+        let limiter = RateLimiter::new(5, Duration::from_secs(10));
+        limiter.set_retry_after(1, Duration::from_millis(100)).await;
+
+        let start = Instant::now();
+        limiter.acquire(1).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(90),
+            "expected retry-after delay, got {elapsed:?}"
+        );
+    }
+}

--- a/crates/zetesis/src/repo.rs
+++ b/crates/zetesis/src/repo.rs
@@ -1,0 +1,176 @@
+use snafu::ResultExt;
+use sqlx::SqlitePool;
+
+use harmonia_db::DbError;
+use harmonia_db::error::QuerySnafu;
+
+use crate::types::{IndexerCaps, IndexerCategory};
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct IndexerRow {
+    pub id: i64,
+    pub name: String,
+    pub url: String,
+    pub protocol: String,
+    pub api_key: Option<String>,
+    pub enabled: bool,
+    pub cf_bypass: bool,
+    pub status: String,
+    pub last_tested: Option<String>,
+    pub caps_json: Option<String>,
+    pub priority: i32,
+    pub added_at: String,
+}
+
+pub async fn insert_indexer(
+    pool: &SqlitePool,
+    name: &str,
+    url: &str,
+    protocol: &str,
+    api_key: Option<&str>,
+    cf_bypass: bool,
+    priority: i32,
+) -> Result<i64, DbError> {
+    let result = sqlx::query_scalar::<_, i64>(
+        "INSERT INTO indexers (name, url, protocol, api_key, cf_bypass, priority)
+         VALUES (?, ?, ?, ?, ?, ?)
+         RETURNING id",
+    )
+    .bind(name)
+    .bind(url)
+    .bind(protocol)
+    .bind(api_key)
+    .bind(cf_bypass)
+    .bind(priority)
+    .fetch_one(pool)
+    .await
+    .context(QuerySnafu { table: "indexers" })?;
+
+    Ok(result)
+}
+
+pub async fn get_indexer(pool: &SqlitePool, id: i64) -> Result<Option<IndexerRow>, DbError> {
+    let row = sqlx::query_as::<_, IndexerRow>("SELECT * FROM indexers WHERE id = ?")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+        .context(QuerySnafu { table: "indexers" })?;
+
+    Ok(row)
+}
+
+pub async fn list_indexers(pool: &SqlitePool) -> Result<Vec<IndexerRow>, DbError> {
+    let rows = sqlx::query_as::<_, IndexerRow>("SELECT * FROM indexers ORDER BY priority ASC")
+        .fetch_all(pool)
+        .await
+        .context(QuerySnafu { table: "indexers" })?;
+
+    Ok(rows)
+}
+
+pub async fn get_eligible_indexers(pool: &SqlitePool) -> Result<Vec<IndexerRow>, DbError> {
+    let rows = sqlx::query_as::<_, IndexerRow>(
+        "SELECT * FROM indexers
+         WHERE enabled = TRUE AND status != 'failed'
+         ORDER BY priority ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "indexers" })?;
+
+    Ok(rows)
+}
+
+pub async fn update_indexer_status(
+    pool: &SqlitePool,
+    id: i64,
+    status: &str,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE indexers SET status = ? WHERE id = ?")
+        .bind(status)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "indexers" })?;
+
+    Ok(())
+}
+
+pub async fn update_indexer_caps(
+    pool: &SqlitePool,
+    id: i64,
+    caps_json: &str,
+    last_tested: &str,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE indexers SET caps_json = ?, last_tested = ? WHERE id = ?")
+        .bind(caps_json)
+        .bind(last_tested)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "indexers" })?;
+
+    Ok(())
+}
+
+pub async fn delete_indexer(pool: &SqlitePool, id: i64) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM indexers WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "indexers" })?;
+
+    Ok(())
+}
+
+pub async fn upsert_indexer_categories(
+    pool: &SqlitePool,
+    indexer_id: i64,
+    caps: &IndexerCaps,
+) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM indexer_categories WHERE indexer_id = ?")
+        .bind(indexer_id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "indexer_categories",
+        })?;
+
+    fn collect_categories(cats: &[IndexerCategory], out: &mut Vec<(u32, String)>) {
+        for cat in cats {
+            out.push((cat.id, cat.name.clone()));
+            collect_categories(&cat.subcategories, out);
+        }
+    }
+
+    let mut flat = Vec::new();
+    collect_categories(&caps.categories, &mut flat);
+
+    for (cat_id, name) in flat {
+        sqlx::query(
+            "INSERT OR REPLACE INTO indexer_categories (indexer_id, category_id, name)
+             VALUES (?, ?, ?)",
+        )
+        .bind(indexer_id)
+        .bind(cat_id as i64)
+        .bind(&name)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "indexer_categories",
+        })?;
+    }
+
+    Ok(())
+}
+
+pub async fn restore_degraded_cf_indexers(pool: &SqlitePool) -> Result<u64, DbError> {
+    let result = sqlx::query(
+        "UPDATE indexers SET status = 'active' WHERE status = 'degraded' AND cf_bypass = TRUE",
+    )
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "indexers" })?;
+
+    Ok(result.rows_affected())
+}

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -1,0 +1,421 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::stream::{self, StreamExt};
+use sqlx::SqlitePool;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, instrument, warn};
+
+use harmonia_common::{EventSender, HarmoniaEvent, QueryId};
+use horismos::ZetesisConfig;
+
+use crate::cf_bypass::CloudflareProxy;
+use crate::client::newznab::NewznabClient;
+use crate::client::torznab::TorznabClient;
+use crate::client::{DynIndexerClient, IndexerConfig};
+use crate::error::ZetesisError;
+use crate::rate_limit::RateLimiter;
+use crate::repo::{self, IndexerRow};
+use crate::types::{IndexerCaps, SearchMediaType, SearchQuery, SearchResult};
+
+pub struct ZetesisService {
+    read_pool: SqlitePool,
+    write_pool: SqlitePool,
+    cf_proxy: Arc<dyn CloudflareProxy>,
+    rate_limiter: RateLimiter,
+    http: reqwest::Client,
+    config: ZetesisConfig,
+    event_tx: EventSender,
+}
+
+impl ZetesisService {
+    pub fn new(
+        read_pool: SqlitePool,
+        write_pool: SqlitePool,
+        cf_proxy: Arc<dyn CloudflareProxy>,
+        config: ZetesisConfig,
+        event_tx: EventSender,
+    ) -> Self {
+        let rate_limiter = RateLimiter::new(
+            config.per_indexer_rate_limit_requests,
+            Duration::from_secs(config.per_indexer_rate_limit_window_seconds),
+        );
+
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(config.request_timeout_secs))
+            .build()
+            .unwrap_or_default();
+
+        Self {
+            read_pool,
+            write_pool,
+            cf_proxy,
+            rate_limiter,
+            http,
+            config,
+            event_tx,
+        }
+    }
+
+    #[instrument(skip(self, ct))]
+    pub async fn search(
+        &self,
+        query: &SearchQuery,
+        ct: CancellationToken,
+    ) -> Result<Vec<SearchResult>, ZetesisError> {
+        let query_id = QueryId::new();
+
+        // Step 1: Filter eligible indexers
+        let indexers = repo::get_eligible_indexers(&self.read_pool)
+            .await
+            .map_err(|e| ZetesisError::Database {
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        // Step 2: Filter by search function support
+        let eligible = filter_by_capability(&indexers, query);
+
+        info!(
+            query_id = %query_id,
+            eligible_count = eligible.len(),
+            "starting search fan-out"
+        );
+
+        // Step 3: Parallel fan-out
+        let cf_proxy = Arc::clone(&self.cf_proxy);
+        let http = self.http.clone();
+        let timeout = Duration::from_secs(self.config.search_timeout_seconds);
+        let rate_limiter = &self.rate_limiter;
+
+        let results: Vec<SearchResult> = stream::iter(eligible)
+            .map(|indexer| {
+                let cf = Arc::clone(&cf_proxy);
+                let h = http.clone();
+                let ct = ct.clone();
+                let q = query;
+                async move {
+                    rate_limiter.acquire(indexer.id).await;
+                    let client = make_client(indexer, h, cf, timeout);
+                    match client.search_boxed(q, ct).await {
+                        Ok(results) => results,
+                        Err(e) => {
+                            warn!(
+                                indexer_id = indexer.id,
+                                indexer_name = %indexer.name,
+                                error = %e,
+                                "search failed for indexer"
+                            );
+                            self.handle_search_error(indexer, &e).await;
+                            Vec::new()
+                        }
+                    }
+                }
+            })
+            .buffer_unordered(self.config.max_concurrent_searches)
+            .flat_map(stream::iter)
+            .collect()
+            .await;
+
+        // Step 4: Deduplication
+        let deduped = deduplicate(results);
+
+        // Step 5: Emit event
+        let _ = self.event_tx.send(HarmoniaEvent::SearchCompleted {
+            query_id,
+            result_count: deduped.len(),
+        });
+
+        info!(
+            query_id = %query_id,
+            result_count = deduped.len(),
+            "search completed"
+        );
+
+        Ok(deduped)
+    }
+
+    async fn handle_search_error(&self, indexer: &IndexerRow, error: &ZetesisError) {
+        let new_status = match error {
+            ZetesisError::AuthFailed { .. } => Some("failed"),
+            ZetesisError::NoCfBypass { .. } => Some("degraded"),
+            ZetesisError::CfProxyTimeout { .. } | ZetesisError::CfProxyError { .. } => {
+                Some("degraded")
+            }
+            ZetesisError::ParseResponse { .. } => Some("degraded"),
+            ZetesisError::HttpRequest { .. } => {
+                if indexer.status == "degraded" {
+                    Some("failed")
+                } else {
+                    Some("degraded")
+                }
+            }
+            _ => None,
+        };
+
+        if let Some(status) = new_status
+            && let Err(e) = repo::update_indexer_status(&self.write_pool, indexer.id, status).await
+        {
+            warn!(
+                indexer_id = indexer.id,
+                error = %e,
+                "failed to update indexer status"
+            );
+        }
+    }
+}
+
+fn filter_by_capability<'a>(
+    indexers: &'a [IndexerRow],
+    query: &SearchQuery,
+) -> Vec<&'a IndexerRow> {
+    let function_type = query.search_function();
+
+    indexers
+        .iter()
+        .filter(|indexer| {
+            if query.media_type == SearchMediaType::Any {
+                return true;
+            }
+
+            let Some(ref caps_json) = indexer.caps_json else {
+                return false;
+            };
+
+            let Ok(caps) = serde_json::from_str::<IndexerCaps>(caps_json) else {
+                return false;
+            };
+
+            crate::types::supports_function(&caps, function_type)
+        })
+        .collect()
+}
+
+fn deduplicate(results: Vec<SearchResult>) -> Vec<SearchResult> {
+    let mut seen_hashes: HashMap<String, usize> = HashMap::new();
+    let mut seen_guids: HashMap<String, usize> = HashMap::new();
+    let mut deduped: Vec<SearchResult> = Vec::with_capacity(results.len());
+
+    for result in results {
+        if let Some(ref hash) = result.info_hash {
+            let hash_lower = hash.to_lowercase();
+            if seen_hashes.contains_key(&hash_lower) {
+                continue;
+            }
+            seen_hashes.insert(hash_lower, deduped.len());
+        } else if let Some(ref guid) = result.guid {
+            if seen_guids.contains_key(guid) {
+                continue;
+            }
+            seen_guids.insert(guid.clone(), deduped.len());
+        }
+
+        deduped.push(result);
+    }
+
+    deduped
+}
+
+fn make_client(
+    indexer: &IndexerRow,
+    http: reqwest::Client,
+    cf_proxy: Arc<dyn CloudflareProxy>,
+    timeout: Duration,
+) -> Box<dyn DynIndexerClient> {
+    let config = IndexerConfig {
+        id: indexer.id,
+        name: indexer.name.clone(),
+        url: indexer.url.clone(),
+        api_key: indexer.api_key.clone(),
+        cf_bypass: indexer.cf_bypass,
+    };
+
+    match indexer.protocol.as_str() {
+        "newznab" => Box::new(NewznabClient::new(config, http, cf_proxy, timeout)),
+        _ => Box::new(TorznabClient::new(config, http, cf_proxy, timeout)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ReleaseProtocol;
+
+    fn make_result(
+        title: &str,
+        info_hash: Option<&str>,
+        guid: Option<&str>,
+        indexer_id: i64,
+    ) -> SearchResult {
+        SearchResult {
+            title: title.to_string(),
+            guid: guid.map(str::to_string),
+            download_url: format!("https://example.com/{title}"),
+            size_bytes: Some(1_000_000),
+            seeders: Some(10),
+            leechers: Some(2),
+            info_hash: info_hash.map(str::to_string),
+            category_id: Some(2000),
+            publication_date: None,
+            indexer_id,
+            protocol: ReleaseProtocol::Torrent,
+            download_volume_factor: 1.0,
+            upload_volume_factor: 1.0,
+            custom_attrs: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn dedup_by_info_hash() {
+        let results = vec![
+            make_result("Release.A", Some("abc123"), None, 1),
+            make_result("Release.A.dupe", Some("abc123"), None, 2),
+            make_result("Release.B", Some("def456"), None, 1),
+        ];
+
+        let deduped = deduplicate(results);
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].title, "Release.A");
+        assert_eq!(deduped[1].title, "Release.B");
+    }
+
+    #[test]
+    fn dedup_by_guid() {
+        let results = vec![
+            make_result("NZB.A", None, Some("guid-1"), 1),
+            make_result("NZB.A.dupe", None, Some("guid-1"), 2),
+            make_result("NZB.B", None, Some("guid-2"), 1),
+        ];
+
+        let deduped = deduplicate(results);
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].title, "NZB.A");
+        assert_eq!(deduped[1].title, "NZB.B");
+    }
+
+    #[test]
+    fn dedup_case_insensitive_hash() {
+        let results = vec![
+            make_result("Release.A", Some("ABC123"), None, 1),
+            make_result("Release.A.dupe", Some("abc123"), None, 2),
+        ];
+
+        let deduped = deduplicate(results);
+        assert_eq!(deduped.len(), 1);
+    }
+
+    #[test]
+    fn dedup_keeps_higher_priority() {
+        let results = vec![
+            make_result("Release.Priority1", Some("hash1"), None, 1),
+            make_result("Release.Priority2", Some("hash1"), None, 2),
+        ];
+
+        let deduped = deduplicate(results);
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].indexer_id, 1);
+    }
+
+    #[test]
+    fn dedup_no_hash_no_guid_keeps_all() {
+        let results = vec![
+            make_result("Release.A", None, None, 1),
+            make_result("Release.B", None, None, 2),
+        ];
+
+        let deduped = deduplicate(results);
+        assert_eq!(deduped.len(), 2);
+    }
+
+    #[test]
+    fn filter_capability_any_includes_all() {
+        let indexers = vec![IndexerRow {
+            id: 1,
+            name: "Test1".to_string(),
+            url: "https://example.com/api".to_string(),
+            protocol: "torznab".to_string(),
+            api_key: None,
+            enabled: true,
+            cf_bypass: false,
+            status: "active".to_string(),
+            last_tested: None,
+            caps_json: None,
+            priority: 50,
+            added_at: "2024-01-01T00:00:00Z".to_string(),
+        }];
+
+        let query = SearchQuery {
+            media_type: SearchMediaType::Any,
+            ..Default::default()
+        };
+
+        let eligible = filter_by_capability(&indexers, &query);
+        assert_eq!(eligible.len(), 1);
+    }
+
+    #[test]
+    fn filter_capability_typed_excludes_no_caps() {
+        let indexers = vec![IndexerRow {
+            id: 1,
+            name: "NoCaps".to_string(),
+            url: "https://example.com/api".to_string(),
+            protocol: "torznab".to_string(),
+            api_key: None,
+            enabled: true,
+            cf_bypass: false,
+            status: "active".to_string(),
+            last_tested: None,
+            caps_json: None,
+            priority: 50,
+            added_at: "2024-01-01T00:00:00Z".to_string(),
+        }];
+
+        let query = SearchQuery {
+            media_type: SearchMediaType::Tv,
+            ..Default::default()
+        };
+
+        let eligible = filter_by_capability(&indexers, &query);
+        assert!(eligible.is_empty());
+    }
+
+    #[test]
+    fn filter_capability_typed_includes_supported() {
+        let caps = IndexerCaps {
+            server: crate::types::ServerInfo {
+                title: None,
+                version: None,
+            },
+            limits: crate::types::SearchLimits::default(),
+            search_functions: vec![crate::types::SearchFunction {
+                function_type: "tvsearch".to_string(),
+                available: true,
+            }],
+            categories: vec![],
+        };
+
+        let indexers = vec![IndexerRow {
+            id: 1,
+            name: "TVIndexer".to_string(),
+            url: "https://example.com/api".to_string(),
+            protocol: "torznab".to_string(),
+            api_key: None,
+            enabled: true,
+            cf_bypass: false,
+            status: "active".to_string(),
+            last_tested: None,
+            caps_json: Some(serde_json::to_string(&caps).unwrap()),
+            priority: 50,
+            added_at: "2024-01-01T00:00:00Z".to_string(),
+        }];
+
+        let query = SearchQuery {
+            media_type: SearchMediaType::Tv,
+            ..Default::default()
+        };
+
+        let eligible = filter_by_capability(&indexers, &query);
+        assert_eq!(eligible.len(), 1);
+    }
+}

--- a/crates/zetesis/src/types.rs
+++ b/crates/zetesis/src/types.rs
@@ -1,0 +1,152 @@
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default)]
+pub struct SearchQuery {
+    pub query_text: Option<String>,
+    pub media_type: SearchMediaType,
+    pub category_ids: Vec<u32>,
+    pub imdb_id: Option<String>,
+    pub tvdb_id: Option<u32>,
+    pub tmdb_id: Option<u32>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub author: Option<String>,
+    pub season: Option<u32>,
+    pub episode: Option<u32>,
+    pub limit: u32,
+    pub offset: u32,
+}
+
+impl SearchQuery {
+    pub fn new() -> Self {
+        Self {
+            limit: 100,
+            ..Default::default()
+        }
+    }
+
+    pub fn search_function(&self) -> &'static str {
+        match self.media_type {
+            SearchMediaType::Any => "search",
+            SearchMediaType::Tv => "tvsearch",
+            SearchMediaType::Movie => "movie",
+            SearchMediaType::Music => "music",
+            SearchMediaType::Book => "book",
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SearchMediaType {
+    #[default]
+    Any,
+    Tv,
+    Movie,
+    Music,
+    Book,
+}
+
+impl SearchMediaType {
+    pub fn fallback_category(&self) -> Option<u32> {
+        match self {
+            Self::Any => None,
+            Self::Tv => Some(5000),
+            Self::Movie => Some(2000),
+            Self::Music => Some(3000),
+            Self::Book => Some(7000),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub title: String,
+    pub guid: Option<String>,
+    pub download_url: String,
+    pub size_bytes: Option<u64>,
+    pub seeders: Option<u32>,
+    pub leechers: Option<u32>,
+    pub info_hash: Option<String>,
+    pub category_id: Option<u32>,
+    pub publication_date: Option<String>,
+    pub indexer_id: i64,
+    pub protocol: ReleaseProtocol,
+    pub download_volume_factor: f64,
+    pub upload_volume_factor: f64,
+    pub custom_attrs: HashMap<String, String>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReleaseProtocol {
+    Torrent,
+    Nzb,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum DownloadResponse {
+    TorrentFile(Bytes),
+    MagnetUri(String),
+    NzbFile(Bytes),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexerCaps {
+    pub server: ServerInfo,
+    pub limits: SearchLimits,
+    pub search_functions: Vec<SearchFunction>,
+    pub categories: Vec<IndexerCategory>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerInfo {
+    pub title: Option<String>,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchLimits {
+    pub default: u32,
+    pub max: u32,
+}
+
+impl Default for SearchLimits {
+    fn default() -> Self {
+        Self {
+            default: 100,
+            max: 100,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchFunction {
+    pub function_type: String,
+    pub available: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexerCategory {
+    pub id: u32,
+    pub name: String,
+    #[serde(default)]
+    pub subcategories: Vec<IndexerCategory>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IndexerStatus {
+    pub healthy: bool,
+    pub caps: Option<IndexerCaps>,
+    pub error: Option<String>,
+}
+
+pub fn supports_function(caps: &IndexerCaps, function_type: &str) -> bool {
+    caps.search_functions
+        .iter()
+        .any(|f| f.function_type == function_type && f.available)
+}


### PR DESCRIPTION
## Summary

- Add `crates/zetesis/` — Torznab/Newznab indexer protocol implementation with search routing, rate limiting, Cloudflare bypass, and result deduplication
- Expand `ZetesisConfig` in horismos with all fields from design docs (CF bypass, rate limits, caps refresh, concurrent searches)
- Add migration `004_indexers.sql` for `indexers` and `indexer_categories` tables
- Add workspace deps: quick-xml, dashmap, tokio-util, futures, bytes, regex

## What's in the crate

| Module | Purpose |
|--------|---------|
| `client/` | `IndexerClient` trait + `TorznabClient`, `NewznabClient` implementations |
| `client/xml.rs` | Shared XML parsing for feeds and `t=caps` responses |
| `search.rs` | 5-step search routing: eligible filter → capability check → parallel fan-out → dedup → emit event |
| `rate_limit.rs` | Per-indexer token bucket with `Retry-After` support |
| `cf_bypass/` | `CloudflareProxy` trait, `ByparrProxy` (Byparr/FlareSolverr sidecar), `NoProxy`, cookie persistence |
| `repo.rs` | Indexer DB CRUD operations |
| `error.rs` | `ZetesisError` with snafu location tracking |
| `types.rs` | `SearchQuery`, `SearchResult`, `IndexerCaps`, `DownloadResponse`, etc. |

## Validation

```
cargo fmt --all -- --check  ✅
cargo clippy -p zetesis -- -D warnings  ✅
cargo test -p zetesis  ✅ (33 tests)
```

## Test plan

- [x] TorznabClient correctly parses sample XML responses
- [x] NewznabClient correctly parses sample XML responses
- [x] `t=caps` response parsing produces correct IndexerCaps struct
- [x] Search routing filters by capability for typed searches
- [x] Deduplication by info_hash keeps higher-priority indexer result
- [x] Deduplication by guid for NZB results
- [x] Rate limiter delays requests beyond burst limit
- [x] Rate limiter respects Retry-After
- [x] ByparrProxy request/response serialization
- [x] NoProxy returns NoCfBypass immediately
- [x] Cookie jar stores, retrieves, expires, and refreshes cookies
- [x] ZetesisError has all variants with location tracking
- [x] Migration adds indexers + indexer_categories tables
- [x] No `unwrap()` in library code