### PR TITLE
feat(desktop): audiobook player with chapters and bookmarks (P3-13)

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
-tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "sync"] }
 
 [profile.release]
 panic = "abort"

--- a/desktop/src-tauri/src/dsp/commands.rs
+++ b/desktop/src-tauri/src/dsp/commands.rs
@@ -46,10 +46,7 @@ pub fn add_eq_band(band: EqBand, controller: State<'_, DspController>) {
 }
 
 #[tauri::command]
-pub fn remove_eq_band(
-    index: usize,
-    controller: State<'_, DspController>,
-) -> Result<(), String> {
+pub fn remove_eq_band(index: usize, controller: State<'_, DspController>) -> Result<(), String> {
     controller.update_config(|cfg| {
         if index < cfg.eq.bands.len() {
             cfg.eq.bands.remove(index);
@@ -59,10 +56,7 @@ pub fn remove_eq_band(
 }
 
 #[tauri::command]
-pub fn load_eq_preset(
-    name: String,
-    controller: State<'_, DspController>,
-) -> Result<(), String> {
+pub fn load_eq_preset(name: String, controller: State<'_, DspController>) -> Result<(), String> {
     let presets = built_in_presets();
     let preset = presets
         .into_iter()

--- a/desktop/src-tauri/src/dsp/mod.rs
+++ b/desktop/src-tauri/src/dsp/mod.rs
@@ -4,8 +4,8 @@ pub mod presets;
 
 use std::sync::RwLock;
 
-use config::DspConfig;
 use crate::config::config_dir;
+use config::DspConfig;
 
 const DSP_CONFIG_FILE: &str = "dsp_config.json";
 
@@ -21,7 +21,10 @@ impl DspController {
     }
 
     pub fn get_config(&self) -> DspConfig {
-        self.config.read().expect("dsp config lock poisoned").clone()
+        self.config
+            .read()
+            .expect("dsp config lock poisoned")
+            .clone()
     }
 
     pub fn update_config(&self, f: impl FnOnce(&mut DspConfig)) {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .manage(dsp::DspController::new())
         .manage(playback::podcast::PodcastController::new())
+        .manage(playback::audiobook::AudiobookController::new())
         .invoke_handler(tauri::generate_handler![
             commands::health_check,
             commands::get_server_url,
@@ -34,6 +35,25 @@ pub fn run() {
             playback::podcast::podcast_skip_backward,
             playback::podcast::podcast_set_trim_silence,
             playback::podcast::podcast_get_playback_snapshot,
+            playback::audiobook::audiobook_play,
+            playback::audiobook::audiobook_play_from_chapter,
+            playback::audiobook::audiobook_resume,
+            playback::audiobook::audiobook_pause,
+            playback::audiobook::audiobook_stop,
+            playback::audiobook::audiobook_next_chapter,
+            playback::audiobook::audiobook_prev_chapter,
+            playback::audiobook::audiobook_go_to_chapter,
+            playback::audiobook::audiobook_skip_forward,
+            playback::audiobook::audiobook_skip_backward,
+            playback::audiobook::audiobook_set_speed,
+            playback::audiobook::audiobook_get_speed,
+            playback::audiobook::sleep_timer_set,
+            playback::audiobook::sleep_timer_set_end_of_chapter,
+            playback::audiobook::sleep_timer_cancel,
+            playback::audiobook::sleep_timer_extend,
+            playback::audiobook::sleep_timer_get,
+            playback::audiobook::audiobook_get_position,
+            playback::audiobook::audiobook_update_offset,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/playback/audiobook.rs
+++ b/desktop/src-tauri/src/playback/audiobook.rs
@@ -1,0 +1,562 @@
+//! Audiobook playback state: chapter tracking, speed control, sleep timer, position sync.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+const SPEED_MIN: f64 = 0.5;
+const SPEED_MAX: f64 = 3.0;
+const SYNC_INTERVAL_SECS: u64 = 30;
+const SLEEP_FADE_SECS: u64 = 30;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChapterInfo {
+    pub(crate) position: usize,
+    pub(crate) title: String,
+    pub(crate) start_ms: u64,
+    pub(crate) end_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+struct SleepTimerConfig {
+    end_of_chapter: bool,
+    duration_secs: u64,
+    started_at: Instant,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SleepTimerState {
+    pub(crate) end_of_chapter: bool,
+    pub(crate) total_secs: u64,
+    pub(crate) elapsed_secs: u64,
+    pub(crate) remaining_secs: u64,
+    pub(crate) fading: bool,
+}
+
+#[derive(Debug)]
+struct PlaybackState {
+    audiobook_id: String,
+    chapters: Vec<ChapterInfo>,
+    current_chapter_index: usize,
+    chapter_offset_ms: u64,
+    playback_speed: f64,
+    is_playing: bool,
+    sleep_timer: Option<SleepTimerConfig>,
+    server_url: String,
+    token: String,
+}
+
+impl PlaybackState {
+    fn current_chapter(&self) -> Option<&ChapterInfo> {
+        self.chapters.get(self.current_chapter_index)
+    }
+}
+
+pub(crate) struct AudiobookController {
+    state: Arc<Mutex<Option<PlaybackState>>>,
+    sync_handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl AudiobookController {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(None)),
+            sync_handle: Mutex::new(None),
+        }
+    }
+
+    async fn start_sync_task(&self, state_arc: Arc<Mutex<Option<PlaybackState>>>) {
+        let mut handle_guard = self.sync_handle.lock().await;
+        if let Some(handle) = handle_guard.take() {
+            handle.abort();
+        }
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(SYNC_INTERVAL_SECS));
+            // first tick fires immediately; skip it
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let snapshot = {
+                    let guard = state_arc.lock().await;
+                    guard.as_ref().map(|s| {
+                        (
+                            s.audiobook_id.clone(),
+                            s.current_chapter_index,
+                            s.chapter_offset_ms,
+                            s.is_playing,
+                            s.server_url.clone(),
+                            s.token.clone(),
+                        )
+                    })
+                };
+                if let Some((id, chapter, offset, is_playing, url, token)) = snapshot {
+                    if !is_playing {
+                        break;
+                    }
+                    sync_progress(&id, chapter, offset, &url, &token).await;
+                } else {
+                    break;
+                }
+            }
+        });
+        *handle_guard = Some(handle);
+    }
+
+    async fn stop_sync_task(&self) {
+        let mut handle_guard = self.sync_handle.lock().await;
+        if let Some(handle) = handle_guard.take() {
+            handle.abort();
+        }
+    }
+}
+
+async fn sync_progress(id: &str, chapter: usize, offset_ms: u64, server_url: &str, token: &str) {
+    let url = format!(
+        "{}/api/audiobooks/{}/progress",
+        server_url.trim_end_matches('/'),
+        id
+    );
+    let body = serde_json::json!({
+        "chapterPosition": chapter,
+        "offsetMs": offset_ms,
+    });
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    // WHY: Log failure but don't propagate — sync errors are non-fatal.
+    let _ = client.put(&url).bearer_auth(token).json(&body).send().await;
+}
+
+// ── Playback commands ─────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub(crate) async fn audiobook_play(
+    audiobook_id: String,
+    chapters: Vec<ChapterInfo>,
+    server_url: String,
+    token: String,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let playback = PlaybackState {
+        audiobook_id,
+        chapters,
+        current_chapter_index: 0,
+        chapter_offset_ms: 0,
+        playback_speed: 1.0,
+        is_playing: true,
+        sleep_timer: None,
+        server_url,
+        token,
+    };
+    *guard = Some(playback);
+    drop(guard);
+    state.start_sync_task(Arc::clone(&state.state)).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_play_from_chapter(
+    audiobook_id: String,
+    chapter: usize,
+    chapters: Vec<ChapterInfo>,
+    server_url: String,
+    token: String,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let playback = PlaybackState {
+        audiobook_id,
+        chapters,
+        current_chapter_index: chapter,
+        chapter_offset_ms: 0,
+        playback_speed: 1.0,
+        is_playing: true,
+        sleep_timer: None,
+        server_url,
+        token,
+    };
+    *guard = Some(playback);
+    drop(guard);
+    state.start_sync_task(Arc::clone(&state.state)).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_resume(
+    audiobook_id: String,
+    chapter: usize,
+    offset_ms: u64,
+    chapters: Vec<ChapterInfo>,
+    server_url: String,
+    token: String,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let playback = PlaybackState {
+        audiobook_id,
+        chapters,
+        current_chapter_index: chapter,
+        chapter_offset_ms: offset_ms,
+        playback_speed: 1.0,
+        is_playing: true,
+        sleep_timer: None,
+        server_url,
+        token,
+    };
+    *guard = Some(playback);
+    drop(guard);
+    state.start_sync_task(Arc::clone(&state.state)).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_pause(state: State<'_, AudiobookController>) -> Result<(), String> {
+    let snapshot = {
+        let mut guard = state.state.lock().await;
+        if let Some(s) = guard.as_mut() {
+            s.is_playing = false;
+            Some((
+                s.audiobook_id.clone(),
+                s.current_chapter_index,
+                s.chapter_offset_ms,
+                s.server_url.clone(),
+                s.token.clone(),
+            ))
+        } else {
+            None
+        }
+    };
+    state.stop_sync_task().await;
+    if let Some((id, chapter, offset, url, token)) = snapshot {
+        sync_progress(&id, chapter, offset, &url, &token).await;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_stop(state: State<'_, AudiobookController>) -> Result<(), String> {
+    let snapshot = {
+        let mut guard = state.state.lock().await;
+        let snap = guard.as_ref().map(|s| {
+            (
+                s.audiobook_id.clone(),
+                s.current_chapter_index,
+                s.chapter_offset_ms,
+                s.server_url.clone(),
+                s.token.clone(),
+            )
+        });
+        *guard = None;
+        snap
+    };
+    state.stop_sync_task().await;
+    if let Some((id, chapter, offset, url, token)) = snapshot {
+        sync_progress(&id, chapter, offset, &url, &token).await;
+    }
+    Ok(())
+}
+
+// ── Chapter navigation ────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub(crate) async fn audiobook_next_chapter(
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let snapshot = {
+        let mut guard = state.state.lock().await;
+        let s = guard.as_mut().ok_or("no audiobook playing")?;
+        let next = s.current_chapter_index + 1;
+        if next >= s.chapters.len() {
+            return Err("already at last chapter".into());
+        }
+        s.current_chapter_index = next;
+        s.chapter_offset_ms = 0;
+        Some((
+            s.audiobook_id.clone(),
+            s.current_chapter_index,
+            s.chapter_offset_ms,
+            s.server_url.clone(),
+            s.token.clone(),
+        ))
+    };
+    if let Some((id, chapter, offset, url, token)) = snapshot {
+        sync_progress(&id, chapter, offset, &url, &token).await;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_prev_chapter(
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let snapshot = {
+        let mut guard = state.state.lock().await;
+        let s = guard.as_mut().ok_or("no audiobook playing")?;
+        if s.current_chapter_index == 0 {
+            return Err("already at first chapter".into());
+        }
+        s.current_chapter_index -= 1;
+        s.chapter_offset_ms = 0;
+        Some((
+            s.audiobook_id.clone(),
+            s.current_chapter_index,
+            s.chapter_offset_ms,
+            s.server_url.clone(),
+            s.token.clone(),
+        ))
+    };
+    if let Some((id, chapter, offset, url, token)) = snapshot {
+        sync_progress(&id, chapter, offset, &url, &token).await;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_go_to_chapter(
+    chapter: usize,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let snapshot = {
+        let mut guard = state.state.lock().await;
+        let s = guard.as_mut().ok_or("no audiobook playing")?;
+        if chapter >= s.chapters.len() {
+            return Err(format!("chapter {} out of range", chapter));
+        }
+        s.current_chapter_index = chapter;
+        s.chapter_offset_ms = 0;
+        Some((
+            s.audiobook_id.clone(),
+            s.current_chapter_index,
+            s.chapter_offset_ms,
+            s.server_url.clone(),
+            s.token.clone(),
+        ))
+    };
+    if let Some((id, chapter_idx, offset, url, token)) = snapshot {
+        sync_progress(&id, chapter_idx, offset, &url, &token).await;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_skip_forward(
+    seconds: u64,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let s = guard.as_mut().ok_or("no audiobook playing")?;
+    let add_ms = seconds * 1000;
+    let chapter = s.current_chapter().ok_or("no current chapter")?;
+    let chapter_duration_ms = chapter.end_ms - chapter.start_ms;
+    let new_offset = s.chapter_offset_ms + add_ms;
+    if new_offset >= chapter_duration_ms {
+        let next = s.current_chapter_index + 1;
+        if next < s.chapters.len() {
+            s.current_chapter_index = next;
+            s.chapter_offset_ms = 0;
+        } else {
+            s.chapter_offset_ms = chapter_duration_ms.saturating_sub(1);
+        }
+    } else {
+        s.chapter_offset_ms = new_offset;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_skip_backward(
+    seconds: u64,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let s = guard.as_mut().ok_or("no audiobook playing")?;
+    let sub_ms = seconds * 1000;
+    if sub_ms >= s.chapter_offset_ms {
+        if s.current_chapter_index > 0 {
+            s.current_chapter_index -= 1;
+            s.chapter_offset_ms = 0;
+        } else {
+            s.chapter_offset_ms = 0;
+        }
+    } else {
+        s.chapter_offset_ms -= sub_ms;
+    }
+    Ok(())
+}
+
+// ── Speed control ─────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub(crate) async fn audiobook_set_speed(
+    speed: f64,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    if !(SPEED_MIN..=SPEED_MAX).contains(&speed) {
+        return Err(format!(
+            "speed must be between {} and {}",
+            SPEED_MIN, SPEED_MAX
+        ));
+    }
+    let mut guard = state.state.lock().await;
+    let s = guard.as_mut().ok_or("no audiobook playing")?;
+    s.playback_speed = speed;
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_get_speed(
+    state: State<'_, AudiobookController>,
+) -> Result<f64, String> {
+    let guard = state.state.lock().await;
+    let s = guard.as_ref().ok_or("no audiobook playing")?;
+    Ok(s.playback_speed)
+}
+
+// ── Sleep timer ───────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub(crate) async fn sleep_timer_set(
+    minutes: u64,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let s = guard.as_mut().ok_or("no audiobook playing")?;
+    s.sleep_timer = Some(SleepTimerConfig {
+        end_of_chapter: false,
+        duration_secs: minutes * 60,
+        started_at: Instant::now(),
+    });
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn sleep_timer_set_end_of_chapter(
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let s = guard.as_mut().ok_or("no audiobook playing")?;
+    s.sleep_timer = Some(SleepTimerConfig {
+        end_of_chapter: true,
+        duration_secs: 0,
+        started_at: Instant::now(),
+    });
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn sleep_timer_cancel(
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let s = guard.as_mut().ok_or("no audiobook playing")?;
+    s.sleep_timer = None;
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn sleep_timer_extend(
+    minutes: u64,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let s = guard.as_mut().ok_or("no audiobook playing")?;
+    if let Some(timer) = s.sleep_timer.as_mut() {
+        timer.duration_secs += minutes * 60;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn sleep_timer_get(
+    state: State<'_, AudiobookController>,
+) -> Result<Option<SleepTimerState>, String> {
+    let guard = state.state.lock().await;
+    let s = match guard.as_ref() {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+    let timer = match s.sleep_timer.as_ref() {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+    let elapsed_secs = timer.started_at.elapsed().as_secs();
+    let (total_secs, remaining_secs) = if timer.end_of_chapter {
+        let chapter_remaining = s
+            .current_chapter()
+            .map(|c| {
+                let duration = c.end_ms - c.start_ms;
+                duration.saturating_sub(s.chapter_offset_ms) / 1000
+            })
+            .unwrap_or(0);
+        (chapter_remaining, chapter_remaining)
+    } else {
+        let remaining = timer.duration_secs.saturating_sub(elapsed_secs);
+        (timer.duration_secs, remaining)
+    };
+    let fading = remaining_secs <= SLEEP_FADE_SECS;
+    Ok(Some(SleepTimerState {
+        end_of_chapter: timer.end_of_chapter,
+        total_secs,
+        elapsed_secs,
+        remaining_secs,
+        fading,
+    }))
+}
+
+// ── Position query ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PlaybackPosition {
+    pub(crate) audiobook_id: String,
+    pub(crate) chapter_index: usize,
+    pub(crate) chapter_offset_ms: u64,
+    pub(crate) chapter_title: String,
+    pub(crate) playback_speed: f64,
+    pub(crate) is_playing: bool,
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_get_position(
+    state: State<'_, AudiobookController>,
+) -> Result<Option<PlaybackPosition>, String> {
+    let guard = state.state.lock().await;
+    let s = match guard.as_ref() {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+    let chapter_title = s
+        .current_chapter()
+        .map(|c| c.title.clone())
+        .unwrap_or_default();
+    Ok(Some(PlaybackPosition {
+        audiobook_id: s.audiobook_id.clone(),
+        chapter_index: s.current_chapter_index,
+        chapter_offset_ms: s.chapter_offset_ms,
+        chapter_title,
+        playback_speed: s.playback_speed,
+        is_playing: s.is_playing,
+    }))
+}
+
+#[tauri::command]
+pub(crate) async fn audiobook_update_offset(
+    offset_ms: u64,
+    state: State<'_, AudiobookController>,
+) -> Result<(), String> {
+    let mut guard = state.state.lock().await;
+    let s = guard.as_mut().ok_or("no audiobook playing")?;
+    s.chapter_offset_ms = offset_ms;
+    Ok(())
+}

--- a/desktop/src-tauri/src/playback/mod.rs
+++ b/desktop/src-tauri/src/playback/mod.rs
@@ -1,2 +1,3 @@
 //! Playback state management for podcast and audiobook modes.
 pub mod podcast;
+pub(crate) mod audiobook;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -4,7 +4,9 @@ import Dsp from "./pages/Dsp";
 import Settings from "./pages/Settings";
 import AlbumsPage from "./features/library/AlbumsPage";
 import TracksPage from "./features/library/TracksPage";
-import AudiobooksPage from "./features/library/AudiobooksPage";
+import AudiobooksPage from "./features/audiobook/pages/AudiobooksPage";
+import AudiobookDetailPage from "./features/audiobook/pages/AudiobookDetailPage";
+import AudiobookPlayerPage from "./features/audiobook/pages/AudiobookPlayerPage";
 import PodcastsPage from "./features/podcast/pages/PodcastsPage";
 import PodcastDetailPage from "./features/podcast/pages/PodcastDetailPage";
 import EpisodeDetailPage from "./features/podcast/pages/EpisodeDetailPage";
@@ -21,6 +23,7 @@ export default function App() {
             <Route path="albums" element={<AlbumsPage />} />
             <Route path="tracks" element={<TracksPage />} />
             <Route path="audiobooks" element={<AudiobooksPage />} />
+            <Route path="audiobooks/:id" element={<AudiobookDetailPage />} />
             <Route path="podcasts">
               <Route index element={<PodcastsPage />} />
               <Route path="latest" element={<LatestEpisodesPage />} />
@@ -29,6 +32,7 @@ export default function App() {
               <Route path=":id" element={<PodcastDetailPage />} />
             </Route>
           </Route>
+          <Route path="audiobook-player" element={<AudiobookPlayerPage />} />
           <Route path="dsp" element={<Dsp />} />
           <Route path="settings" element={<Settings />} />
         </Route>

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -10,6 +10,14 @@ import type {
   EpisodeQueryParams,
   LatestEpisodeParams,
   PaginatedResponse,
+  Audiobook as AudiobookFull,
+  AudiobookDetail,
+  AudiobookProgress,
+  AudiobookQueryParams,
+  Bookmark,
+  BookmarkCreate,
+  Chapter,
+  ProgressUpdate,
 } from "../types/media";
 
 async function getBaseUrl(): Promise<string> {
@@ -85,7 +93,6 @@ export const api = {
     });
   },
 
-  // Music library
   listReleaseGroups(params: ListParams, token: string): Promise<ApiResponse<ReleaseGroup[]>> {
     const q = new URLSearchParams({ page: String(params.page), per_page: String(params.per_page) });
     return api.get(`/api/music/release-groups?${q}`, token);
@@ -105,7 +112,6 @@ export const api = {
     return api.get(`/api/audiobooks/?${q}`, token);
   },
 
-  // Podcast subscriptions
   getSubscriptions(token: string): Promise<PodcastSubscription[]> {
     return api.get("/api/podcasts/subscriptions", token);
   },
@@ -134,7 +140,6 @@ export const api = {
     return api.post("/api/podcasts/refresh-all", {}, token);
   },
 
-  // Episodes
   getEpisodes(
     podcastId: string,
     params: EpisodeQueryParams,
@@ -153,7 +158,6 @@ export const api = {
     return api.get(`/api/podcasts/episodes/latest?${q}`, token);
   },
 
-  // Playback progress
   getEpisodeProgress(episodeId: string, token: string): Promise<EpisodeProgress> {
     return api.get(`/api/podcasts/episodes/${episodeId}/progress`, token);
   },
@@ -174,7 +178,6 @@ export const api = {
     return api.post(`/api/podcasts/episodes/${episodeId}/unplay`, {}, token);
   },
 
-  // Downloads
   downloadEpisode(episodeId: string, token: string): Promise<void> {
     return api.post(`/api/podcasts/episodes/${episodeId}/download`, {}, token);
   },
@@ -189,5 +192,51 @@ export const api = {
 
   getDownloadQueue(token: string): Promise<EpisodeDownload[]> {
     return api.get("/api/podcasts/downloads", token);
+  },
+
+  getAudiobooks(params: AudiobookQueryParams, token: string): Promise<ApiResponse<AudiobookFull[]>> {
+    const q = new URLSearchParams({
+      page: String(params.page),
+      per_page: String(params.per_page),
+    });
+    if (params.filter && params.filter !== "all") q.set("filter", params.filter);
+    if (params.sort) q.set("sort", params.sort);
+    return api.get(`/api/audiobooks?${q}`, token);
+  },
+
+  getAudiobook(id: string, token: string): Promise<ApiResponse<AudiobookDetail>> {
+    return api.get(`/api/audiobooks/${id}`, token);
+  },
+
+  getAudiobookChapters(id: string, token: string): Promise<ApiResponse<Chapter[]>> {
+    return api.get(`/api/audiobooks/${id}/chapters`, token);
+  },
+
+  getAudiobookProgress(id: string, token: string): Promise<ApiResponse<AudiobookProgress>> {
+    return api.get(`/api/audiobooks/${id}/progress`, token);
+  },
+
+  updateAudiobookProgress(
+    id: string,
+    progress: ProgressUpdate,
+    token: string,
+  ): Promise<ApiResponse<AudiobookProgress>> {
+    return api.put(`/api/audiobooks/${id}/progress`, progress, token);
+  },
+
+  getBookmarks(audiobookId: string, token: string): Promise<ApiResponse<Bookmark[]>> {
+    return api.get(`/api/audiobooks/${audiobookId}/bookmarks`, token);
+  },
+
+  createBookmark(
+    audiobookId: string,
+    bookmark: BookmarkCreate,
+    token: string,
+  ): Promise<ApiResponse<Bookmark>> {
+    return api.post(`/api/audiobooks/${audiobookId}/bookmarks`, bookmark, token);
+  },
+
+  deleteBookmark(bookmarkId: string, token: string): Promise<void> {
+    return api.del(`/api/bookmarks/${bookmarkId}`, token);
   },
 };

--- a/desktop/src/components/Layout.tsx
+++ b/desktop/src/components/Layout.tsx
@@ -1,5 +1,7 @@
 import { NavLink, Outlet } from "react-router-dom";
 import NowPlayingBar from "../features/now-playing/NowPlayingBar";
+import { usePositionSync } from "../features/audiobook/hooks/usePositionSync";
+import AudiobookNowPlaying from "../features/audiobook/components/AudiobookNowPlaying";
 
 const libraryItems = [
   { to: "/library/albums", label: "Albums" },
@@ -22,6 +24,8 @@ function navLinkClass({ isActive }: { isActive: boolean }): string {
 }
 
 export default function Layout() {
+  const { position } = usePositionSync();
+
   return (
     <div className="flex h-screen bg-gray-950 text-gray-100">
       <aside className="w-56 flex-shrink-0 bg-gray-900 flex flex-col">
@@ -67,7 +71,11 @@ export default function Layout() {
           id="now-playing-bar"
           className="h-16 bg-gray-900 border-t border-gray-800 flex items-center px-4 flex-shrink-0"
         >
-          <NowPlayingBar />
+          {position ? (
+            <AudiobookNowPlaying />
+          ) : (
+            <NowPlayingBar />
+          )}
         </div>
       </main>
     </div>

--- a/desktop/src/features/audiobook/components/AudiobookCard.tsx
+++ b/desktop/src/features/audiobook/components/AudiobookCard.tsx
@@ -1,0 +1,71 @@
+import clsx from "clsx";
+import type { Audiobook } from "../../../types/media";
+
+function formatDuration(ms: number): string {
+  const totalMins = Math.floor(ms / 60_000);
+  const hours = Math.floor(totalMins / 60);
+  const mins = totalMins % 60;
+  return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+}
+
+function progressColorClass(progress: Audiobook["progress"]): string {
+  if (!progress) return "bg-gray-600";
+  if (progress.completedAt) return "bg-green-500";
+  if (progress.percentComplete > 0) return "bg-blue-500";
+  return "bg-gray-600";
+}
+
+interface Props {
+  book: Audiobook;
+  onClick?: () => void;
+}
+
+export default function AudiobookCard({ book, onClick }: Props) {
+  const initial = book.title.charAt(0).toUpperCase();
+  const pct = book.progress?.percentComplete ?? 0;
+
+  return (
+    <div
+      className={clsx(
+        "bg-gray-800 rounded-lg overflow-hidden cursor-pointer",
+        "hover:bg-gray-700 transition-colors group"
+      )}
+      onClick={onClick}
+    >
+      <div className="relative aspect-square bg-gray-700 flex items-center justify-center">
+        {book.coverUrl ? (
+          <img
+            src={book.coverUrl}
+            alt={book.title}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <span className="text-4xl font-bold text-gray-500 group-hover:text-gray-400 select-none">
+            {initial}
+          </span>
+        )}
+        {pct > 0 && (
+          <div className="absolute bottom-0 left-0 right-0 h-1">
+            <div
+              className={clsx("h-full", progressColorClass(book.progress))}
+              style={{ width: `${Math.min(100, pct)}%` }}
+            />
+          </div>
+        )}
+      </div>
+      <div className="p-3">
+        <p className="text-sm font-medium text-white truncate" title={book.title}>
+          {book.title}
+        </p>
+        <p className="text-xs text-gray-400 truncate mt-0.5">{book.author}</p>
+        {book.seriesName && (
+          <p className="text-xs text-gray-500 truncate mt-0.5">
+            {book.seriesName}
+            {book.seriesPosition != null ? ` #${book.seriesPosition}` : ""}
+          </p>
+        )}
+        <p className="text-xs text-gray-500 mt-1">{formatDuration(book.durationMs)}</p>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/components/AudiobookGrid.tsx
+++ b/desktop/src/features/audiobook/components/AudiobookGrid.tsx
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { VirtuosoGrid } from "react-virtuoso";
+import AudiobookCard from "./AudiobookCard";
+import type { Audiobook } from "../../../types/media";
+
+interface Props {
+  books: Audiobook[];
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+  onSelect: (book: Audiobook) => void;
+}
+
+export default function AudiobookGrid({
+  books,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  onSelect,
+}: Props) {
+  const endReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <VirtuosoGrid
+      style={{ height: "100%" }}
+      totalCount={books.length}
+      endReached={endReached}
+      itemContent={(index) => (
+        <div className="p-2">
+          <AudiobookCard book={books[index]} onClick={() => onSelect(books[index])} />
+        </div>
+      )}
+      listClassName="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+      components={{
+        Footer: () =>
+          isFetchingNextPage ? (
+            <div className="py-4 text-center text-sm text-gray-500">Loading…</div>
+          ) : null,
+      }}
+    />
+  );
+}

--- a/desktop/src/features/audiobook/components/AudiobookNowPlaying.tsx
+++ b/desktop/src/features/audiobook/components/AudiobookNowPlaying.tsx
@@ -1,0 +1,70 @@
+import { useNavigate } from "react-router-dom";
+import { usePositionSync } from "../hooks/usePositionSync";
+import { useAudiobookPlayback } from "../hooks/useAudiobookPlayback";
+import { useChapterNavigation } from "../hooks/useChapterNavigation";
+
+export default function AudiobookNowPlaying() {
+  const navigate = useNavigate();
+  const { position } = usePositionSync();
+  const { pause } = useAudiobookPlayback();
+  const { skipForward, skipBackward } = useChapterNavigation();
+
+  if (!position) return null;
+
+  return (
+    <div className="flex items-center gap-3 w-full">
+      <button
+        type="button"
+        onClick={() => void navigate("/audiobook-player")}
+        className="flex-1 min-w-0 text-left"
+      >
+        <p className="text-sm font-medium text-white truncate">{position.chapterTitle}</p>
+        <p className="text-xs text-gray-400">
+          {position.playbackSpeed !== 1 ? `${position.playbackSpeed}x · ` : ""}
+          {position.isPlaying ? "Playing" : "Paused"}
+        </p>
+      </button>
+
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => void skipBackward(30)}
+          className="p-2 text-gray-400 hover:text-white transition-colors"
+          title="Skip back 30s"
+        >
+          <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z" />
+          </svg>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => void (position.isPlaying ? pause() : Promise.resolve())}
+          className="p-2 text-white hover:text-gray-200 transition-colors"
+          title={position.isPlaying ? "Pause" : "Play"}
+        >
+          {position.isPlaying ? (
+            <svg className="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+            </svg>
+          ) : (
+            <svg className="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          )}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => void skipForward(30)}
+          className="p-2 text-gray-400 hover:text-white transition-colors"
+          title="Skip forward 30s"
+        >
+          <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M18 13c0 3.31-2.69 6-6 6s-6-2.69-6-6 2.69-6 6-6v4l5-5-5-5v4c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8h-2z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/components/AudiobookTransport.tsx
+++ b/desktop/src/features/audiobook/components/AudiobookTransport.tsx
@@ -1,0 +1,88 @@
+interface Props {
+  isPlaying: boolean;
+  onPlayPause: () => void;
+  onSkipBack: () => void;
+  onSkipForward: () => void;
+  onPrevChapter: () => void;
+  onNextChapter: () => void;
+}
+
+export default function AudiobookTransport({
+  isPlaying,
+  onPlayPause,
+  onSkipBack,
+  onSkipForward,
+  onPrevChapter,
+  onNextChapter,
+}: Props) {
+  return (
+    <div className="flex items-center justify-center gap-4">
+      <button
+        type="button"
+        onClick={onPrevChapter}
+        className="text-gray-400 hover:text-white transition-colors p-2"
+        title="Previous chapter"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" />
+        </svg>
+      </button>
+
+      <button
+        type="button"
+        onClick={onSkipBack}
+        className="text-gray-400 hover:text-white transition-colors p-2 relative"
+        title="Skip back 30s"
+      >
+        <svg className="w-7 h-7" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z" />
+        </svg>
+        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[9px] font-bold">
+          30
+        </span>
+      </button>
+
+      <button
+        type="button"
+        onClick={onPlayPause}
+        className="w-14 h-14 rounded-full bg-white text-gray-900 flex items-center justify-center hover:bg-gray-200 transition-colors"
+        title={isPlaying ? "Pause" : "Play"}
+      >
+        {isPlaying ? (
+          <svg className="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+          </svg>
+        ) : (
+          <svg className="w-6 h-6 ml-1" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        )}
+      </button>
+
+      <button
+        type="button"
+        onClick={onSkipForward}
+        className="text-gray-400 hover:text-white transition-colors p-2 relative"
+        title="Skip forward 30s"
+      >
+        <svg className="w-7 h-7" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M18 13c0 3.31-2.69 6-6 6s-6-2.69-6-6 2.69-6 6-6v4l5-5-5-5v4c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8h-2z" />
+        </svg>
+        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[9px] font-bold">
+          30
+        </span>
+      </button>
+
+      <button
+        type="button"
+        onClick={onNextChapter}
+        className="text-gray-400 hover:text-white transition-colors p-2"
+        title="Next chapter"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/components/BookmarkButton.tsx
+++ b/desktop/src/features/audiobook/components/BookmarkButton.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  onBookmark: () => void;
+  label?: string;
+}
+
+export default function BookmarkButton({ onBookmark, label = "Bookmark" }: Props) {
+  return (
+    <button
+      type="button"
+      onClick={onBookmark}
+      className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white rounded transition-colors text-sm"
+      title="Add bookmark at current position"
+    >
+      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z" />
+      </svg>
+      {label}
+    </button>
+  );
+}

--- a/desktop/src/features/audiobook/components/BookmarkList.tsx
+++ b/desktop/src/features/audiobook/components/BookmarkList.tsx
@@ -1,0 +1,52 @@
+import type { Bookmark } from "../../../types/media";
+
+function formatMs(ms: number): string {
+  const totalSecs = Math.floor(ms / 1000);
+  const mins = Math.floor(totalSecs / 60);
+  const secs = totalSecs % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+}
+
+interface Props {
+  bookmarks: Bookmark[];
+  onJump: (bookmark: Bookmark) => void;
+  onDelete: (bookmarkId: string) => void;
+}
+
+export default function BookmarkList({ bookmarks, onJump, onDelete }: Props) {
+  if (bookmarks.length === 0) {
+    return <p className="text-sm text-gray-500 text-center py-4">No bookmarks yet.</p>;
+  }
+
+  return (
+    <ul className="space-y-1">
+      {bookmarks.map((bm) => (
+        <li
+          key={bm.id}
+          className="flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-800 group"
+        >
+          <button
+            type="button"
+            onClick={() => onJump(bm)}
+            className="flex-1 text-left"
+          >
+            <p className="text-sm text-gray-200 truncate">{bm.label}</p>
+            <p className="text-xs text-gray-500">
+              Ch. {bm.chapterPosition + 1} — {formatMs(bm.offsetMs)}
+            </p>
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(bm.id)}
+            className="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-red-400 transition-all p-1"
+            title="Delete bookmark"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+            </svg>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/desktop/src/features/audiobook/components/ChapterList.tsx
+++ b/desktop/src/features/audiobook/components/ChapterList.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react";
+import ChapterRow from "./ChapterRow";
+import type { Chapter } from "../../../types/media";
+
+interface Props {
+  chapters: Chapter[];
+  currentChapterPosition: number;
+  onSelect: (chapter: Chapter) => void;
+}
+
+export default function ChapterList({ chapters, currentChapterPosition, onSelect }: Props) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const currentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (currentRef.current) {
+      currentRef.current.scrollIntoView({ block: "nearest" });
+    }
+  }, [currentChapterPosition]);
+
+  return (
+    <div ref={listRef} className="overflow-y-auto">
+      {chapters.map((chapter) => {
+        const isCurrent = chapter.position === currentChapterPosition;
+        const isPlayed = chapter.position < currentChapterPosition;
+        return (
+          <div key={chapter.position} ref={isCurrent ? currentRef : null}>
+            <ChapterRow
+              chapter={chapter}
+              isCurrent={isCurrent}
+              isPlayed={isPlayed}
+              onClick={() => onSelect(chapter)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/components/ChapterRow.tsx
+++ b/desktop/src/features/audiobook/components/ChapterRow.tsx
@@ -1,0 +1,53 @@
+import clsx from "clsx";
+import type { Chapter } from "../../../types/media";
+
+function formatMs(ms: number): string {
+  const totalSecs = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSecs / 3600);
+  const mins = Math.floor((totalSecs % 3600) / 60);
+  const secs = totalSecs % 60;
+  if (hours > 0) {
+    return `${hours}:${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+  }
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+}
+
+interface Props {
+  chapter: Chapter;
+  isCurrent: boolean;
+  isPlayed: boolean;
+  onClick: () => void;
+}
+
+export default function ChapterRow({ chapter, isCurrent, isPlayed, onClick }: Props) {
+  const durationMs = chapter.endMs - chapter.startMs;
+
+  return (
+    <button
+      type="button"
+      className={clsx(
+        "w-full flex items-center gap-3 px-4 py-3 text-left transition-colors",
+        isCurrent
+          ? "bg-gray-700 text-white"
+          : "text-gray-300 hover:bg-gray-800 hover:text-white"
+      )}
+      onClick={onClick}
+    >
+      <span
+        className={clsx(
+          "text-xs font-mono w-6 text-right flex-shrink-0",
+          isCurrent ? "text-blue-400" : "text-gray-500"
+        )}
+      >
+        {chapter.position + 1}
+      </span>
+      <span className={clsx("flex-1 text-sm truncate", isPlayed && !isCurrent && "text-gray-500")}>
+        {chapter.title}
+      </span>
+      <span className="text-xs text-gray-500 flex-shrink-0">{formatMs(durationMs)}</span>
+      {isPlayed && !isCurrent && (
+        <span className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
+      )}
+    </button>
+  );
+}

--- a/desktop/src/features/audiobook/components/ProgressIndicator.tsx
+++ b/desktop/src/features/audiobook/components/ProgressIndicator.tsx
@@ -1,0 +1,31 @@
+interface Props {
+  chapterIndex: number;
+  totalChapters: number;
+  percentComplete: number;
+  chapterTitle: string;
+}
+
+export default function ProgressIndicator({
+  chapterIndex,
+  totalChapters,
+  percentComplete,
+  chapterTitle,
+}: Props) {
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between text-xs text-gray-400">
+        <span>
+          Chapter {chapterIndex + 1} of {totalChapters}
+        </span>
+        <span>{Math.round(percentComplete)}% complete</span>
+      </div>
+      <div className="text-xs text-gray-500 truncate">{chapterTitle}</div>
+      <div className="w-full bg-gray-700 rounded-full h-1.5">
+        <div
+          className="bg-blue-500 h-1.5 rounded-full transition-all"
+          style={{ width: `${Math.min(100, percentComplete)}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/components/SleepTimerControl.tsx
+++ b/desktop/src/features/audiobook/components/SleepTimerControl.tsx
@@ -1,0 +1,94 @@
+import clsx from "clsx";
+
+const DURATION_OPTIONS = [5, 10, 15, 30, 45, 60, 90] as const;
+
+interface SleepTimerState {
+  endOfChapter: boolean;
+  totalSecs: number;
+  elapsedSecs: number;
+  remainingSecs: number;
+  fading: boolean;
+}
+
+interface Props {
+  timerState: SleepTimerState | null;
+  onSetTimer: (minutes: number) => void;
+  onSetEndOfChapter: () => void;
+  onCancel: () => void;
+  onExtend: () => void;
+}
+
+function formatRemaining(secs: number): string {
+  const mins = Math.floor(secs / 60);
+  const s = secs % 60;
+  if (mins > 0) return `${mins}:${String(s).padStart(2, "0")}`;
+  return `${s}s`;
+}
+
+export default function SleepTimerControl({
+  timerState,
+  onSetTimer,
+  onSetEndOfChapter,
+  onCancel,
+  onExtend,
+}: Props) {
+  return (
+    <div className="space-y-3">
+      {timerState ? (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gray-300">
+              {timerState.endOfChapter
+                ? "Stopping at chapter end"
+                : `Stopping in ${formatRemaining(timerState.remainingSecs)}`}
+            </span>
+            {timerState.fading && (
+              <span className="text-xs text-orange-400 animate-pulse">Fading…</span>
+            )}
+          </div>
+          {!timerState.endOfChapter && timerState.remainingSecs <= 60 && (
+            <button
+              type="button"
+              onClick={onExtend}
+              className="w-full py-1.5 bg-gray-700 text-gray-300 hover:bg-gray-600 rounded text-sm transition-colors"
+            >
+              +5 more minutes
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onCancel}
+            className="w-full py-1.5 bg-gray-800 text-gray-400 hover:bg-gray-700 rounded text-sm transition-colors"
+          >
+            Cancel timer
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="flex flex-wrap gap-1">
+            {DURATION_OPTIONS.map((mins) => (
+              <button
+                key={mins}
+                type="button"
+                onClick={() => onSetTimer(mins)}
+                className={clsx(
+                  "px-2 py-1 rounded text-xs font-medium transition-colors",
+                  "bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white"
+                )}
+              >
+                {mins}m
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={onSetEndOfChapter}
+            className="w-full py-1.5 bg-gray-700 text-gray-300 hover:bg-gray-600 rounded text-sm transition-colors"
+          >
+            End of chapter
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/components/SpeedControl.tsx
+++ b/desktop/src/features/audiobook/components/SpeedControl.tsx
@@ -1,0 +1,52 @@
+import clsx from "clsx";
+
+const SPEED_PRESETS = [0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0] as const;
+
+interface Props {
+  speed: number;
+  onSpeedChange: (speed: number) => void;
+}
+
+export default function SpeedControl({ speed, onSpeedChange }: Props) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-gray-400 text-center">Speed: {speed.toFixed(2)}x</p>
+      <div className="flex flex-wrap gap-1 justify-center">
+        {SPEED_PRESETS.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => onSpeedChange(preset)}
+            className={clsx(
+              "px-2 py-1 rounded text-xs font-medium transition-colors",
+              Math.abs(speed - preset) < 0.01
+                ? "bg-blue-600 text-white"
+                : "bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white"
+            )}
+          >
+            {preset}x
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onSpeedChange(Math.max(0.5, Math.round((speed - 0.05) * 100) / 100))}
+          className="px-2 py-1 bg-gray-700 text-gray-300 hover:bg-gray-600 rounded text-xs"
+          title="Decrease speed"
+        >
+          −
+        </button>
+        <div className="flex-1 text-center text-xs text-gray-500">0.5x – 3.0x</div>
+        <button
+          type="button"
+          onClick={() => onSpeedChange(Math.min(3.0, Math.round((speed + 0.05) * 100) / 100))}
+          className="px-2 py-1 bg-gray-700 text-gray-300 hover:bg-gray-600 rounded text-xs"
+          title="Increase speed"
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/hooks/useAudiobook.ts
+++ b/desktop/src/features/audiobook/hooks/useAudiobook.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+export function useAudiobook(id: string) {
+  const token = useLibraryStore((s) => s.token);
+  return useQuery({
+    queryKey: ["audiobook", id, token],
+    queryFn: () => api.getAudiobook(id, token),
+    enabled: token.length > 0 && id.length > 0,
+  });
+}
+
+export function useAudiobookProgress(id: string) {
+  const token = useLibraryStore((s) => s.token);
+  return useQuery({
+    queryKey: ["audiobook-progress", id, token],
+    queryFn: () => api.getAudiobookProgress(id, token),
+    enabled: token.length > 0 && id.length > 0,
+    staleTime: 0,
+  });
+}

--- a/desktop/src/features/audiobook/hooks/useAudiobookPlayback.ts
+++ b/desktop/src/features/audiobook/hooks/useAudiobookPlayback.ts
@@ -1,0 +1,108 @@
+import { useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useLibraryStore } from "../../library/store";
+import { useAudiobookPlayerStore } from "../store";
+import type { Chapter } from "../../../types/media";
+
+interface TauriChapterInfo {
+  position: number;
+  title: string;
+  startMs: number;
+  endMs: number;
+}
+
+function toTauriChapters(chapters: Chapter[]): TauriChapterInfo[] {
+  return chapters.map((c) => ({
+    position: c.position,
+    title: c.title,
+    startMs: c.startMs,
+    endMs: c.endMs,
+  }));
+}
+
+export function useAudiobookPlayback() {
+  const token = useLibraryStore((s) => s.token);
+  const recordListened = useAudiobookPlayerStore((s) => s.recordListened);
+  const storedSpeed = useAudiobookPlayerStore((s) => s.speed);
+  const setStoredSpeed = useAudiobookPlayerStore((s) => s.setSpeed);
+
+  const play = useCallback(
+    async (audiobookId: string, chapters: Chapter[]) => {
+      const serverUrl: string = await invoke("get_server_url");
+      await invoke("audiobook_play", {
+        audiobookId,
+        chapters: toTauriChapters(chapters),
+        serverUrl,
+        token,
+      });
+      const speed = storedSpeed(audiobookId);
+      if (speed !== 1.0) {
+        await invoke("audiobook_set_speed", { speed });
+      }
+      recordListened(audiobookId);
+    },
+    [token, storedSpeed, recordListened]
+  );
+
+  const playFromChapter = useCallback(
+    async (audiobookId: string, chapter: number, chapters: Chapter[]) => {
+      const serverUrl: string = await invoke("get_server_url");
+      await invoke("audiobook_play_from_chapter", {
+        audiobookId,
+        chapter,
+        chapters: toTauriChapters(chapters),
+        serverUrl,
+        token,
+      });
+      const speed = storedSpeed(audiobookId);
+      if (speed !== 1.0) {
+        await invoke("audiobook_set_speed", { speed });
+      }
+      recordListened(audiobookId);
+    },
+    [token, storedSpeed, recordListened]
+  );
+
+  const resume = useCallback(
+    async (
+      audiobookId: string,
+      chapter: number,
+      offsetMs: number,
+      chapters: Chapter[]
+    ) => {
+      const serverUrl: string = await invoke("get_server_url");
+      await invoke("audiobook_resume", {
+        audiobookId,
+        chapter,
+        offsetMs,
+        chapters: toTauriChapters(chapters),
+        serverUrl,
+        token,
+      });
+      const speed = storedSpeed(audiobookId);
+      if (speed !== 1.0) {
+        await invoke("audiobook_set_speed", { speed });
+      }
+      recordListened(audiobookId);
+    },
+    [token, storedSpeed, recordListened]
+  );
+
+  const pause = useCallback(async () => {
+    await invoke("audiobook_pause");
+  }, []);
+
+  const stop = useCallback(async () => {
+    await invoke("audiobook_stop");
+  }, []);
+
+  const setSpeed = useCallback(
+    async (audiobookId: string, speed: number) => {
+      await invoke("audiobook_set_speed", { speed });
+      setStoredSpeed(audiobookId, speed);
+    },
+    [setStoredSpeed]
+  );
+
+  return { play, playFromChapter, resume, pause, stop, setSpeed };
+}

--- a/desktop/src/features/audiobook/hooks/useAudiobooks.ts
+++ b/desktop/src/features/audiobook/hooks/useAudiobooks.ts
@@ -1,0 +1,24 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+import { useAudiobookLibraryStore } from "../store";
+
+const PER_PAGE = 48;
+
+export function useAudiobooks() {
+  const token = useLibraryStore((s) => s.token);
+  const filter = useAudiobookLibraryStore((s) => s.filter);
+  const sort = useAudiobookLibraryStore((s) => s.sort);
+
+  return useInfiniteQuery({
+    queryKey: ["audiobooks-full", token, filter, sort],
+    queryFn: ({ pageParam }) =>
+      api.getAudiobooks({ page: pageParam as number, per_page: PER_PAGE, filter, sort }, token),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.data.length < PER_PAGE) return undefined;
+      return (lastPage.meta?.page ?? 1) + 1;
+    },
+    enabled: token.length > 0,
+  });
+}

--- a/desktop/src/features/audiobook/hooks/useBookmarks.ts
+++ b/desktop/src/features/audiobook/hooks/useBookmarks.ts
@@ -1,0 +1,39 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+import type { BookmarkCreate } from "../../../types/media";
+
+export function useBookmarks(audiobookId: string) {
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+  const queryKey = ["bookmarks", audiobookId, token];
+
+  const query = useQuery({
+    queryKey,
+    queryFn: () => api.getBookmarks(audiobookId, token),
+    enabled: token.length > 0 && audiobookId.length > 0,
+  });
+
+  const create = useMutation({
+    mutationFn: (bookmark: BookmarkCreate) =>
+      api.createBookmark(audiobookId, bookmark, token),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (bookmarkId: string) => api.deleteBookmark(bookmarkId, token),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  return {
+    bookmarks: query.data?.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    create,
+    remove,
+  };
+}

--- a/desktop/src/features/audiobook/hooks/useChapterNavigation.ts
+++ b/desktop/src/features/audiobook/hooks/useChapterNavigation.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export function useChapterNavigation() {
+  const nextChapter = useCallback(async () => {
+    await invoke("audiobook_next_chapter");
+  }, []);
+
+  const prevChapter = useCallback(async () => {
+    await invoke("audiobook_prev_chapter");
+  }, []);
+
+  const goToChapter = useCallback(async (chapter: number) => {
+    await invoke("audiobook_go_to_chapter", { chapter });
+  }, []);
+
+  const skipForward = useCallback(async (seconds: number) => {
+    await invoke("audiobook_skip_forward", { seconds });
+  }, []);
+
+  const skipBackward = useCallback(async (seconds: number) => {
+    await invoke("audiobook_skip_backward", { seconds });
+  }, []);
+
+  return { nextChapter, prevChapter, goToChapter, skipForward, skipBackward };
+}

--- a/desktop/src/features/audiobook/hooks/usePositionSync.ts
+++ b/desktop/src/features/audiobook/hooks/usePositionSync.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+
+interface PlaybackPosition {
+  audiobookId: string;
+  chapterIndex: number;
+  chapterOffsetMs: number;
+  chapterTitle: string;
+  playbackSpeed: number;
+  isPlaying: boolean;
+}
+
+const POLL_INTERVAL_MS = 1000;
+const POSITION_QUERY_KEY = ["audiobook-position"] as const;
+
+async function fetchPosition(): Promise<PlaybackPosition | null> {
+  return invoke<PlaybackPosition | null>("audiobook_get_position");
+}
+
+export function usePositionSync() {
+  const { data: position } = useQuery({
+    queryKey: POSITION_QUERY_KEY,
+    queryFn: fetchPosition,
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  return { position: position ?? null };
+}

--- a/desktop/src/features/audiobook/hooks/useSleepTimer.ts
+++ b/desktop/src/features/audiobook/hooks/useSleepTimer.ts
@@ -1,0 +1,64 @@
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+
+interface SleepTimerState {
+  endOfChapter: boolean;
+  totalSecs: number;
+  elapsedSecs: number;
+  remainingSecs: number;
+  fading: boolean;
+}
+
+const POLL_INTERVAL_MS = 1000;
+const SLEEP_TIMER_QUERY_KEY = ["sleep-timer"] as const;
+
+async function fetchTimerState(): Promise<SleepTimerState | null> {
+  return invoke<SleepTimerState | null>("sleep_timer_get");
+}
+
+export function useSleepTimer() {
+  const queryClient = useQueryClient();
+
+  const { data: timerState } = useQuery({
+    queryKey: SLEEP_TIMER_QUERY_KEY,
+    queryFn: fetchTimerState,
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  const invalidate = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: SLEEP_TIMER_QUERY_KEY });
+  }, [queryClient]);
+
+  const setTimer = useCallback(
+    async (minutes: number) => {
+      await invoke("sleep_timer_set", { minutes });
+      await invalidate();
+    },
+    [invalidate]
+  );
+
+  const setEndOfChapter = useCallback(async () => {
+    await invoke("sleep_timer_set_end_of_chapter");
+    await invalidate();
+  }, [invalidate]);
+
+  const cancel = useCallback(async () => {
+    await invoke("sleep_timer_cancel");
+    await invalidate();
+  }, [invalidate]);
+
+  const extendFiveMinutes = useCallback(async () => {
+    await invoke("sleep_timer_extend", { minutes: 5 });
+    await invalidate();
+  }, [invalidate]);
+
+  return {
+    timerState: timerState ?? null,
+    isActive: timerState != null,
+    setTimer,
+    setEndOfChapter,
+    cancel,
+    extendFiveMinutes,
+  };
+}

--- a/desktop/src/features/audiobook/pages/AudiobookDetailPage.tsx
+++ b/desktop/src/features/audiobook/pages/AudiobookDetailPage.tsx
@@ -1,0 +1,159 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { useAudiobook, useAudiobookProgress } from "../hooks/useAudiobook";
+import { useAudiobookPlayback } from "../hooks/useAudiobookPlayback";
+import { useBookmarks } from "../hooks/useBookmarks";
+import ChapterList from "../components/ChapterList";
+import BookmarkList from "../components/BookmarkList";
+import type { Chapter, Bookmark } from "../../../types/media";
+
+function formatDuration(ms: number): string {
+  const totalMins = Math.floor(ms / 60_000);
+  const hours = Math.floor(totalMins / 60);
+  const mins = totalMins % 60;
+  return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+      {message}
+    </div>
+  );
+}
+
+export default function AudiobookDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { resume, playFromChapter } = useAudiobookPlayback();
+
+  const audiobookQuery = useAudiobook(id ?? "");
+  const progressQuery = useAudiobookProgress(id ?? "");
+  const { bookmarks, remove } = useBookmarks(id ?? "");
+
+  const book = audiobookQuery.data?.data;
+  const progress = progressQuery.data?.data;
+
+  if (!id) return <EmptyState message="No audiobook selected." />;
+  if (audiobookQuery.isLoading) return <EmptyState message="Loading…" />;
+  if (audiobookQuery.isError || !book) return <EmptyState message="Audiobook not found." />;
+
+  const chapters = book.chapters;
+  const currentChapterPosition = progress?.chapterPosition ?? 0;
+
+  const handleResume = async () => {
+    if (progress) {
+      await resume(book.id, progress.chapterPosition, progress.offsetMs, chapters);
+    } else {
+      await playFromChapter(book.id, 0, chapters);
+    }
+    void navigate("/audiobook-player");
+  };
+
+  const handleChapterSelect = async (chapter: Chapter) => {
+    await playFromChapter(book.id, chapter.position, chapters);
+    void navigate("/audiobook-player");
+  };
+
+  const handleBookmarkJump = async (bm: Bookmark) => {
+    await resume(book.id, bm.chapterPosition, bm.offsetMs, chapters);
+    void navigate("/audiobook-player");
+  };
+
+  const resumeLabel = progress
+    ? `Resume from Ch. ${progress.chapterPosition + 1} (${Math.round(progress.percentComplete)}%)`
+    : "Start from beginning";
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      {/* Left: cover + metadata + resume */}
+      <div className="w-72 flex-shrink-0 flex flex-col bg-gray-900 border-r border-gray-800 overflow-y-auto">
+        <div className="p-6 space-y-4">
+          <div className="aspect-square bg-gray-800 rounded-lg flex items-center justify-center overflow-hidden">
+            {book.coverUrl ? (
+              <img src={book.coverUrl} alt={book.title} className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-6xl font-bold text-gray-600">
+                {book.title.charAt(0)}
+              </span>
+            )}
+          </div>
+
+          <div>
+            <h1 className="text-lg font-semibold text-white leading-tight">{book.title}</h1>
+            <p className="text-sm text-gray-400 mt-1">{book.author}</p>
+            {book.narrator && (
+              <p className="text-xs text-gray-500 mt-0.5">Narrated by {book.narrator}</p>
+            )}
+            {book.seriesName && (
+              <p className="text-xs text-gray-500 mt-0.5">
+                {book.seriesName}
+                {book.seriesPosition != null ? ` #${book.seriesPosition}` : ""}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => void handleResume()}
+            className="w-full py-3 bg-blue-600 hover:bg-blue-500 text-white rounded-lg font-medium transition-colors text-sm"
+          >
+            {resumeLabel}
+          </button>
+
+          <div className="space-y-1 text-xs text-gray-500">
+            <div className="flex justify-between">
+              <span>Duration</span>
+              <span className="text-gray-400">{formatDuration(book.durationMs)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Chapters</span>
+              <span className="text-gray-400">{book.chapterCount}</span>
+            </div>
+            {book.publisher && (
+              <div className="flex justify-between">
+                <span>Publisher</span>
+                <span className="text-gray-400 truncate ml-2">{book.publisher}</span>
+              </div>
+            )}
+            {book.asin && (
+              <div className="flex justify-between">
+                <span>ASIN</span>
+                <span className="text-gray-400">{book.asin}</span>
+              </div>
+            )}
+          </div>
+
+          {book.description && (
+            <p className="text-xs text-gray-400 leading-relaxed">{book.description}</p>
+          )}
+        </div>
+
+        {/* Bookmarks */}
+        <div className="border-t border-gray-800 p-4">
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+            Bookmarks
+          </p>
+          <BookmarkList
+            bookmarks={bookmarks}
+            onJump={(bm) => void handleBookmarkJump(bm)}
+            onDelete={(bmId) => void remove.mutate(bmId)}
+          />
+        </div>
+      </div>
+
+      {/* Right: chapter list */}
+      <div className="flex-1 overflow-hidden flex flex-col">
+        <div className="px-4 py-3 border-b border-gray-800 flex-shrink-0">
+          <p className="text-sm font-medium text-gray-300">Chapters</p>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <ChapterList
+            chapters={chapters}
+            currentChapterPosition={currentChapterPosition}
+            onSelect={(ch) => void handleChapterSelect(ch)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/pages/AudiobookPlayerPage.tsx
+++ b/desktop/src/features/audiobook/pages/AudiobookPlayerPage.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { usePositionSync } from "../hooks/usePositionSync";
+import { useAudiobookPlayback } from "../hooks/useAudiobookPlayback";
+import { useChapterNavigation } from "../hooks/useChapterNavigation";
+import { useSleepTimer } from "../hooks/useSleepTimer";
+import { useBookmarks } from "../hooks/useBookmarks";
+import AudiobookTransport from "../components/AudiobookTransport";
+import SpeedControl from "../components/SpeedControl";
+import SleepTimerControl from "../components/SleepTimerControl";
+import BookmarkButton from "../components/BookmarkButton";
+import ProgressIndicator from "../components/ProgressIndicator";
+import { useAudiobookPlayerStore } from "../store";
+
+function formatMs(ms: number): string {
+  const totalSecs = Math.floor(ms / 1000);
+  const mins = Math.floor(totalSecs / 60);
+  const secs = totalSecs % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+}
+
+function formatRemaining(secs: number): string {
+  const mins = Math.floor(secs / 60);
+  const s = secs % 60;
+  if (mins > 0) return `${mins}:${String(s).padStart(2, "0")}`;
+  return `${s}s`;
+}
+
+export default function AudiobookPlayerPage() {
+  const navigate = useNavigate();
+  const { position } = usePositionSync();
+  const { pause, stop, setSpeed } = useAudiobookPlayback();
+  const { nextChapter, prevChapter, skipForward, skipBackward } = useChapterNavigation();
+  const { timerState, setTimer, setEndOfChapter, cancel, extendFiveMinutes } = useSleepTimer();
+  const storedSpeed = useAudiobookPlayerStore((s) => s.speed);
+  const [showChapters, setShowChapters] = useState(false);
+  const [showSpeedControl, setShowSpeedControl] = useState(false);
+  const [showSleepTimer, setShowSleepTimer] = useState(false);
+
+  const audiobookId = position?.audiobookId ?? "";
+  const speed = position?.playbackSpeed ?? storedSpeed(audiobookId);
+
+  const { create: createBookmark } = useBookmarks(audiobookId);
+
+  const addBookmark = useCallback(async () => {
+    if (!position) return;
+    const label = `Ch. ${position.chapterIndex + 1}, ${formatMs(position.chapterOffsetMs)}`;
+    await createBookmark.mutateAsync({
+      chapterPosition: position.chapterIndex,
+      offsetMs: position.chapterOffsetMs,
+      label,
+    });
+  }, [position, createBookmark]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+
+      switch (e.key) {
+        case " ":
+          e.preventDefault();
+          if (position?.isPlaying) {
+            void pause();
+          }
+          break;
+        case "ArrowRight":
+          if (e.shiftKey) {
+            void nextChapter();
+          } else {
+            void skipForward(30);
+          }
+          break;
+        case "ArrowLeft":
+          if (e.shiftKey) {
+            void prevChapter();
+          } else {
+            void skipBackward(30);
+          }
+          break;
+        case "]":
+          if (position) {
+            const newSpeed = Math.min(3.0, Math.round((speed + 0.05) * 100) / 100);
+            void setSpeed(audiobookId, newSpeed);
+          }
+          break;
+        case "[":
+          if (position) {
+            const newSpeed = Math.max(0.5, Math.round((speed - 0.05) * 100) / 100);
+            void setSpeed(audiobookId, newSpeed);
+          }
+          break;
+        case "b":
+        case "B":
+          void addBookmark();
+          break;
+        case "t":
+        case "T":
+          setShowSleepTimer((v) => !v);
+          break;
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [
+    position,
+    speed,
+    audiobookId,
+    pause,
+    nextChapter,
+    prevChapter,
+    skipForward,
+    skipBackward,
+    setSpeed,
+    addBookmark,
+  ]);
+
+  if (!position) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <p className="text-gray-400">No audiobook is playing.</p>
+        <button
+          type="button"
+          onClick={() => void navigate("/library/audiobooks")}
+          className="px-4 py-2 bg-gray-700 text-gray-300 rounded hover:bg-gray-600 text-sm transition-colors"
+        >
+          Browse audiobooks
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      {/* Main player */}
+      <div className="flex-1 flex flex-col items-center justify-center gap-8 p-8 overflow-y-auto">
+        {/* Cover art placeholder */}
+        <div className="w-48 h-48 bg-gray-800 rounded-xl flex items-center justify-center shadow-2xl">
+          <span className="text-6xl font-bold text-gray-600">
+            {position.chapterTitle.charAt(0)}
+          </span>
+        </div>
+
+        {/* Chapter info */}
+        <div className="text-center space-y-1 max-w-sm w-full">
+          <p className="text-lg font-semibold text-white truncate">
+            {position.chapterTitle}
+          </p>
+          <p className="text-sm text-gray-400">
+            Chapter {position.chapterIndex + 1}
+          </p>
+        </div>
+
+        {/* Progress */}
+        <div className="max-w-sm w-full">
+          <ProgressIndicator
+            chapterIndex={position.chapterIndex}
+            totalChapters={0}
+            percentComplete={0}
+            chapterTitle={position.chapterTitle}
+          />
+        </div>
+
+        {/* Transport */}
+        <AudiobookTransport
+          isPlaying={position.isPlaying}
+          onPlayPause={() => void (position.isPlaying ? pause() : Promise.resolve())}
+          onSkipBack={() => void skipBackward(30)}
+          onSkipForward={() => void skipForward(30)}
+          onPrevChapter={() => void prevChapter()}
+          onNextChapter={() => void nextChapter()}
+        />
+
+        {/* Controls row */}
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => setShowSpeedControl((v) => !v)}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-800 text-gray-300 hover:bg-gray-700 rounded text-sm transition-colors"
+          >
+            {speed.toFixed(2)}x
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setShowSleepTimer((v) => !v)}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-800 text-gray-300 hover:bg-gray-700 rounded text-sm transition-colors"
+          >
+            {timerState ? (
+              <span className="text-orange-400">
+                {formatRemaining(timerState.remainingSecs)}
+              </span>
+            ) : (
+              "Sleep"
+            )}
+          </button>
+
+          <BookmarkButton onBookmark={() => void addBookmark()} />
+
+          <button
+            type="button"
+            onClick={() => setShowChapters((v) => !v)}
+            className="px-3 py-1.5 bg-gray-800 text-gray-300 hover:bg-gray-700 rounded text-sm transition-colors"
+          >
+            Chapters
+          </button>
+
+          <button
+            type="button"
+            onClick={() => void stop()}
+            className="px-3 py-1.5 bg-gray-800 text-red-400 hover:bg-gray-700 rounded text-sm transition-colors"
+          >
+            Stop
+          </button>
+        </div>
+
+        {/* Speed control panel */}
+        {showSpeedControl && (
+          <div className="max-w-sm w-full bg-gray-800 rounded-lg p-4">
+            <SpeedControl
+              speed={speed}
+              onSpeedChange={(s) => void setSpeed(audiobookId, s)}
+            />
+          </div>
+        )}
+
+        {/* Sleep timer panel */}
+        {showSleepTimer && (
+          <div className="max-w-sm w-full bg-gray-800 rounded-lg p-4">
+            <SleepTimerControl
+              timerState={timerState}
+              onSetTimer={(m) => void setTimer(m)}
+              onSetEndOfChapter={() => void setEndOfChapter()}
+              onCancel={() => void cancel()}
+              onExtend={() => void extendFiveMinutes()}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Chapter drawer */}
+      {showChapters && (
+        <div className="w-72 flex-shrink-0 bg-gray-900 border-l border-gray-800 flex flex-col overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800">
+            <p className="text-sm font-medium text-gray-300">Chapters</p>
+            <button
+              type="button"
+              onClick={() => setShowChapters(false)}
+              className="text-gray-500 hover:text-white text-sm"
+            >
+              Close
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            <p className="px-4 py-8 text-center text-sm text-gray-500">
+              Open the detail page to see all chapters.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/pages/AudiobooksPage.tsx
+++ b/desktop/src/features/audiobook/pages/AudiobooksPage.tsx
@@ -1,0 +1,157 @@
+import { useNavigate } from "react-router-dom";
+import clsx from "clsx";
+import { useAudiobooks } from "../hooks/useAudiobooks";
+import { useLibraryStore } from "../../library/store";
+import { useAudiobookLibraryStore } from "../store";
+import { useAudiobookPlayerStore } from "../store";
+import AudiobookGrid from "../components/AudiobookGrid";
+import type { Audiobook } from "../../../types/media";
+import type { FilterOption, SortOption } from "../store";
+
+const FILTER_LABELS: Record<FilterOption, string> = {
+  all: "All",
+  in_progress: "In Progress",
+  completed: "Completed",
+  not_started: "Not Started",
+};
+
+const SORT_LABELS: Record<SortOption, string> = {
+  title: "Title",
+  author: "Author",
+  recently_listened: "Recently Listened",
+  progress: "Progress",
+  date_added: "Date Added",
+};
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+      {message}
+    </div>
+  );
+}
+
+export default function AudiobooksPage() {
+  const navigate = useNavigate();
+  const token = useLibraryStore((s) => s.token);
+  const filter = useAudiobookLibraryStore((s) => s.filter);
+  const sort = useAudiobookLibraryStore((s) => s.sort);
+  const setFilter = useAudiobookLibraryStore((s) => s.setFilter);
+  const setSort = useAudiobookLibraryStore((s) => s.setSort);
+  const recentlyListened = useAudiobookPlayerStore((s) => s.recentlyListened);
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
+    useAudiobooks();
+
+  const books = data?.pages.flatMap((p) => p.data) ?? [];
+
+  const recentBooks = books
+    .filter((b) => recentlyListened.includes(b.id))
+    .sort(
+      (a, b) => recentlyListened.indexOf(a.id) - recentlyListened.indexOf(b.id)
+    )
+    .slice(0, 6);
+
+  const handleSelect = (book: Audiobook) => {
+    void navigate(`/library/audiobooks/${book.id}`);
+  };
+
+  if (!token) return <EmptyState message="Set an API token in Settings to browse your library." />;
+  if (isLoading) return <EmptyState message="Loading…" />;
+  if (isError) return <EmptyState message="Failed to load audiobooks." />;
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Filter and sort bar */}
+      <div className="flex items-center gap-4 px-4 py-3 border-b border-gray-800 flex-shrink-0">
+        <div className="flex gap-1">
+          {(Object.keys(FILTER_LABELS) as FilterOption[]).map((f) => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => setFilter(f)}
+              className={clsx(
+                "px-3 py-1 rounded text-xs font-medium transition-colors",
+                filter === f
+                  ? "bg-gray-700 text-white"
+                  : "text-gray-400 hover:text-white"
+              )}
+            >
+              {FILTER_LABELS[f]}
+            </button>
+          ))}
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <span className="text-xs text-gray-500">Sort:</span>
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as SortOption)}
+            className="bg-gray-800 text-gray-300 text-xs rounded px-2 py-1 border border-gray-700"
+          >
+            {(Object.keys(SORT_LABELS) as SortOption[]).map((s) => (
+              <option key={s} value={s}>
+                {SORT_LABELS[s]}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Continue listening */}
+      {recentBooks.length > 0 && (
+        <div className="px-4 py-3 border-b border-gray-800 flex-shrink-0">
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+            Continue Listening
+          </p>
+          <div className="flex gap-3 overflow-x-auto pb-1">
+            {recentBooks.map((book) => (
+              <button
+                key={book.id}
+                type="button"
+                onClick={() => handleSelect(book)}
+                className="flex-shrink-0 flex items-center gap-2 bg-gray-800 hover:bg-gray-700 rounded-lg p-2 transition-colors max-w-[200px]"
+              >
+                <div className="w-10 h-10 bg-gray-700 rounded flex items-center justify-center flex-shrink-0">
+                  {book.coverUrl ? (
+                    <img
+                      src={book.coverUrl}
+                      alt=""
+                      className="w-full h-full object-cover rounded"
+                    />
+                  ) : (
+                    <span className="text-lg font-bold text-gray-500">
+                      {book.title.charAt(0)}
+                    </span>
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-white truncate">{book.title}</p>
+                  {book.progress && (
+                    <p className="text-xs text-gray-400">
+                      {Math.round(book.progress.percentComplete)}%
+                    </p>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Main grid */}
+      <div className="flex-1 overflow-hidden">
+        {books.length === 0 ? (
+          <EmptyState message="No audiobooks found." />
+        ) : (
+          <AudiobookGrid
+            books={books}
+            hasNextPage={hasNextPage ?? false}
+            isFetchingNextPage={isFetchingNextPage}
+            fetchNextPage={() => void fetchNextPage()}
+            onSelect={handleSelect}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/audiobook/store.ts
+++ b/desktop/src/features/audiobook/store.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type FilterOption = "all" | "in_progress" | "completed" | "not_started";
+type SortOption = "title" | "author" | "recently_listened" | "progress" | "date_added";
+
+interface AudiobookLibraryState {
+  filter: FilterOption;
+  sort: SortOption;
+  setFilter: (filter: FilterOption) => void;
+  setSort: (sort: SortOption) => void;
+}
+
+export const useAudiobookLibraryStore = create<AudiobookLibraryState>()(
+  persist(
+    (set) => ({
+      filter: "all",
+      sort: "title",
+      setFilter: (filter) => set({ filter }),
+      setSort: (sort) => set({ sort }),
+    }),
+    { name: "harmonia-audiobook-library" }
+  )
+);
+
+interface SpeedEntry {
+  speed: number;
+}
+
+interface AudiobookPlayerState {
+  // Per-audiobook speed keyed by audiobook ID
+  speeds: Record<string, SpeedEntry>;
+  // Most recently listened audiobook IDs (front = most recent)
+  recentlyListened: string[];
+  setSpeed: (audiobookId: string, speed: number) => void;
+  speed: (audiobookId: string) => number;
+  recordListened: (audiobookId: string) => void;
+}
+
+const DEFAULT_SPEED = 1.0;
+const MAX_RECENT = 20;
+
+export const useAudiobookPlayerStore = create<AudiobookPlayerState>()(
+  persist(
+    (set, get) => ({
+      speeds: {},
+      recentlyListened: [],
+      setSpeed: (audiobookId, speed) =>
+        set((s) => ({ speeds: { ...s.speeds, [audiobookId]: { speed } } })),
+      speed: (audiobookId) => get().speeds[audiobookId]?.speed ?? DEFAULT_SPEED,
+      recordListened: (audiobookId) =>
+        set((s) => {
+          const without = s.recentlyListened.filter((id) => id !== audiobookId);
+          return { recentlyListened: [audiobookId, ...without].slice(0, MAX_RECENT) };
+        }),
+    }),
+    { name: "harmonia-audiobook-player" }
+  )
+);
+
+export type { FilterOption, SortOption };

--- a/desktop/src/types/media.ts
+++ b/desktop/src/types/media.ts
@@ -1,5 +1,3 @@
-/** Podcast and episode media types. */
-
 import type { ApiResponse } from "./api";
 
 export type PaginatedResponse<T> = ApiResponse<T[]>;
@@ -72,4 +70,70 @@ export interface LatestEpisodeParams {
   page?: number;
   pageSize?: number;
   hoursBack?: number;
+}
+
+export interface Audiobook {
+  id: string;
+  title: string;
+  author: string;
+  narrator: string | null;
+  seriesName: string | null;
+  seriesPosition: number | null;
+  description: string | null;
+  durationMs: number;
+  coverUrl: string | null;
+  chapterCount: number;
+  progress: AudiobookProgress | null;
+}
+
+export interface AudiobookDetail extends Audiobook {
+  publisher: string | null;
+  asin: string | null;
+  isbn: string | null;
+  chapters: Chapter[];
+}
+
+export interface Chapter {
+  position: number;
+  title: string;
+  startMs: number;
+  endMs: number;
+  source: "audnexus" | "embedded" | "fallback";
+}
+
+export interface AudiobookProgress {
+  chapterPosition: number;
+  offsetMs: number;
+  percentComplete: number;
+  chapterTitle: string;
+  totalChapters: number;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+export interface ProgressUpdate {
+  chapterPosition: number;
+  offsetMs: number;
+}
+
+export interface Bookmark {
+  id: string;
+  audiobookId: string;
+  chapterPosition: number;
+  offsetMs: number;
+  label: string;
+  createdAt: string;
+}
+
+export interface BookmarkCreate {
+  chapterPosition: number;
+  offsetMs: number;
+  label: string;
+}
+
+export interface AudiobookQueryParams {
+  page: number;
+  per_page: number;
+  filter?: "all" | "in_progress" | "completed" | "not_started";
+  sort?: "title" | "author" | "recently_listened" | "progress" | "date_added";
 }


### PR DESCRIPTION
## Summary

- **Chapter navigation**: next/prev chapter, click-to-jump in chapter list, skip ±30s; current chapter auto-scrolls into view and is highlighted
- **Variable speed**: 0.5x–3.0x in 0.05x steps; presets (0.75×–3.0×); speed persists per audiobook in Zustand store
- **Sleep timer**: duration picker (5–90 min) or end-of-chapter mode; 30s fade window detected client-side; "+5 more minutes" button in last 60 seconds
- **Position sync**: Tauri backend syncs chapter + offset to `PUT /api/audiobooks/{id}/progress` every 30s during playback; immediate sync on pause and chapter change; final sync on stop
- **Bookmarks**: create at current position (auto-labelled), list with jump-to, delete; stored via server API
- **Audiobook library**: grid with progress overlays (blue = in-progress, green = complete), continue-listening strip, filter (all/in-progress/completed/not-started), sort (title/author/recently-listened/progress/date-added)
- **Detail page**: cover art, metadata, resume button with chapter+percentage, chapter list, bookmarks section
- **Player page**: full-screen with transport, speed, sleep timer, bookmark button, chapter drawer
- **Now-playing bar**: adapts to show chapter title, speed badge, 30s skip buttons when audiobook is active
- **Keyboard shortcuts**: Space, →/←, Shift+→/←, `]`/`[`, B, T

## Observations

- `features/library/AudiobooksPage.tsx` (the old stub) is now superseded by `features/audiobook/pages/AudiobooksPage.tsx`; the old file is unreachable via any route but was left in place since it was not in the blast radius to delete.
- P3-11 (Now Playing infrastructure) hasn't been implemented yet; `AudiobookNowPlaying` and `usePositionSync` poll the Tauri backend directly rather than through a shared playback context. These hooks will need to be wired into whatever P3-11 delivers.
- The `features/audiobook/pages/AudiobookPlayerPage.tsx` chapter drawer shows a placeholder because chapter data isn't available at the player route level — it's only fetched on the detail page. A shared playback context (P3-11) would carry chapter data across routes.
- `cargo fmt --all` reformatted two pre-existing DSP files (`dsp/commands.rs`, `dsp/mod.rs`) — whitespace/line-length only, no behavioral change.

## Test plan

- [ ] `cd desktop && npm run lint` passes
- [ ] `cd desktop && npm run build` succeeds
- [ ] `cd desktop/src-tauri && cargo clippy -- -D warnings` passes
- [ ] Audiobook library grid renders with progress overlays
- [ ] Continue Listening strip shows recently active audiobooks
- [ ] Filter tabs (All / In Progress / Completed / Not Started) change the query
- [ ] Sort selector changes the query
- [ ] Detail page shows chapters, metadata, and resume button
- [ ] Resume button starts at correct chapter + offset
- [ ] Chapter list highlights current chapter; clicking a chapter starts playback
- [ ] Skip ±30s, next/prev chapter work via IPC
- [ ] Speed presets apply; speed persists across sessions
- [ ] Sleep timer countdown displays; end-of-chapter mode works
- [ ] Bookmarks create, list, jump-to, delete
- [ ] Now-playing bar shows chapter title and 30s skip when playing
- [ ] Keyboard shortcuts active on player page