### PR TITLE
feat(desktop): podcast player with subscriptions and episodes (P3-14)

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
 mod commands;
 mod config;
 mod dsp;
+mod playback;
 
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .manage(dsp::DspController::new())
+        .manage(playback::podcast::PodcastController::new())
         .invoke_handler(tauri::generate_handler![
             commands::health_check,
             commands::get_server_url,
@@ -24,6 +26,14 @@ pub fn run() {
             dsp::commands::set_replaygain,
             dsp::commands::set_compressor,
             dsp::commands::set_volume,
+            playback::podcast::podcast_play_episode,
+            playback::podcast::podcast_resume_episode,
+            playback::podcast::podcast_set_speed,
+            playback::podcast::podcast_get_speed,
+            playback::podcast::podcast_skip_forward,
+            playback::podcast::podcast_skip_backward,
+            playback::podcast::podcast_set_trim_silence,
+            playback::podcast::podcast_get_playback_snapshot,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/playback/mod.rs
+++ b/desktop/src-tauri/src/playback/mod.rs
@@ -1,0 +1,2 @@
+//! Playback state management for podcast and audiobook modes.
+pub mod podcast;

--- a/desktop/src-tauri/src/playback/podcast.rs
+++ b/desktop/src-tauri/src/playback/podcast.rs
@@ -1,0 +1,191 @@
+//! Podcast-specific playback state and Tauri IPC commands.
+//!
+//! Manages speed, position tracking, and trim-silence state for podcast
+//! playback. Actual audio rendering is delegated to the akroasis-core engine
+//! when P3-11 integration is complete; this module owns only the
+//! podcast-specific metadata layer.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tauri::State;
+
+const MIN_SPEED: f64 = 0.5;
+const MAX_SPEED: f64 = 3.0;
+const DEFAULT_SPEED: f64 = 1.0;
+// WHY: 30 s is the industry-standard sync interval for podcast progress.
+const DEFAULT_SYNC_INTERVAL: Duration = Duration::from_secs(30);
+
+struct PodcastPlayback {
+    episode_id: String,
+    playback_speed: f64,
+    position_sync_interval: Duration,
+    last_sync: Instant,
+    trim_silence: bool,
+    position_ms: u64,
+}
+
+impl PodcastPlayback {
+    fn new(episode_id: String, speed: f64, trim_silence: bool, position_ms: u64) -> Self {
+        Self {
+            episode_id,
+            playback_speed: speed,
+            position_sync_interval: DEFAULT_SYNC_INTERVAL,
+            last_sync: Instant::now(),
+            trim_silence,
+            position_ms,
+        }
+    }
+
+    fn sync_due(&self) -> bool {
+        self.last_sync.elapsed() >= self.position_sync_interval
+    }
+
+    fn mark_synced(&mut self) {
+        self.last_sync = Instant::now();
+    }
+}
+
+/// Snapshot of podcast playback state returned to the frontend.
+#[derive(Debug, Serialize)]
+pub struct PlaybackSnapshot {
+    pub episode_id: String,
+    pub position_ms: u64,
+    pub playback_speed: f64,
+    pub trim_silence: bool,
+    pub sync_due: bool,
+}
+
+/// Managed state for podcast playback, held by the Tauri application.
+pub struct PodcastController {
+    state: Mutex<Option<PodcastPlayback>>,
+    speed: Mutex<f64>,
+    trim_silence: Mutex<bool>,
+}
+
+impl Default for PodcastController {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(None),
+            speed: Mutex::new(DEFAULT_SPEED),
+            trim_silence: Mutex::new(false),
+        }
+    }
+}
+
+impl PodcastController {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[tauri::command]
+pub fn podcast_play_episode(
+    episode_id: String,
+    controller: State<'_, PodcastController>,
+) -> Result<(), String> {
+    let speed = *controller.speed.lock().expect("speed lock poisoned");
+    let trim = *controller.trim_silence.lock().expect("trim_silence lock poisoned");
+    let mut state = controller.state.lock().expect("state lock poisoned");
+    *state = Some(PodcastPlayback::new(episode_id, speed, trim, 0));
+    Ok(())
+}
+
+#[tauri::command]
+pub fn podcast_resume_episode(
+    episode_id: String,
+    position_ms: u64,
+    controller: State<'_, PodcastController>,
+) -> Result<(), String> {
+    let speed = *controller.speed.lock().expect("speed lock poisoned");
+    let trim = *controller.trim_silence.lock().expect("trim_silence lock poisoned");
+    let mut state = controller.state.lock().expect("state lock poisoned");
+    *state = Some(PodcastPlayback::new(episode_id, speed, trim, position_ms));
+    Ok(())
+}
+
+#[tauri::command]
+pub fn podcast_set_speed(
+    speed: f64,
+    controller: State<'_, PodcastController>,
+) -> Result<(), String> {
+    if !(MIN_SPEED..=MAX_SPEED).contains(&speed) {
+        return Err(format!("speed must be between {MIN_SPEED} and {MAX_SPEED}"));
+    }
+    *controller.speed.lock().expect("speed lock poisoned") = speed;
+    if let Some(pb) = controller.state.lock().expect("state lock poisoned").as_mut() {
+        pb.playback_speed = speed;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn podcast_get_speed(controller: State<'_, PodcastController>) -> Result<f64, String> {
+    Ok(*controller.speed.lock().expect("speed lock poisoned"))
+}
+
+#[tauri::command]
+pub fn podcast_skip_forward(
+    seconds: u64,
+    controller: State<'_, PodcastController>,
+) -> Result<(), String> {
+    let mut state = controller.state.lock().expect("state lock poisoned");
+    match state.as_mut() {
+        Some(pb) => {
+            pb.position_ms = pb.position_ms.saturating_add(seconds.saturating_mul(1_000));
+            Ok(())
+        }
+        None => Err("no episode is playing".to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn podcast_skip_backward(
+    seconds: u64,
+    controller: State<'_, PodcastController>,
+) -> Result<(), String> {
+    let mut state = controller.state.lock().expect("state lock poisoned");
+    match state.as_mut() {
+        Some(pb) => {
+            pb.position_ms = pb.position_ms.saturating_sub(seconds.saturating_mul(1_000));
+            Ok(())
+        }
+        None => Err("no episode is playing".to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn podcast_set_trim_silence(
+    enabled: bool,
+    controller: State<'_, PodcastController>,
+) -> Result<(), String> {
+    *controller.trim_silence.lock().expect("trim_silence lock poisoned") = enabled;
+    if let Some(pb) = controller.state.lock().expect("state lock poisoned").as_mut() {
+        pb.trim_silence = enabled;
+    }
+    Ok(())
+}
+
+/// Returns a snapshot of the current playback state; `None` if nothing is playing.
+/// The `sync_due` field signals whether the frontend should push a progress update.
+#[tauri::command]
+pub fn podcast_get_playback_snapshot(
+    controller: State<'_, PodcastController>,
+) -> Result<Option<PlaybackSnapshot>, String> {
+    let mut state = controller.state.lock().expect("state lock poisoned");
+    let snapshot = state.as_mut().map(|pb| {
+        let sync_due = pb.sync_due();
+        if sync_due {
+            pb.mark_synced();
+        }
+        PlaybackSnapshot {
+            episode_id: pb.episode_id.clone(),
+            position_ms: pb.position_ms,
+            playback_speed: pb.playback_speed,
+            trim_silence: pb.trim_silence,
+            sync_due,
+        }
+    });
+    Ok(snapshot)
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -5,6 +5,11 @@ import Settings from "./pages/Settings";
 import AlbumsPage from "./features/library/AlbumsPage";
 import TracksPage from "./features/library/TracksPage";
 import AudiobooksPage from "./features/library/AudiobooksPage";
+import PodcastsPage from "./features/podcast/pages/PodcastsPage";
+import PodcastDetailPage from "./features/podcast/pages/PodcastDetailPage";
+import EpisodeDetailPage from "./features/podcast/pages/EpisodeDetailPage";
+import LatestEpisodesPage from "./features/podcast/pages/LatestEpisodesPage";
+import DownloadQueuePage from "./features/podcast/pages/DownloadQueuePage";
 
 export default function App() {
   return (
@@ -16,6 +21,13 @@ export default function App() {
             <Route path="albums" element={<AlbumsPage />} />
             <Route path="tracks" element={<TracksPage />} />
             <Route path="audiobooks" element={<AudiobooksPage />} />
+            <Route path="podcasts">
+              <Route index element={<PodcastsPage />} />
+              <Route path="latest" element={<LatestEpisodesPage />} />
+              <Route path="downloads" element={<DownloadQueuePage />} />
+              <Route path="episodes/:id" element={<EpisodeDetailPage />} />
+              <Route path=":id" element={<PodcastDetailPage />} />
+            </Route>
           </Route>
           <Route path="dsp" element={<Dsp />} />
           <Route path="settings" element={<Settings />} />

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -1,5 +1,16 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { ApiResponse, ListParams, ReleaseGroup, Track, Audiobook } from "../types/api";
+import type {
+  PodcastSubscription,
+  Episode,
+  EpisodeDetail,
+  EpisodeProgress,
+  EpisodeProgressUpdate,
+  EpisodeDownload,
+  EpisodeQueryParams,
+  LatestEpisodeParams,
+  PaginatedResponse,
+} from "../types/media";
 
 async function getBaseUrl(): Promise<string> {
   return invoke<string>("get_server_url");
@@ -18,7 +29,29 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}: ${response.statusText}`);
   }
+  const contentType = response.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    return undefined as unknown as T;
+  }
   return response.json() as Promise<T>;
+}
+
+function buildEpisodeQuery(params: EpisodeQueryParams): URLSearchParams {
+  const q = new URLSearchParams();
+  if (params.page !== undefined) q.set("page", String(params.page));
+  if (params.pageSize !== undefined) q.set("page_size", String(params.pageSize));
+  if (params.sortBy !== undefined) q.set("sort_by", params.sortBy);
+  if (params.sortOrder !== undefined) q.set("sort_order", params.sortOrder);
+  if (params.filter !== undefined) q.set("filter", params.filter);
+  return q;
+}
+
+function buildLatestQuery(params: LatestEpisodeParams): URLSearchParams {
+  const q = new URLSearchParams();
+  if (params.page !== undefined) q.set("page", String(params.page));
+  if (params.pageSize !== undefined) q.set("page_size", String(params.pageSize));
+  if (params.hoursBack !== undefined) q.set("hours_back", String(params.hoursBack));
+  return q;
 }
 
 export const api = {
@@ -37,6 +70,22 @@ export const api = {
     });
   },
 
+  put<T>(path: string, body: unknown, token?: string): Promise<T> {
+    return request<T>(path, {
+      method: "PUT",
+      body: JSON.stringify(body),
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    });
+  },
+
+  del<T>(path: string, token?: string): Promise<T> {
+    return request<T>(path, {
+      method: "DELETE",
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    });
+  },
+
+  // Music library
   listReleaseGroups(params: ListParams, token: string): Promise<ApiResponse<ReleaseGroup[]>> {
     const q = new URLSearchParams({ page: String(params.page), per_page: String(params.per_page) });
     return api.get(`/api/music/release-groups?${q}`, token);
@@ -54,5 +103,91 @@ export const api = {
   listAudiobooks(params: ListParams, token: string): Promise<ApiResponse<Audiobook[]>> {
     const q = new URLSearchParams({ page: String(params.page), per_page: String(params.per_page) });
     return api.get(`/api/audiobooks/?${q}`, token);
+  },
+
+  // Podcast subscriptions
+  getSubscriptions(token: string): Promise<PodcastSubscription[]> {
+    return api.get("/api/podcasts/subscriptions", token);
+  },
+
+  subscribe(feedUrl: string, token: string): Promise<PodcastSubscription> {
+    return api.post("/api/podcasts/subscriptions", { feedUrl }, token);
+  },
+
+  unsubscribe(podcastId: string, token: string): Promise<void> {
+    return api.del(`/api/podcasts/subscriptions/${podcastId}`, token);
+  },
+
+  updateSubscription(
+    podcastId: string,
+    settings: { autoDownload?: boolean; refreshIntervalMinutes?: number },
+    token: string,
+  ): Promise<PodcastSubscription> {
+    return api.put(`/api/podcasts/subscriptions/${podcastId}`, settings, token);
+  },
+
+  refreshFeed(podcastId: string, token: string): Promise<void> {
+    return api.post(`/api/podcasts/${podcastId}/refresh`, {}, token);
+  },
+
+  refreshAllFeeds(token: string): Promise<void> {
+    return api.post("/api/podcasts/refresh-all", {}, token);
+  },
+
+  // Episodes
+  getEpisodes(
+    podcastId: string,
+    params: EpisodeQueryParams,
+    token: string,
+  ): Promise<PaginatedResponse<Episode>> {
+    const q = buildEpisodeQuery(params);
+    return api.get(`/api/podcasts/${podcastId}/episodes?${q}`, token);
+  },
+
+  getEpisode(episodeId: string, token: string): Promise<EpisodeDetail> {
+    return api.get(`/api/podcasts/episodes/${episodeId}`, token);
+  },
+
+  getLatestEpisodes(params: LatestEpisodeParams, token: string): Promise<PaginatedResponse<Episode>> {
+    const q = buildLatestQuery(params);
+    return api.get(`/api/podcasts/episodes/latest?${q}`, token);
+  },
+
+  // Playback progress
+  getEpisodeProgress(episodeId: string, token: string): Promise<EpisodeProgress> {
+    return api.get(`/api/podcasts/episodes/${episodeId}/progress`, token);
+  },
+
+  updateEpisodeProgress(
+    episodeId: string,
+    progress: EpisodeProgressUpdate,
+    token: string,
+  ): Promise<EpisodeProgress> {
+    return api.put(`/api/podcasts/episodes/${episodeId}/progress`, progress, token);
+  },
+
+  markEpisodeCompleted(episodeId: string, token: string): Promise<void> {
+    return api.post(`/api/podcasts/episodes/${episodeId}/complete`, {}, token);
+  },
+
+  markEpisodeUnplayed(episodeId: string, token: string): Promise<void> {
+    return api.post(`/api/podcasts/episodes/${episodeId}/unplay`, {}, token);
+  },
+
+  // Downloads
+  downloadEpisode(episodeId: string, token: string): Promise<void> {
+    return api.post(`/api/podcasts/episodes/${episodeId}/download`, {}, token);
+  },
+
+  cancelDownload(episodeId: string, token: string): Promise<void> {
+    return api.post(`/api/podcasts/episodes/${episodeId}/download/cancel`, {}, token);
+  },
+
+  deleteDownload(episodeId: string, token: string): Promise<void> {
+    return api.del(`/api/podcasts/episodes/${episodeId}/download`, token);
+  },
+
+  getDownloadQueue(token: string): Promise<EpisodeDownload[]> {
+    return api.get("/api/podcasts/downloads", token);
   },
 };

--- a/desktop/src/components/Layout.tsx
+++ b/desktop/src/components/Layout.tsx
@@ -1,10 +1,25 @@
 import { NavLink, Outlet } from "react-router-dom";
+import NowPlayingBar from "../features/now-playing/NowPlayingBar";
 
 const libraryItems = [
   { to: "/library/albums", label: "Albums" },
   { to: "/library/tracks", label: "Tracks" },
   { to: "/library/audiobooks", label: "Audiobooks" },
 ];
+
+const podcastItems = [
+  { to: "/library/podcasts", label: "Podcasts", end: true },
+  { to: "/library/podcasts/latest", label: "Latest Episodes" },
+  { to: "/library/podcasts/downloads", label: "Downloads" },
+];
+
+function navLinkClass({ isActive }: { isActive: boolean }): string {
+  return `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+    isActive
+      ? "bg-gray-800 text-white"
+      : "text-gray-400 hover:bg-gray-800 hover:text-white"
+  }`;
+}
 
 export default function Layout() {
   return (
@@ -15,46 +30,30 @@ export default function Layout() {
         </div>
         <nav className="flex-1 px-2 py-4 space-y-1 overflow-y-auto">
           <p className="px-3 pt-1 pb-2 text-xs font-medium text-gray-500 uppercase tracking-wider">
-            Library
+            Music
           </p>
           {libraryItems.map(({ to, label }) => (
-            <NavLink
-              key={to}
-              to={to}
-              className={({ isActive }) =>
-                `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                  isActive
-                    ? "bg-gray-800 text-white"
-                    : "text-gray-400 hover:bg-gray-800 hover:text-white"
-                }`
-              }
-            >
+            <NavLink key={to} to={to} className={navLinkClass}>
               {label}
             </NavLink>
           ))}
+
           <div className="pt-3">
-            <NavLink
-              to="/dsp"
-              className={({ isActive }) =>
-                `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                  isActive
-                    ? "bg-gray-800 text-white"
-                    : "text-gray-400 hover:bg-gray-800 hover:text-white"
-                }`
-              }
-            >
+            <p className="px-3 pt-1 pb-2 text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Podcasts
+            </p>
+            {podcastItems.map(({ to, label, end }) => (
+              <NavLink key={to} to={to} end={end} className={navLinkClass}>
+                {label}
+              </NavLink>
+            ))}
+          </div>
+
+          <div className="pt-3">
+            <NavLink to="/dsp" className={navLinkClass}>
               DSP
             </NavLink>
-            <NavLink
-              to="/settings"
-              className={({ isActive }) =>
-                `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                  isActive
-                    ? "bg-gray-800 text-white"
-                    : "text-gray-400 hover:bg-gray-800 hover:text-white"
-                }`
-              }
-            >
+            <NavLink to="/settings" className={navLinkClass}>
               Settings
             </NavLink>
           </div>
@@ -68,7 +67,7 @@ export default function Layout() {
           id="now-playing-bar"
           className="h-16 bg-gray-900 border-t border-gray-800 flex items-center px-4 flex-shrink-0"
         >
-          <span className="text-sm text-gray-500">Now playing — coming in P3-11</span>
+          <NowPlayingBar />
         </div>
       </main>
     </div>

--- a/desktop/src/features/now-playing/NowPlayingBar.tsx
+++ b/desktop/src/features/now-playing/NowPlayingBar.tsx
@@ -1,0 +1,29 @@
+/** Adaptive now-playing bar: renders podcast mode when an episode is active. */
+
+import { usePodcastStore } from "../podcast/store";
+import PodcastNowPlaying from "../podcast/components/PodcastNowPlaying";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../api/client";
+import { useLibraryStore } from "../library/store";
+
+export default function NowPlayingBar() {
+  const token = useLibraryStore((s) => s.token);
+  const currentEpisodeId = usePodcastStore((s) => s.currentEpisodeId);
+
+  const { data: episode } = useQuery({
+    queryKey: ["podcasts", "episode", currentEpisodeId, token],
+    queryFn: () => api.getEpisode(currentEpisodeId!, token),
+    enabled: !!currentEpisodeId && token.length > 0,
+    staleTime: 60_000,
+  });
+
+  if (currentEpisodeId && episode) {
+    return (
+      <PodcastNowPlaying episodeTitle={episode.title} podcastTitle={episode.podcastTitle} />
+    );
+  }
+
+  return (
+    <span className="text-sm text-gray-500">Nothing playing</span>
+  );
+}

--- a/desktop/src/features/podcast/components/DownloadProgress.tsx
+++ b/desktop/src/features/podcast/components/DownloadProgress.tsx
@@ -1,0 +1,34 @@
+/** Per-episode download indicator pulled from the download queue. */
+
+import { useDownloadQueue } from "../hooks/useDownloadQueue";
+
+interface Props {
+  episodeId: string;
+}
+
+export default function DownloadProgress({ episodeId }: Props) {
+  const { data: queue } = useDownloadQueue();
+  const entry = queue?.find((d) => d.episodeId === episodeId);
+
+  if (!entry) return null;
+
+  if (entry.status === "completed") {
+    return <span className="text-xs text-green-500 font-medium flex-shrink-0">↓</span>;
+  }
+
+  if (entry.status === "failed") {
+    return <span className="text-xs text-red-400 flex-shrink-0" title="Download failed">✕</span>;
+  }
+
+  return (
+    <div className="flex-shrink-0 flex flex-col items-end gap-0.5">
+      <span className="text-xs text-blue-400">{Math.round(entry.progressPercent)}%</span>
+      <div className="w-12 h-0.5 bg-gray-700 rounded">
+        <div
+          className="h-0.5 bg-blue-500 rounded transition-all"
+          style={{ width: `${entry.progressPercent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/components/EpisodeActions.tsx
+++ b/desktop/src/features/podcast/components/EpisodeActions.tsx
@@ -1,0 +1,69 @@
+/** Download, mark played/unplayed, and share actions for an episode. */
+
+import type { Episode } from "../../../types/media";
+import { useMarkEpisodeCompleted, useMarkEpisodeUnplayed } from "../hooks/useEpisodes";
+import { useDownloadEpisode, useDeleteDownload } from "../hooks/useDownloadQueue";
+
+interface Props {
+  episode: Episode;
+}
+
+export default function EpisodeActions({ episode }: Props) {
+  const markCompleted = useMarkEpisodeCompleted();
+  const markUnplayed = useMarkEpisodeUnplayed();
+  const download = useDownloadEpisode();
+  const deleteDownload = useDeleteDownload();
+
+  const isCompleted = episode.progress?.completed ?? false;
+
+  const copyLink = () => {
+    void navigator.clipboard.writeText(episode.audioUrl);
+  };
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {!episode.downloaded ? (
+        <button
+          onClick={() => download.mutate(episode.id)}
+          disabled={download.isPending}
+          className="px-3 py-1.5 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm text-gray-200 disabled:opacity-50 transition-colors"
+        >
+          {download.isPending ? "Queuing…" : "Download"}
+        </button>
+      ) : (
+        <button
+          onClick={() => deleteDownload.mutate(episode.id)}
+          disabled={deleteDownload.isPending}
+          className="px-3 py-1.5 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm text-gray-200 disabled:opacity-50 transition-colors"
+        >
+          Delete download
+        </button>
+      )}
+
+      {isCompleted ? (
+        <button
+          onClick={() => markUnplayed.mutate(episode.id)}
+          disabled={markUnplayed.isPending}
+          className="px-3 py-1.5 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm text-gray-200 disabled:opacity-50 transition-colors"
+        >
+          Mark unplayed
+        </button>
+      ) : (
+        <button
+          onClick={() => markCompleted.mutate(episode.id)}
+          disabled={markCompleted.isPending}
+          className="px-3 py-1.5 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm text-gray-200 disabled:opacity-50 transition-colors"
+        >
+          Mark played
+        </button>
+      )}
+
+      <button
+        onClick={copyLink}
+        className="px-3 py-1.5 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm text-gray-200 transition-colors"
+      >
+        Copy link
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/components/EpisodeList.tsx
+++ b/desktop/src/features/podcast/components/EpisodeList.tsx
@@ -1,0 +1,24 @@
+/** Virtualized list of episode rows. */
+
+import { Virtuoso } from "react-virtuoso";
+import type { Episode } from "../../../types/media";
+import EpisodeRow from "./EpisodeRow";
+
+interface Props {
+  episodes: Episode[];
+  onPlay: (id: string) => void;
+  onEndReached: () => void;
+}
+
+export default function EpisodeList({ episodes, onPlay, onEndReached }: Props) {
+  return (
+    <Virtuoso
+      style={{ height: "100%" }}
+      data={episodes}
+      endReached={onEndReached}
+      itemContent={(_index, episode) => (
+        <EpisodeRow key={episode.id} episode={episode} onPlay={onPlay} />
+      )}
+    />
+  );
+}

--- a/desktop/src/features/podcast/components/EpisodeRow.tsx
+++ b/desktop/src/features/podcast/components/EpisodeRow.tsx
@@ -1,0 +1,89 @@
+/** Single episode row: title, date, duration, played/downloaded status. */
+
+import type { Episode } from "../../../types/media";
+import DownloadProgress from "./DownloadProgress";
+
+interface Props {
+  episode: Episode;
+  onPlay: (id: string) => void;
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function EpisodeRow({ episode, onPlay }: Props) {
+  const isCompleted = episode.progress?.completed ?? false;
+  const isInProgress = !isCompleted && (episode.progress?.positionMs ?? 0) > 0;
+
+  return (
+    <div
+      className={`flex items-start gap-3 px-4 py-3 border-b border-gray-800 hover:bg-gray-800/50 transition-colors ${
+        isCompleted ? "opacity-60" : ""
+      }`}
+    >
+      <button
+        onClick={() => onPlay(episode.id)}
+        className="flex-shrink-0 w-8 h-8 mt-0.5 rounded-full bg-blue-600 hover:bg-blue-500 flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
+        aria-label={`Play ${episode.title}`}
+      >
+        <span className="text-white text-xs ml-0.5">▶</span>
+      </button>
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-100 truncate">{episode.title}</p>
+        <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-400">
+          <span>{formatDate(episode.publishedAt)}</span>
+          <span>·</span>
+          <span>{formatDuration(episode.durationMs)}</span>
+          {isInProgress && (
+            <>
+              <span>·</span>
+              <span className="text-blue-400">
+                {Math.round(episode.progress!.percentComplete)}%
+              </span>
+            </>
+          )}
+          {isCompleted && (
+            <>
+              <span>·</span>
+              <span className="text-green-500">Played</span>
+            </>
+          )}
+        </div>
+        {isInProgress && episode.progress && (
+          <div className="mt-1.5 h-0.5 bg-gray-700 rounded">
+            <div
+              className="h-0.5 bg-blue-500 rounded"
+              style={{ width: `${episode.progress.percentComplete}%` }}
+            />
+          </div>
+        )}
+      </div>
+
+      {episode.downloaded && (
+        <span
+          className="flex-shrink-0 mt-1 text-xs text-green-500 font-medium"
+          title="Downloaded"
+        >
+          ↓
+        </span>
+      )}
+      {!episode.downloaded && episode.progress === null && (
+        <DownloadProgress episodeId={episode.id} />
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/components/PodcastCard.tsx
+++ b/desktop/src/features/podcast/components/PodcastCard.tsx
@@ -1,0 +1,42 @@
+/** Podcast subscription tile with cover art and unplayed count badge. */
+
+import { useNavigate } from "react-router-dom";
+import type { PodcastSubscription } from "../../../types/media";
+
+interface Props {
+  podcast: PodcastSubscription;
+}
+
+export default function PodcastCard({ podcast }: Props) {
+  const navigate = useNavigate();
+
+  return (
+    <button
+      onClick={() => navigate(`/library/podcasts/${podcast.id}`)}
+      className="group relative w-full text-left rounded-lg overflow-hidden bg-gray-800 hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+    >
+      <div className="aspect-square w-full bg-gray-700 overflow-hidden">
+        {podcast.imageUrl ? (
+          <img
+            src={podcast.imageUrl}
+            alt={podcast.title}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-gray-500 text-3xl">
+            🎙
+          </div>
+        )}
+      </div>
+      <div className="p-2">
+        <p className="text-xs font-medium text-gray-100 truncate">{podcast.title}</p>
+        {podcast.unplayedCount > 0 && (
+          <span className="mt-1 inline-block px-1.5 py-0.5 rounded-full bg-blue-600 text-white text-xs font-semibold">
+            {podcast.unplayedCount}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/desktop/src/features/podcast/components/PodcastGrid.tsx
+++ b/desktop/src/features/podcast/components/PodcastGrid.tsx
@@ -1,0 +1,29 @@
+/** Responsive grid of podcast subscription cards. */
+
+import { useCallback } from "react";
+import { VirtuosoGrid } from "react-virtuoso";
+import type { PodcastSubscription } from "../../../types/media";
+import PodcastCard from "./PodcastCard";
+
+interface Props {
+  subscriptions: PodcastSubscription[];
+  onEndReached: () => void;
+}
+
+export default function PodcastGrid({ subscriptions, onEndReached }: Props) {
+  const endReached = useCallback(() => onEndReached(), [onEndReached]);
+
+  return (
+    <VirtuosoGrid
+      style={{ height: "100%" }}
+      totalCount={subscriptions.length}
+      endReached={endReached}
+      itemContent={(index) => (
+        <div className="p-2">
+          <PodcastCard podcast={subscriptions[index]} />
+        </div>
+      )}
+      listClassName="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+    />
+  );
+}

--- a/desktop/src/features/podcast/components/PodcastNowPlaying.tsx
+++ b/desktop/src/features/podcast/components/PodcastNowPlaying.tsx
@@ -1,0 +1,40 @@
+/** Now-playing bar variant rendered when a podcast episode is active. */
+
+import { usePodcastStore } from "../store";
+import PodcastTransport from "./PodcastTransport";
+import PodcastSpeedControl from "./PodcastSpeedControl";
+
+interface Props {
+  episodeTitle: string;
+  podcastTitle: string;
+}
+
+export default function PodcastNowPlaying({ episodeTitle, podcastTitle }: Props) {
+  const { positionMs, speed } = usePodcastStore();
+
+  function formatPosition(ms: number): string {
+    const s = Math.floor(ms / 1000);
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    const sec = s % 60;
+    if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+    return `${m}:${String(sec).padStart(2, "0")}`;
+  }
+
+  return (
+    <div className="flex items-center gap-4 w-full px-2">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-100 truncate">{episodeTitle}</p>
+        <p className="text-xs text-gray-400 truncate">{podcastTitle}</p>
+      </div>
+
+      <PodcastTransport />
+
+      <div className="flex items-center gap-3 flex-shrink-0">
+        <span className="text-xs text-gray-400 font-mono">{formatPosition(positionMs)}</span>
+        <span className="text-xs font-semibold text-blue-400">{speed.toFixed(1)}×</span>
+        <PodcastSpeedControl />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/components/PodcastSpeedControl.tsx
+++ b/desktop/src/features/podcast/components/PodcastSpeedControl.tsx
@@ -1,0 +1,27 @@
+/** Speed selector with presets and fine-grained control for podcast playback. */
+
+import { usePodcastPlayback } from "../hooks/usePodcastPlayback";
+
+const PRESETS = [1.0, 1.2, 1.5, 2.0];
+
+export default function PodcastSpeedControl() {
+  const { speed, changeSpeed } = usePodcastPlayback();
+
+  return (
+    <div className="flex items-center gap-1">
+      {PRESETS.map((preset) => (
+        <button
+          key={preset}
+          onClick={() => void changeSpeed(preset)}
+          className={`px-2 py-1 rounded text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+            Math.abs(speed - preset) < 0.01
+              ? "bg-blue-600 text-white"
+              : "text-gray-400 hover:text-gray-100 hover:bg-gray-700"
+          }`}
+        >
+          {preset}×
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/components/PodcastTransport.tsx
+++ b/desktop/src/features/podcast/components/PodcastTransport.tsx
@@ -1,0 +1,55 @@
+/** Podcast-specific playback controls: skip 15s back, play/pause, skip 30s forward. */
+
+import { usePodcastPlayback } from "../hooks/usePodcastPlayback";
+import { usePodcastStore } from "../store";
+
+export default function PodcastTransport() {
+  const { isPlaying, currentEpisodeId, pause, resumeEpisode, skipForward, skipBackward } =
+    usePodcastPlayback();
+  const positionMs = usePodcastStore((s) => s.positionMs);
+
+  const disabled = !currentEpisodeId;
+
+  const handlePlayPause = () => {
+    if (isPlaying) {
+      void pause();
+    } else if (currentEpisodeId) {
+      void resumeEpisode(currentEpisodeId, positionMs);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => void skipBackward()}
+        disabled={disabled}
+        className="flex flex-col items-center px-2 py-1 rounded text-gray-400 hover:text-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+        aria-label="Skip backward 15 seconds"
+        title="← 15s"
+      >
+        <span className="text-lg leading-none">↩</span>
+        <span className="text-[10px] font-medium">15s</span>
+      </button>
+
+      <button
+        onClick={handlePlayPause}
+        disabled={disabled}
+        className="w-10 h-10 rounded-full bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
+        aria-label={isPlaying ? "Pause" : "Play"}
+      >
+        <span className="text-white text-sm">{isPlaying ? "⏸" : "▶"}</span>
+      </button>
+
+      <button
+        onClick={() => void skipForward()}
+        disabled={disabled}
+        className="flex flex-col items-center px-2 py-1 rounded text-gray-400 hover:text-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+        aria-label="Skip forward 30 seconds"
+        title="30s →"
+      >
+        <span className="text-lg leading-none">↪</span>
+        <span className="text-[10px] font-medium">30s</span>
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/components/ShowNotesPanel.tsx
+++ b/desktop/src/features/podcast/components/ShowNotesPanel.tsx
@@ -1,0 +1,73 @@
+/** Sanitized HTML show notes renderer. Links open in system browser. */
+
+import { useEffect, useRef, useMemo } from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+interface Props {
+  html: string | null;
+}
+
+const DANGEROUS_TAGS = ["script", "iframe", "form", "object", "embed", "meta", "link", "base"];
+
+function sanitizeHtml(dirty: string): string {
+  const doc = new DOMParser().parseFromString(dirty, "text/html");
+
+  DANGEROUS_TAGS.forEach((tag) => {
+    doc.querySelectorAll(tag).forEach((el) => el.remove());
+  });
+
+  doc.querySelectorAll("*").forEach((el) => {
+    Array.from(el.attributes).forEach((attr) => {
+      const name = attr.name.toLowerCase();
+      const value = attr.value.toLowerCase().trimStart();
+      if (
+        name.startsWith("on") ||
+        (name === "href" && value.startsWith("javascript:")) ||
+        (name === "src" && value.startsWith("javascript:")) ||
+        name === "srcdoc"
+      ) {
+        el.removeAttribute(attr.name);
+      }
+    });
+  });
+
+  return doc.body.innerHTML;
+}
+
+export default function ShowNotesPanel({ html }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sanitized = useMemo(() => (html ? sanitizeHtml(html) : null), [html]);
+
+  // Intercept all link clicks and open in system browser.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handler = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const anchor = target.closest("a");
+      if (!anchor) return;
+      const href = anchor.getAttribute("href");
+      if (!href) return;
+      e.preventDefault();
+      void openUrl(href);
+    };
+
+    container.addEventListener("click", handler);
+    return () => container.removeEventListener("click", handler);
+  }, [sanitized]);
+
+  if (!sanitized) {
+    return <p className="text-sm text-gray-500 italic">No show notes available.</p>;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="prose prose-invert prose-sm max-w-none text-gray-300"
+      // WHY: dangerouslySetInnerHTML is safe here because sanitizeHtml strips all
+      // script tags, event handlers, and javascript: URLs before rendering.
+      dangerouslySetInnerHTML={{ __html: sanitized }}
+    />
+  );
+}

--- a/desktop/src/features/podcast/components/SubscribeDialog.tsx
+++ b/desktop/src/features/podcast/components/SubscribeDialog.tsx
@@ -1,0 +1,92 @@
+/** RSS feed URL input dialog for adding a new podcast subscription. */
+
+import { useState } from "react";
+import { useSubscribe } from "../hooks/useSubscriptions";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export default function SubscribeDialog({ open, onClose }: Props) {
+  const [feedUrl, setFeedUrl] = useState("");
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const subscribe = useSubscribe();
+
+  if (!open) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setUrlError(null);
+
+    if (!isValidUrl(feedUrl)) {
+      setUrlError("Enter a valid http:// or https:// URL.");
+      return;
+    }
+
+    subscribe.mutate(feedUrl, {
+      onSuccess: () => {
+        setFeedUrl("");
+        onClose();
+      },
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="subscribe-dialog-title"
+    >
+      <div className="bg-gray-900 rounded-xl shadow-2xl w-full max-w-md mx-4 p-6">
+        <h2 id="subscribe-dialog-title" className="text-lg font-semibold text-gray-100 mb-4">
+          Subscribe to Podcast
+        </h2>
+        <form onSubmit={handleSubmit} noValidate>
+          <label htmlFor="feed-url" className="block text-sm text-gray-400 mb-1">
+            RSS feed URL
+          </label>
+          <input
+            id="feed-url"
+            type="url"
+            value={feedUrl}
+            onChange={(e) => setFeedUrl(e.target.value)}
+            placeholder="https://example.com/feed.xml"
+            className="w-full px-3 py-2 rounded-lg bg-gray-800 border border-gray-700 text-gray-100 placeholder-gray-500 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            autoFocus
+          />
+          {urlError && <p className="mt-1 text-xs text-red-400">{urlError}</p>}
+          {subscribe.isError && (
+            <p className="mt-1 text-xs text-red-400">Failed to subscribe. Check the URL and try again.</p>
+          )}
+          <div className="flex justify-end gap-3 mt-5">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg text-sm text-gray-400 hover:text-gray-200 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={subscribe.isPending || feedUrl.length === 0}
+              className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors"
+            >
+              {subscribe.isPending ? "Subscribing…" : "Subscribe"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/hooks/useDownloadQueue.ts
+++ b/desktop/src/features/podcast/hooks/useDownloadQueue.ts
@@ -1,0 +1,51 @@
+/** TanStack Query hooks for podcast download queue management. */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+const QUEUE_POLL_INTERVAL_MS = 5_000;
+
+export function useDownloadQueue() {
+  const token = useLibraryStore((s) => s.token);
+  return useQuery({
+    queryKey: ["podcasts", "downloads", token],
+    queryFn: () => api.getDownloadQueue(token),
+    enabled: token.length > 0,
+    // WHY: Poll while downloads are active to show live progress.
+    refetchInterval: QUEUE_POLL_INTERVAL_MS,
+  });
+}
+
+export function useDownloadEpisode() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (episodeId: string) => api.downloadEpisode(episodeId, token),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ["podcasts", "downloads"] });
+    },
+  });
+}
+
+export function useCancelDownload() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (episodeId: string) => api.cancelDownload(episodeId, token),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ["podcasts", "downloads"] });
+    },
+  });
+}
+
+export function useDeleteDownload() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (episodeId: string) => api.deleteDownload(episodeId, token),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ["podcasts", "episodes"] });
+    },
+  });
+}

--- a/desktop/src/features/podcast/hooks/useEpisodeProgress.ts
+++ b/desktop/src/features/podcast/hooks/useEpisodeProgress.ts
@@ -1,0 +1,47 @@
+/** Tracks per-episode playback position and syncs to the server. */
+
+import { useEffect, useRef } from "react";
+import { useLibraryStore } from "../../library/store";
+import { usePodcastStore } from "../store";
+import { api } from "../../../api/client";
+
+const SYNC_INTERVAL_MS = 30_000;
+// WHY: 95% matches industry convention for marking podcasts auto-complete.
+const COMPLETION_THRESHOLD = 0.95;
+
+export function useEpisodeProgress(episodeId: string | null, durationMs: number) {
+  const token = useLibraryStore((s) => s.token);
+  const isPlaying = usePodcastStore((s) => s.isPlaying);
+  const positionMs = usePodcastStore((s) => s.positionMs);
+  const positionRef = useRef(positionMs);
+
+  // Keep ref current so the sync interval always uses the latest position.
+  useEffect(() => {
+    positionRef.current = positionMs;
+  });
+
+  // Periodic server sync during playback.
+  useEffect(() => {
+    if (!episodeId || !isPlaying || !token) return;
+
+    const id = setInterval(() => {
+      void api.updateEpisodeProgress(episodeId, { positionMs: positionRef.current }, token);
+    }, SYNC_INTERVAL_MS);
+
+    return () => clearInterval(id);
+  }, [episodeId, isPlaying, token]);
+
+  // Sync immediately on pause.
+  useEffect(() => {
+    if (!episodeId || isPlaying || !token || positionMs === 0) return;
+    void api.updateEpisodeProgress(episodeId, { positionMs }, token);
+  }, [episodeId, isPlaying, positionMs, token]);
+
+  // Auto-complete at 95% of episode duration.
+  useEffect(() => {
+    if (!episodeId || !token || durationMs === 0) return;
+    if (positionMs / durationMs >= COMPLETION_THRESHOLD) {
+      void api.markEpisodeCompleted(episodeId, token);
+    }
+  }, [episodeId, positionMs, durationMs, token]);
+}

--- a/desktop/src/features/podcast/hooks/useEpisodes.ts
+++ b/desktop/src/features/podcast/hooks/useEpisodes.ts
@@ -1,0 +1,49 @@
+/** TanStack Query hooks for episode listing and mutations. */
+
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+import type { EpisodeQueryParams } from "../../../types/media";
+
+const PAGE_SIZE = 50;
+
+export function useEpisodes(podcastId: string, filter: EpisodeQueryParams["filter"] = "all") {
+  const token = useLibraryStore((s) => s.token);
+  return useInfiniteQuery({
+    queryKey: ["podcasts", "episodes", podcastId, filter, token],
+    queryFn: ({ pageParam }) =>
+      api.getEpisodes(
+        podcastId,
+        { page: pageParam as number, pageSize: PAGE_SIZE, filter },
+        token,
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.data.length < PAGE_SIZE) return undefined;
+      return (lastPage.meta?.page ?? 1) + 1;
+    },
+    enabled: token.length > 0 && podcastId.length > 0,
+  });
+}
+
+export function useMarkEpisodeCompleted() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (episodeId: string) => api.markEpisodeCompleted(episodeId, token),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ["podcasts", "episodes"] });
+    },
+  });
+}
+
+export function useMarkEpisodeUnplayed() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (episodeId: string) => api.markEpisodeUnplayed(episodeId, token),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ["podcasts", "episodes"] });
+    },
+  });
+}

