### PR TITLE
fix(ci): bump MSRV check from 1.85 to 1.88

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,12 +51,12 @@ jobs:
         run: cargo test --workspace --doc
 
   msrv:
-    name: MSRV (1.85)
+    name: MSRV (1.88)
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dtolnay/rust-toolchain@1d5ce320ee1180be73d3022222c4ff0c635765dc # 1.85
+      - uses: dtolnay/rust-toolchain@e814c742d4444ce2f3f6abddea7faf00161ed941 # 1.88
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Check MSRV
         run: cargo check --workspace


### PR DESCRIPTION
## Summary
- Bumps MSRV CI check toolchain from 1.85 to 1.88
- Required because `time@0.3.47` and `zip@8.2` have MSRV of 1.88
- The MSRV check was introduced in #75 but the version didn't account for transitive deps

## Test plan
- [ ] MSRV CI job passes with 1.88 toolchain