### PR TITLE
feat(syndesmos): external API integration (P3-06)

### DIFF
--- a/crates/syndesmos/src/plex/mod.rs
+++ b/crates/syndesmos/src/plex/mod.rs
@@ -71,26 +71,13 @@ pub(crate) mod tests {
 
     pub(crate) struct MockPlexApi {
         pub(crate) sections_refreshed: Arc<Mutex<Vec<u32>>>,
-        pub(crate) fail_count: Arc<std::sync::atomic::AtomicU32>,
     }
 
     impl MockPlexApi {
         pub(crate) fn new() -> Self {
             Self {
                 sections_refreshed: Arc::new(Mutex::new(Vec::new())),
-                fail_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             }
-        }
-
-        #[expect(
-            dead_code,
-            reason = "available for future tests requiring pre-configured failures"
-        )]
-        pub(crate) fn with_failures(failures: u32) -> Self {
-            let mock = Self::new();
-            mock.fail_count
-                .store(failures, std::sync::atomic::Ordering::SeqCst);
-            mock
         }
 
         pub(crate) fn refreshed_sections(&self) -> Vec<u32> {
@@ -104,22 +91,7 @@ pub(crate) mod tests {
             section_id: u32,
         ) -> BoxFuture<'_, Result<(), SyndesmodError>> {
             let sections = self.sections_refreshed.clone();
-            let fail_count = self.fail_count.clone();
             Box::pin(async move {
-                let remaining = fail_count.fetch_update(
-                    std::sync::atomic::Ordering::SeqCst,
-                    std::sync::atomic::Ordering::SeqCst,
-                    |n| if n > 0 { Some(n - 1) } else { None },
-                );
-                if remaining.is_ok() {
-                    return Err(SyndesmodError::PlexApiCall {
-                        source: reqwest::Client::new()
-                            .get("http://invalid.test/")
-                            .build()
-                            .unwrap_err(),
-                        location: snafu::location!(),
-                    });
-                }
                 sections.lock().unwrap().push(section_id);
                 Ok(())
             })


### PR DESCRIPTION
## Summary

- Adds the `syndesmos` crate: external API integration for Plex, Last.fm, and Tidal
- Implements `ExternalIntegration` trait with all four methods: `notify_plex_import`, `scrobble`, `sync_tidal_want_list`, `get_artist_data`
- Aggelia event handler for `PlexNotifyRequired` → Plex library refresh and `ScrobbleRequired` → Last.fm scrobble
- Per-service circuit breakers (Plex, Last.fm, Tidal) with configurable threshold (default: 5 failures) and cooldown (default: 5 min)
- Exponential-backoff retry: 1 initial + 3 retries at 2 s, 8 s, 32 s
- All integrations degrade gracefully when unconfigured (`Ok(())` / `Ok(None)` / `Ok(vec![])`)
- `SyndesmosConfig` added to horismos (`PlexConfig`, `LastfmConfig`, `TidalConfig`, all `Option<_>`)
- Removes unused `MockPlexApi::with_failures` and `fail_count` — dead code containing a latent panic (`unwrap_err()` on a URL that reqwest accepts as valid)

## Test count

36 tests, all green:
- `retry`: 7 tests (backoff, circuit breaker trip/reset, attempt count)
- `events`: 3 tests (PlexNotifyRequired, ScrobbleRequired, cancellation)
- `plex/notify`: 4 tests (section mapping, no-section graceful, by-section direct)
- `lastfm/artist`: 3 tests (found, not found, JSON parse)
- `lastfm/scrobble`: 2 tests (mock parameters, circuit path)
- `lastfm/auth`: 3 tests (auth URL, signature sort, format exclusion)
- `tidal/wantlist`: 5 tests (delta, event emit, no event, empty, parse)
- `lib` (SyndesmosService): 9 tests (all four methods: unconfigured + configured)

## Validation results

```
cargo fmt --all -- --check     OK
cargo clippy -p syndesmos -- -D warnings   OK (zero warnings)
cargo test -p syndesmos        36 passed, 0 failed
```

## Observations

- `MockPlexApi::with_failures` used `reqwest::Client::new().get("http://invalid.test/").build().unwrap_err()` to generate a `reqwest::Error`. Because `http://invalid.test/` is a syntactically valid URL, `build()` succeeds and `unwrap_err()` would panic if this path were ever hit. The entire failure-simulation path was removed; retry behavior is tested generically in `retry.rs`.
- `#[tokio::test(start_paused = true)]` requires the `test-util` tokio feature. The prompt spec omitted it; correctly added to dev-dependencies.