### PR TITLE
chore(deny): fix inaccurate advisory dep-chain attributions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,12 +3,12 @@
 
 [advisories]
 ignore = [
-    { id = "RUSTSEC-2023-0071", reason = "rsa via sqlx-mysql — no upstream fix available" },
+    { id = "RUSTSEC-2023-0071", reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use" },
     { id = "RUSTSEC-2025-0012", reason = "backoff unmaintained — transitive dep via librqbit" },
     { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol" },
     { id = "RUSTSEC-2025-0060", reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper" },
-    { id = "RUSTSEC-2024-0384", reason = "instant unmaintained — transitive dep via curve25519-dalek" },
-    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained — transitive dep via axum/sqlx" },
+    { id = "RUSTSEC-2024-0384", reason = "instant unmaintained — transitive dep via backoff/librqbit, no alternative" },
+    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

- Three advisory ignore reasons in `deny.toml` named the wrong crate in the dependency chain. Verified against `cargo deny check advisories` output.
- RUSTSEC-2023-0071: `rsa` arrives via `jsonwebtoken → exousia`, not `sqlx-mysql`
- RUSTSEC-2024-0384: `instant` arrives via `backoff → librqbit`, not `curve25519-dalek`
- RUSTSEC-2024-0436: `paste` arrives via `lofty → taxis`, not `axum/sqlx`

All 6 ignores still trigger without them (no stale entries). `cargo deny check` passes cleanly.

## Validation

```
cargo deny check advisories  # advisories ok
cargo deny check licenses    # licenses ok
cargo deny check bans        # bans ok
cargo deny check             # advisories ok, bans ok, licenses ok, sources ok
```

## Observations

- PR #76 (`chore(deny): standardize deny.toml with reasons and stricter policy`) completed the table-format migration and the `multiple-versions = "deny"` tightening. This PR corrects the inaccurate `via X` attributions that were carried over from that change.
- ring uses ISC license (not OpenSSL); the prompt's reference deny.toml listed `"OpenSSL"` for ring, but the actual license in this dep graph is ISC, which is already allowed.
- `LGPL-3.0-or-later`, `NCSA`, `Unicode-DFS-2016`, and `OpenSSL` do not appear in any transitive dep; not added to the license allow list.