### PR TITLE
feat(aitesis): request management (P3-05)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aitesis"
+version = "0.1.0"
+dependencies = [
+ "harmonia-common",
+ "harmonia-db",
+ "horismos",
+ "jiff",
+ "rstest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/zetesis",
     "crates/ergasia",
     "crates/syndesmos",
+    "crates/aitesis",
     "crates/harmonia-host",
 ]
 exclude = [
@@ -39,6 +40,7 @@ komide          = { path = "crates/komide" }
 zetesis         = { path = "crates/zetesis" }
 ergasia         = { path = "crates/ergasia" }
 syndesmos       = { path = "crates/syndesmos" }
+aitesis         = { path = "crates/aitesis" }
 
 # ── Async runtime ──────────────────────────────────────────────────────────────
 tokio           = { version = "1", features = ["full"] }

--- a/crates/aitesis/Cargo.toml
+++ b/crates/aitesis/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "aitesis"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Household media request management for Harmonia"
+
+[dependencies]
+harmonia-common.workspace = true
+horismos.workspace = true
+harmonia-db.workspace = true
+sqlx.workspace = true
+snafu.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+serde.workspace = true
+uuid.workspace = true
+jiff.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/aitesis/src/approval.rs
+++ b/crates/aitesis/src/approval.rs
@@ -1,0 +1,299 @@
+//! Approval logic: Admin auto-approve on submission, Member requires explicit approval.
+
+use harmonia_common::{RequestId, UserId, WantId};
+use sqlx::SqlitePool;
+use tracing::instrument;
+
+use crate::error::{AitesisError, InsufficientPermissionSnafu, RequestNotFoundSnafu};
+use crate::types::{MediaRequest, RequestStatus, UserRole};
+use crate::workflow::validate_transition;
+
+/// Trait boundary to Epignosis — validates that requested media is identifiable.
+#[expect(
+    async_fn_in_trait,
+    reason = "async fn in trait stable since 1.75; dyn dispatch not required here"
+)]
+pub trait IdentityValidator: Send + Sync {
+    async fn validate(
+        &self,
+        media_type: harmonia_common::MediaType,
+        title: &str,
+        external_id: Option<&str>,
+    ) -> Result<(), AitesisError>;
+}
+
+/// Trait boundary to Episkope — begins monitoring for a requested item.
+#[expect(
+    async_fn_in_trait,
+    reason = "async fn in trait stable since 1.75; dyn dispatch not required here"
+)]
+pub trait MonitorService: Send + Sync {
+    async fn create_want(&self, request: &MediaRequest) -> Result<WantId, AitesisError>;
+}
+
+/// Trait boundary to Exousia — looks up a user's role without coupling to the auth crate.
+#[expect(
+    async_fn_in_trait,
+    reason = "async fn in trait stable since 1.75; dyn dispatch not required here"
+)]
+pub trait UserRoleProvider: Send + Sync {
+    async fn role_of(&self, user_id: UserId) -> Result<UserRole, AitesisError>;
+}
+
+/// Approves a request: validates identity, creates a want, transitions to Monitoring.
+///
+/// Requires `admin_id` to have the Admin role.
+#[instrument(skip(pool, identity, monitor), fields(request_id = %request_id, admin_id = %admin_id))]
+pub(crate) async fn approve_request<I, M>(
+    pool: &SqlitePool,
+    request_id: RequestId,
+    admin_id: UserId,
+    admin_role: UserRole,
+    identity: &I,
+    monitor: &M,
+) -> Result<MediaRequest, AitesisError>
+where
+    I: IdentityValidator,
+    M: MonitorService,
+{
+    if admin_role != UserRole::Admin {
+        return InsufficientPermissionSnafu.fail();
+    }
+
+    let request = crate::repo::get_request(pool, &request_id)
+        .await?
+        .ok_or_else(|| {
+            RequestNotFoundSnafu {
+                id: request_id.to_string(),
+            }
+            .build()
+        })?;
+
+    validate_transition(request.status, RequestStatus::Approved)?;
+
+    identity
+        .validate(
+            request.media_type,
+            &request.title,
+            request.external_id.as_deref(),
+        )
+        .await?;
+
+    let want_id = monitor.create_want(&request).await?;
+
+    let now = jiff::Timestamp::now();
+    crate::repo::update_status(
+        pool,
+        &request_id,
+        RequestStatus::Monitoring,
+        Some(&admin_id),
+        Some(now),
+        None,
+        Some(&want_id),
+    )
+    .await?;
+
+    crate::repo::get_request(pool, &request_id)
+        .await?
+        .ok_or_else(|| {
+            RequestNotFoundSnafu {
+                id: request_id.to_string(),
+            }
+            .build()
+        })
+}
+
+/// Denies a request: transitions to Denied with an optional reason.
+///
+/// Requires `admin_id` to have the Admin role.
+#[instrument(skip(pool), fields(request_id = %request_id, admin_id = %admin_id))]
+pub(crate) async fn deny_request(
+    pool: &SqlitePool,
+    request_id: RequestId,
+    admin_id: UserId,
+    admin_role: UserRole,
+    reason: Option<String>,
+) -> Result<MediaRequest, AitesisError> {
+    if admin_role != UserRole::Admin {
+        return InsufficientPermissionSnafu.fail();
+    }
+
+    let request = crate::repo::get_request(pool, &request_id)
+        .await?
+        .ok_or_else(|| {
+            RequestNotFoundSnafu {
+                id: request_id.to_string(),
+            }
+            .build()
+        })?;
+
+    validate_transition(request.status, RequestStatus::Denied)?;
+
+    let now = jiff::Timestamp::now();
+    crate::repo::update_status(
+        pool,
+        &request_id,
+        RequestStatus::Denied,
+        Some(&admin_id),
+        Some(now),
+        reason.as_deref(),
+        None,
+    )
+    .await?;
+
+    crate::repo::get_request(pool, &request_id)
+        .await?
+        .ok_or_else(|| {
+            RequestNotFoundSnafu {
+                id: request_id.to_string(),
+            }
+            .build()
+        })
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use harmonia_common::{MediaType, UserId, WantId};
+    use harmonia_db::migrate::MIGRATOR;
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use harmonia_common::RequestId;
+
+    use crate::repo::insert_request;
+    use crate::types::{MediaRequest, RequestStatus};
+
+    pub(crate) struct AlwaysValidIdentity;
+    impl IdentityValidator for AlwaysValidIdentity {
+        async fn validate(
+            &self,
+            _media_type: harmonia_common::MediaType,
+            _title: &str,
+            _external_id: Option<&str>,
+        ) -> Result<(), AitesisError> {
+            Ok(())
+        }
+    }
+
+    pub(crate) struct AlwaysCreateMonitor;
+    impl MonitorService for AlwaysCreateMonitor {
+        async fn create_want(&self, _request: &MediaRequest) -> Result<WantId, AitesisError> {
+            Ok(WantId::new())
+        }
+    }
+
+    pub(crate) async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn submitted_request(user_id: UserId) -> MediaRequest {
+        MediaRequest {
+            id: RequestId::new(),
+            user_id,
+            media_type: MediaType::Music,
+            title: "Led Zeppelin IV".to_string(),
+            external_id: None,
+            status: RequestStatus::Submitted,
+            decided_by: None,
+            decided_at: None,
+            deny_reason: None,
+            want_id: None,
+            created_at: jiff::Timestamp::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn approve_transitions_to_monitoring() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let admin_id = UserId::new();
+        let req = submitted_request(user_id);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        let updated = approve_request(
+            &pool,
+            req_id,
+            admin_id,
+            UserRole::Admin,
+            &AlwaysValidIdentity,
+            &AlwaysCreateMonitor,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(updated.status, RequestStatus::Monitoring);
+        assert_eq!(updated.decided_by, Some(admin_id));
+        assert!(updated.want_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn approve_by_member_returns_insufficient_permission() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let req = submitted_request(user_id);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        let err = approve_request(
+            &pool,
+            req_id,
+            user_id,
+            UserRole::Member,
+            &AlwaysValidIdentity,
+            &AlwaysCreateMonitor,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, AitesisError::InsufficientPermission { .. }));
+    }
+
+    #[tokio::test]
+    async fn deny_transitions_to_denied_with_reason() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let admin_id = UserId::new();
+        let req = submitted_request(user_id);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        let updated = deny_request(
+            &pool,
+            req_id,
+            admin_id,
+            UserRole::Admin,
+            Some("Not available in this region".to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(updated.status, RequestStatus::Denied);
+        assert_eq!(
+            updated.deny_reason.as_deref(),
+            Some("Not available in this region")
+        );
+        assert_eq!(updated.decided_by, Some(admin_id));
+    }
+
+    #[tokio::test]
+    async fn deny_already_denied_returns_invalid_transition() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let admin_id = UserId::new();
+        let req = submitted_request(user_id);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        deny_request(&pool, req_id, admin_id, UserRole::Admin, None)
+            .await
+            .unwrap();
+
+        let err = deny_request(&pool, req_id, admin_id, UserRole::Admin, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AitesisError::InvalidTransition { .. }));
+    }
+}

--- a/crates/aitesis/src/error.rs
+++ b/crates/aitesis/src/error.rs
@@ -1,0 +1,56 @@
+//! AitesisError — typed errors for the request management subsystem.
+
+use snafu::Snafu;
+
+use harmonia_db::DbError;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum AitesisError {
+    #[snafu(display("request limit exceeded"))]
+    RequestLimitExceeded {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("request not found: {id}"))]
+    RequestNotFound {
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("request already exists"))]
+    RequestAlreadyExists {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("media identity invalid: {detail}"))]
+    MediaIdentityInvalid {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("invalid status transition: {from} -> {to}"))]
+    InvalidTransition {
+        from: String,
+        to: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("insufficient permission for this action"))]
+    InsufficientPermission {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("database error: {source}"))]
+    Database {
+        source: DbError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/aitesis/src/lib.rs
+++ b/crates/aitesis/src/lib.rs
@@ -1,0 +1,692 @@
+//! Aitesis — household media request management for Harmonia.
+//!
+//! Replaces Overseerr. Handles submission, approval workflow, per-user limits,
+//! and handoff to Episkope for monitoring.
+
+pub mod approval;
+pub mod error;
+pub mod limits;
+pub mod repo;
+pub mod types;
+pub mod workflow;
+
+pub use approval::{IdentityValidator, MonitorService, UserRoleProvider};
+pub use error::AitesisError;
+pub use types::{CreateRequestInput, MediaRequest, RequestStatus, UserRole};
+
+use harmonia_common::{RequestId, UserId};
+use horismos::AitesisConfig;
+use sqlx::SqlitePool;
+use tracing::instrument;
+
+use crate::error::{InsufficientPermissionSnafu, RequestNotFoundSnafu};
+
+/// Service trait for the full request lifecycle.
+#[expect(
+    async_fn_in_trait,
+    reason = "async fn in trait stable since 1.75; dyn dispatch not required here"
+)]
+pub trait RequestService: Send + Sync {
+    /// Submits a new request. Admin users auto-approve when `auto_approve_admins` is set.
+    async fn submit_request(
+        &self,
+        user_id: UserId,
+        input: CreateRequestInput,
+    ) -> Result<MediaRequest, AitesisError>;
+
+    /// Approves a Submitted request — requires Admin role.
+    async fn approve(
+        &self,
+        request_id: RequestId,
+        admin_id: UserId,
+    ) -> Result<MediaRequest, AitesisError>;
+
+    /// Denies a Submitted request — requires Admin role.
+    async fn deny(
+        &self,
+        request_id: RequestId,
+        admin_id: UserId,
+        reason: Option<String>,
+    ) -> Result<MediaRequest, AitesisError>;
+
+    /// Returns a single request by ID.
+    async fn get_request(&self, request_id: RequestId) -> Result<MediaRequest, AitesisError>;
+
+    /// Lists requests, optionally filtered by user or status.
+    async fn list_requests(
+        &self,
+        user_id: Option<UserId>,
+        status: Option<RequestStatus>,
+    ) -> Result<Vec<MediaRequest>, AitesisError>;
+
+    /// Cancels a request. Users may cancel their own; admins may cancel any.
+    async fn cancel_request(
+        &self,
+        request_id: RequestId,
+        user_id: UserId,
+    ) -> Result<(), AitesisError>;
+}
+
+/// Live implementation backed by SQLite.
+///
+/// Type parameters allow injecting mock role providers, identity validators, and
+/// monitor services for tests without requiring heap allocation via `dyn Trait`.
+pub struct AitesisServiceImpl<R, I, M> {
+    read: SqlitePool,
+    write: SqlitePool,
+    config: AitesisConfig,
+    user_roles: R,
+    identity: I,
+    monitor: M,
+}
+
+impl<R, I, M> AitesisServiceImpl<R, I, M>
+where
+    R: UserRoleProvider,
+    I: IdentityValidator,
+    M: MonitorService,
+{
+    pub fn new(
+        read: SqlitePool,
+        write: SqlitePool,
+        config: AitesisConfig,
+        user_roles: R,
+        identity: I,
+        monitor: M,
+    ) -> Self {
+        Self {
+            read,
+            write,
+            config,
+            user_roles,
+            identity,
+            monitor,
+        }
+    }
+}
+
+impl<R, I, M> RequestService for AitesisServiceImpl<R, I, M>
+where
+    R: UserRoleProvider,
+    I: IdentityValidator,
+    M: MonitorService,
+{
+    #[instrument(skip(self), fields(user_id = %user_id))]
+    async fn submit_request(
+        &self,
+        user_id: UserId,
+        input: CreateRequestInput,
+    ) -> Result<MediaRequest, AitesisError> {
+        let role = self.user_roles.role_of(user_id).await?;
+
+        limits::check_limits(
+            &self.read,
+            &user_id,
+            role,
+            self.config.max_pending_per_user,
+            self.config.max_requests_per_day,
+        )
+        .await?;
+
+        let auto_approve = role == UserRole::Admin && self.config.auto_approve_admins;
+        let status = if auto_approve {
+            RequestStatus::Approved
+        } else {
+            RequestStatus::Submitted
+        };
+
+        let now = jiff::Timestamp::now();
+        let request = MediaRequest {
+            id: RequestId::new(),
+            user_id,
+            media_type: input.media_type,
+            title: input.title,
+            external_id: input.external_id,
+            status,
+            decided_by: None,
+            decided_at: None,
+            deny_reason: None,
+            want_id: None,
+            created_at: now,
+        };
+
+        repo::insert_request(&self.write, &request).await?;
+
+        // Admin auto-approve: immediately validate identity, create the want, and
+        // transition to Monitoring in a single submit call.
+        if auto_approve {
+            self.identity
+                .validate(
+                    request.media_type,
+                    &request.title,
+                    request.external_id.as_deref(),
+                )
+                .await?;
+            let want_id = self.monitor.create_want(&request).await?;
+            repo::update_status(
+                &self.write,
+                &request.id,
+                RequestStatus::Monitoring,
+                Some(&user_id),
+                Some(jiff::Timestamp::now()),
+                None,
+                Some(&want_id),
+            )
+            .await?;
+            return repo::get_request(&self.read, &request.id)
+                .await?
+                .ok_or_else(|| {
+                    RequestNotFoundSnafu {
+                        id: request.id.to_string(),
+                    }
+                    .build()
+                });
+        }
+
+        Ok(request)
+    }
+
+    #[instrument(skip(self), fields(request_id = %request_id, admin_id = %admin_id))]
+    async fn approve(
+        &self,
+        request_id: RequestId,
+        admin_id: UserId,
+    ) -> Result<MediaRequest, AitesisError> {
+        let role = self.user_roles.role_of(admin_id).await?;
+        approval::approve_request(
+            &self.write,
+            request_id,
+            admin_id,
+            role,
+            &self.identity,
+            &self.monitor,
+        )
+        .await
+    }
+
+    #[instrument(skip(self), fields(request_id = %request_id, admin_id = %admin_id))]
+    async fn deny(
+        &self,
+        request_id: RequestId,
+        admin_id: UserId,
+        reason: Option<String>,
+    ) -> Result<MediaRequest, AitesisError> {
+        let role = self.user_roles.role_of(admin_id).await?;
+        approval::deny_request(&self.write, request_id, admin_id, role, reason).await
+    }
+
+    #[instrument(skip(self), fields(request_id = %request_id))]
+    async fn get_request(&self, request_id: RequestId) -> Result<MediaRequest, AitesisError> {
+        repo::get_request(&self.read, &request_id)
+            .await?
+            .ok_or_else(|| {
+                RequestNotFoundSnafu {
+                    id: request_id.to_string(),
+                }
+                .build()
+            })
+    }
+
+    #[instrument(skip(self))]
+    async fn list_requests(
+        &self,
+        user_id: Option<UserId>,
+        status: Option<RequestStatus>,
+    ) -> Result<Vec<MediaRequest>, AitesisError> {
+        match (user_id, status) {
+            (Some(uid), Some(st)) => {
+                let all = repo::list_by_user(&self.read, &uid).await?;
+                Ok(all.into_iter().filter(|r| r.status == st).collect())
+            }
+            (Some(uid), None) => repo::list_by_user(&self.read, &uid).await,
+            (None, Some(st)) => repo::list_by_status(&self.read, st).await,
+            (None, None) => repo::list_all(&self.read).await,
+        }
+    }
+
+    #[instrument(skip(self), fields(request_id = %request_id, user_id = %user_id))]
+    async fn cancel_request(
+        &self,
+        request_id: RequestId,
+        user_id: UserId,
+    ) -> Result<(), AitesisError> {
+        let request = repo::get_request(&self.read, &request_id)
+            .await?
+            .ok_or_else(|| {
+                RequestNotFoundSnafu {
+                    id: request_id.to_string(),
+                }
+                .build()
+            })?;
+
+        let role = self.user_roles.role_of(user_id).await?;
+        let is_owner = request.user_id == user_id;
+        let is_admin = role == UserRole::Admin;
+
+        if !is_owner && !is_admin {
+            return InsufficientPermissionSnafu.fail();
+        }
+
+        // Terminal statuses cannot be cancelled.
+        if matches!(
+            request.status,
+            RequestStatus::Fulfilled | RequestStatus::Failed | RequestStatus::Denied
+        ) {
+            return crate::error::InvalidTransitionSnafu {
+                from: request.status.as_str().to_string(),
+                to: "cancelled".to_string(),
+            }
+            .fail();
+        }
+
+        repo::delete_request(&self.write, &request_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use harmonia_common::{MediaType, UserId, WantId};
+    use harmonia_db::migrate::MIGRATOR;
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::approval::{IdentityValidator, MonitorService, UserRoleProvider};
+    use crate::types::{CreateRequestInput, MediaRequest, RequestStatus, UserRole};
+
+    // ── Mock helpers ──────────────────────────────────────────────────────────
+
+    struct MockRoles {
+        role: UserRole,
+    }
+
+    impl UserRoleProvider for MockRoles {
+        async fn role_of(&self, _user_id: UserId) -> Result<UserRole, AitesisError> {
+            Ok(self.role)
+        }
+    }
+
+    struct AlwaysValidIdentity;
+    impl IdentityValidator for AlwaysValidIdentity {
+        async fn validate(
+            &self,
+            _media_type: harmonia_common::MediaType,
+            _title: &str,
+            _external_id: Option<&str>,
+        ) -> Result<(), AitesisError> {
+            Ok(())
+        }
+    }
+
+    struct AlwaysCreateMonitor;
+    impl MonitorService for AlwaysCreateMonitor {
+        async fn create_want(&self, _request: &MediaRequest) -> Result<WantId, AitesisError> {
+            Ok(WantId::new())
+        }
+    }
+
+    fn default_config() -> AitesisConfig {
+        AitesisConfig::default()
+    }
+
+    type TestService = AitesisServiceImpl<MockRoles, AlwaysValidIdentity, AlwaysCreateMonitor>;
+
+    async fn make_service(role: UserRole) -> (TestService, SqlitePool) {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let config = default_config();
+        let svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            config,
+            MockRoles { role },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        (svc, pool)
+    }
+
+    fn music_input() -> CreateRequestInput {
+        CreateRequestInput {
+            media_type: MediaType::Music,
+            title: "Kind of Blue".to_string(),
+            external_id: None,
+        }
+    }
+
+    // ── Submit tests ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn member_submit_status_is_submitted() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let user_id = UserId::new();
+        let req = svc.submit_request(user_id, music_input()).await.unwrap();
+        assert_eq!(req.status, RequestStatus::Submitted);
+    }
+
+    #[tokio::test]
+    async fn admin_submit_with_auto_approve_status_is_monitoring() {
+        let (svc, _pool) = make_service(UserRole::Admin).await;
+        let user_id = UserId::new();
+        let req = svc.submit_request(user_id, music_input()).await.unwrap();
+        // auto_approve_admins is true by default — goes straight to Monitoring
+        assert_eq!(req.status, RequestStatus::Monitoring);
+    }
+
+    // ── Approve tests ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn admin_approves_member_request_transitions_to_monitoring() {
+        let (member_svc, pool) = make_service(UserRole::Member).await;
+        let member_id = UserId::new();
+        let req = member_svc
+            .submit_request(member_id, music_input())
+            .await
+            .unwrap();
+        assert_eq!(req.status, RequestStatus::Submitted);
+
+        let admin_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let admin_id = UserId::new();
+        let approved = admin_svc.approve(req.id, admin_id).await.unwrap();
+        assert_eq!(approved.status, RequestStatus::Monitoring);
+        assert_eq!(approved.decided_by, Some(admin_id));
+        assert!(approved.want_id.is_some());
+    }
+
+    // ── Deny tests ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn admin_denies_request_records_reason() {
+        let (member_svc, pool) = make_service(UserRole::Member).await;
+        let member_id = UserId::new();
+        let req = member_svc
+            .submit_request(member_id, music_input())
+            .await
+            .unwrap();
+
+        let admin_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let admin_id = UserId::new();
+        let denied = admin_svc
+            .deny(req.id, admin_id, Some("Out of scope".to_string()))
+            .await
+            .unwrap();
+
+        assert_eq!(denied.status, RequestStatus::Denied);
+        assert_eq!(denied.deny_reason.as_deref(), Some("Out of scope"));
+    }
+
+    // ── Cancel tests ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn user_cancels_own_request() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let user_id = UserId::new();
+        let req = svc.submit_request(user_id, music_input()).await.unwrap();
+
+        svc.cancel_request(req.id, user_id).await.unwrap();
+
+        let result = svc.get_request(req.id).await;
+        assert!(matches!(result, Err(AitesisError::RequestNotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn member_cannot_cancel_other_user_request() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let alice = UserId::new();
+        let bob = UserId::new();
+        let req = svc.submit_request(alice, music_input()).await.unwrap();
+
+        let err = svc.cancel_request(req.id, bob).await.unwrap_err();
+        assert!(matches!(err, AitesisError::InsufficientPermission { .. }));
+    }
+
+    // ── Limit tests ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn member_blocked_when_pending_limit_reached() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let config = AitesisConfig {
+            max_pending_per_user: 2,
+            max_requests_per_day: 100,
+            auto_approve_admins: true,
+        };
+        let svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            config,
+            MockRoles {
+                role: UserRole::Member,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let user_id = UserId::new();
+
+        svc.submit_request(user_id, music_input()).await.unwrap();
+        svc.submit_request(user_id, music_input()).await.unwrap();
+
+        let err = svc
+            .submit_request(user_id, music_input())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AitesisError::RequestLimitExceeded { .. }));
+    }
+
+    #[tokio::test]
+    async fn member_blocked_when_daily_limit_reached() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let config = AitesisConfig {
+            max_pending_per_user: 100,
+            max_requests_per_day: 2,
+            auto_approve_admins: true,
+        };
+        let svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            config,
+            MockRoles {
+                role: UserRole::Member,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let user_id = UserId::new();
+
+        svc.submit_request(user_id, music_input()).await.unwrap();
+        svc.submit_request(user_id, music_input()).await.unwrap();
+
+        let err = svc
+            .submit_request(user_id, music_input())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AitesisError::RequestLimitExceeded { .. }));
+    }
+
+    #[tokio::test]
+    async fn admin_exempt_from_limits() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let config = AitesisConfig {
+            max_pending_per_user: 1,
+            max_requests_per_day: 1,
+            // WHY: auto_approve disabled so requests stay in Submitted/Monitoring counts
+            // would normally trigger the limit — but admin is exempt regardless.
+            auto_approve_admins: false,
+        };
+        let svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            config,
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let user_id = UserId::new();
+
+        svc.submit_request(user_id, music_input()).await.unwrap();
+        svc.submit_request(user_id, music_input()).await.unwrap();
+        svc.submit_request(user_id, music_input()).await.unwrap();
+    }
+
+    // ── Invalid transition ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn denied_request_cannot_be_approved() {
+        let (member_svc, pool) = make_service(UserRole::Member).await;
+        let member_id = UserId::new();
+        let req = member_svc
+            .submit_request(member_id, music_input())
+            .await
+            .unwrap();
+
+        let admin_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let admin_id = UserId::new();
+
+        admin_svc.deny(req.id, admin_id, None).await.unwrap();
+
+        let err = admin_svc.approve(req.id, admin_id).await.unwrap_err();
+        assert!(matches!(err, AitesisError::InvalidTransition { .. }));
+    }
+
+    // ── List tests ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_requests_filter_by_user() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let config = default_config();
+
+        let alice = UserId::new();
+        let bob = UserId::new();
+
+        let alice_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            config.clone(),
+            MockRoles {
+                role: UserRole::Member,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let bob_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            config,
+            MockRoles {
+                role: UserRole::Member,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+
+        alice_svc
+            .submit_request(alice, music_input())
+            .await
+            .unwrap();
+        alice_svc
+            .submit_request(alice, music_input())
+            .await
+            .unwrap();
+        bob_svc.submit_request(bob, music_input()).await.unwrap();
+
+        let alice_requests = alice_svc.list_requests(Some(alice), None).await.unwrap();
+        assert_eq!(alice_requests.len(), 2);
+        assert!(alice_requests.iter().all(|r| r.user_id == alice));
+    }
+
+    #[tokio::test]
+    async fn list_requests_filter_by_status() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let user_id = UserId::new();
+
+        svc.submit_request(user_id, music_input()).await.unwrap();
+        svc.submit_request(user_id, music_input()).await.unwrap();
+
+        let submitted = svc
+            .list_requests(None, Some(RequestStatus::Submitted))
+            .await
+            .unwrap();
+        assert_eq!(submitted.len(), 2);
+
+        let monitoring = svc
+            .list_requests(None, Some(RequestStatus::Monitoring))
+            .await
+            .unwrap();
+        assert!(monitoring.is_empty());
+    }
+
+    // ── Full lifecycle ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn full_lifecycle_submitted_to_fulfilled() {
+        let (member_svc, pool) = make_service(UserRole::Member).await;
+        let member_id = UserId::new();
+        let req = member_svc
+            .submit_request(member_id, music_input())
+            .await
+            .unwrap();
+        assert_eq!(req.status, RequestStatus::Submitted);
+
+        let admin_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let admin_id = UserId::new();
+
+        let monitoring = admin_svc.approve(req.id, admin_id).await.unwrap();
+        assert_eq!(monitoring.status, RequestStatus::Monitoring);
+
+        // Simulate Episkope updating status to Fulfilled
+        crate::repo::update_status(
+            &pool,
+            &req.id,
+            RequestStatus::Fulfilled,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let fulfilled = admin_svc.get_request(req.id).await.unwrap();
+        assert_eq!(fulfilled.status, RequestStatus::Fulfilled);
+    }
+}

