### PR TITLE
chore: delete orphaned commitlint.config.js

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  extends: ['@commitlint/config-conventional'],
-  rules: {
-    'subject-case': [0],
-  },
-};


### PR DESCRIPTION
## Summary
- Removed orphaned commitlint.config.js
- CI uses inline bash for commit validation, not the commitlint Node.js toolchain

## Test plan
- [ ] No references to commitlint config in CI or package.json
- [ ] CI workflows unaffected