### PR TITLE
feat(desktop): media management UI for all 8 types (P3-15)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -14,6 +14,17 @@ import LatestEpisodesPage from "./features/podcast/pages/LatestEpisodesPage";
 import DownloadQueuePage from "./features/podcast/pages/DownloadQueuePage";
 import QueuePage from "./features/now-playing/pages/QueuePage";
 import SignalPathPage from "./features/now-playing/pages/SignalPathPage";
+import DashboardPage from "./features/management/pages/DashboardPage";
+import MediaBrowsePage from "./features/management/pages/MediaBrowsePage";
+import MediaDetailPage from "./features/management/pages/MediaDetailPage";
+import MetadataEditPage from "./features/management/pages/MetadataEditPage";
+import ManageDownloadQueuePage from "./features/management/pages/DownloadQueuePage";
+import SearchPage from "./features/management/pages/SearchPage";
+import RequestsPage from "./features/management/pages/RequestsPage";
+import WantedPage from "./features/management/pages/WantedPage";
+import IndexerSettingsPage from "./features/management/pages/IndexerSettingsPage";
+import QualityProfilesPage from "./features/management/pages/QualityProfilesPage";
+import LibraryHealthPage from "./features/management/pages/LibraryHealthPage";
 
 export default function App() {
   return (
@@ -39,6 +50,19 @@ export default function App() {
           <Route path="settings" element={<Settings />} />
           <Route path="queue" element={<QueuePage />} />
           <Route path="signal-path" element={<SignalPathPage />} />
+          <Route path="manage">
+            <Route index element={<DashboardPage />} />
+            <Route path="media" element={<MediaBrowsePage />} />
+            <Route path="media/:id" element={<MediaDetailPage />} />
+            <Route path="media/:id/edit" element={<MetadataEditPage />} />
+            <Route path="downloads" element={<ManageDownloadQueuePage />} />
+            <Route path="search" element={<SearchPage />} />
+            <Route path="requests" element={<RequestsPage />} />
+            <Route path="wanted" element={<WantedPage />} />
+            <Route path="indexers" element={<IndexerSettingsPage />} />
+            <Route path="quality-profiles" element={<QualityProfilesPage />} />
+            <Route path="health" element={<LibraryHealthPage />} />
+          </Route>
         </Route>
       </Routes>
     </BrowserRouter>

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -19,6 +19,33 @@ import type {
   Chapter,
   ProgressUpdate,
 } from "../types/media";
+import type {
+  ScanStatus,
+  MediaItem,
+  MediaItemDetail,
+  MetadataUpdate,
+  QualityProfile,
+  QualityProfileUpdate,
+  LibraryHealthReport,
+  SearchQuery,
+  SearchResult,
+  DownloadRequest,
+  DownloadStatus,
+  QueueSnapshot,
+  MediaRequest,
+  WantedItem,
+  Indexer,
+  IndexerCreate,
+  IndexerUpdate,
+  IndexerTestResult,
+  Subtitle,
+  SubtitleSearchResult,
+  MediaQueryParams,
+  RequestQueryParams,
+  RequestCreate,
+  WantedQueryParams,
+  WantedItemCreate,
+} from "../types/management";
 
 async function getBaseUrl(): Promise<string> {
   return invoke<string>("get_server_url");
@@ -241,5 +268,184 @@ export const api = {
 
   deleteBookmark(bookmarkId: string, token: string): Promise<void> {
     return api.del(`/api/bookmarks/${bookmarkId}`, token);
+  },
+
+  // Library scanning
+  triggerLibraryScan(token: string, path?: string): Promise<ScanStatus> {
+    return api.post("/api/manage/scan", path ? { path } : {}, token);
+  },
+
+  getScanStatus(token: string): Promise<ScanStatus> {
+    return api.get("/api/manage/scan/status", token);
+  },
+
+  // Media items
+  getMediaItems(params: MediaQueryParams, token: string): Promise<PaginatedResponse<MediaItem>> {
+    const q = new URLSearchParams();
+    if (params.mediaType) q.set("media_type", params.mediaType);
+    if (params.status) q.set("status", params.status);
+    if (params.qualityTier) q.set("quality_tier", params.qualityTier);
+    if (params.hasMetadata !== undefined) q.set("has_metadata", String(params.hasMetadata));
+    if (params.page !== undefined) q.set("page", String(params.page));
+    if (params.pageSize !== undefined) q.set("page_size", String(params.pageSize));
+    if (params.sortBy) q.set("sort_by", params.sortBy);
+    if (params.sortOrder) q.set("sort_order", params.sortOrder);
+    return api.get(`/api/manage/media?${q}`, token);
+  },
+
+  getMediaItem(id: string, token: string): Promise<MediaItemDetail> {
+    return api.get(`/api/manage/media/${id}`, token);
+  },
+
+  deleteMediaItem(id: string, token: string): Promise<void> {
+    return api.del(`/api/manage/media/${id}`, token);
+  },
+
+  refreshMetadata(id: string, token: string): Promise<void> {
+    return api.post(`/api/manage/media/${id}/refresh`, {}, token);
+  },
+
+  updateMetadata(id: string, metadata: MetadataUpdate, token: string): Promise<MediaItemDetail> {
+    return api.put(`/api/manage/media/${id}/metadata`, metadata, token);
+  },
+
+  // Quality profiles
+  getQualityProfiles(token: string): Promise<QualityProfile[]> {
+    return api.get("/api/manage/quality-profiles", token);
+  },
+
+  getQualityProfile(id: string, token: string): Promise<QualityProfile> {
+    return api.get(`/api/manage/quality-profiles/${id}`, token);
+  },
+
+  updateQualityProfile(
+    id: string,
+    profile: QualityProfileUpdate,
+    token: string,
+  ): Promise<QualityProfile> {
+    return api.put(`/api/manage/quality-profiles/${id}`, profile, token);
+  },
+
+  // Library health
+  getLibraryHealth(token: string): Promise<LibraryHealthReport> {
+    return api.get("/api/manage/health", token);
+  },
+
+  // Acquisition
+  searchIndexers(query: SearchQuery, token: string): Promise<SearchResult[]> {
+    return api.post("/api/manage/search", query, token);
+  },
+
+  triggerDownload(req: DownloadRequest, token: string): Promise<DownloadStatus> {
+    return api.post("/api/manage/downloads", req, token);
+  },
+
+  getManageDownloadQueue(token: string): Promise<QueueSnapshot> {
+    return api.get("/api/manage/downloads/queue", token);
+  },
+
+  cancelManageDownload(downloadId: string, token: string): Promise<void> {
+    return api.del(`/api/manage/downloads/${downloadId}`, token);
+  },
+
+  retryDownload(downloadId: string, token: string): Promise<void> {
+    return api.post(`/api/manage/downloads/${downloadId}/retry`, {}, token);
+  },
+
+  // Requests
+  getRequests(params: RequestQueryParams, token: string): Promise<PaginatedResponse<MediaRequest>> {
+    const q = new URLSearchParams();
+    if (params.status) q.set("status", params.status);
+    if (params.page !== undefined) q.set("page", String(params.page));
+    if (params.pageSize !== undefined) q.set("page_size", String(params.pageSize));
+    return api.get(`/api/manage/requests?${q}`, token);
+  },
+
+  createRequest(request: RequestCreate, token: string): Promise<MediaRequest> {
+    return api.post("/api/manage/requests", request, token);
+  },
+
+  approveRequest(requestId: string, token: string): Promise<MediaRequest> {
+    return api.post(`/api/manage/requests/${requestId}/approve`, {}, token);
+  },
+
+  denyRequest(requestId: string, reason: string, token: string): Promise<MediaRequest> {
+    return api.post(`/api/manage/requests/${requestId}/deny`, { reason }, token);
+  },
+
+  cancelRequest(requestId: string, token: string): Promise<void> {
+    return api.del(`/api/manage/requests/${requestId}`, token);
+  },
+
+  // Wanted
+  getWantedMedia(params: WantedQueryParams, token: string): Promise<PaginatedResponse<WantedItem>> {
+    const q = new URLSearchParams();
+    if (params.mediaType) q.set("media_type", params.mediaType);
+    if (params.page !== undefined) q.set("page", String(params.page));
+    if (params.pageSize !== undefined) q.set("page_size", String(params.pageSize));
+    return api.get(`/api/manage/wanted?${q}`, token);
+  },
+
+  addWanted(item: WantedItemCreate, token: string): Promise<WantedItem> {
+    return api.post("/api/manage/wanted", item, token);
+  },
+
+  removeWanted(id: string, token: string): Promise<void> {
+    return api.del(`/api/manage/wanted/${id}`, token);
+  },
+
+  triggerWantedSearch(id: string, token: string): Promise<void> {
+    return api.post(`/api/manage/wanted/${id}/search`, {}, token);
+  },
+
+  // Indexers
+  getIndexers(token: string): Promise<Indexer[]> {
+    return api.get("/api/manage/indexers", token);
+  },
+
+  addIndexer(config: IndexerCreate, token: string): Promise<Indexer> {
+    return api.post("/api/manage/indexers", config, token);
+  },
+
+  updateIndexer(id: string, config: IndexerUpdate, token: string): Promise<Indexer> {
+    return api.put(`/api/manage/indexers/${id}`, config, token);
+  },
+
+  deleteIndexer(id: string, token: string): Promise<void> {
+    return api.del(`/api/manage/indexers/${id}`, token);
+  },
+
+  testIndexer(id: string, token: string): Promise<IndexerTestResult> {
+    return api.post(`/api/manage/indexers/${id}/test`, {}, token);
+  },
+
+  // Subtitles
+  getSubtitles(mediaId: string, token: string): Promise<Subtitle[]> {
+    return api.get(`/api/manage/media/${mediaId}/subtitles`, token);
+  },
+
+  searchSubtitles(mediaId: string, token: string): Promise<SubtitleSearchResult[]> {
+    return api.get(`/api/manage/media/${mediaId}/subtitles/search`, token);
+  },
+
+  downloadSubtitle(mediaId: string, subtitleId: string, token: string): Promise<void> {
+    return api.post(`/api/manage/media/${mediaId}/subtitles/${subtitleId}/download`, {}, token);
+  },
+
+  deleteSubtitle(subtitleId: string, token: string): Promise<void> {
+    return api.del(`/api/manage/subtitles/${subtitleId}`, token);
+  },
+
+  // Bulk actions
+  bulkRefreshMetadata(ids: string[], token: string): Promise<void> {
+    return api.post("/api/manage/media/bulk/refresh", { ids }, token);
+  },
+
+  bulkDelete(ids: string[], token: string): Promise<void> {
+    return api.post("/api/manage/media/bulk/delete", { ids }, token);
+  },
+
+  bulkSetQualityProfile(ids: string[], qualityProfileId: string, token: string): Promise<void> {
+    return api.post("/api/manage/media/bulk/quality-profile", { ids, qualityProfileId }, token);
   },
 };

--- a/desktop/src/components/Layout.tsx
+++ b/desktop/src/components/Layout.tsx
@@ -15,12 +15,35 @@ const podcastItems = [
   { to: "/library/podcasts/downloads", label: "Downloads" },
 ];
 
+const managementItems = [
+  { to: "/manage", label: "Dashboard", end: true },
+  { to: "/manage/media", label: "Browse Media" },
+  { to: "/manage/downloads", label: "Download Queue" },
+  { to: "/manage/search", label: "Search" },
+  { to: "/manage/requests", label: "Requests" },
+  { to: "/manage/wanted", label: "Wanted" },
+  { to: "/manage/indexers", label: "Indexers" },
+  { to: "/manage/quality-profiles", label: "Quality Profiles" },
+  { to: "/manage/health", label: "Library Health" },
+];
+
 function navLinkClass({ isActive }: { isActive: boolean }): string {
   return `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
     isActive
       ? "bg-gray-800 text-white"
       : "text-gray-400 hover:bg-gray-800 hover:text-white"
   }`;
+}
+
+function SidebarSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="pt-3">
+      <p className="px-3 pt-1 pb-2 text-xs font-medium text-gray-500 uppercase tracking-wider">
+        {title}
+      </p>
+      {children}
+    </div>
+  );
 }
 
 export default function Layout() {
@@ -42,16 +65,21 @@ export default function Layout() {
             </NavLink>
           ))}
 
-          <div className="pt-3">
-            <p className="px-3 pt-1 pb-2 text-xs font-medium text-gray-500 uppercase tracking-wider">
-              Podcasts
-            </p>
+          <SidebarSection title="Podcasts">
             {podcastItems.map(({ to, label, end }) => (
               <NavLink key={to} to={to} end={end} className={navLinkClass}>
                 {label}
               </NavLink>
             ))}
-          </div>
+          </SidebarSection>
+
+          <SidebarSection title="Management">
+            {managementItems.map(({ to, label, end }) => (
+              <NavLink key={to} to={to} end={end} className={navLinkClass}>
+                {label}
+              </NavLink>
+            ))}
+          </SidebarSection>
 
           <div className="pt-3">
             <NavLink to="/dsp" className={navLinkClass}>

--- a/desktop/src/features/management/components/ActivityFeed.tsx
+++ b/desktop/src/features/management/components/ActivityFeed.tsx
@@ -1,0 +1,30 @@
+import type { MediaEvent } from "../../../types/management";
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+interface Props {
+  events: MediaEvent[];
+}
+
+export default function ActivityFeed({ events }: Props) {
+  if (events.length === 0) {
+    return <p className="text-sm text-gray-500 py-4">No recent activity.</p>;
+  }
+
+  return (
+    <ul className="space-y-1.5">
+      {events.map((event, i) => (
+        <li key={i} className="flex gap-3 text-sm">
+          <span className="text-gray-500 flex-shrink-0 w-16">{formatTime(event.timestamp)}</span>
+          <span className="text-gray-400 flex-shrink-0 w-24 capitalize">{event.type}</span>
+          <span className="text-gray-300 truncate">{event.detail}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/desktop/src/features/management/components/DownloadRow.tsx
+++ b/desktop/src/features/management/components/DownloadRow.tsx
@@ -1,0 +1,73 @@
+import type { DownloadStatus } from "../../../types/management";
+
+const STATUS_COLORS: Record<DownloadStatus["status"], string> = {
+  queued: "text-gray-400",
+  downloading: "text-blue-400",
+  extracting: "text-purple-400",
+  importing: "text-yellow-400",
+  completed: "text-green-400",
+  failed: "text-red-400",
+};
+
+function formatSpeed(bytesPerSec: number | null): string {
+  if (bytesPerSec === null) return "—";
+  if (bytesPerSec < 1024) return `${bytesPerSec.toFixed(0)} B/s`;
+  if (bytesPerSec < 1024 * 1024) return `${(bytesPerSec / 1024).toFixed(1)} KB/s`;
+  return `${(bytesPerSec / (1024 * 1024)).toFixed(1)} MB/s`;
+}
+
+interface Props {
+  download: DownloadStatus;
+  onCancel?: (id: string) => void;
+  onRetry?: (id: string) => void;
+  cancelling?: boolean;
+  retrying?: boolean;
+}
+
+export default function DownloadRow({ download, onCancel, onRetry, cancelling, retrying }: Props) {
+  return (
+    <div className="flex flex-col gap-1 p-3 rounded bg-gray-800/50 border border-gray-700">
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-sm text-gray-100 truncate flex-1">{download.title}</span>
+        <span className={`text-xs font-medium ${STATUS_COLORS[download.status]}`}>
+          {download.status}
+        </span>
+        <div className="flex gap-2 flex-shrink-0">
+          {download.status === "failed" && onRetry && (
+            <button
+              onClick={() => onRetry(download.id)}
+              disabled={retrying}
+              className="px-2 py-1 text-xs rounded bg-yellow-700 hover:bg-yellow-600 disabled:opacity-50 text-white transition-colors"
+            >
+              Retry
+            </button>
+          )}
+          {(download.status === "queued" || download.status === "downloading") && onCancel && (
+            <button
+              onClick={() => onCancel(download.id)}
+              disabled={cancelling}
+              className="px-2 py-1 text-xs rounded bg-red-800 hover:bg-red-700 disabled:opacity-50 text-white transition-colors"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+      {download.status === "downloading" && (
+        <div className="flex items-center gap-3">
+          <div className="flex-1 bg-gray-700 rounded-full h-1.5">
+            <div
+              className="bg-blue-500 h-1.5 rounded-full transition-all"
+              style={{ width: `${download.progressPercent}%` }}
+            />
+          </div>
+          <span className="text-xs text-gray-400 w-10 text-right">
+            {download.progressPercent.toFixed(0)}%
+          </span>
+          <span className="text-xs text-gray-500">{formatSpeed(download.downloadSpeed)}</span>
+          {download.eta && <span className="text-xs text-gray-500">{download.eta}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/management/components/IndexerRow.tsx
+++ b/desktop/src/features/management/components/IndexerRow.tsx
@@ -1,0 +1,96 @@
+import type { Indexer, IndexerTestResult } from "../../../types/management";
+
+const STATUS_COLORS: Record<Indexer["status"], string> = {
+  active: "bg-green-900 text-green-300",
+  degraded: "bg-yellow-900 text-yellow-300",
+  failed: "bg-red-900 text-red-300",
+};
+
+interface Props {
+  indexer: Indexer;
+  testResult: IndexerTestResult | null;
+  onTest: (id: string) => void;
+  onToggle: (id: string, enabled: boolean) => void;
+  onDelete: (id: string) => void;
+  onMoveUp: (id: string) => void;
+  onMoveDown: (id: string) => void;
+  testing: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+}
+
+export default function IndexerRow({
+  indexer,
+  testResult,
+  onTest,
+  onToggle,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+  testing,
+  isFirst,
+  isLast,
+}: Props) {
+  return (
+    <div className="p-3 rounded bg-gray-800/50 border border-gray-700 space-y-2">
+      <div className="flex items-center gap-3">
+        <div className="flex flex-col gap-0.5">
+          <button
+            onClick={() => onMoveUp(indexer.id)}
+            disabled={isFirst}
+            className="text-gray-500 hover:text-gray-300 disabled:opacity-30 text-xs leading-none"
+            aria-label="Move up"
+          >
+            ▲
+          </button>
+          <button
+            onClick={() => onMoveDown(indexer.id)}
+            disabled={isLast}
+            className="text-gray-500 hover:text-gray-300 disabled:opacity-30 text-xs leading-none"
+            aria-label="Move down"
+          >
+            ▼
+          </button>
+        </div>
+        <span className="text-xs text-gray-500 w-6 text-center">{indexer.priority}</span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-gray-100">{indexer.name}</p>
+          <p className="text-xs text-gray-400 truncate">{indexer.url}</p>
+        </div>
+        <span className="text-xs text-gray-500 uppercase">{indexer.protocol}</span>
+        <span className={`px-2 py-0.5 text-xs font-medium rounded ${STATUS_COLORS[indexer.status]}`}>
+          {indexer.status}
+        </span>
+        <label className="flex items-center gap-1 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={indexer.enabled}
+            onChange={(e) => onToggle(indexer.id, e.target.checked)}
+            className="rounded border-gray-600 bg-gray-700"
+          />
+          <span className="text-xs text-gray-400">Enabled</span>
+        </label>
+        <button
+          onClick={() => onTest(indexer.id)}
+          disabled={testing}
+          className="px-2 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-gray-300 transition-colors"
+        >
+          Test
+        </button>
+        <button
+          onClick={() => onDelete(indexer.id)}
+          className="px-2 py-1 text-xs rounded bg-red-900 hover:bg-red-800 text-red-300 transition-colors"
+        >
+          Delete
+        </button>
+      </div>
+      {testResult && (
+        <p className={`text-xs ${testResult.success ? "text-green-400" : "text-red-400"}`}>
+          {testResult.success
+            ? `OK — ${testResult.responseTimeMs}ms, ${testResult.categories} categories`
+            : `Failed: ${testResult.error}`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/management/components/LibraryStatsCards.tsx
+++ b/desktop/src/features/management/components/LibraryStatsCards.tsx
@@ -1,0 +1,67 @@
+import type { LibraryHealthReport, MediaType } from "../../../types/management";
+
+const MEDIA_LABELS: Record<MediaType, string> = {
+  music: "Music",
+  audiobook: "Audiobooks",
+  ebook: "Ebooks",
+  podcast: "Podcasts",
+  manga: "Manga",
+  news: "News",
+  movie: "Movies",
+  tv: "TV",
+};
+
+interface Props {
+  report: LibraryHealthReport;
+}
+
+export default function LibraryStatsCards({ report }: Props) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-4 gap-3">
+        <StatCard label="Total Items" value={report.totalItems.toLocaleString()} />
+        <StatCard
+          label="Missing Metadata"
+          value={report.missingMetadata.toLocaleString()}
+          highlight={report.missingMetadata > 0}
+        />
+        <StatCard
+          label="Orphaned Files"
+          value={report.orphanedFiles.toLocaleString()}
+          highlight={report.orphanedFiles > 0}
+        />
+        <StatCard
+          label="Duplicates"
+          value={report.duplicates.toLocaleString()}
+          highlight={report.duplicates > 0}
+        />
+      </div>
+      <div className="grid grid-cols-4 gap-3">
+        {(Object.entries(report.byMediaType) as [MediaType, number][]).map(([type, count]) => (
+          <StatCard key={type} label={MEDIA_LABELS[type]} value={count.toLocaleString()} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  highlight,
+}: {
+  label: string;
+  value: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`p-4 rounded border ${highlight ? "border-red-700 bg-red-900/20" : "border-gray-700 bg-gray-800/50"}`}
+    >
+      <p className="text-xs text-gray-400 mb-1">{label}</p>
+      <p className={`text-2xl font-semibold ${highlight ? "text-red-300" : "text-gray-100"}`}>
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/features/management/components/MediaItemRow.tsx
+++ b/desktop/src/features/management/components/MediaItemRow.tsx
@@ -1,0 +1,54 @@
+import { useNavigate } from "react-router-dom";
+import MediaStatusBadge from "./MediaStatusBadge";
+import QualityBadge from "./QualityBadge";
+import type { MediaItem } from "../../../types/management";
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "—";
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+interface Props {
+  item: MediaItem;
+  selected: boolean;
+  onSelect: (id: string, checked: boolean) => void;
+}
+
+export default function MediaItemRow({ item, selected, onSelect }: Props) {
+  const navigate = useNavigate();
+
+  return (
+    <tr
+      className="border-b border-gray-800 hover:bg-gray-800/50 cursor-pointer"
+      onClick={() => navigate(`/manage/media/${item.id}`)}
+    >
+      <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={(e) => onSelect(item.id, e.target.checked)}
+          className="rounded border-gray-600 bg-gray-700"
+        />
+      </td>
+      <td className="px-3 py-2 text-sm text-gray-100">{item.title}</td>
+      <td className="px-3 py-2">
+        <MediaStatusBadge status={item.status} />
+      </td>
+      <td className="px-3 py-2">
+        <QualityBadge score={item.qualityScore} />
+      </td>
+      <td className="px-3 py-2 text-sm text-gray-400">{formatBytes(item.fileSize)}</td>
+      <td className="px-3 py-2 text-sm text-gray-400">{formatDate(item.addedAt)}</td>
+    </tr>
+  );
+}

--- a/desktop/src/features/management/components/MediaStatusBadge.tsx
+++ b/desktop/src/features/management/components/MediaStatusBadge.tsx
@@ -1,0 +1,19 @@
+const STATUS_COLORS: Record<string, string> = {
+  imported: "bg-blue-900 text-blue-300",
+  enriched: "bg-purple-900 text-purple-300",
+  organized: "bg-indigo-900 text-indigo-300",
+  available: "bg-green-900 text-green-300",
+  failed: "bg-red-900 text-red-300",
+  missing: "bg-gray-700 text-gray-400",
+};
+
+interface Props {
+  status: string;
+}
+
+export default function MediaStatusBadge({ status }: Props) {
+  const colorClass = STATUS_COLORS[status] ?? "bg-gray-700 text-gray-400";
+  return (
+    <span className={`px-2 py-0.5 text-xs font-medium rounded ${colorClass}`}>{status}</span>
+  );
+}

--- a/desktop/src/features/management/components/MediaTypeSelector.tsx
+++ b/desktop/src/features/management/components/MediaTypeSelector.tsx
@@ -1,0 +1,45 @@
+import { useManagementStore } from "../store";
+import type { MediaType } from "../../../types/management";
+
+const MEDIA_TYPES: { type: MediaType; label: string }[] = [
+  { type: "music", label: "Music" },
+  { type: "audiobook", label: "Audiobooks" },
+  { type: "ebook", label: "Ebooks" },
+  { type: "podcast", label: "Podcasts" },
+  { type: "manga", label: "Manga" },
+  { type: "news", label: "News" },
+  { type: "movie", label: "Movies" },
+  { type: "tv", label: "TV" },
+];
+
+interface Props {
+  counts?: Partial<Record<MediaType, number>>;
+}
+
+export default function MediaTypeSelector({ counts }: Props) {
+  const selected = useManagementStore((s) => s.selectedMediaType);
+  const setSelectedMediaType = useManagementStore((s) => s.setSelectedMediaType);
+
+  return (
+    <div className="flex gap-1 border-b border-gray-800 overflow-x-auto">
+      {MEDIA_TYPES.map(({ type, label }) => (
+        <button
+          key={type}
+          onClick={() => setSelectedMediaType(type)}
+          className={`px-4 py-2 text-sm font-medium whitespace-nowrap border-b-2 transition-colors ${
+            selected === type
+              ? "border-blue-500 text-white"
+              : "border-transparent text-gray-400 hover:text-white hover:border-gray-600"
+          }`}
+        >
+          {label}
+          {counts?.[type] !== undefined && (
+            <span className="ml-2 px-1.5 py-0.5 text-xs rounded-full bg-gray-700 text-gray-300">
+              {counts[type]}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/features/management/components/MetadataForm.tsx
+++ b/desktop/src/features/management/components/MetadataForm.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import type { MediaItemDetail, MetadataUpdate } from "../../../types/management";
+
+interface Props {
+  item: MediaItemDetail;
+  onSave: (update: MetadataUpdate) => void;
+  saving: boolean;
+}
+
+export default function MetadataForm({ item, onSave, saving }: Props) {
+  const [title, setTitle] = useState(item.title);
+  const [extra, setExtra] = useState<Record<string, unknown>>(item.fullMetadata);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    onSave({ title, ...extra });
+  }
+
+  function handleFieldChange(key: string, value: string) {
+    setExtra((prev) => ({ ...prev, [key]: value }));
+  }
+
+  const extraFields = Object.entries(item.fullMetadata).filter(
+    ([key]) => key !== "title",
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">Title</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full px-3 py-2 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+        />
+      </div>
+      {extraFields.map(([key, val]) => (
+        <div key={key}>
+          <label className="block text-xs text-gray-400 mb-1 capitalize">
+            {key.replace(/_/g, " ")}
+          </label>
+          <input
+            type="text"
+            value={String(val ?? "")}
+            onChange={(e) => handleFieldChange(key, e.target.value)}
+            className="w-full px-3 py-2 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+        </div>
+      ))}
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={saving}
+          className="px-4 py-2 text-sm rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white transition-colors"
+        >
+          {saving ? "Saving…" : "Save Changes"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/desktop/src/features/management/components/QualityBadge.tsx
+++ b/desktop/src/features/management/components/QualityBadge.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  score: number | null;
+}
+
+function tier(score: number): { label: string; className: string } {
+  if (score >= 90) return { label: "Lossless", className: "bg-green-900 text-green-300" };
+  if (score >= 70) return { label: "High", className: "bg-blue-900 text-blue-300" };
+  if (score >= 50) return { label: "Good", className: "bg-yellow-900 text-yellow-300" };
+  return { label: "Low", className: "bg-red-900 text-red-300" };
+}
+
+export default function QualityBadge({ score }: Props) {
+  if (score === null) {
+    return (
+      <span className="px-2 py-0.5 text-xs font-medium rounded bg-gray-700 text-gray-400">
+        Unknown
+      </span>
+    );
+  }
+
+  const { label, className } = tier(score);
+  return (
+    <span className={`px-2 py-0.5 text-xs font-medium rounded ${className}`} title={`Score: ${score}`}>
+      {label}
+    </span>
+  );
+}

--- a/desktop/src/features/management/components/RequestRow.tsx
+++ b/desktop/src/features/management/components/RequestRow.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import type { MediaRequest } from "../../../types/management";
+
+const STATUS_COLORS: Record<MediaRequest["status"], string> = {
+  pending: "bg-yellow-900 text-yellow-300",
+  approved: "bg-green-900 text-green-300",
+  denied: "bg-red-900 text-red-300",
+  fulfilled: "bg-blue-900 text-blue-300",
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+interface Props {
+  request: MediaRequest;
+  isAdmin: boolean;
+  onApprove?: (id: string) => void;
+  onDeny?: (id: string, reason: string) => void;
+  onCancel?: (id: string) => void;
+}
+
+export default function RequestRow({ request, isAdmin, onApprove, onDeny, onCancel }: Props) {
+  const [denyReason, setDenyReason] = useState("");
+  const [showDenyForm, setShowDenyForm] = useState(false);
+
+  function handleDeny() {
+    if (!denyReason.trim()) return;
+    onDeny?.(request.id, denyReason);
+    setShowDenyForm(false);
+    setDenyReason("");
+  }
+
+  return (
+    <div className="p-3 rounded bg-gray-800/50 border border-gray-700 space-y-2">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-gray-100 truncate">{request.title}</p>
+          <p className="text-xs text-gray-400">
+            {request.userName} · {request.mediaType} · {formatDate(request.createdAt)}
+          </p>
+        </div>
+        <span className={`px-2 py-0.5 text-xs font-medium rounded ${STATUS_COLORS[request.status]}`}>
+          {request.status}
+        </span>
+      </div>
+      {request.denyReason && (
+        <p className="text-xs text-red-400">Reason: {request.denyReason}</p>
+      )}
+      {isAdmin && request.status === "pending" && (
+        <div className="flex gap-2">
+          {!showDenyForm && (
+            <>
+              <button
+                onClick={() => onApprove?.(request.id)}
+                className="px-3 py-1 text-xs rounded bg-green-700 hover:bg-green-600 text-white transition-colors"
+              >
+                Approve
+              </button>
+              <button
+                onClick={() => setShowDenyForm(true)}
+                className="px-3 py-1 text-xs rounded bg-red-800 hover:bg-red-700 text-white transition-colors"
+              >
+                Deny
+              </button>
+              <button
+                onClick={() => onCancel?.(request.id)}
+                className="px-3 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors"
+              >
+                Cancel
+              </button>
+            </>
+          )}
+          {showDenyForm && (
+            <div className="flex gap-2 flex-1">
+              <input
+                type="text"
+                value={denyReason}
+                onChange={(e) => setDenyReason(e.target.value)}
+                placeholder="Reason for denial"
+                className="flex-1 px-2 py-1 text-xs rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+              />
+              <button
+                onClick={handleDeny}
+                className="px-3 py-1 text-xs rounded bg-red-700 hover:bg-red-600 text-white transition-colors"
+              >
+                Confirm
+              </button>
+              <button
+                onClick={() => setShowDenyForm(false)}
+                className="px-3 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/management/components/ScanProgress.tsx
+++ b/desktop/src/features/management/components/ScanProgress.tsx
@@ -1,0 +1,45 @@
+import type { ScanStatus } from "../../../types/management";
+
+interface Props {
+  status: ScanStatus;
+  onTrigger: () => void;
+  triggering: boolean;
+}
+
+export default function ScanProgress({ status, onTrigger, triggering }: Props) {
+  return (
+    <div className="p-4 rounded border border-gray-700 bg-gray-800/50 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-200">Library Scan</h3>
+        <button
+          onClick={onTrigger}
+          disabled={status.running || triggering}
+          className="px-3 py-1 text-xs rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white transition-colors"
+        >
+          {status.running ? "Scanning…" : "Scan Now"}
+        </button>
+      </div>
+      {status.running && (
+        <div className="space-y-1">
+          <div className="w-full bg-gray-700 rounded-full h-1.5">
+            <div className="bg-blue-500 h-1.5 rounded-full animate-pulse w-full" />
+          </div>
+          <p className="text-xs text-gray-400">
+            {status.itemsScanned.toLocaleString()} scanned · {status.itemsAdded} added ·{" "}
+            {status.itemsRemoved} removed
+          </p>
+          {status.estimatedCompletion && (
+            <p className="text-xs text-gray-500">
+              Est. completion: {new Date(status.estimatedCompletion).toLocaleTimeString()}
+            </p>
+          )}
+        </div>
+      )}
+      {!status.running && status.startedAt && (
+        <p className="text-xs text-gray-500">
+          Last scan: {new Date(status.startedAt).toLocaleString()} · {status.itemsScanned} items
+        </p>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/management/components/SearchResultRow.tsx
+++ b/desktop/src/features/management/components/SearchResultRow.tsx
@@ -1,0 +1,47 @@
+import type { SearchResult, MediaType } from "../../../types/management";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatAge(iso: string): string {
+  const days = Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000);
+  if (days === 0) return "today";
+  if (days === 1) return "1d";
+  if (days < 30) return `${days}d`;
+  if (days < 365) return `${Math.floor(days / 30)}mo`;
+  return `${Math.floor(days / 365)}y`;
+}
+
+interface Props {
+  result: SearchResult;
+  onGrab: (result: SearchResult, mediaType: MediaType) => void;
+  grabbing: boolean;
+  selectedMediaType: MediaType;
+}
+
+export default function SearchResultRow({ result, onGrab, grabbing, selectedMediaType }: Props) {
+  return (
+    <tr className="border-b border-gray-800 hover:bg-gray-800/50">
+      <td className="px-3 py-2 text-sm text-gray-100">{result.title}</td>
+      <td className="px-3 py-2 text-xs text-gray-400">{result.indexerName}</td>
+      <td className="px-3 py-2 text-sm text-gray-300">{formatBytes(result.size)}</td>
+      <td className="px-3 py-2 text-sm text-green-400">{result.seeders}</td>
+      <td className="px-3 py-2 text-sm text-gray-400">{result.leechers}</td>
+      <td className="px-3 py-2 text-xs text-gray-300">{result.quality ?? "—"}</td>
+      <td className="px-3 py-2 text-xs text-gray-400">{formatAge(result.publicationDate)}</td>
+      <td className="px-3 py-2 text-xs text-gray-500 uppercase">{result.protocol}</td>
+      <td className="px-3 py-2">
+        <button
+          onClick={() => onGrab(result, selectedMediaType)}
+          disabled={grabbing}
+          className="px-3 py-1 text-xs rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white transition-colors"
+        >
+          Grab
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/desktop/src/features/management/components/SubtitleManager.tsx
+++ b/desktop/src/features/management/components/SubtitleManager.tsx
@@ -1,0 +1,81 @@
+import { useSubtitles } from "../hooks/useSubtitles";
+import type { SubtitleSearchResult } from "../../../types/management";
+
+interface Props {
+  mediaId: string;
+}
+
+export default function SubtitleManager({ mediaId }: Props) {
+  const { subtitles, search, download, remove } = useSubtitles(mediaId);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-200">Subtitles</h3>
+        <button
+          onClick={() => search.refetch()}
+          disabled={search.isFetching}
+          className="px-3 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-gray-300 transition-colors"
+        >
+          {search.isFetching ? "Searching…" : "Search Subtitles"}
+        </button>
+      </div>
+
+      {subtitles.isLoading && <p className="text-sm text-gray-500">Loading subtitles…</p>}
+      {subtitles.isError && (
+        <p className="text-sm text-red-400">Failed to load subtitles.</p>
+      )}
+      {subtitles.data && subtitles.data.length === 0 && (
+        <p className="text-sm text-gray-500">No subtitles downloaded.</p>
+      )}
+      {subtitles.data && subtitles.data.length > 0 && (
+        <ul className="space-y-2">
+          {subtitles.data.map((sub) => (
+            <li key={sub.id} className="flex items-center justify-between gap-3 text-sm">
+              <span className="text-gray-300">
+                {sub.language} · {sub.format.toUpperCase()}
+              </span>
+              <span className="text-xs text-gray-500 truncate flex-1">{sub.filePath}</span>
+              <button
+                onClick={() => remove.mutate(sub.id)}
+                className="px-2 py-0.5 text-xs rounded bg-red-900 hover:bg-red-800 text-red-300 transition-colors"
+              >
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {search.data && search.data.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium text-gray-400 uppercase tracking-wider">
+            Search Results
+          </h4>
+          <ul className="space-y-1.5">
+            {search.data.map((result: SubtitleSearchResult) => (
+              <li
+                key={result.id}
+                className="flex items-center justify-between gap-3 p-2 rounded bg-gray-700/50"
+              >
+                <span className="text-sm text-gray-300">
+                  {result.language} · {result.format.toUpperCase()}
+                </span>
+                <span className="text-xs text-gray-500">
+                  ★ {result.rating.toFixed(1)} · {result.downloadCount} dl
+                </span>
+                <button
+                  onClick={() => download.mutate(result.id)}
+                  disabled={download.isPending}
+                  className="px-2 py-0.5 text-xs rounded bg-blue-700 hover:bg-blue-600 disabled:opacity-50 text-white transition-colors"
+                >
+                  Download
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/management/components/WantedRow.tsx
+++ b/desktop/src/features/management/components/WantedRow.tsx
@@ -1,0 +1,45 @@
+import type { WantedItem } from "../../../types/management";
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "Never";
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+interface Props {
+  item: WantedItem;
+  onSearch: (id: string) => void;
+  onRemove: (id: string) => void;
+  searching: boolean;
+}
+
+export default function WantedRow({ item, onSearch, onRemove, searching }: Props) {
+  return (
+    <tr className="border-b border-gray-800 hover:bg-gray-800/50">
+      <td className="px-3 py-2 text-sm text-gray-100">{item.title}</td>
+      <td className="px-3 py-2 text-xs text-gray-400 capitalize">{item.mediaType}</td>
+      <td className="px-3 py-2 text-xs text-gray-400">{formatDate(item.lastSearchedAt)}</td>
+      <td className="px-3 py-2 text-xs text-gray-400">{item.searchCount}</td>
+      <td className="px-3 py-2">
+        <div className="flex gap-2">
+          <button
+            onClick={() => onSearch(item.id)}
+            disabled={searching}
+            className="px-2 py-1 text-xs rounded bg-blue-700 hover:bg-blue-600 disabled:opacity-50 text-white transition-colors"
+          >
+            Search
+          </button>
+          <button
+            onClick={() => onRemove(item.id)}
+            className="px-2 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors"
+          >
+            Remove
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/desktop/src/features/management/hooks/useDownloadQueue.ts
+++ b/desktop/src/features/management/hooks/useDownloadQueue.ts
@@ -1,0 +1,29 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+const QUEUE_POLL_INTERVAL = 5_000;
+
+export function useDownloadQueue() {
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const queue = useQuery({
+    queryKey: ["manage-download-queue", token],
+    queryFn: () => api.getManageDownloadQueue(token),
+    enabled: token.length > 0,
+    refetchInterval: QUEUE_POLL_INTERVAL,
+  });
+
+  const cancel = useMutation({
+    mutationFn: (downloadId: string) => api.cancelManageDownload(downloadId, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-download-queue"] }),
+  });
+
+  const retry = useMutation({
+    mutationFn: (downloadId: string) => api.retryDownload(downloadId, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-download-queue"] }),
+  });
+
+  return { queue, cancel, retry };
+}

--- a/desktop/src/features/management/hooks/useIndexerSearch.ts
+++ b/desktop/src/features/management/hooks/useIndexerSearch.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+import type { SearchQuery, DownloadRequest } from "../../../types/management";
+
+export function useIndexerSearch() {
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const search = useMutation({
+    mutationFn: (query: SearchQuery) => api.searchIndexers(query, token),
+  });
+
+  const grab = useMutation({
+    mutationFn: (req: DownloadRequest) => api.triggerDownload(req, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-download-queue"] }),
+  });
+
+  return { search, grab };
+}

--- a/desktop/src/features/management/hooks/useIndexers.ts
+++ b/desktop/src/features/management/hooks/useIndexers.ts
@@ -1,0 +1,37 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+import type { IndexerCreate, IndexerUpdate } from "../../../types/management";
+
+export function useIndexers() {
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const indexers = useQuery({
+    queryKey: ["manage-indexers", token],
+    queryFn: () => api.getIndexers(token),
+    enabled: token.length > 0,
+  });
+
+  const add = useMutation({
+    mutationFn: (config: IndexerCreate) => api.addIndexer(config, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-indexers"] }),
+  });
+
+  const update = useMutation({
+    mutationFn: ({ id, config }: { id: string; config: IndexerUpdate }) =>
+      api.updateIndexer(id, config, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-indexers"] }),
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => api.deleteIndexer(id, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-indexers"] }),
+  });
+
+  const test = useMutation({
+    mutationFn: (id: string) => api.testIndexer(id, token),
+  });
+
+  return { indexers, add, update, remove, test };
+}

--- a/desktop/src/features/management/hooks/useLibraryHealth.ts
+++ b/desktop/src/features/management/hooks/useLibraryHealth.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+export function useLibraryHealth() {
+  const token = useLibraryStore((s) => s.token);
+
+  return useQuery({
+    queryKey: ["manage-library-health", token],
+    queryFn: () => api.getLibraryHealth(token),
+    enabled: token.length > 0,
+  });
+}

--- a/desktop/src/features/management/hooks/useMediaItem.ts
+++ b/desktop/src/features/management/hooks/useMediaItem.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+export function useMediaItem(id: string) {
+  const token = useLibraryStore((s) => s.token);
+
+  return useQuery({
+    queryKey: ["manage-media-item", id, token],
+    queryFn: () => api.getMediaItem(id, token),
+    enabled: token.length > 0 && id.length > 0,
+  });
+}

--- a/desktop/src/features/management/hooks/useMediaItems.ts
+++ b/desktop/src/features/management/hooks/useMediaItems.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+import { useManagementStore } from "../store";
+import type { MediaQueryParams } from "../../../types/management";
+
+export function useMediaItems(overrides?: Partial<MediaQueryParams>) {
+  const token = useLibraryStore((s) => s.token);
+  const selectedMediaType = useManagementStore((s) => s.selectedMediaType);
+  const filters = useManagementStore((s) => s.filters);
+
+  const params: MediaQueryParams = {
+    mediaType: selectedMediaType,
+    status: filters.status !== "all" ? filters.status : undefined,
+    qualityTier: filters.qualityTier !== "all" ? filters.qualityTier : undefined,
+    hasMetadata:
+      filters.hasMetadata === "yes" ? true : filters.hasMetadata === "no" ? false : undefined,
+    page: 1,
+    pageSize: 50,
+    ...overrides,
+  };
+
+  return useQuery({
+    queryKey: ["manage-media-items", token, params],
+    queryFn: () => api.getMediaItems(params, token),
+    enabled: token.length > 0,
+  });
+}

--- a/desktop/src/features/management/hooks/useRequests.ts
+++ b/desktop/src/features/management/hooks/useRequests.ts
@@ -1,0 +1,38 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+import type { RequestQueryParams, RequestCreate } from "../../../types/management";
+
+export function useRequests(params: RequestQueryParams = {}) {
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const requests = useQuery({
+    queryKey: ["manage-requests", token, params],
+    queryFn: () => api.getRequests(params, token),
+    enabled: token.length > 0,
+  });
+
+  const create = useMutation({
+    mutationFn: (request: RequestCreate) => api.createRequest(request, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-requests"] }),
+  });
+
+  const approve = useMutation({
+    mutationFn: (requestId: string) => api.approveRequest(requestId, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-requests"] }),
+  });
+
+  const deny = useMutation({
+    mutationFn: ({ requestId, reason }: { requestId: string; reason: string }) =>
+      api.denyRequest(requestId, reason, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-requests"] }),
+  });
+
+  const cancel = useMutation({
+    mutationFn: (requestId: string) => api.cancelRequest(requestId, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-requests"] }),
+  });
+
+  return { requests, create, approve, deny, cancel };
+}

--- a/desktop/src/features/management/hooks/useScanStatus.ts
+++ b/desktop/src/features/management/hooks/useScanStatus.ts
@@ -1,0 +1,27 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+const SCAN_POLL_INTERVAL = 3_000;
+
+export function useScanStatus() {
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const status = useQuery({
+    queryKey: ["manage-scan-status", token],
+    queryFn: () => api.getScanStatus(token),
+    enabled: token.length > 0,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      return data?.running ? SCAN_POLL_INTERVAL : false;
+    },
+  });
+
+  const trigger = useMutation({
+    mutationFn: (path?: string) => api.triggerLibraryScan(token, path),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-scan-status"] }),
+  });
+
+  return { status, trigger };
+}

--- a/desktop/src/features/management/hooks/useSubtitles.ts
+++ b/desktop/src/features/management/hooks/useSubtitles.ts
@@ -1,0 +1,32 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+
+export function useSubtitles(mediaId: string) {
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const subtitles = useQuery({
+    queryKey: ["manage-subtitles", mediaId, token],
+    queryFn: () => api.getSubtitles(mediaId, token),
+    enabled: token.length > 0 && mediaId.length > 0,
+  });
+
+  const search = useQuery({
+    queryKey: ["manage-subtitle-search", mediaId, token],
+    queryFn: () => api.searchSubtitles(mediaId, token),
+    enabled: false,
+  });
+
+  const download = useMutation({
+    mutationFn: (subtitleId: string) => api.downloadSubtitle(mediaId, subtitleId, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-subtitles", mediaId] }),
+  });
+
+  const remove = useMutation({
+    mutationFn: (subtitleId: string) => api.deleteSubtitle(subtitleId, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-subtitles", mediaId] }),
+  });
+
+  return { subtitles, search, download, remove };
+}

--- a/desktop/src/features/management/hooks/useWanted.ts
+++ b/desktop/src/features/management/hooks/useWanted.ts
@@ -1,0 +1,31 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client";
+import { useLibraryStore } from "../../library/store";
+import type { WantedQueryParams, WantedItemCreate } from "../../../types/management";
+
+export function useWanted(params: WantedQueryParams = {}) {
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const wanted = useQuery({
+    queryKey: ["manage-wanted", token, params],
+    queryFn: () => api.getWantedMedia(params, token),
+    enabled: token.length > 0,
+  });
+
+  const add = useMutation({
+    mutationFn: (item: WantedItemCreate) => api.addWanted(item, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-wanted"] }),
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => api.removeWanted(id, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-wanted"] }),
+  });
+
+  const triggerSearch = useMutation({
+    mutationFn: (id: string) => api.triggerWantedSearch(id, token),
+  });
+
+  return { wanted, add, remove, triggerSearch };
+}

--- a/desktop/src/features/management/pages/DashboardPage.tsx
+++ b/desktop/src/features/management/pages/DashboardPage.tsx
@@ -1,0 +1,90 @@
+import { useScanStatus } from "../hooks/useScanStatus";
+import { useLibraryHealth } from "../hooks/useLibraryHealth";
+import { useDownloadQueue } from "../hooks/useDownloadQueue";
+import { useRequests } from "../hooks/useRequests";
+import ScanProgress from "../components/ScanProgress";
+import LibraryStatsCards from "../components/LibraryStatsCards";
+import DownloadRow from "../components/DownloadRow";
+import { Link } from "react-router-dom";
+
+export default function DashboardPage() {
+  const { status: scan, trigger } = useScanStatus();
+  const health = useLibraryHealth();
+  const { queue, cancel, retry } = useDownloadQueue();
+  const { requests } = useRequests({ status: "pending" });
+
+  const pendingCount = requests.data?.data.length ?? 0;
+  const activeDownloads = queue.data?.active ?? [];
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <h1 className="text-xl font-semibold text-gray-100">Management Dashboard</h1>
+
+      {scan.data && (
+        <ScanProgress
+          status={scan.data}
+          onTrigger={() => trigger.mutate(undefined)}
+          triggering={trigger.isPending}
+        />
+      )}
+      {scan.isLoading && <p className="text-sm text-gray-500">Loading scan status…</p>}
+
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-medium text-gray-300 uppercase tracking-wider">
+            Library Overview
+          </h2>
+          <Link to="/manage/health" className="text-xs text-blue-400 hover:text-blue-300">
+            Full health report →
+          </Link>
+        </div>
+        {health.isLoading && <p className="text-sm text-gray-500">Loading health report…</p>}
+        {health.isError && <p className="text-sm text-red-400">Failed to load health report.</p>}
+        {health.data && <LibraryStatsCards report={health.data} />}
+      </section>
+
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-medium text-gray-300 uppercase tracking-wider">
+            Active Downloads
+          </h2>
+          <Link to="/manage/downloads" className="text-xs text-blue-400 hover:text-blue-300">
+            View all →
+          </Link>
+        </div>
+        {queue.isLoading && <p className="text-sm text-gray-500">Loading download queue…</p>}
+        {activeDownloads.length === 0 && !queue.isLoading && (
+          <p className="text-sm text-gray-500">No active downloads.</p>
+        )}
+        <div className="space-y-2">
+          {activeDownloads.map((dl) => (
+            <DownloadRow
+              key={dl.id}
+              download={dl}
+              onCancel={(id) => cancel.mutate(id)}
+              onRetry={(id) => retry.mutate(id)}
+              cancelling={cancel.isPending}
+              retrying={retry.isPending}
+            />
+          ))}
+        </div>
+      </section>
+
+      {pendingCount > 0 && (
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-medium text-gray-300 uppercase tracking-wider">
+              Pending Requests
+            </h2>
+            <Link to="/manage/requests" className="text-xs text-blue-400 hover:text-blue-300">
+              Review {pendingCount} →
+            </Link>
+          </div>
+          <p className="text-sm text-yellow-400">
+            {pendingCount} request{pendingCount !== 1 ? "s" : ""} awaiting decision.
+          </p>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/DownloadQueuePage.tsx
+++ b/desktop/src/features/management/pages/DownloadQueuePage.tsx
@@ -1,0 +1,97 @@
+import { useDownloadQueue } from "../hooks/useDownloadQueue";
+import DownloadRow from "../components/DownloadRow";
+
+function Section({ title, count }: { title: string; count: number }) {
+  return (
+    <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
+      {title}
+      <span className="ml-2 text-gray-600">({count})</span>
+    </h2>
+  );
+}
+
+export default function DownloadQueuePage() {
+  const { queue, cancel, retry } = useDownloadQueue();
+
+  if (queue.isLoading) {
+    return <div className="p-6 text-sm text-gray-500">Loading…</div>;
+  }
+  if (queue.isError) {
+    return <div className="p-6 text-sm text-red-400">Failed to load download queue.</div>;
+  }
+
+  const { active = [], queued = [], completed = [], failed = [] } = queue.data ?? {};
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <h1 className="text-xl font-semibold text-gray-100">Download Queue</h1>
+
+      <section className="space-y-2">
+        <Section title="Active" count={active.length} />
+        {active.length === 0 ? (
+          <p className="text-sm text-gray-500">Nothing downloading.</p>
+        ) : (
+          <div className="space-y-2">
+            {active.map((dl) => (
+              <DownloadRow
+                key={dl.id}
+                download={dl}
+                onCancel={(id) => cancel.mutate(id)}
+                cancelling={cancel.isPending}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <Section title="Queued" count={queued.length} />
+        {queued.length === 0 ? (
+          <p className="text-sm text-gray-500">Queue empty.</p>
+        ) : (
+          <div className="space-y-2">
+            {queued.map((dl) => (
+              <DownloadRow
+                key={dl.id}
+                download={dl}
+                onCancel={(id) => cancel.mutate(id)}
+                cancelling={cancel.isPending}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <Section title="Failed" count={failed.length} />
+        {failed.length === 0 ? (
+          <p className="text-sm text-gray-500">No failed downloads.</p>
+        ) : (
+          <div className="space-y-2">
+            {failed.map((dl) => (
+              <DownloadRow
+                key={dl.id}
+                download={dl}
+                onRetry={(id) => retry.mutate(id)}
+                retrying={retry.isPending}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <Section title="Completed" count={completed.length} />
+        {completed.length === 0 ? (
+          <p className="text-sm text-gray-500">No completed downloads.</p>
+        ) : (
+          <div className="space-y-2">
+            {completed.map((dl) => (
+              <DownloadRow key={dl.id} download={dl} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/IndexerSettingsPage.tsx
+++ b/desktop/src/features/management/pages/IndexerSettingsPage.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import { useIndexers } from "../hooks/useIndexers";
+import { useManagementStore } from "../store";
+import IndexerRow from "../components/IndexerRow";
+import type { IndexerTestResult } from "../../../types/management";
+
+export default function IndexerSettingsPage() {
+  const isAdmin = useManagementStore((s) => s.isAdmin);
+  const { indexers, add, update, remove, test } = useIndexers();
+
+  const [newName, setNewName] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+  const [newApiKey, setNewApiKey] = useState("");
+  const [newProtocol, setNewProtocol] = useState<"torznab" | "newznab">("torznab");
+  const [testResults, setTestResults] = useState<Record<string, IndexerTestResult>>({});
+  const [testingId, setTestingId] = useState<string | null>(null);
+
+  if (!isAdmin) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <p className="text-sm text-gray-500">Admin access required.</p>
+      </div>
+    );
+  }
+
+  function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newName.trim() || !newUrl.trim()) return;
+    const list = indexers.data ?? [];
+    add.mutate(
+      {
+        name: newName.trim(),
+        url: newUrl.trim(),
+        apiKey: newApiKey.trim(),
+        protocol: newProtocol,
+        priority: list.length + 1,
+      },
+      {
+        onSuccess: () => {
+          setNewName("");
+          setNewUrl("");
+          setNewApiKey("");
+        },
+      },
+    );
+  }
+
+  function handleTest(id: string) {
+    setTestingId(id);
+    test.mutate(id, {
+      onSuccess: (result) => {
+        setTestResults((prev) => ({ ...prev, [id]: result }));
+        setTestingId(null);
+      },
+      onError: () => setTestingId(null),
+    });
+  }
+
+  function handleMoveUp(id: string) {
+    const list = indexers.data ?? [];
+    const idx = list.findIndex((x) => x.id === id);
+    if (idx <= 0) return;
+    const prev = list[idx - 1];
+    update.mutate({ id, config: { priority: prev.priority } });
+    update.mutate({ id: prev.id, config: { priority: list[idx].priority } });
+  }
+
+  function handleMoveDown(id: string) {
+    const list = indexers.data ?? [];
+    const idx = list.findIndex((x) => x.id === id);
+    if (idx < 0 || idx >= list.length - 1) return;
+    const next = list[idx + 1];
+    update.mutate({ id, config: { priority: next.priority } });
+    update.mutate({ id: next.id, config: { priority: list[idx].priority } });
+  }
+
+  const list = [...(indexers.data ?? [])].sort((a, b) => a.priority - b.priority);
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <h1 className="text-xl font-semibold text-gray-100">Indexer Settings</h1>
+
+      <form
+        onSubmit={handleAdd}
+        className="p-4 rounded border border-gray-700 bg-gray-800/50 space-y-3"
+      >
+        <h2 className="text-sm font-medium text-gray-300">Add Indexer</h2>
+        <div className="flex gap-3 flex-wrap">
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Name"
+            className="w-36 px-3 py-1.5 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+          <input
+            type="url"
+            value={newUrl}
+            onChange={(e) => setNewUrl(e.target.value)}
+            placeholder="URL"
+            className="flex-1 min-w-52 px-3 py-1.5 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+          <input
+            type="text"
+            value={newApiKey}
+            onChange={(e) => setNewApiKey(e.target.value)}
+            placeholder="API Key"
+            className="w-44 px-3 py-1.5 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+          <select
+            value={newProtocol}
+            onChange={(e) => setNewProtocol(e.target.value as "torznab" | "newznab")}
+            className="text-sm rounded bg-gray-700 border border-gray-600 text-gray-300 px-2 py-1.5 focus:outline-none"
+          >
+            <option value="torznab">torznab</option>
+            <option value="newznab">newznab</option>
+          </select>
+          <button
+            type="submit"
+            disabled={add.isPending || !newName.trim() || !newUrl.trim()}
+            className="px-4 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white transition-colors"
+          >
+            Add
+          </button>
+        </div>
+      </form>
+
+      {indexers.isLoading && <p className="text-sm text-gray-500">Loading…</p>}
+      {indexers.isError && <p className="text-sm text-red-400">Failed to load indexers.</p>}
+      {!indexers.isLoading && list.length === 0 && (
+        <p className="text-sm text-gray-500">No indexers configured.</p>
+      )}
+      <div className="space-y-3">
+        {list.map((indexer, i) => (
+          <IndexerRow
+            key={indexer.id}
+            indexer={indexer}
+            testResult={testResults[indexer.id] ?? null}
+            onTest={handleTest}
+            onToggle={(id, enabled) => update.mutate({ id, config: { enabled } })}
+            onDelete={(id) => remove.mutate(id)}
+            onMoveUp={handleMoveUp}
+            onMoveDown={handleMoveDown}
+            testing={testingId === indexer.id}
+            isFirst={i === 0}
+            isLast={i === list.length - 1}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/LibraryHealthPage.tsx
+++ b/desktop/src/features/management/pages/LibraryHealthPage.tsx
@@ -1,0 +1,136 @@
+import { useLibraryHealth } from "../hooks/useLibraryHealth";
+import { useScanStatus } from "../hooks/useScanStatus";
+import LibraryStatsCards from "../components/LibraryStatsCards";
+import ScanProgress from "../components/ScanProgress";
+import type { QualityBucket } from "../../../types/management";
+
+function QualityBar({ bucket, max }: { bucket: QualityBucket; max: number }) {
+  const width = max > 0 ? (bucket.count / max) * 100 : 0;
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-xs text-gray-400 w-32 truncate flex-shrink-0">{bucket.label}</span>
+      <div className="flex-1 bg-gray-700 rounded h-4 relative">
+        <div
+          className="bg-blue-500 h-4 rounded transition-all"
+          style={{ width: `${width}%` }}
+        />
+      </div>
+      <span className="text-xs text-gray-300 w-16 text-right flex-shrink-0">
+        {bucket.count.toLocaleString()} ({bucket.percentage.toFixed(1)}%)
+      </span>
+    </div>
+  );
+}
+
+export default function LibraryHealthPage() {
+  const health = useLibraryHealth();
+  const { status: scan, trigger } = useScanStatus();
+
+  if (health.isLoading) {
+    return <div className="p-6 text-sm text-gray-500">Loading health report…</div>;
+  }
+  if (health.isError) {
+    return <div className="p-6 text-sm text-red-400">Failed to load health report.</div>;
+  }
+  if (!health.data) {
+    return null;
+  }
+
+  const report = health.data;
+  const maxBucketCount = Math.max(...report.qualityDistribution.map((b) => b.count), 1);
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <h1 className="text-xl font-semibold text-gray-100">Library Health</h1>
+
+      {scan.data && (
+        <ScanProgress
+          status={scan.data}
+          onTrigger={() => trigger.mutate(undefined)}
+          triggering={trigger.isPending}
+        />
+      )}
+
+      <section>
+        <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
+          Overview
+        </h2>
+        <LibraryStatsCards report={report} />
+      </section>
+
+      {report.qualityDistribution.length > 0 && (
+        <section>
+          <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
+            Quality Distribution
+          </h2>
+          <div className="space-y-2">
+            {report.qualityDistribution.map((bucket) => (
+              <QualityBar key={bucket.label} bucket={bucket} max={maxBucketCount} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="grid grid-cols-3 gap-4">
+        <HealthSection
+          title="Missing Metadata"
+          count={report.missingMetadata}
+          description="Items without complete metadata."
+          severity={report.missingMetadata > 0 ? "warn" : "ok"}
+        />
+        <HealthSection
+          title="Orphaned Files"
+          count={report.orphanedFiles}
+          description="Files in library directories not tracked in the database."
+          severity={report.orphanedFiles > 0 ? "warn" : "ok"}
+        />
+        <HealthSection
+          title="Duplicates"
+          count={report.duplicates}
+          description="Potential duplicate items detected."
+          severity={report.duplicates > 0 ? "warn" : "ok"}
+        />
+      </section>
+
+      <section>
+        <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
+          Status Breakdown
+        </h2>
+        <div className="grid grid-cols-3 gap-3">
+          {Object.entries(report.byStatus).map(([status, count]) => (
+            <div key={status} className="p-3 rounded border border-gray-700 bg-gray-800/50">
+              <p className="text-xs text-gray-400 capitalize">{status}</p>
+              <p className="text-lg font-semibold text-gray-100">{count.toLocaleString()}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function HealthSection({
+  title,
+  count,
+  description,
+  severity,
+}: {
+  title: string;
+  count: number;
+  description: string;
+  severity: "ok" | "warn";
+}) {
+  return (
+    <div
+      className={`p-4 rounded border ${severity === "warn" && count > 0 ? "border-yellow-700 bg-yellow-900/10" : "border-gray-700 bg-gray-800/50"}`}
+    >
+      <p className="text-sm font-medium text-gray-200 mb-1">{title}</p>
+      <p
+        className={`text-2xl font-semibold mb-1 ${severity === "warn" && count > 0 ? "text-yellow-300" : "text-gray-100"}`}
+      >
+        {count.toLocaleString()}
+      </p>
+      <p className="text-xs text-gray-500">{description}</p>
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/MediaBrowsePage.tsx
+++ b/desktop/src/features/management/pages/MediaBrowsePage.tsx
@@ -1,0 +1,223 @@
+import { useState } from "react";
+import { useQueryClient, useMutation } from "@tanstack/react-query";
+import { useMediaItems } from "../hooks/useMediaItems";
+import { useManagementStore } from "../store";
+import { useLibraryStore } from "../../library/store";
+import MediaTypeSelector from "../components/MediaTypeSelector";
+import MediaItemRow from "../components/MediaItemRow";
+import { api } from "../../../api/client";
+import type { MediaType } from "../../../types/management";
+
+const STATUS_OPTIONS = ["all", "imported", "enriched", "organized", "available", "failed"];
+const QUALITY_OPTIONS = ["all", "lossless", "high", "good", "low"];
+
+const MEDIA_TYPE_COUNTS: Partial<Record<MediaType, number>> = {};
+
+export default function MediaBrowsePage() {
+  const token = useLibraryStore((s) => s.token);
+  const { filters, setFilter } = useManagementStore();
+  const queryClient = useQueryClient();
+
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [sortBy, setSortBy] = useState<"title" | "status" | "quality" | "size" | "addedAt">(
+    "title",
+  );
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
+  const [bulkQualityProfile, setBulkQualityProfile] = useState("");
+
+  const { data, isLoading, isError } = useMediaItems({ sortBy, sortOrder });
+
+  const bulkRefresh = useMutation({
+    mutationFn: () => api.bulkRefreshMetadata(selectedIds, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-media-items"] }),
+  });
+
+  const bulkDelete = useMutation({
+    mutationFn: () => api.bulkDelete(selectedIds, token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["manage-media-items"] });
+      setSelectedIds([]);
+    },
+  });
+
+  const bulkSetProfile = useMutation({
+    mutationFn: () => api.bulkSetQualityProfile(selectedIds, bulkQualityProfile, token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-media-items"] }),
+  });
+
+  function toggleSelect(id: string, checked: boolean) {
+    setSelectedIds((prev) => (checked ? [...prev, id] : prev.filter((x) => x !== id)));
+  }
+
+  function toggleAll(checked: boolean) {
+    if (!data) return;
+    setSelectedIds(checked ? data.data.map((item) => item.id) : []);
+  }
+
+  function toggleSort(col: typeof sortBy) {
+    if (sortBy === col) {
+      setSortOrder((o) => (o === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(col);
+      setSortOrder("asc");
+    }
+  }
+
+  function sortIcon(col: typeof sortBy): string {
+    if (sortBy !== col) return "↕";
+    return sortOrder === "asc" ? "↑" : "↓";
+  }
+
+  const items = data?.data ?? [];
+  const allSelected = items.length > 0 && selectedIds.length === items.length;
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="border-b border-gray-800">
+        <MediaTypeSelector counts={MEDIA_TYPE_COUNTS} />
+      </div>
+
+      <div className="flex gap-4 px-4 py-3 border-b border-gray-800 flex-wrap">
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-gray-400">Status</label>
+          <select
+            value={filters.status}
+            onChange={(e) => setFilter({ status: e.target.value })}
+            className="text-xs rounded bg-gray-700 border border-gray-600 text-gray-300 px-2 py-1 focus:outline-none"
+          >
+            {STATUS_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-gray-400">Quality</label>
+          <select
+            value={filters.qualityTier}
+            onChange={(e) => setFilter({ qualityTier: e.target.value })}
+            className="text-xs rounded bg-gray-700 border border-gray-600 text-gray-300 px-2 py-1 focus:outline-none"
+          >
+            {QUALITY_OPTIONS.map((q) => (
+              <option key={q} value={q}>
+                {q}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-gray-400">Metadata</label>
+          <select
+            value={filters.hasMetadata}
+            onChange={(e) =>
+              setFilter({ hasMetadata: e.target.value as "all" | "yes" | "no" })
+            }
+            className="text-xs rounded bg-gray-700 border border-gray-600 text-gray-300 px-2 py-1 focus:outline-none"
+          >
+            <option value="all">All</option>
+            <option value="yes">Has metadata</option>
+            <option value="no">Missing metadata</option>
+          </select>
+        </div>
+      </div>
+
+      {selectedIds.length > 0 && (
+        <div className="flex gap-3 px-4 py-2 bg-blue-900/20 border-b border-blue-800 flex-wrap">
+          <span className="text-xs text-blue-300">{selectedIds.length} selected</span>
+          <button
+            onClick={() => bulkRefresh.mutate()}
+            disabled={bulkRefresh.isPending}
+            className="px-2 py-0.5 text-xs rounded bg-blue-700 hover:bg-blue-600 disabled:opacity-50 text-white transition-colors"
+          >
+            Refresh Metadata
+          </button>
+          <div className="flex gap-1">
+            <input
+              type="text"
+              value={bulkQualityProfile}
+              onChange={(e) => setBulkQualityProfile(e.target.value)}
+              placeholder="Profile ID"
+              className="px-2 py-0.5 text-xs rounded bg-gray-700 border border-gray-600 text-gray-300 focus:outline-none w-32"
+            />
+            <button
+              onClick={() => bulkSetProfile.mutate()}
+              disabled={bulkSetProfile.isPending || !bulkQualityProfile}
+              className="px-2 py-0.5 text-xs rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-gray-300 transition-colors"
+            >
+              Set Profile
+            </button>
+          </div>
+          <button
+            onClick={() => {
+              if (confirm(`Delete ${selectedIds.length} items?`)) {
+                bulkDelete.mutate();
+              }
+            }}
+            disabled={bulkDelete.isPending}
+            className="px-2 py-0.5 text-xs rounded bg-red-800 hover:bg-red-700 disabled:opacity-50 text-red-300 transition-colors"
+          >
+            Delete
+          </button>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-auto">
+        {isLoading && (
+          <p className="p-4 text-sm text-gray-500">Loading…</p>
+        )}
+        {isError && (
+          <p className="p-4 text-sm text-red-400">Failed to load media items.</p>
+        )}
+        {!isLoading && !isError && items.length === 0 && (
+          <p className="p-4 text-sm text-gray-500">No items found.</p>
+        )}
+        {items.length > 0 && (
+          <table className="w-full text-left">
+            <thead className="sticky top-0 bg-gray-900 border-b border-gray-700">
+              <tr>
+                <th className="px-3 py-2 w-8">
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    onChange={(e) => toggleAll(e.target.checked)}
+                    className="rounded border-gray-600 bg-gray-700"
+                  />
+                </th>
+                {(
+                  [
+                    { col: "title", label: "Title" },
+                    { col: "status", label: "Status" },
+                    { col: "quality", label: "Quality" },
+                    { col: "size", label: "Size" },
+                    { col: "addedAt", label: "Added" },
+                  ] as const
+                ).map(({ col, label }) => (
+                  <th key={col} className="px-3 py-2">
+                    <button
+                      onClick={() => toggleSort(col)}
+                      className="text-xs font-medium text-gray-400 hover:text-gray-200 flex items-center gap-1"
+                    >
+                      {label}
+                      <span className="text-gray-600">{sortIcon(col)}</span>
+                    </button>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <MediaItemRow
+                  key={item.id}
+                  item={item}
+                  selected={selectedIds.includes(item.id)}
+                  onSelect={toggleSelect}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/MediaDetailPage.tsx
+++ b/desktop/src/features/management/pages/MediaDetailPage.tsx
@@ -1,0 +1,182 @@
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMediaItem } from "../hooks/useMediaItem";
+import { useLibraryStore } from "../../library/store";
+import MediaStatusBadge from "../components/MediaStatusBadge";
+import QualityBadge from "../components/QualityBadge";
+import SubtitleManager from "../components/SubtitleManager";
+import ActivityFeed from "../components/ActivityFeed";
+import { api } from "../../../api/client";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+const SUBTITLE_TYPES: Set<string> = new Set(["movie", "tv"]);
+
+export default function MediaDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const { data: item, isLoading, isError } = useMediaItem(id ?? "");
+
+  const refreshMetadata = useMutation({
+    mutationFn: () => api.refreshMetadata(id ?? "", token),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["manage-media-item", id] }),
+  });
+
+  const deleteItem = useMutation({
+    mutationFn: () => api.deleteMediaItem(id ?? "", token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["manage-media-items"] });
+      navigate("/manage/media");
+    },
+  });
+
+  if (isLoading) {
+    return <div className="p-6 text-sm text-gray-500">Loading…</div>;
+  }
+  if (isError || !item) {
+    return <div className="p-6 text-sm text-red-400">Failed to load media item.</div>;
+  }
+
+  const showSubtitles = SUBTITLE_TYPES.has(item.mediaType);
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <div className="flex items-start gap-4">
+        <div className="flex-1 min-w-0">
+          <h1 className="text-xl font-semibold text-gray-100">{item.title}</h1>
+          <p className="text-sm text-gray-400 capitalize">{item.mediaType}</p>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <MediaStatusBadge status={item.status} />
+          <QualityBadge score={item.qualityScore} />
+        </div>
+      </div>
+
+      <div className="flex gap-3 flex-wrap">
+        <Link
+          to={`/manage/media/${id}/edit`}
+          className="px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+        >
+          Edit Metadata
+        </Link>
+        <button
+          onClick={() => refreshMetadata.mutate()}
+          disabled={refreshMetadata.isPending}
+          className="px-3 py-1.5 text-sm rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-gray-300 transition-colors"
+        >
+          Refresh Metadata
+        </button>
+        <Link
+          to={`/manage/search?mediaId=${id}`}
+          className="px-3 py-1.5 text-sm rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors"
+        >
+          Find Upgrade
+        </Link>
+        <button
+          onClick={() => {
+            if (confirm("Delete this item?")) deleteItem.mutate();
+          }}
+          disabled={deleteItem.isPending}
+          className="px-3 py-1.5 text-sm rounded bg-red-800 hover:bg-red-700 disabled:opacity-50 text-red-300 transition-colors"
+        >
+          Delete
+        </button>
+      </div>
+
+      <section className="grid grid-cols-2 gap-6">
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
+              Metadata
+            </h2>
+            <dl className="space-y-2">
+              {Object.entries(item.fullMetadata).map(([key, val]) => (
+                <div key={key} className="grid grid-cols-3 gap-2 text-sm">
+                  <dt className="text-gray-500 capitalize">{key.replace(/_/g, " ")}</dt>
+                  <dd className="col-span-2 text-gray-300">{String(val ?? "—")}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          {item.externalIds.length > 0 && (
+            <div>
+              <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
+                External IDs
+              </h2>
+              <ul className="space-y-1">
+                {item.externalIds.map((ext) => (
+                  <li key={ext.source} className="flex gap-3 text-sm">
+                    <span className="text-gray-500 uppercase w-24">{ext.source}</span>
+                    <span className="text-gray-300">{ext.externalId}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
+              Files
+            </h2>
+            {item.files.length === 0 ? (
+              <p className="text-sm text-gray-500">No files tracked.</p>
+            ) : (
+              <ul className="space-y-2">
+                {item.files.map((file, i) => (
+                  <li key={i} className="p-2 rounded bg-gray-800/50 text-sm space-y-1">
+                    <p className="text-gray-300 truncate" title={file.path}>
+                      {file.path}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {formatBytes(file.size)}
+                      {file.codec && ` · ${file.codec}`}
+                      {file.quality && ` · ${file.quality}`}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {item.qualityProfile && (
+            <div>
+              <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-2">
+                Quality Profile
+              </h2>
+              <p className="text-sm text-gray-300">{item.qualityProfile.name}</p>
+              <p className="text-xs text-gray-500">
+                Cutoff: {item.qualityProfile.cutoffQualityScore} ·{" "}
+                {item.qualityProfile.upgradeAllowed ? "Upgrades allowed" : "No upgrades"}
+              </p>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {showSubtitles && (
+        <section>
+          <SubtitleManager mediaId={id ?? ""} />
+        </section>
+      )}
+
+      {item.history.length > 0 && (
+        <section>
+          <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
+            History
+          </h2>
+          <ActivityFeed events={item.history} />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/MetadataEditPage.tsx
+++ b/desktop/src/features/management/pages/MetadataEditPage.tsx
@@ -1,0 +1,50 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMediaItem } from "../hooks/useMediaItem";
+import { useLibraryStore } from "../../library/store";
+import MetadataForm from "../components/MetadataForm";
+import { api } from "../../../api/client";
+import type { MetadataUpdate } from "../../../types/management";
+
+export default function MetadataEditPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+
+  const { data: item, isLoading, isError } = useMediaItem(id ?? "");
+
+  const save = useMutation({
+    mutationFn: (update: MetadataUpdate) => api.updateMetadata(id ?? "", update, token),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["manage-media-item", id, token], updated);
+      navigate(`/manage/media/${id}`);
+    },
+  });
+
+  if (isLoading) {
+    return <div className="p-6 text-sm text-gray-500">Loading…</div>;
+  }
+  if (isError || !item) {
+    return <div className="p-6 text-sm text-red-400">Failed to load media item.</div>;
+  }
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => navigate(-1)}
+          className="text-xs text-gray-400 hover:text-gray-200 transition-colors"
+        >
+          ← Back
+        </button>
+        <h1 className="text-xl font-semibold text-gray-100">Edit Metadata</h1>
+      </div>
+      <p className="text-sm text-gray-400">{item.title}</p>
+      <MetadataForm item={item} onSave={(update) => save.mutate(update)} saving={save.isPending} />
+      {save.isError && (
+        <p className="text-sm text-red-400">Failed to save metadata. Please try again.</p>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/QualityProfilesPage.tsx
+++ b/desktop/src/features/management/pages/QualityProfilesPage.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useLibraryStore } from "../../library/store";
+import { api } from "../../../api/client";
+import type { QualityProfile, QualityProfileUpdate } from "../../../types/management";
+
+function ProfileCard({
+  profile,
+  onSave,
+  saving,
+}: {
+  profile: QualityProfile;
+  onSave: (id: string, update: QualityProfileUpdate) => void;
+  saving: boolean;
+}) {
+  const [cutoff, setCutoff] = useState(profile.cutoffQualityScore);
+  const [upgradeAllowed, setUpgradeAllowed] = useState(profile.upgradeAllowed);
+
+  function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    onSave(profile.id, { cutoffQualityScore: cutoff, upgradeAllowed });
+  }
+
+  return (
+    <form
+      onSubmit={handleSave}
+      className="p-4 rounded border border-gray-700 bg-gray-800/50 space-y-3"
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-gray-100">{profile.name}</p>
+          <p className="text-xs text-gray-500 capitalize">{profile.mediaType}</p>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Quality Cutoff</label>
+          <input
+            type="number"
+            min={0}
+            max={100}
+            value={cutoff}
+            onChange={(e) => setCutoff(Number(e.target.value))}
+            className="w-full px-2 py-1 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none"
+          />
+        </div>
+        <div className="flex items-end gap-2 pb-1">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={upgradeAllowed}
+              onChange={(e) => setUpgradeAllowed(e.target.checked)}
+              className="rounded border-gray-600 bg-gray-700"
+            />
+            <span className="text-xs text-gray-300">Allow Upgrades</span>
+          </label>
+        </div>
+      </div>
+      {profile.preferredCodecs.length > 0 && (
+        <p className="text-xs text-gray-500">
+          Preferred: {profile.preferredCodecs.join(", ")}
+        </p>
+      )}
+      <button
+        type="submit"
+        disabled={saving}
+        className="px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white transition-colors"
+      >
+        {saving ? "Saving…" : "Save"}
+      </button>
+    </form>
+  );
+}
+
+export default function QualityProfilesPage() {
+  const token = useLibraryStore((s) => s.token);
+  const queryClient = useQueryClient();
+  const [savingId, setSavingId] = useState<string | null>(null);
+
+  const profiles = useQuery({
+    queryKey: ["manage-quality-profiles", token],
+    queryFn: () => api.getQualityProfiles(token),
+    enabled: token.length > 0,
+  });
+
+  const updateProfile = useMutation({
+    mutationFn: ({ id, update }: { id: string; update: QualityProfileUpdate }) =>
+      api.updateQualityProfile(id, update, token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["manage-quality-profiles"] });
+      setSavingId(null);
+    },
+    onError: () => setSavingId(null),
+  });
+
+  function handleSave(id: string, update: QualityProfileUpdate) {
+    setSavingId(id);
+    updateProfile.mutate({ id, update });
+  }
+
+  const profileList: QualityProfile[] = profiles.data ?? [];
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <h1 className="text-xl font-semibold text-gray-100">Quality Profiles</h1>
+      {profiles.isLoading && <p className="text-sm text-gray-500">Loading…</p>}
+      {profiles.isError && (
+        <p className="text-sm text-red-400">Failed to load quality profiles.</p>
+      )}
+      {!profiles.isLoading && profileList.length === 0 && (
+        <p className="text-sm text-gray-500">No quality profiles configured.</p>
+      )}
+      <div className="grid grid-cols-2 gap-4">
+        {profileList.map((profile) => (
+          <ProfileCard
+            key={profile.id}
+            profile={profile}
+            onSave={handleSave}
+            saving={savingId === profile.id && updateProfile.isPending}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/RequestsPage.tsx
+++ b/desktop/src/features/management/pages/RequestsPage.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { useRequests } from "../hooks/useRequests";
+import { useManagementStore } from "../store";
+import RequestRow from "../components/RequestRow";
+import type { MediaRequest, MediaType } from "../../../types/management";
+
+type TabStatus = "pending" | "approved" | "denied";
+
+const TABS: { status: TabStatus; label: string }[] = [
+  { status: "pending", label: "Pending" },
+  { status: "approved", label: "Approved" },
+  { status: "denied", label: "Denied" },
+];
+
+const MEDIA_TYPES: MediaType[] = [
+  "music", "audiobook", "ebook", "podcast", "manga", "news", "movie", "tv",
+];
+
+export default function RequestsPage() {
+  const isAdmin = useManagementStore((s) => s.isAdmin);
+  const [tab, setTab] = useState<TabStatus>("pending");
+  const [newTitle, setNewTitle] = useState("");
+  const [newType, setNewType] = useState<MediaType>("movie");
+  const [newExternalId, setNewExternalId] = useState("");
+
+  const { requests, create, approve, deny, cancel } = useRequests({ status: tab });
+
+  function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newTitle.trim()) return;
+    create.mutate(
+      {
+        mediaType: newType,
+        title: newTitle.trim(),
+        externalId: newExternalId.trim() || undefined,
+      },
+      {
+        onSuccess: () => {
+          setNewTitle("");
+          setNewExternalId("");
+        },
+      },
+    );
+  }
+
+  const items: MediaRequest[] = requests.data?.data ?? [];
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <h1 className="text-xl font-semibold text-gray-100">Request Queue</h1>
+
+      <form onSubmit={handleCreate} className="p-4 rounded border border-gray-700 bg-gray-800/50 space-y-3">
+        <h2 className="text-sm font-medium text-gray-300">New Request</h2>
+        <div className="flex gap-3 flex-wrap">
+          <select
+            value={newType}
+            onChange={(e) => setNewType(e.target.value as MediaType)}
+            className="text-sm rounded bg-gray-700 border border-gray-600 text-gray-300 px-2 py-1.5 focus:outline-none"
+          >
+            {MEDIA_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            placeholder="Title"
+            className="flex-1 min-w-40 px-3 py-1.5 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+          <input
+            type="text"
+            value={newExternalId}
+            onChange={(e) => setNewExternalId(e.target.value)}
+            placeholder="External ID (IMDB, TMDB…)"
+            className="w-52 px-3 py-1.5 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+          <button
+            type="submit"
+            disabled={create.isPending || !newTitle.trim()}
+            className="px-4 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white transition-colors"
+          >
+            Submit
+          </button>
+        </div>
+      </form>
+
+      <div className="flex gap-1 border-b border-gray-800">
+        {TABS.map(({ status, label }) => (
+          <button
+            key={status}
+            onClick={() => setTab(status)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              tab === status
+                ? "border-blue-500 text-white"
+                : "border-transparent text-gray-400 hover:text-white"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {requests.isLoading && <p className="text-sm text-gray-500">Loading…</p>}
+      {requests.isError && <p className="text-sm text-red-400">Failed to load requests.</p>}
+      {!requests.isLoading && items.length === 0 && (
+        <p className="text-sm text-gray-500">No {tab} requests.</p>
+      )}
+      <div className="space-y-3">
+        {items.map((req) => (
+          <RequestRow
+            key={req.id}
+            request={req}
+            isAdmin={isAdmin}
+            onApprove={(id) => approve.mutate(id)}
+            onDeny={(id, reason) => deny.mutate({ requestId: id, reason })}
+            onCancel={(id) => cancel.mutate(id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/SearchPage.tsx
+++ b/desktop/src/features/management/pages/SearchPage.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useManagementStore } from "../store";
+import { useIndexerSearch } from "../hooks/useIndexerSearch";
+import MediaTypeSelector from "../components/MediaTypeSelector";
+import SearchResultRow from "../components/SearchResultRow";
+import type { SearchResult, MediaType } from "../../../types/management";
+
+type SortField = "seeders" | "size" | "age" | "quality";
+
+function sortResults(results: SearchResult[], field: SortField, order: "asc" | "desc"): SearchResult[] {
+  const sorted = [...results].sort((a, b) => {
+    let diff = 0;
+    switch (field) {
+      case "seeders": diff = a.seeders - b.seeders; break;
+      case "size": diff = a.size - b.size; break;
+      case "age":
+        diff = new Date(a.publicationDate).getTime() - new Date(b.publicationDate).getTime();
+        break;
+      case "quality":
+        diff = (a.quality ?? "").localeCompare(b.quality ?? "");
+        break;
+    }
+    return order === "asc" ? diff : -diff;
+  });
+  return sorted;
+}
+
+export default function SearchPage() {
+  const [searchParams] = useSearchParams();
+  const selectedMediaType = useManagementStore((s) => s.selectedMediaType);
+  const { search, grab } = useIndexerSearch();
+
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
+  const [indexerFilter, setIndexerFilter] = useState("all");
+  const [sortField, setSortField] = useState<SortField>("seeders");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    if (!query.trim()) return;
+    search.mutate({ query: query.trim(), mediaType: selectedMediaType });
+  }
+
+  function handleGrab(result: SearchResult, mediaType: MediaType) {
+    grab.mutate({
+      searchResultUrl: result.downloadUrl,
+      mediaType,
+    });
+  }
+
+  function toggleSort(field: SortField) {
+    if (sortField === field) {
+      setSortOrder((o) => (o === "asc" ? "desc" : "asc"));
+    } else {
+      setSortField(field);
+      setSortOrder("desc");
+    }
+  }
+
+  const results = search.data ?? [];
+  const indexerNames = [...new Set(results.map((r) => r.indexerName))];
+  const filtered = indexerFilter === "all" ? results : results.filter((r) => r.indexerName === indexerFilter);
+  const sorted = sortResults(filtered, sortField, sortOrder);
+
+  function sortIcon(field: SortField): string {
+    if (sortField !== field) return "↕";
+    return sortOrder === "asc" ? "↑" : "↓";
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="border-b border-gray-800">
+        <MediaTypeSelector />
+      </div>
+
+      <div className="p-4 border-b border-gray-800 space-y-3">
+        <form onSubmit={handleSearch} className="flex gap-3">
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search indexers…"
+            className="flex-1 px-3 py-2 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+          <button
+            type="submit"
+            disabled={search.isPending || !query.trim()}
+            className="px-4 py-2 text-sm rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white transition-colors"
+          >
+            {search.isPending ? "Searching…" : "Search"}
+          </button>
+        </form>
+        {indexerNames.length > 1 && (
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-gray-400">Indexer</label>
+            <select
+              value={indexerFilter}
+              onChange={(e) => setIndexerFilter(e.target.value)}
+              className="text-xs rounded bg-gray-700 border border-gray-600 text-gray-300 px-2 py-1 focus:outline-none"
+            >
+              <option value="all">All</option>
+              {indexerNames.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        {search.isError && (
+          <p className="p-4 text-sm text-red-400">Search failed. Check indexer configuration.</p>
+        )}
+        {!search.isPending && results.length === 0 && search.isSuccess && (
+          <p className="p-4 text-sm text-gray-500">No results found.</p>
+        )}
+        {sorted.length > 0 && (
+          <table className="w-full text-left">
+            <thead className="sticky top-0 bg-gray-900 border-b border-gray-700">
+              <tr>
+                <th className="px-3 py-2 text-xs font-medium text-gray-400">Title</th>
+                <th className="px-3 py-2 text-xs font-medium text-gray-400">Indexer</th>
+                <th className="px-3 py-2">
+                  <button onClick={() => toggleSort("size")} className="text-xs font-medium text-gray-400 hover:text-gray-200 flex items-center gap-1">
+                    Size <span className="text-gray-600">{sortIcon("size")}</span>
+                  </button>
+                </th>
+                <th className="px-3 py-2">
+                  <button onClick={() => toggleSort("seeders")} className="text-xs font-medium text-gray-400 hover:text-gray-200 flex items-center gap-1">
+                    Seeds <span className="text-gray-600">{sortIcon("seeders")}</span>
+                  </button>
+                </th>
+                <th className="px-3 py-2 text-xs font-medium text-gray-400">Leech</th>
+                <th className="px-3 py-2">
+                  <button onClick={() => toggleSort("quality")} className="text-xs font-medium text-gray-400 hover:text-gray-200 flex items-center gap-1">
+                    Quality <span className="text-gray-600">{sortIcon("quality")}</span>
+                  </button>
+                </th>
+                <th className="px-3 py-2">
+                  <button onClick={() => toggleSort("age")} className="text-xs font-medium text-gray-400 hover:text-gray-200 flex items-center gap-1">
+                    Age <span className="text-gray-600">{sortIcon("age")}</span>
+                  </button>
+                </th>
+                <th className="px-3 py-2 text-xs font-medium text-gray-400">Protocol</th>
+                <th className="px-3 py-2 text-xs font-medium text-gray-400">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((result, i) => (
+                <SearchResultRow
+                  key={i}
+                  result={result}
+                  onGrab={handleGrab}
+                  grabbing={grab.isPending}
+                  selectedMediaType={selectedMediaType}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/management/pages/WantedPage.tsx
+++ b/desktop/src/features/management/pages/WantedPage.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { useWanted } from "../hooks/useWanted";
+import WantedRow from "../components/WantedRow";
+import type { MediaType } from "../../../types/management";
+
+const MEDIA_TYPES: MediaType[] = [
+  "music", "audiobook", "ebook", "podcast", "manga", "news", "movie", "tv",
+];
+
+export default function WantedPage() {
+  const { wanted, add, remove, triggerSearch } = useWanted();
+  const [newTitle, setNewTitle] = useState("");
+  const [newType, setNewType] = useState<MediaType>("movie");
+  const [newProfileId, setNewProfileId] = useState("");
+  const [newExternalId, setNewExternalId] = useState("");
+  const [searchingId, setSearchingId] = useState<string | null>(null);
+
+  function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newTitle.trim() || !newProfileId.trim()) return;
+    add.mutate(
+      {
+        mediaType: newType,
+        title: newTitle.trim(),
+        qualityProfileId: newProfileId.trim(),
+        externalId: newExternalId.trim() || undefined,
+      },
+      {
+        onSuccess: () => {
+          setNewTitle("");
+          setNewProfileId("");
+          setNewExternalId("");
+        },
+      },
+    );
+  }
+
+  function handleSearch(id: string) {
+    setSearchingId(id);
+    triggerSearch.mutate(id, { onSettled: () => setSearchingId(null) });
+  }
+
+  const items = wanted.data?.data ?? [];
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <h1 className="text-xl font-semibold text-gray-100">Wanted List</h1>
+
+      <form
+        onSubmit={handleAdd}
+        className="p-4 rounded border border-gray-700 bg-gray-800/50 space-y-3"
+      >
+        <h2 className="text-sm font-medium text-gray-300">Add Wanted</h2>
+        <div className="flex gap-3 flex-wrap">
+          <select
+            value={newType}
+            onChange={(e) => setNewType(e.target.value as MediaType)}
+            className="text-sm rounded bg-gray-700 border border-gray-600 text-gray-300 px-2 py-1.5 focus:outline-none"
+          >
+            {MEDIA_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            placeholder="Title"
+            className="flex-1 min-w-40 px-3 py-1.5 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+          <input
+            type="text"
+            value={newProfileId}
+            onChange={(e) => setNewProfileId(e.target.value)}
+            placeholder="Quality Profile ID"
+            className="w-44 px-3 py-1.5 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+          <input
+            type="text"
+            value={newExternalId}
+            onChange={(e) => setNewExternalId(e.target.value)}
+            placeholder="External ID (optional)"
+            className="w-48 px-3 py-1.5 text-sm rounded bg-gray-700 border border-gray-600 text-gray-100 focus:outline-none focus:border-blue-500"
+          />
+          <button
+            type="submit"
+            disabled={add.isPending || !newTitle.trim() || !newProfileId.trim()}
+            className="px-4 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white transition-colors"
+          >
+            Add
+          </button>
+        </div>
+      </form>
+
+      {wanted.isLoading && <p className="text-sm text-gray-500">Loading…</p>}
+      {wanted.isError && <p className="text-sm text-red-400">Failed to load wanted list.</p>}
+      {!wanted.isLoading && items.length === 0 && (
+        <p className="text-sm text-gray-500">No items on the wanted list.</p>
+      )}
+      {items.length > 0 && (
+        <table className="w-full text-left">
+          <thead className="border-b border-gray-700">
+            <tr>
+              <th className="px-3 py-2 text-xs font-medium text-gray-400">Title</th>
+              <th className="px-3 py-2 text-xs font-medium text-gray-400">Type</th>
+              <th className="px-3 py-2 text-xs font-medium text-gray-400">Last Searched</th>
+              <th className="px-3 py-2 text-xs font-medium text-gray-400">Searches</th>
+              <th className="px-3 py-2 text-xs font-medium text-gray-400">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <WantedRow
+                key={item.id}
+                item={item}
+                onSearch={handleSearch}
+                onRemove={(id) => remove.mutate(id)}
+                searching={searchingId === item.id && triggerSearch.isPending}
+              />
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/management/store.ts
+++ b/desktop/src/features/management/store.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { MediaType } from "../../types/management";
+
+interface FilterState {
+  status: string;
+  qualityTier: string;
+  hasMetadata: "all" | "yes" | "no";
+}
+
+interface ManagementState {
+  selectedMediaType: MediaType;
+  filters: FilterState;
+  isAdmin: boolean;
+  setSelectedMediaType: (mediaType: MediaType) => void;
+  setFilter: (filter: Partial<FilterState>) => void;
+  setIsAdmin: (isAdmin: boolean) => void;
+  resetFilters: () => void;
+}
+
+const defaultFilters: FilterState = {
+  status: "all",
+  qualityTier: "all",
+  hasMetadata: "all",
+};
+
+export const useManagementStore = create<ManagementState>()(
+  persist(
+    (set) => ({
+      selectedMediaType: "music",
+      filters: defaultFilters,
+      isAdmin: false,
+      setSelectedMediaType: (selectedMediaType) => set({ selectedMediaType }),
+      setFilter: (filter) =>
+        set((s) => ({ filters: { ...s.filters, ...filter } })),
+      setIsAdmin: (isAdmin) => set({ isAdmin }),
+      resetFilters: () => set({ filters: defaultFilters }),
+    }),
+    { name: "harmonia-management" },
+  ),
+);

--- a/desktop/src/types/management.ts
+++ b/desktop/src/types/management.ts
@@ -1,0 +1,249 @@
+import type { PaginatedResponse } from "./media";
+
+export type { PaginatedResponse };
+
+export type MediaType =
+  | "music"
+  | "audiobook"
+  | "ebook"
+  | "podcast"
+  | "manga"
+  | "news"
+  | "movie"
+  | "tv";
+
+export interface MediaItem {
+  id: string;
+  mediaType: MediaType;
+  title: string;
+  status: string;
+  qualityScore: number | null;
+  fileSize: number | null;
+  filePath: string | null;
+  addedAt: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface MediaItemDetail extends MediaItem {
+  fullMetadata: Record<string, unknown>;
+  qualityProfile: QualityProfile | null;
+  files: MediaFile[];
+  externalIds: ExternalId[];
+  history: MediaEvent[];
+}
+
+export interface MediaFile {
+  path: string;
+  size: number;
+  codec: string | null;
+  quality: string | null;
+}
+
+export interface ExternalId {
+  source: string;
+  externalId: string;
+}
+
+export interface MediaEvent {
+  type: string;
+  timestamp: string;
+  detail: string;
+}
+
+export interface MetadataUpdate {
+  title?: string;
+  [key: string]: unknown;
+}
+
+export interface ScanStatus {
+  running: boolean;
+  itemsScanned: number;
+  itemsAdded: number;
+  itemsRemoved: number;
+  startedAt: string | null;
+  estimatedCompletion: string | null;
+}
+
+export interface QualityProfile {
+  id: string;
+  name: string;
+  mediaType: MediaType;
+  cutoffQualityScore: number;
+  upgradeAllowed: boolean;
+  preferredCodecs: string[];
+}
+
+export interface QualityProfileUpdate {
+  name?: string;
+  cutoffQualityScore?: number;
+  upgradeAllowed?: boolean;
+  preferredCodecs?: string[];
+}
+
+export interface LibraryHealthReport {
+  totalItems: number;
+  byMediaType: Record<MediaType, number>;
+  byStatus: Record<string, number>;
+  qualityDistribution: QualityBucket[];
+  missingMetadata: number;
+  orphanedFiles: number;
+  duplicates: number;
+}
+
+export interface QualityBucket {
+  label: string;
+  count: number;
+  percentage: number;
+}
+
+export interface SearchQuery {
+  query: string;
+  mediaType?: MediaType;
+  categoryIds?: number[];
+}
+
+export interface SearchResult {
+  title: string;
+  indexerName: string;
+  size: number;
+  seeders: number;
+  leechers: number;
+  quality: string | null;
+  downloadUrl: string;
+  protocol: "torrent" | "nzb";
+  infoHash: string | null;
+  publicationDate: string;
+}
+
+export interface DownloadRequest {
+  searchResultUrl: string;
+  mediaId?: string;
+  mediaType: MediaType;
+}
+
+export interface DownloadStatus {
+  id: string;
+  title: string;
+  status: "queued" | "downloading" | "extracting" | "importing" | "completed" | "failed";
+  progressPercent: number;
+  downloadSpeed: number | null;
+  eta: string | null;
+}
+
+export interface QueueSnapshot {
+  active: DownloadStatus[];
+  queued: DownloadStatus[];
+  completed: DownloadStatus[];
+  failed: DownloadStatus[];
+}
+
+export interface MediaRequest {
+  id: string;
+  userId: string;
+  userName: string;
+  mediaType: MediaType;
+  title: string;
+  externalId: string | null;
+  status: "pending" | "approved" | "denied" | "fulfilled";
+  createdAt: string;
+  decidedAt: string | null;
+  decidedBy: string | null;
+  denyReason: string | null;
+}
+
+export interface WantedItem {
+  id: string;
+  mediaType: MediaType;
+  title: string;
+  externalId: string | null;
+  qualityProfileId: string;
+  addedAt: string;
+  lastSearchedAt: string | null;
+  searchCount: number;
+}
+
+export interface Indexer {
+  id: string;
+  name: string;
+  url: string;
+  protocol: "torznab" | "newznab";
+  enabled: boolean;
+  status: "active" | "degraded" | "failed";
+  priority: number;
+  lastCheckedAt: string | null;
+}
+
+export interface IndexerCreate {
+  name: string;
+  url: string;
+  apiKey: string;
+  protocol: "torznab" | "newznab";
+  priority: number;
+}
+
+export interface IndexerUpdate {
+  name?: string;
+  url?: string;
+  apiKey?: string;
+  enabled?: boolean;
+  priority?: number;
+}
+
+export interface IndexerTestResult {
+  success: boolean;
+  responseTimeMs: number;
+  categories: number;
+  error: string | null;
+}
+
+export interface Subtitle {
+  id: string;
+  language: string;
+  format: "srt" | "ass" | "ssa";
+  filePath: string;
+  downloadedAt: string;
+}
+
+export interface SubtitleSearchResult {
+  id: string;
+  language: string;
+  format: string;
+  rating: number;
+  downloadCount: number;
+}
+
+export interface MediaQueryParams {
+  mediaType?: MediaType;
+  status?: string;
+  qualityTier?: string;
+  hasMetadata?: boolean;
+  page?: number;
+  pageSize?: number;
+  sortBy?: "title" | "status" | "quality" | "size" | "addedAt";
+  sortOrder?: "asc" | "desc";
+}
+
+export interface RequestQueryParams {
+  status?: "pending" | "approved" | "denied" | "fulfilled";
+  page?: number;
+  pageSize?: number;
+}
+
+export interface RequestCreate {
+  mediaType: MediaType;
+  title: string;
+  externalId?: string;
+}
+
+export interface WantedQueryParams {
+  mediaType?: MediaType;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface WantedItemCreate {
+  mediaType: MediaType;
+  title: string;
+  externalId?: string;
+  qualityProfileId: string;
+}


### PR DESCRIPTION
## Summary

- **11 management pages** under `/manage`: Dashboard, Media Browse, Media Detail, Metadata Edit, Download Queue, Indexer Search, Requests, Wanted, Indexer Settings, Quality Profiles, Library Health
- **14 reusable components**: media type tab bar, sortable item rows, status/quality badges, download progress rows, subtitle manager, scan progress, stats cards, activity feed
- **10 TanStack Query hooks**: download queue and scan status poll automatically (5s/3s); all others use standard query invalidation on mutation success
- **36 new API endpoints** in `client.ts` covering scan, media CRUD, quality profiles, acquisition search, download queue, requests, wanted list, indexers, and subtitles
- **30 TypeScript types** in `management.ts`; no `any` types anywhere in new code
- **Zustand store** persists selected media type and filter state; `isAdmin` flag gates indexer settings and request approval actions
- **Admin gating**: IndexerSettingsPage and request approve/deny actions check `isAdmin` from the store
- **Bulk actions** on media browse: refresh metadata, delete, set quality profile for multiple selected items
- **CSS bar chart** in LibraryHealthPage for quality distribution — no chart dependency added

## Validation

- `npm run lint`: pass
- `npm run build`: pass (208 modules, TypeScript clean)
- `cargo clippy -- -D warnings`: pass

## Observations

- Chunk size warning in Vite build (501 KB); code splitting is a future performance task, not a correctness issue.
- The management store's `isAdmin` flag is a stub pending real auth integration (P3 auth track). Currently defaults to `false`; operator can set it via `setIsAdmin` once auth lands.
- `SubtitleManager` uses `search.refetch()` to trigger an explicit search rather than auto-fetching, keeping the query disabled until the user requests it.