--- a/desktop/src/features/podcast/hooks/useLatestEpisodes.ts
+++ b/desktop/src/features/podcast/hooks/useLatestEpisodes.ts
@@ -1,0 +1,26 @@
+/** TanStack Query hook for the cross-podcast latest episodes feed. */
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+const PAGE_SIZE = 50;
+const DEFAULT_HOURS_BACK = 168; // 1 week
+
+export function useLatestEpisodes(hoursBack: number = DEFAULT_HOURS_BACK) {
+  const token = useLibraryStore((s) => s.token);
+  return useInfiniteQuery({
+    queryKey: ["podcasts", "latest", hoursBack, token],
+    queryFn: ({ pageParam }) =>
+      api.getLatestEpisodes(
+        { page: pageParam as number, pageSize: PAGE_SIZE, hoursBack },
+        token,
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.data.length < PAGE_SIZE) return undefined;
+      return (lastPage.meta?.page ?? 1) + 1;
+    },
+    enabled: token.length > 0,
+  });
+}

--- a/desktop/src/features/podcast/hooks/usePodcast.ts
+++ b/desktop/src/features/podcast/hooks/usePodcast.ts
@@ -1,0 +1,14 @@
+/** TanStack Query hook for a single podcast's metadata. */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+export function usePodcast(podcastId: string) {
+  const token = useLibraryStore((s) => s.token);
+  return useQuery({
+    queryKey: ["podcasts", "subscription", podcastId, token],
+    queryFn: () => api.getSubscriptions(token).then((subs) => subs.find((s) => s.id === podcastId)),
+    enabled: token.length > 0 && podcastId.length > 0,
+  });
+}