--- a/crates/aitesis/src/limits.rs
+++ b/crates/aitesis/src/limits.rs
@@ -1,0 +1,124 @@
+//! Per-user request limits: max pending and daily rate limit.
+//!
+//! Admin users are exempt from all limits.
+
+use harmonia_common::UserId;
+use sqlx::SqlitePool;
+
+use crate::error::{AitesisError, RequestLimitExceededSnafu};
+use crate::types::UserRole;
+
+/// Checks per-user request limits and returns an error if any limit is exceeded.
+///
+/// Admin users are exempt.
+pub(crate) async fn check_limits(
+    pool: &SqlitePool,
+    user_id: &UserId,
+    role: UserRole,
+    max_pending: u32,
+    max_per_day: u32,
+) -> Result<(), AitesisError> {
+    if role == UserRole::Admin {
+        return Ok(());
+    }
+
+    let pending = crate::repo::count_pending_by_user(pool, user_id).await?;
+    if pending >= i64::from(max_pending) {
+        return RequestLimitExceededSnafu.fail();
+    }
+
+    let today = crate::repo::count_today_by_user(pool, user_id).await?;
+    if today >= i64::from(max_per_day) {
+        return RequestLimitExceededSnafu.fail();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use harmonia_common::{MediaType, RequestId, UserId};
+    use harmonia_db::migrate::MIGRATOR;
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::repo::insert_request;
+    use crate::types::{MediaRequest, RequestStatus};
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_request(user_id: UserId, status: RequestStatus) -> MediaRequest {
+        MediaRequest {
+            id: RequestId::new(),
+            user_id,
+            media_type: MediaType::Music,
+            title: "Album".to_string(),
+            external_id: None,
+            status,
+            decided_by: None,
+            decided_at: None,
+            deny_reason: None,
+            want_id: None,
+            created_at: jiff::Timestamp::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn member_within_limits_passes() {
+        let pool = setup().await;
+        let user = UserId::new();
+        let result = check_limits(&pool, &user, UserRole::Member, 25, 10).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn admin_is_exempt_from_limits() {
+        let pool = setup().await;
+        let user = UserId::new();
+        // Insert requests beyond Member limits
+        for _ in 0..30 {
+            insert_request(&pool, &make_request(user, RequestStatus::Submitted))
+                .await
+                .unwrap();
+        }
+        let result = check_limits(&pool, &user, UserRole::Admin, 25, 10).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn member_exceeding_pending_limit_returns_error() {
+        let pool = setup().await;
+        let user = UserId::new();
+        for _ in 0..3 {
+            insert_request(&pool, &make_request(user, RequestStatus::Submitted))
+                .await
+                .unwrap();
+        }
+        let result = check_limits(&pool, &user, UserRole::Member, 3, 100).await;
+        assert!(matches!(
+            result,
+            Err(AitesisError::RequestLimitExceeded { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn member_exceeding_daily_limit_returns_error() {
+        let pool = setup().await;
+        let user = UserId::new();
+        // Insert requests that are terminal (won't count toward pending)
+        for _ in 0..2 {
+            insert_request(&pool, &make_request(user, RequestStatus::Fulfilled))
+                .await
+                .unwrap();
+        }
+        let result = check_limits(&pool, &user, UserRole::Member, 25, 2).await;
+        assert!(matches!(
+            result,
+            Err(AitesisError::RequestLimitExceeded { .. })
+        ));
+    }
+}

--- a/crates/aitesis/src/repo.rs
+++ b/crates/aitesis/src/repo.rs
@@ -1,0 +1,452 @@
+//! Database operations for the `requests` table.
+
+use harmonia_common::{RequestId, UserId, WantId};
+use harmonia_db::error::QuerySnafu as DbQuerySnafu;
+use snafu::ResultExt;
+use sqlx::SqlitePool;
+
+use crate::error::DatabaseSnafu;
+use crate::types::{MediaRequest, RequestStatus};
+
+/// Row type for SQLx fetches from the `requests` table.
+#[derive(sqlx::FromRow)]
+struct RequestRow {
+    id: Vec<u8>,
+    user_id: Vec<u8>,
+    media_type: String,
+    title: String,
+    external_id: Option<String>,
+    status: String,
+    decided_by: Option<Vec<u8>>,
+    decided_at: Option<String>,
+    deny_reason: Option<String>,
+    want_id: Option<Vec<u8>>,
+    created_at: String,
+}
+
+impl RequestRow {
+    fn into_domain(self) -> Option<MediaRequest> {
+        use uuid::Uuid;
+
+        let id = Uuid::from_slice(&self.id).ok()?;
+        let user_id_uuid = Uuid::from_slice(&self.user_id).ok()?;
+        let status = RequestStatus::parse(&self.status)?;
+        let media_type = media_type_from_str(&self.media_type)?;
+
+        let decided_by = self
+            .decided_by
+            .as_deref()
+            .and_then(|b| Uuid::from_slice(b).ok())
+            .map(UserId::from_uuid);
+
+        let decided_at = self
+            .decided_at
+            .as_deref()
+            .and_then(|s| s.parse::<jiff::Timestamp>().ok());
+
+        let want_id = self
+            .want_id
+            .as_deref()
+            .and_then(|b| Uuid::from_slice(b).ok())
+            .map(WantId::from_uuid);
+
+        let created_at = self.created_at.parse::<jiff::Timestamp>().ok()?;
+
+        Some(MediaRequest {
+            id: RequestId::from_uuid(id),
+            user_id: UserId::from_uuid(user_id_uuid),
+            media_type,
+            title: self.title,
+            external_id: self.external_id,
+            status,
+            decided_by,
+            decided_at,
+            deny_reason: self.deny_reason,
+            want_id,
+            created_at,
+        })
+    }
+}
+
+fn media_type_from_str(s: &str) -> Option<harmonia_common::MediaType> {
+    use harmonia_common::MediaType;
+    match s {
+        "music" => Some(MediaType::Music),
+        "audiobook" => Some(MediaType::Audiobook),
+        "book" => Some(MediaType::Book),
+        "comic" => Some(MediaType::Comic),
+        "podcast" => Some(MediaType::Podcast),
+        "news" => Some(MediaType::News),
+        "movie" => Some(MediaType::Movie),
+        "tv" => Some(MediaType::Tv),
+        _ => None,
+    }
+}
+
+pub async fn insert_request(
+    pool: &SqlitePool,
+    request: &MediaRequest,
+) -> Result<(), crate::error::AitesisError> {
+    sqlx::query(
+        "INSERT INTO requests
+         (id, user_id, media_type, title, external_id, status,
+          decided_by, decided_at, deny_reason, want_id, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(request.id.as_bytes().as_slice())
+    .bind(request.user_id.as_bytes().as_slice())
+    .bind(request.media_type.to_string())
+    .bind(&request.title)
+    .bind(&request.external_id)
+    .bind(request.status.as_str())
+    .bind(request.decided_by.as_ref().map(|id| id.as_bytes().to_vec()))
+    .bind(request.decided_at.map(|t| t.to_string()))
+    .bind(&request.deny_reason)
+    .bind(request.want_id.as_ref().map(|id| id.as_bytes().to_vec()))
+    .bind(request.created_at.to_string())
+    .execute(pool)
+    .await
+    .context(DbQuerySnafu { table: "requests" })
+    .context(DatabaseSnafu)?;
+    Ok(())
+}
+
+pub async fn get_request(
+    pool: &SqlitePool,
+    id: &RequestId,
+) -> Result<Option<MediaRequest>, crate::error::AitesisError> {
+    let row = sqlx::query_as::<_, RequestRow>(
+        "SELECT id, user_id, media_type, title, external_id, status,
+                decided_by, decided_at, deny_reason, want_id, created_at
+         FROM requests WHERE id = ?",
+    )
+    .bind(id.as_bytes().as_slice())
+    .fetch_optional(pool)
+    .await
+    .context(DbQuerySnafu { table: "requests" })
+    .context(DatabaseSnafu)?;
+
+    Ok(row.and_then(RequestRow::into_domain))
+}
+
+pub async fn update_status(
+    pool: &SqlitePool,
+    id: &RequestId,
+    status: RequestStatus,
+    decided_by: Option<&UserId>,
+    decided_at: Option<jiff::Timestamp>,
+    deny_reason: Option<&str>,
+    want_id: Option<&WantId>,
+) -> Result<(), crate::error::AitesisError> {
+    sqlx::query(
+        "UPDATE requests
+         SET status = ?, decided_by = ?, decided_at = ?, deny_reason = ?, want_id = ?
+         WHERE id = ?",
+    )
+    .bind(status.as_str())
+    .bind(decided_by.map(|uid| uid.as_bytes().to_vec()))
+    .bind(decided_at.map(|t| t.to_string()))
+    .bind(deny_reason)
+    .bind(want_id.map(|wid| wid.as_bytes().to_vec()))
+    .bind(id.as_bytes().as_slice())
+    .execute(pool)
+    .await
+    .context(DbQuerySnafu { table: "requests" })
+    .context(DatabaseSnafu)?;
+    Ok(())
+}
+
+pub async fn delete_request(
+    pool: &SqlitePool,
+    id: &RequestId,
+) -> Result<(), crate::error::AitesisError> {
+    sqlx::query("DELETE FROM requests WHERE id = ?")
+        .bind(id.as_bytes().as_slice())
+        .execute(pool)
+        .await
+        .context(DbQuerySnafu { table: "requests" })
+        .context(DatabaseSnafu)?;
+    Ok(())
+}
+
+pub async fn list_by_user(
+    pool: &SqlitePool,
+    user_id: &UserId,
+) -> Result<Vec<MediaRequest>, crate::error::AitesisError> {
+    let rows = sqlx::query_as::<_, RequestRow>(
+        "SELECT id, user_id, media_type, title, external_id, status,
+                decided_by, decided_at, deny_reason, want_id, created_at
+         FROM requests WHERE user_id = ? ORDER BY created_at DESC",
+    )
+    .bind(user_id.as_bytes().as_slice())
+    .fetch_all(pool)
+    .await
+    .context(DbQuerySnafu { table: "requests" })
+    .context(DatabaseSnafu)?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(RequestRow::into_domain)
+        .collect())
+}
+
+pub async fn list_by_status(
+    pool: &SqlitePool,
+    status: RequestStatus,
+) -> Result<Vec<MediaRequest>, crate::error::AitesisError> {
+    let rows = sqlx::query_as::<_, RequestRow>(
+        "SELECT id, user_id, media_type, title, external_id, status,
+                decided_by, decided_at, deny_reason, want_id, created_at
+         FROM requests WHERE status = ? ORDER BY created_at DESC",
+    )
+    .bind(status.as_str())
+    .fetch_all(pool)
+    .await
+    .context(DbQuerySnafu { table: "requests" })
+    .context(DatabaseSnafu)?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(RequestRow::into_domain)
+        .collect())
+}
+
+pub async fn list_all(pool: &SqlitePool) -> Result<Vec<MediaRequest>, crate::error::AitesisError> {
+    let rows = sqlx::query_as::<_, RequestRow>(
+        "SELECT id, user_id, media_type, title, external_id, status,
+                decided_by, decided_at, deny_reason, want_id, created_at
+         FROM requests ORDER BY created_at DESC",
+    )
+    .fetch_all(pool)
+    .await
+    .context(DbQuerySnafu { table: "requests" })
+    .context(DatabaseSnafu)?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(RequestRow::into_domain)
+        .collect())
+}
+
+/// Count of requests in Submitted, Approved, or Monitoring states for a user.
+pub async fn count_pending_by_user(
+    pool: &SqlitePool,
+    user_id: &UserId,
+) -> Result<i64, crate::error::AitesisError> {
+    let row: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM requests
+         WHERE user_id = ? AND status IN ('submitted', 'approved', 'monitoring')",
+    )
+    .bind(user_id.as_bytes().as_slice())
+    .fetch_one(pool)
+    .await
+    .context(DbQuerySnafu { table: "requests" })
+    .context(DatabaseSnafu)?;
+    Ok(row.0)
+}
+
+/// Count of requests created today (UTC) for a user.
+pub async fn count_today_by_user(
+    pool: &SqlitePool,
+    user_id: &UserId,
+) -> Result<i64, crate::error::AitesisError> {
+    let row: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM requests
+         WHERE user_id = ?
+           AND created_at >= strftime('%Y-%m-%dT00:00:00Z', 'now')",
+    )
+    .bind(user_id.as_bytes().as_slice())
+    .fetch_one(pool)
+    .await
+    .context(DbQuerySnafu { table: "requests" })
+    .context(DatabaseSnafu)?;
+    Ok(row.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use harmonia_common::{MediaType, RequestId, UserId};
+    use harmonia_db::migrate::MIGRATOR;
+    use sqlx::SqlitePool;
+
+    use crate::types::{MediaRequest, RequestStatus};
+
+    use super::*;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_request(user_id: UserId, status: RequestStatus) -> MediaRequest {
+        MediaRequest {
+            id: RequestId::new(),
+            user_id,
+            media_type: MediaType::Music,
+            title: "Test Album".to_string(),
+            external_id: None,
+            status,
+            decided_by: None,
+            decided_at: None,
+            deny_reason: None,
+            want_id: None,
+            created_at: jiff::Timestamp::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_request() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let req = make_request(user_id, RequestStatus::Submitted);
+        let req_id = req.id;
+
+        insert_request(&pool, &req).await.unwrap();
+
+        let fetched = get_request(&pool, &req_id).await.unwrap().unwrap();
+        assert_eq!(fetched.id, req_id);
+        assert_eq!(fetched.status, RequestStatus::Submitted);
+        assert_eq!(fetched.title, "Test Album");
+    }
+
+    #[tokio::test]
+    async fn get_request_returns_none_when_missing() {
+        let pool = setup().await;
+        let id = RequestId::new();
+        let result = get_request(&pool, &id).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn update_status_changes_request_status() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let admin_id = UserId::new();
+        let req = make_request(user_id, RequestStatus::Submitted);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        let now = jiff::Timestamp::now();
+        update_status(
+            &pool,
+            &req_id,
+            RequestStatus::Approved,
+            Some(&admin_id),
+            Some(now),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let fetched = get_request(&pool, &req_id).await.unwrap().unwrap();
+        assert_eq!(fetched.status, RequestStatus::Approved);
+        assert_eq!(fetched.decided_by, Some(admin_id));
+    }
+
+    #[tokio::test]
+    async fn delete_request_removes_row() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let req = make_request(user_id, RequestStatus::Submitted);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        delete_request(&pool, &req_id).await.unwrap();
+
+        let result = get_request(&pool, &req_id).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_by_user_returns_only_that_user() {
+        let pool = setup().await;
+        let alice = UserId::new();
+        let bob = UserId::new();
+
+        insert_request(&pool, &make_request(alice, RequestStatus::Submitted))
+            .await
+            .unwrap();
+        insert_request(&pool, &make_request(alice, RequestStatus::Monitoring))
+            .await
+            .unwrap();
+        insert_request(&pool, &make_request(bob, RequestStatus::Submitted))
+            .await
+            .unwrap();
+
+        let alice_requests = list_by_user(&pool, &alice).await.unwrap();
+        assert_eq!(alice_requests.len(), 2);
+        assert!(alice_requests.iter().all(|r| r.user_id == alice));
+    }
+
+    #[tokio::test]
+    async fn list_by_status_filters_correctly() {
+        let pool = setup().await;
+        let user = UserId::new();
+
+        insert_request(&pool, &make_request(user, RequestStatus::Submitted))
+            .await
+            .unwrap();
+        insert_request(&pool, &make_request(user, RequestStatus::Submitted))
+            .await
+            .unwrap();
+        insert_request(&pool, &make_request(user, RequestStatus::Approved))
+            .await
+            .unwrap();
+
+        let submitted = list_by_status(&pool, RequestStatus::Submitted)
+            .await
+            .unwrap();
+        assert_eq!(submitted.len(), 2);
+
+        let approved = list_by_status(&pool, RequestStatus::Approved)
+            .await
+            .unwrap();
+        assert_eq!(approved.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn count_pending_by_user_counts_active_statuses() {
+        let pool = setup().await;
+        let user = UserId::new();
+
+        insert_request(&pool, &make_request(user, RequestStatus::Submitted))
+            .await
+            .unwrap();
+        insert_request(&pool, &make_request(user, RequestStatus::Monitoring))
+            .await
+            .unwrap();
+        insert_request(&pool, &make_request(user, RequestStatus::Fulfilled))
+            .await
+            .unwrap();
+        insert_request(&pool, &make_request(user, RequestStatus::Denied))
+            .await
+            .unwrap();
+
+        let count = count_pending_by_user(&pool, &user).await.unwrap();
+        // Only Submitted + Monitoring count; Fulfilled and Denied do not
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn count_today_by_user_counts_all_todays_requests() {
+        let pool = setup().await;
+        let user = UserId::new();
+        let other = UserId::new();
+
+        insert_request(&pool, &make_request(user, RequestStatus::Submitted))
+            .await
+            .unwrap();
+        insert_request(&pool, &make_request(user, RequestStatus::Denied))
+            .await
+            .unwrap();
+        insert_request(&pool, &make_request(other, RequestStatus::Submitted))
+            .await
+            .unwrap();
+
+        let count = count_today_by_user(&pool, &user).await.unwrap();
+        // Both of user's requests were inserted today
+        assert_eq!(count, 2);
+    }
+}

--- a/crates/aitesis/src/types.rs
+++ b/crates/aitesis/src/types.rs
@@ -1,0 +1,128 @@
+//! Domain types for the Aitesis request management subsystem.
+
+use harmonia_common::{MediaType, RequestId, UserId, WantId};
+use serde::{Deserialize, Serialize};
+
+pub type Timestamp = jiff::Timestamp;
+
+/// A household media request from submission through fulfillment.
+#[derive(Debug, Clone)]
+pub struct MediaRequest {
+    pub id: RequestId,
+    pub user_id: UserId,
+    pub media_type: MediaType,
+    pub title: String,
+    /// IMDB, TVDB, MusicBrainz ID — used by Epignosis for identity resolution.
+    pub external_id: Option<String>,
+    pub status: RequestStatus,
+    pub decided_by: Option<UserId>,
+    pub decided_at: Option<Timestamp>,
+    pub deny_reason: Option<String>,
+    /// Links to the `wants` table after approval — set when Episkope accepts the want.
+    pub want_id: Option<WantId>,
+    pub created_at: Timestamp,
+}
+
+/// Lifecycle state of a media request.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequestStatus {
+    /// Awaiting approval (Member) or auto-processing (Admin).
+    Submitted,
+    /// Approved, pending monitoring setup.
+    Approved,
+    /// Rejected by admin.
+    Denied,
+    /// Handed to Episkope — actively searching.
+    Monitoring,
+    /// Download complete, media available.
+    Fulfilled,
+    /// Could not be fulfilled after reasonable attempts.
+    Failed,
+}
+
+impl RequestStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Submitted => "submitted",
+            Self::Approved => "approved",
+            Self::Denied => "denied",
+            Self::Monitoring => "monitoring",
+            Self::Fulfilled => "fulfilled",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "submitted" => Some(Self::Submitted),
+            "approved" => Some(Self::Approved),
+            "denied" => Some(Self::Denied),
+            "monitoring" => Some(Self::Monitoring),
+            "fulfilled" => Some(Self::Fulfilled),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+}
+
+/// Input for creating a new media request.
+#[derive(Debug, Clone)]
+pub struct CreateRequestInput {
+    pub media_type: MediaType,
+    pub title: String,
+    pub external_id: Option<String>,
+}
+
+/// Role of a user within the household — determines auto-approval and limit exemptions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserRole {
+    Admin,
+    Member,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn request_status_serde_roundtrip() {
+        let statuses = [
+            RequestStatus::Submitted,
+            RequestStatus::Approved,
+            RequestStatus::Denied,
+            RequestStatus::Monitoring,
+            RequestStatus::Fulfilled,
+            RequestStatus::Failed,
+        ];
+        for status in statuses {
+            let json = serde_json::to_string(&status).unwrap();
+            let recovered: RequestStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(status, recovered);
+        }
+    }
+
+    #[test]
+    fn request_status_as_str_and_parse_roundtrip() {
+        let statuses = [
+            RequestStatus::Submitted,
+            RequestStatus::Approved,
+            RequestStatus::Denied,
+            RequestStatus::Monitoring,
+            RequestStatus::Fulfilled,
+            RequestStatus::Failed,
+        ];
+        for status in statuses {
+            let s = status.as_str();
+            let parsed = RequestStatus::parse(s).unwrap();
+            assert_eq!(status, parsed);
+        }
+    }
+
+    #[test]
+    fn request_status_parse_unknown_returns_none() {
+        assert!(RequestStatus::parse("unknown_status").is_none());
+    }
+}

--- a/crates/aitesis/src/workflow.rs
+++ b/crates/aitesis/src/workflow.rs
@@ -1,0 +1,94 @@
+//! Request state machine — validates status transitions.
+
+use crate::error::{AitesisError, InvalidTransitionSnafu};
+use crate::types::RequestStatus;
+
+/// Valid transitions:
+/// ```text
+/// Submitted → Approved
+/// Submitted → Denied
+/// Approved  → Monitoring
+/// Monitoring → Fulfilled
+/// Monitoring → Failed
+/// ```
+pub(crate) fn validate_transition(
+    from: RequestStatus,
+    to: RequestStatus,
+) -> Result<(), AitesisError> {
+    let allowed = matches!(
+        (from, to),
+        (RequestStatus::Submitted, RequestStatus::Approved)
+            | (RequestStatus::Submitted, RequestStatus::Denied)
+            | (RequestStatus::Approved, RequestStatus::Monitoring)
+            | (RequestStatus::Monitoring, RequestStatus::Fulfilled)
+            | (RequestStatus::Monitoring, RequestStatus::Failed)
+    );
+
+    if allowed {
+        Ok(())
+    } else {
+        InvalidTransitionSnafu {
+            from: from.as_str().to_string(),
+            to: to.as_str().to_string(),
+        }
+        .fail()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::RequestStatus;
+
+    #[test]
+    fn submitted_to_approved_is_valid() {
+        assert!(validate_transition(RequestStatus::Submitted, RequestStatus::Approved).is_ok());
+    }
+
+    #[test]
+    fn submitted_to_denied_is_valid() {
+        assert!(validate_transition(RequestStatus::Submitted, RequestStatus::Denied).is_ok());
+    }
+
+    #[test]
+    fn approved_to_monitoring_is_valid() {
+        assert!(validate_transition(RequestStatus::Approved, RequestStatus::Monitoring).is_ok());
+    }
+
+    #[test]
+    fn monitoring_to_fulfilled_is_valid() {
+        assert!(validate_transition(RequestStatus::Monitoring, RequestStatus::Fulfilled).is_ok());
+    }
+
+    #[test]
+    fn monitoring_to_failed_is_valid() {
+        assert!(validate_transition(RequestStatus::Monitoring, RequestStatus::Failed).is_ok());
+    }
+
+    #[test]
+    fn denied_to_approved_is_invalid() {
+        let err = validate_transition(RequestStatus::Denied, RequestStatus::Approved).unwrap_err();
+        assert!(matches!(err, AitesisError::InvalidTransition { .. }));
+    }
+
+    #[test]
+    fn fulfilled_to_monitoring_is_invalid() {
+        let err =
+            validate_transition(RequestStatus::Fulfilled, RequestStatus::Monitoring).unwrap_err();
+        assert!(matches!(err, AitesisError::InvalidTransition { .. }));
+    }
+
+    #[test]
+    fn submitted_to_monitoring_is_invalid() {
+        let err =
+            validate_transition(RequestStatus::Submitted, RequestStatus::Monitoring).unwrap_err();
+        assert!(matches!(err, AitesisError::InvalidTransition { .. }));
+    }
+
+    #[test]
+    fn full_lifecycle_transitions_are_valid() {
+        validate_transition(RequestStatus::Submitted, RequestStatus::Approved).unwrap();
+        validate_transition(RequestStatus::Approved, RequestStatus::Monitoring).unwrap();
+        validate_transition(RequestStatus::Monitoring, RequestStatus::Fulfilled).unwrap();
+    }
+}

--- a/crates/harmonia-db/migrations/005_requests.sql
+++ b/crates/harmonia-db/migrations/005_requests.sql
@@ -1,0 +1,20 @@
+-- Aitesis request management tables
+-- Tracks household media requests from submission through fulfillment.
+
+CREATE TABLE requests (
+    id          BLOB NOT NULL PRIMARY KEY,
+    user_id     BLOB NOT NULL,
+    media_type  TEXT NOT NULL,
+    title       TEXT NOT NULL,
+    external_id TEXT,
+    status      TEXT NOT NULL DEFAULT 'submitted'
+                    CHECK (status IN ('submitted', 'approved', 'denied', 'monitoring', 'fulfilled', 'failed')),
+    decided_by  BLOB,
+    decided_at  TEXT,
+    deny_reason TEXT,
+    want_id     BLOB,
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_requests_user_status ON requests(user_id, status);
+CREATE INDEX idx_requests_status ON requests(status);

--- a/crates/horismos/src/config.rs
+++ b/crates/horismos/src/config.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::subsystems::{
-    AggeliaConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig, KomideConfig,
-    KritikeConfig, ParocheConfig, ProsthekeConfig, SyndesmosConfig, SyntaxisConfig, TaxisConfig,
-    ZetesisConfig,
+    AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
+    KomideConfig, KritikeConfig, ParocheConfig, ProsthekeConfig, SyndesmosConfig, SyntaxisConfig,
+    TaxisConfig, ZetesisConfig,
 };
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -34,4 +34,6 @@ pub struct Config {
     pub komide: KomideConfig,
     #[serde(default)]
     pub syndesmos: SyndesmosConfig,
+    #[serde(default)]
+    pub aitesis: AitesisConfig,
 }

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -11,8 +11,8 @@ pub use diff::{ConfigChange, diff_config};
 pub use error::HorismosError;
 pub use handle::{ConfigHandle, ConfigManager};
 pub use subsystems::{
-    AggeliaConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig, KomideConfig,
-    KritikeConfig, LastfmConfig, LibraryConfig, MediaType, ParocheConfig, PlexConfig,
+    AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
+    KomideConfig, KritikeConfig, LastfmConfig, LibraryConfig, MediaType, ParocheConfig, PlexConfig,
     ProsthekeConfig, SyndesmosConfig, SyntaxisConfig, TaxisConfig, TidalConfig, TrackerSeedPolicy,
     WatcherMode, ZetesisConfig,
 };

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -364,3 +364,23 @@ impl Default for SyndesmosConfig {
         }
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AitesisConfig {
+    /// Maximum number of Submitted + Approved + Monitoring requests per user.
+    pub max_pending_per_user: u32,
+    /// Maximum requests a user may create in a single calendar day (UTC).
+    pub max_requests_per_day: u32,
+    /// When true, Admin users' requests are approved and sent to monitoring immediately.
+    pub auto_approve_admins: bool,
+}
+
+impl Default for AitesisConfig {
+    fn default() -> Self {
+        Self {
+            max_pending_per_user: 25,
+            max_requests_per_day: 10,
+            auto_approve_admins: true,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the `aitesis` crate: household media request management replacing Overseerr
- Household model — Admin users auto-approve on submission, Member users require admin decision
- Per-user limits: configurable max pending and daily rate limit, Admin users exempt
- State machine validates transitions: Submitted → Approved → Monitoring → Fulfilled/Failed
- Clean trait boundaries to Exousia (`UserRoleProvider`), Epignosis (`IdentityValidator`), and Episkope (`MonitorService`) — no hard crate dependencies on those subsystems
- `requests` table migration (005_requests.sql) with status CHECK constraint and indexes
- `AitesisConfig` added to horismos with `max_pending_per_user` (25), `max_requests_per_day` (10), `auto_approve_admins` (true)

## Test results

41 tests, all green:
- repo: insert, get, update, delete, list by user, list by status, count pending, count today
- workflow: all valid transitions, all invalid transitions
- limits: within limits, exceeds pending, exceeds daily, admin exempt
- approval: approve transitions to Monitoring, deny with reason, member cannot approve, double-deny invalid
- service (lib): Member submit → Submitted, Admin submit → Monitoring, approve, deny, cancel own, cancel other forbidden, full lifecycle, list by user, list by status

## Validation gate

```
cargo fmt --all -- --check   ✓
cargo clippy -p aitesis -- -D warnings   ✓
cargo test -p aitesis   ✓ (41/41)
```

## Observations

- `async fn` in traits is not dyn-compatible in Rust 2024. Used type parameters (`AitesisServiceImpl<R, I, M>`) instead of `Arc<dyn Trait>` to avoid boxing overhead while keeping full testability via mock injection. Consistent with the existing pattern in syndesmos (which uses `BoxFuture` for dyn-compatible inner traits but concrete types at the service level).
- `QuerySnafu` from `harmonia_db::error` is public via `#[snafu(visibility(pub))]`. Used double-context chaining (`.context(DbQuerySnafu{...}).context(DatabaseSnafu)`) to satisfy the spec's `Database { source: DbError }` variant while calling sqlx directly.
- No episkope crate exists yet (P3-08 wires everything). `MonitorService`, `IdentityValidator`, and `UserRoleProvider` trait boundaries are defined in aitesis and will be implemented against the real crates during wiring.