### PR TITLE
ci: align workflows with aletheia reference patterns

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,6 +17,19 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Wait for CI checks to pass
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+           steps.metadata.outputs.dependency-type == 'direct:development')
+        run: |
+          if ! gh pr checks "$PR_URL" --watch --interval 30 --required; then
+            echo "Required CI checks did not pass — skipping auto-merge"
+            exit 0
+          fi
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Auto-merge patch updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --squash "$PR_URL"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,19 +10,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+
       - uses: Swatinem/rust-cache@v2
+
       - name: Format
         run: cargo fmt --all -- --check
+
       - name: Clippy (all features)
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
       - name: Test (default features)
         run: cargo test --workspace
+
       - name: Test (all features)
         run: cargo test --workspace --all-features
+
       - name: Audit dependencies
         run: |
-          cargo install cargo-audit --locked 2>/dev/null || true
+          cargo install cargo-audit --locked
           cargo audit

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -32,29 +32,27 @@ jobs:
             console.log(`PR has ${fileCount} files with ${totalChanges} total line changes`);
 
             if (totalChanges > 500 || fileCount > 30) {
+              // Check if we already commented
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+              const alreadyCommented = comments.data.some(c =>
+                c.body?.includes('Large PR detected')
+              );
+              if (alreadyCommented) return;
+
               const body = [
                 `⚠️ **Large PR detected** — ${fileCount} files, ${totalChanges} lines changed.`,
                 '',
                 'Consider splitting into smaller PRs for easier review. Not a blocker, just a signal.',
               ].join('\n');
 
-              const { data: comments } = await github.rest.issues.listComments({
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
+                body,
               });
-
-              const existing = comments.find(c =>
-                c.user.login === 'github-actions[bot]' &&
-                c.body.includes('Large PR detected')
-              );
-
-              if (!existing) {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body,
-                });
-              }
             }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,15 +50,45 @@ jobs:
       - name: Doc tests
         run: cargo test --workspace --doc
 
-  secrets:
-    name: Secret Scan
+  msrv:
+    name: MSRV (1.85)
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.85
+      - uses: Swatinem/rust-cache@v2
+      - name: Check MSRV
+        run: cargo check --workspace
+
+  docs:
+    continue-on-error: true
+    name: Rustdoc
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build docs
+        run: cargo doc --workspace --no-deps
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          fetch-depth: 0
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+      - name: Measure coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,9 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo install cargo-audit --locked 2>/dev/null || true
-      - name: Audit Rust dependencies
-        run: cargo audit
+      - run: cargo install cargo-audit --locked
+      - name: Run cargo-audit
+        run: |
+          IGNORES=$(grep -oP 'id = "\K[^"]+' deny.toml | sed 's/^/--ignore /' | tr '\n' ' ')
+          cargo audit $IGNORES
 
   cargo-deny:
     runs-on: ubuntu-latest
@@ -40,3 +42,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: TruffleHog secret scan
+        uses: trufflesecurity/trufflehog@v3.93.7
+        with:
+          extra_args: --only-verified


### PR DESCRIPTION
## Summary

Aligns all six `.github/workflows/` files with the aletheia reference patterns, consolidating secret scanning into `security.yml`, adding Rust quality jobs, and improving reliability and readability across the board.

## Changes

- **`rust.yml`**
  - [x] Removed `secrets` job (Gitleaks now lives in `security.yml`)
  - [x] Added `msrv` job (Rust 1.85, `continue-on-error: true`)
  - [x] Added `docs` job (`RUSTDOCFLAGS=-D warnings`, `continue-on-error: true`)
  - [x] Added `coverage` job (cargo-llvm-cov, uploads `lcov.info` artifact)

- **`security.yml`**
  - [x] Updated `cargo-audit` step to pull ignores from `deny.toml` via shell expansion
  - [x] Removed `2>/dev/null || true` from `cargo install cargo-audit` so errors surface
  - [x] Added `secret-scan` job using TruffleHog v3.93.7 (`--only-verified`)
  - (CST comment on cron was already present)

- **`dependabot-auto-merge.yml`**
  - [x] Added `Wait for CI checks to pass` step before merge steps, using `gh pr checks --watch --required`

- **`pr-hygiene.yml`**
  - [x] Replaced old duplicate-comment check (keyed on `github-actions[bot]` login) with `alreadyCommented` pattern using `c.body?.includes`
  - [x] Comment check now runs before body construction and uses early return

- **`stale.yml`**
  - No changes needed — CST comment was already present

- **`nightly.yml`**
  - [x] Added blank lines between steps for readability
  - [x] Removed `2>/dev/null || true` from `cargo install cargo-audit`
  - (CST comment on cron was already present)

## Test plan

- [ ] YAML validation: all 10 workflow files parse cleanly with `python3 -c "import yaml; yaml.safe_load(...)"`
- [ ] `rust.yml` — verify `msrv`, `docs`, `coverage` jobs appear in Actions UI on next PR
- [ ] `security.yml` — verify TruffleHog scan runs and `cargo-audit` respects deny.toml ignores
- [ ] `dependabot-auto-merge.yml` — verify CI wait step runs before merge on next Dependabot patch PR
- [ ] `pr-hygiene.yml` — verify duplicate comment check uses `alreadyCommented` logic and does not re-comment on re-push

## Observations (outside scope)

- `stale.yml` and `nightly.yml` CST comments were already in place in the base branch — no changes were needed for those two files beyond nightly readability and audit cleanup.
- The `pr-hygiene.yml` already had partial duplicate-check logic before this PR; this replaces it with the canonical `alreadyCommented` pattern that avoids depending on the `github-actions[bot]` login string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)