--- a/desktop/src/features/podcast/hooks/usePodcastPlayback.ts
+++ b/desktop/src/features/podcast/hooks/usePodcastPlayback.ts
@@ -1,0 +1,120 @@
+/** Tauri IPC commands for podcast playback plus keyboard shortcuts. */
+
+import { useCallback, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { usePodcastStore } from "../store";
+import { useLibraryStore } from "../../library/store";
+import { api } from "../../../api/client";
+
+const SKIP_FORWARD_SECONDS = 30;
+const SKIP_BACKWARD_SECONDS = 15;
+const SPEED_STEP = 0.1;
+const MIN_SPEED = 0.5;
+const MAX_SPEED = 3.0;
+
+export function usePodcastPlayback() {
+  const token = useLibraryStore((s) => s.token);
+  const { speed, currentEpisodeId, isPlaying, setSpeed, setCurrentEpisodeId, setIsPlaying } =
+    usePodcastStore();
+
+  const playEpisode = useCallback(
+    async (episodeId: string) => {
+      await invoke("podcast_play_episode", { episodeId });
+      setCurrentEpisodeId(episodeId);
+      setIsPlaying(true);
+    },
+    [setCurrentEpisodeId, setIsPlaying],
+  );
+
+  const resumeEpisode = useCallback(
+    async (episodeId: string, positionMs: number) => {
+      await invoke("podcast_resume_episode", { episodeId, positionMs });
+      setCurrentEpisodeId(episodeId);
+      setIsPlaying(true);
+    },
+    [setCurrentEpisodeId, setIsPlaying],
+  );
+
+  const pause = useCallback(async () => {
+    if (!currentEpisodeId) return;
+    // WHY: P3-11 audio engine integration point — pause is a no-op until then.
+    setIsPlaying(false);
+    if (currentEpisodeId && token) {
+      const pos = usePodcastStore.getState().positionMs;
+      void api.updateEpisodeProgress(currentEpisodeId, { positionMs: pos }, token);
+    }
+  }, [currentEpisodeId, setIsPlaying, token]);
+
+  const skipForward = useCallback(async () => {
+    await invoke("podcast_skip_forward", { seconds: SKIP_FORWARD_SECONDS });
+  }, []);
+
+  const skipBackward = useCallback(async () => {
+    await invoke("podcast_skip_backward", { seconds: SKIP_BACKWARD_SECONDS });
+  }, []);
+
+  const changeSpeed = useCallback(
+    async (newSpeed: number) => {
+      const clamped = Math.min(MAX_SPEED, Math.max(MIN_SPEED, newSpeed));
+      await invoke("podcast_set_speed", { speed: clamped });
+      setSpeed(clamped);
+    },
+    [setSpeed],
+  );
+
+  // Keyboard shortcuts active whenever an episode is loaded.
+  useEffect(() => {
+    if (!currentEpisodeId) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const active = document.activeElement;
+      if (
+        active instanceof HTMLInputElement ||
+        active instanceof HTMLTextAreaElement ||
+        active instanceof HTMLSelectElement
+      ) {
+        return;
+      }
+
+      switch (e.key) {
+        case " ":
+          e.preventDefault();
+          if (isPlaying) {
+            void pause();
+          } else if (currentEpisodeId) {
+            void resumeEpisode(currentEpisodeId, usePodcastStore.getState().positionMs);
+          }
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          void skipForward();
+          break;
+        case "ArrowLeft":
+          e.preventDefault();
+          void skipBackward();
+          break;
+        case "]":
+          void changeSpeed(speed + SPEED_STEP);
+          break;
+        case "[":
+          void changeSpeed(speed - SPEED_STEP);
+          break;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [currentEpisodeId, isPlaying, speed, pause, resumeEpisode, skipForward, skipBackward, changeSpeed]);
+
+  return {
+    currentEpisodeId,
+    isPlaying,
+    speed,
+    playEpisode,
+    resumeEpisode,
+    pause,
+    skipForward,
+    skipBackward,
+    changeSpeed,
+  };
+}

--- a/desktop/src/features/podcast/hooks/useSubscriptions.ts
+++ b/desktop/src/features/podcast/hooks/useSubscriptions.ts
@@ -1,0 +1,75 @@
+/** TanStack Query hooks for podcast subscription management. */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+export function useSubscriptions() {
+  const token = useLibraryStore((s) => s.token);
+  return useQuery({
+    queryKey: ["podcasts", "subscriptions", token],
+    queryFn: () => api.getSubscriptions(token),
+    enabled: token.length > 0,
+  });
+}
+
+export function useSubscribe() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (feedUrl: string) => api.subscribe(feedUrl, token),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ["podcasts", "subscriptions"] });
+    },
+  });
+}
+
+export function useUnsubscribe() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (podcastId: string) => api.unsubscribe(podcastId, token),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ["podcasts", "subscriptions"] });
+    },
+  });
+}
+
+export function useRefreshFeed() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (podcastId: string) => api.refreshFeed(podcastId, token),
+    onSuccess: (_data, podcastId) => {
+      void client.invalidateQueries({ queryKey: ["podcasts", "episodes", podcastId] });
+    },
+  });
+}
+
+export function useRefreshAllFeeds() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.refreshAllFeeds(token),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ["podcasts"] });
+    },
+  });
+}
+
+export function useUpdateSubscription() {
+  const token = useLibraryStore((s) => s.token);
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      podcastId,
+      settings,
+    }: {
+      podcastId: string;
+      settings: { autoDownload?: boolean; refreshIntervalMinutes?: number };
+    }) => api.updateSubscription(podcastId, settings, token),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ["podcasts", "subscriptions"] });
+    },
+  });
+}

--- a/desktop/src/features/podcast/pages/DownloadQueuePage.tsx
+++ b/desktop/src/features/podcast/pages/DownloadQueuePage.tsx
@@ -1,0 +1,91 @@
+/** Download queue: status and progress for all podcast episode downloads. */
+
+import { useDownloadQueue, useCancelDownload } from "../hooks/useDownloadQueue";
+import { useLibraryStore } from "../../library/store";
+import type { EpisodeDownload } from "../../../types/media";
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+      {message}
+    </div>
+  );
+}
+
+function statusLabel(status: EpisodeDownload["status"]): string {
+  switch (status) {
+    case "queued": return "Queued";
+    case "downloading": return "Downloading";
+    case "completed": return "Complete";
+    case "failed": return "Failed";
+  }
+}
+
+function statusColor(status: EpisodeDownload["status"]): string {
+  switch (status) {
+    case "queued": return "text-gray-400";
+    case "downloading": return "text-blue-400";
+    case "completed": return "text-green-500";
+    case "failed": return "text-red-400";
+  }
+}
+
+export default function DownloadQueuePage() {
+  const token = useLibraryStore((s) => s.token);
+  const { data: queue, isLoading, isError } = useDownloadQueue();
+  const cancel = useCancelDownload();
+
+  if (!token) return <EmptyState message="Set an API token in Settings." />;
+  if (isLoading) return <EmptyState message="Loading…" />;
+  if (isError) return <EmptyState message="Failed to load download queue." />;
+  if (!queue || queue.length === 0) return <EmptyState message="No downloads in queue." />;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 py-3 border-b border-gray-800 flex-shrink-0">
+        <h1 className="text-sm font-semibold text-gray-100">Downloads</h1>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {queue.map((entry) => (
+          <div
+            key={entry.episodeId}
+            className="flex items-center gap-3 px-4 py-3 border-b border-gray-800"
+          >
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-100 truncate">{entry.episodeTitle}</p>
+              <p className="text-xs text-gray-500 truncate">{entry.podcastTitle}</p>
+            </div>
+
+            <div className="flex-shrink-0 flex items-center gap-3">
+              {entry.status === "downloading" && (
+                <div className="w-24">
+                  <div className="h-1 bg-gray-700 rounded">
+                    <div
+                      className="h-1 bg-blue-500 rounded transition-all"
+                      style={{ width: `${entry.progressPercent}%` }}
+                    />
+                  </div>
+                  <p className="text-xs text-gray-500 mt-0.5 text-right">
+                    {Math.round(entry.progressPercent)}%
+                  </p>
+                </div>
+              )}
+              <span className={`text-xs font-medium ${statusColor(entry.status)}`}>
+                {statusLabel(entry.status)}
+              </span>
+              {(entry.status === "queued" || entry.status === "downloading") && (
+                <button
+                  onClick={() => cancel.mutate(entry.episodeId)}
+                  disabled={cancel.isPending}
+                  className="text-xs text-gray-400 hover:text-gray-200 disabled:opacity-50 transition-colors"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/pages/EpisodeDetailPage.tsx
+++ b/desktop/src/features/podcast/pages/EpisodeDetailPage.tsx
@@ -1,0 +1,107 @@
+/** Single episode: metadata, play/resume, show notes, and actions. */
+
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+import { usePodcastPlayback } from "../hooks/usePodcastPlayback";
+import { useEpisodeProgress } from "../hooks/useEpisodeProgress";
+import ShowNotesPanel from "../components/ShowNotesPanel";
+import EpisodeActions from "../components/EpisodeActions";
+
+function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1_000_000) return `${Math.round(bytes / 1_000)} KB`;
+  return `${(bytes / 1_000_000).toFixed(1)} MB`;
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+      {message}
+    </div>
+  );
+}
+
+export default function EpisodeDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const episodeId = id ?? "";
+  const token = useLibraryStore((s) => s.token);
+
+  const { data: episode, isLoading, isError } = useQuery({
+    queryKey: ["podcasts", "episode", episodeId, token],
+    queryFn: () => api.getEpisode(episodeId, token),
+    enabled: token.length > 0 && episodeId.length > 0,
+  });
+
+  const { playEpisode, resumeEpisode } = usePodcastPlayback();
+
+  // Register progress tracking for this episode.
+  useEpisodeProgress(episode?.id ?? null, episode?.durationMs ?? 0);
+
+  if (isLoading) return <EmptyState message="Loading…" />;
+  if (isError || !episode) return <EmptyState message="Episode not found." />;
+
+  const resumePosition = episode.progress?.positionMs ?? 0;
+  const isInProgress = resumePosition > 0 && !episode.progress?.completed;
+
+  const handlePlay = () => {
+    if (isInProgress) {
+      void resumeEpisode(episode.id, resumePosition);
+    } else {
+      void playEpisode(episode.id);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      <div className="px-6 py-6 max-w-3xl">
+        <h1 className="text-xl font-semibold text-gray-100">{episode.title}</h1>
+        <p className="text-sm text-gray-400 mt-1">{episode.podcastTitle}</p>
+
+        {/* Metadata */}
+        <div className="flex items-center gap-3 mt-2 text-xs text-gray-500">
+          <span>{new Date(episode.publishedAt).toLocaleDateString()}</span>
+          <span>·</span>
+          <span>{formatDuration(episode.durationMs)}</span>
+          {episode.fileSize !== null && (
+            <>
+              <span>·</span>
+              <span>{formatBytes(episode.fileSize)}</span>
+            </>
+          )}
+          <span>·</span>
+          <span>{episode.enclosureType}</span>
+        </div>
+
+        {/* Play / Resume button */}
+        <button
+          onClick={handlePlay}
+          className="mt-5 px-6 py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-white font-semibold text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
+        >
+          {isInProgress
+            ? `Resume from ${Math.round(episode.progress!.percentComplete)}%`
+            : "Play episode"}
+        </button>
+
+        {/* Actions */}
+        <div className="mt-4">
+          <EpisodeActions episode={episode} />
+        </div>
+
+        {/* Show notes */}
+        <div className="mt-8">
+          <h2 className="text-sm font-semibold text-gray-300 mb-3">Show notes</h2>
+          <ShowNotesPanel html={episode.showNotes} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/pages/LatestEpisodesPage.tsx
+++ b/desktop/src/features/podcast/pages/LatestEpisodesPage.tsx
@@ -1,0 +1,122 @@
+/** Cross-podcast latest episodes feed, grouped by date. */
+
+import { useMemo, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useLatestEpisodes } from "../hooks/useLatestEpisodes";
+import { usePodcastPlayback } from "../hooks/usePodcastPlayback";
+import { useLibraryStore } from "../../library/store";
+import { Virtuoso } from "react-virtuoso";
+import type { Episode } from "../../../types/media";
+
+function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function dayLabel(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diff = Math.floor((now.getTime() - date.getTime()) / 86_400_000);
+  if (diff === 0) return "Today";
+  if (diff === 1) return "Yesterday";
+  if (diff < 7) return "This Week";
+  return "Older";
+}
+
+type Row = { type: "header"; label: string } | { type: "episode"; episode: Episode };
+
+function groupEpisodes(episodes: Episode[]): Row[] {
+  const rows: Row[] = [];
+  let lastLabel = "";
+  for (const ep of episodes) {
+    const label = dayLabel(ep.publishedAt);
+    if (label !== lastLabel) {
+      rows.push({ type: "header", label });
+      lastLabel = label;
+    }
+    rows.push({ type: "episode", episode: ep });
+  }
+  return rows;
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+      {message}
+    </div>
+  );
+}
+
+export default function LatestEpisodesPage() {
+  const token = useLibraryStore((s) => s.token);
+  const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useLatestEpisodes();
+  const { playEpisode } = usePodcastPlayback();
+  const navigate = useNavigate();
+
+  const episodes = useMemo(() => data?.pages.flatMap((p) => p.data) ?? [], [data]);
+  const rows = useMemo(() => groupEpisodes(episodes), [episodes]);
+
+  const endReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  if (!token) return <EmptyState message="Set an API token in Settings to browse podcasts." />;
+  if (isLoading) return <EmptyState message="Loading…" />;
+  if (isError) return <EmptyState message="Failed to load latest episodes." />;
+  if (rows.length === 0) return <EmptyState message="No recent episodes found." />;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 py-3 border-b border-gray-800 flex-shrink-0">
+        <h1 className="text-sm font-semibold text-gray-100">Latest Episodes</h1>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        <Virtuoso
+          style={{ height: "100%" }}
+          data={rows}
+          endReached={endReached}
+          itemContent={(_index, row) => {
+            if (row.type === "header") {
+              return (
+                <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-900/80">
+                  {row.label}
+                </div>
+              );
+            }
+            const ep = row.episode;
+            return (
+              <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-800 hover:bg-gray-800/50 transition-colors">
+                <button
+                  onClick={() => void playEpisode(ep.id)}
+                  className="flex-shrink-0 w-7 h-7 rounded-full bg-blue-600 hover:bg-blue-500 flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  aria-label={`Play ${ep.title}`}
+                >
+                  <span className="text-white text-[10px] ml-0.5">▶</span>
+                </button>
+                <div className="flex-1 min-w-0">
+                  <button
+                    onClick={() => navigate(`/library/podcasts/episodes/${ep.id}`)}
+                    className="text-sm font-medium text-gray-100 truncate block text-left hover:underline w-full"
+                  >
+                    {ep.title}
+                  </button>
+                  <p className="text-xs text-gray-500 truncate">{ep.podcastTitle}</p>
+                </div>
+                <span className="flex-shrink-0 text-xs text-gray-500">
+                  {formatDuration(ep.durationMs)}
+                </span>
+                {ep.progress?.completed && (
+                  <span className="flex-shrink-0 text-xs text-green-500">Played</span>
+                )}
+              </div>
+            );
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/pages/PodcastDetailPage.tsx
+++ b/desktop/src/features/podcast/pages/PodcastDetailPage.tsx
@@ -1,0 +1,178 @@
+/** Single podcast: header, subscription controls, filtered episode list. */
+
+import { useState, useMemo, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { usePodcast } from "../hooks/usePodcast";
+import { useEpisodes, useMarkEpisodeCompleted } from "../hooks/useEpisodes";
+import { useUnsubscribe, useUpdateSubscription } from "../hooks/useSubscriptions";
+import { usePodcastPlayback } from "../hooks/usePodcastPlayback";
+import EpisodeList from "../components/EpisodeList";
+import type { EpisodeQueryParams } from "../../../types/media";
+
+const REFRESH_INTERVALS = [15, 30, 60, 120, 360, 720, 1440] as const;
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+      {message}
+    </div>
+  );
+}
+
+export default function PodcastDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const podcastId = id ?? "";
+
+  const { data: podcast, isLoading, isError } = usePodcast(podcastId);
+  const [filter, setFilter] = useState<EpisodeQueryParams["filter"]>("all");
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useEpisodes(podcastId, filter);
+  const unsubscribe = useUnsubscribe();
+  const updateSubscription = useUpdateSubscription();
+  const markAllPlayed = useMarkEpisodeCompleted();
+  const { playEpisode, resumeEpisode } = usePodcastPlayback();
+
+  const episodes = useMemo(() => data?.pages.flatMap((p) => p.data) ?? [], [data]);
+
+  const endReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const handlePlay = useCallback(
+    (episodeId: string) => {
+      const ep = episodes.find((e) => e.id === episodeId);
+      if (!ep) return;
+      const pos = ep.progress?.positionMs ?? 0;
+      if (pos > 0) {
+        void resumeEpisode(episodeId, pos);
+      } else {
+        void playEpisode(episodeId);
+      }
+    },
+    [episodes, playEpisode, resumeEpisode],
+  );
+
+  const handleUnsubscribe = () => {
+    unsubscribe.mutate(podcastId, {
+      onSuccess: () => navigate("/library/podcasts"),
+    });
+  };
+
+  const handleAutoDownloadToggle = () => {
+    if (!podcast) return;
+    updateSubscription.mutate({
+      podcastId,
+      settings: { autoDownload: !podcast.autoDownload },
+    });
+  };
+
+  const handleRefreshIntervalChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    updateSubscription.mutate({
+      podcastId,
+      settings: { refreshIntervalMinutes: Number(e.target.value) },
+    });
+  };
+
+  if (isLoading) return <EmptyState message="Loading…" />;
+  if (isError || !podcast) return <EmptyState message="Podcast not found." />;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-start gap-4 px-6 py-5 border-b border-gray-800 flex-shrink-0">
+        <div className="w-24 h-24 rounded-lg overflow-hidden bg-gray-700 flex-shrink-0">
+          {podcast.imageUrl ? (
+            <img src={podcast.imageUrl} alt={podcast.title} className="w-full h-full object-cover" />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-4xl">🎙</div>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <h1 className="text-lg font-semibold text-gray-100">{podcast.title}</h1>
+          {podcast.author && <p className="text-sm text-gray-400 mt-0.5">{podcast.author}</p>}
+          {podcast.description && (
+            <p className="text-xs text-gray-500 mt-2 line-clamp-2">{podcast.description}</p>
+          )}
+          <div className="flex items-center gap-3 mt-3 flex-wrap">
+            <button
+              onClick={handleUnsubscribe}
+              disabled={unsubscribe.isPending}
+              className="px-3 py-1.5 rounded-lg text-xs text-gray-300 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors"
+            >
+              Unsubscribe
+            </button>
+            <button
+              onClick={() => {
+                episodes.forEach((ep) => {
+                  if (!ep.progress?.completed) markAllPlayed.mutate(ep.id);
+                });
+              }}
+              className="px-3 py-1.5 rounded-lg text-xs text-gray-300 bg-gray-800 hover:bg-gray-700 transition-colors"
+            >
+              Mark all played
+            </button>
+          </div>
+
+          {/* Subscription settings */}
+          <div className="flex items-center gap-4 mt-3 flex-wrap">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={podcast.autoDownload}
+                onChange={handleAutoDownloadToggle}
+                disabled={updateSubscription.isPending}
+                className="rounded accent-blue-500"
+              />
+              <span className="text-xs text-gray-400">Auto-download</span>
+            </label>
+
+            <div className="flex items-center gap-1.5">
+              <label htmlFor="refresh-interval" className="text-xs text-gray-400">
+                Refresh every
+              </label>
+              <select
+                id="refresh-interval"
+                value={podcast.refreshIntervalMinutes}
+                onChange={handleRefreshIntervalChange}
+                disabled={updateSubscription.isPending}
+                className="text-xs bg-gray-800 text-gray-300 border border-gray-700 rounded px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                {REFRESH_INTERVALS.map((m) => (
+                  <option key={m} value={m}>
+                    {m < 60 ? `${m}m` : `${m / 60}h`}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-800 flex-shrink-0">
+        {(["all", "unplayed", "in_progress", "completed", "downloaded"] as const).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+              filter === f
+                ? "bg-blue-600 text-white"
+                : "text-gray-400 hover:text-gray-200 hover:bg-gray-800"
+            }`}
+          >
+            {f === "in_progress" ? "In progress" : f.charAt(0).toUpperCase() + f.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {/* Episode list */}
+      <div className="flex-1 overflow-hidden">
+        {episodes.length === 0 ? (
+          <EmptyState message="No episodes found for this filter." />
+        ) : (
+          <EpisodeList episodes={episodes} onPlay={handlePlay} onEndReached={endReached} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/pages/PodcastsPage.tsx
+++ b/desktop/src/features/podcast/pages/PodcastsPage.tsx
@@ -1,0 +1,114 @@
+/** Podcast subscriptions grid with subscribe, refresh, sort, and filter controls. */
+
+import { useState, useMemo } from "react";
+import { useSubscriptions, useRefreshAllFeeds } from "../hooks/useSubscriptions";
+import { useLibraryStore } from "../../library/store";
+import PodcastGrid from "../components/PodcastGrid";
+import SubscribeDialog from "../components/SubscribeDialog";
+import type { PodcastSubscription } from "../../../types/media";
+
+type SortOption = "title" | "recent" | "unplayed";
+type FilterOption = "all" | "unplayed" | "recent";
+
+function sortSubscriptions(subs: PodcastSubscription[], sort: SortOption): PodcastSubscription[] {
+  return [...subs].sort((a, b) => {
+    if (sort === "unplayed") return b.unplayedCount - a.unplayedCount;
+    if (sort === "recent") {
+      const dateA = a.lastEpisodeDate ?? "";
+      const dateB = b.lastEpisodeDate ?? "";
+      return dateB.localeCompare(dateA);
+    }
+    return a.title.localeCompare(b.title);
+  });
+}
+
+function filterSubscriptions(
+  subs: PodcastSubscription[],
+  filter: FilterOption,
+): PodcastSubscription[] {
+  if (filter === "unplayed") return subs.filter((s) => s.unplayedCount > 0);
+  if (filter === "recent") {
+    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    return subs.filter((s) => (s.lastEpisodeDate ?? "") >= oneWeekAgo);
+  }
+  return subs;
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+      {message}
+    </div>
+  );
+}
+
+export default function PodcastsPage() {
+  const token = useLibraryStore((s) => s.token);
+  const { data: subscriptions, isLoading, isError } = useSubscriptions();
+  const refreshAll = useRefreshAllFeeds();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [sort, setSort] = useState<SortOption>("title");
+  const [filter, setFilter] = useState<FilterOption>("all");
+
+  const displayed = useMemo(() => {
+    const filtered = filterSubscriptions(subscriptions ?? [], filter);
+    return sortSubscriptions(filtered, sort);
+  }, [subscriptions, sort, filter]);
+
+  if (!token) return <EmptyState message="Set an API token in Settings to browse podcasts." />;
+  if (isLoading) return <EmptyState message="Loading…" />;
+  if (isError) return <EmptyState message="Failed to load subscriptions." />;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-800 flex-shrink-0">
+        <h1 className="text-sm font-semibold text-gray-100 mr-auto">Podcasts</h1>
+
+        <select
+          value={filter}
+          onChange={(e) => setFilter(e.target.value as FilterOption)}
+          className="text-xs bg-gray-800 text-gray-300 border border-gray-700 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="all">All</option>
+          <option value="unplayed">Has Unplayed</option>
+          <option value="recent">Recently Updated</option>
+        </select>
+
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as SortOption)}
+          className="text-xs bg-gray-800 text-gray-300 border border-gray-700 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="title">Title</option>
+          <option value="recent">Most Recent Episode</option>
+          <option value="unplayed">Unplayed Count</option>
+        </select>
+
+        <button
+          onClick={() => refreshAll.mutate()}
+          disabled={refreshAll.isPending}
+          className="px-3 py-1.5 rounded-lg text-xs text-gray-300 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors"
+        >
+          {refreshAll.isPending ? "Refreshing…" : "Refresh all"}
+        </button>
+
+        <button
+          onClick={() => setDialogOpen(true)}
+          className="px-3 py-1.5 rounded-lg text-xs text-white bg-blue-600 hover:bg-blue-500 transition-colors"
+        >
+          + Subscribe
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-hidden">
+        {displayed.length === 0 ? (
+          <EmptyState message="No subscriptions found. Subscribe to a podcast to get started." />
+        ) : (
+          <PodcastGrid subscriptions={displayed} onEndReached={() => {}} />
+        )}
+      </div>
+
+      <SubscribeDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
+    </div>
+  );
+}

--- a/desktop/src/features/podcast/store.ts
+++ b/desktop/src/features/podcast/store.ts
@@ -1,0 +1,35 @@
+/** Global podcast playback state: speed preference and currently playing episode. */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface PodcastState {
+  speed: number;
+  currentEpisodeId: string | null;
+  isPlaying: boolean;
+  positionMs: number;
+  setSpeed: (speed: number) => void;
+  setCurrentEpisodeId: (id: string | null) => void;
+  setIsPlaying: (playing: boolean) => void;
+  setPositionMs: (ms: number) => void;
+}
+
+export const usePodcastStore = create<PodcastState>()(
+  persist(
+    (set) => ({
+      speed: 1.0,
+      currentEpisodeId: null,
+      isPlaying: false,
+      positionMs: 0,
+      setSpeed: (speed) => set({ speed }),
+      setCurrentEpisodeId: (id) => set({ currentEpisodeId: id }),
+      setIsPlaying: (playing) => set({ isPlaying: playing }),
+      setPositionMs: (ms) => set({ positionMs: ms }),
+    }),
+    {
+      name: "harmonia-podcast",
+      // WHY: position is transient — restore speed preference only.
+      partialize: (s) => ({ speed: s.speed }),
+    }
+  )
+);

--- a/desktop/src/types/media.ts
+++ b/desktop/src/types/media.ts
@@ -1,0 +1,75 @@
+/** Podcast and episode media types. */
+
+import type { ApiResponse } from "./api";
+
+export type PaginatedResponse<T> = ApiResponse<T[]>;
+
+export interface PodcastSubscription {
+  id: string;
+  title: string;
+  author: string | null;
+  description: string | null;
+  feedUrl: string;
+  imageUrl: string | null;
+  episodeCount: number;
+  unplayedCount: number;
+  lastEpisodeDate: string | null;
+  autoDownload: boolean;
+  refreshIntervalMinutes: number;
+}
+
+export interface Episode {
+  id: string;
+  podcastId: string;
+  podcastTitle: string;
+  title: string;
+  description: string | null;
+  publishedAt: string;
+  durationMs: number;
+  audioUrl: string;
+  fileSize: number | null;
+  downloaded: boolean;
+  progress: EpisodeProgress | null;
+}
+
+export interface EpisodeDetail extends Episode {
+  showNotes: string | null;
+  enclosureType: string;
+  guid: string;
+  link: string | null;
+}
+
+export interface EpisodeProgress {
+  positionMs: number;
+  durationMs: number;
+  percentComplete: number;
+  completed: boolean;
+  updatedAt: string;
+}
+
+export interface EpisodeProgressUpdate {
+  positionMs: number;
+}
+
+export interface EpisodeDownload {
+  episodeId: string;
+  episodeTitle: string;
+  podcastTitle: string;
+  status: "queued" | "downloading" | "completed" | "failed";
+  progressPercent: number;
+  fileSizeBytes: number | null;
+}
+
+export interface EpisodeQueryParams {
+  page?: number;
+  pageSize?: number;
+  sortBy?: "published" | "title" | "duration";
+  sortOrder?: "asc" | "desc";
+  filter?: "all" | "unplayed" | "in_progress" | "completed" | "downloaded";
+}
+
+export interface LatestEpisodeParams {
+  page?: number;
+  pageSize?: number;
+  hoursBack?: number;
+}


### PR DESCRIPTION
## Summary

- **Subscription management:** grid view with cover art and unplayed count badges, subscribe dialog with URL validation, sort/filter controls, refresh-all button
- **Episode playback:** play/resume at stored position, skip 15s back and 30s forward, 0.5x–3.0x speed with presets persisted globally across episodes
- **Position tracking:** syncs to server every 30s during playback, immediately on pause; auto-complete fires at 95% of episode duration
- **Download queue:** per-episode download/cancel/delete, auto-download toggle per subscription, live status polling
- **Show notes:** DOM-based HTML sanitizer strips script/iframe/form and all event handlers; links intercepted and opened in system browser via `openUrl`
- **Latest episodes feed:** cross-podcast timeline grouped into Today / Yesterday / This Week / Older
- **Keyboard shortcuts:** Space, ← (15s back), → (30s forward), [ (speed −0.1), ] (speed +0.1) active when an episode is loaded
- **Now-playing bar:** adapts to podcast mode with episode title, podcast name, skip controls, speed badge, and speed presets
- **Rust backend:** `PodcastController` (speed, position, trim-silence state), 8 IPC commands including `podcast_get_playback_snapshot` for frontend polling; no `unwrap()` in library code

## Observations

- Cargo.toml uses `edition = "2021"` while RUST.md specifies 2024. Changing edition is out of scope for this PR and requires workspace-level coordination.
- The `usePodcast` hook fetches the full subscriptions list to look up a single podcast by ID. A dedicated `/api/podcasts/:id` endpoint would be more efficient; tracked for when Komide exposes it.
- App close position sync uses the periodic 30s interval as the last sync. A Tauri `window:close-requested` event handler would give a clean final sync; deferred to P3-11 integration when the audio engine lifecycle is established.
- `@tauri-apps/plugin-opener` exports `openUrl` and `openPath`, not `open` as Tauri v1 did. Updated accordingly.

## Test plan

- [ ] Subscribe to a podcast via RSS URL; confirm validation rejects non-URL input
- [ ] Verify subscription grid renders cover art and unplayed count badge
- [ ] Navigate to podcast detail; confirm episode list with played/in-progress/unplayed states
- [ ] Filter episodes by each filter option; confirm correct subset is shown
- [ ] Play an episode; verify skip buttons move position 30s forward and 15s back
- [ ] Change speed; confirm badge updates and persists across navigation
- [ ] Navigate to Latest Episodes; verify timeline grouping
- [ ] Open episode detail; confirm show notes render and links open in browser
- [ ] Toggle auto-download; confirm setting persists
- [ ] Open download queue; confirm status and cancel controls appear
- [ ] Verify keyboard shortcuts: Space, ←/→, [/] respond correctly
- [ ] Confirm now-playing bar shows episode/podcast name in podcast mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)