### PR TITLE
feat(syntaxis): queue orchestration and post-processing (P3-03)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -588,9 +588,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "commoncrypto"
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -821,11 +821,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -835,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -1209,12 +1208,6 @@ dependencies = [
  "futures-sink",
  "spin",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -3777,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64",
  "chrono",
@@ -3796,9 +3789,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4260,6 +4253,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "syntaxis"
+version = "0.1.0"
+dependencies = [
+ "ergasia",
+ "harmonia-common",
+ "harmonia-db",
+ "horismos",
+ "jiff",
+ "rstest",
+ "serde",
+ "snafu",
+ "sqlx",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/ergasia",
     "crates/syndesmos",
     "crates/aitesis",
+    "crates/syntaxis",
     "crates/harmonia-host",
 ]
 exclude = [
@@ -41,6 +42,7 @@ zetesis         = { path = "crates/zetesis" }
 ergasia         = { path = "crates/ergasia" }
 syndesmos       = { path = "crates/syndesmos" }
 aitesis         = { path = "crates/aitesis" }
+syntaxis        = { path = "crates/syntaxis" }
 
 # ── Async runtime ──────────────────────────────────────────────────────────────
 tokio           = { version = "1", features = ["full"] }

--- a/crates/harmonia-db/migrations/006_download_queue.sql
+++ b/crates/harmonia-db/migrations/006_download_queue.sql
@@ -1,0 +1,23 @@
+-- Download queue persistence for Syntaxis.
+-- Tracks all queued, active, and terminal download states for restart recovery.
+
+CREATE TABLE download_queue (
+    id           BLOB NOT NULL PRIMARY KEY,
+    want_id      BLOB NOT NULL,
+    release_id   BLOB NOT NULL,
+    download_url TEXT NOT NULL,
+    protocol     TEXT NOT NULL CHECK (protocol IN ('torrent', 'nzb')),
+    priority     INTEGER NOT NULL DEFAULT 1,
+    tracker_id   INTEGER,
+    info_hash    TEXT,
+    status       TEXT NOT NULL DEFAULT 'queued' CHECK (status IN (
+                     'queued', 'downloading', 'post_processing', 'importing', 'completed', 'failed'
+                 )),
+    added_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    started_at   TEXT,
+    completed_at TEXT,
+    failed_reason TEXT,
+    retry_count  INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_download_queue_status_priority ON download_queue(status, priority DESC);

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -235,17 +235,21 @@ impl Default for ErgasiaConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyntaxisConfig {
-    pub max_queue_size: usize,
-    pub max_retries: u32,
-    pub retry_delay_secs: u64,
+    pub max_concurrent_downloads: usize,
+    pub max_per_tracker: usize,
+    pub retry_count: u32,
+    pub retry_backoff_base_seconds: u64,
+    pub stalled_download_timeout_hours: u64,
 }
 
 impl Default for SyntaxisConfig {
     fn default() -> Self {
         Self {
-            max_queue_size: 1000,
-            max_retries: 3,
-            retry_delay_secs: 60,
+            max_concurrent_downloads: 5,
+            max_per_tracker: 3,
+            retry_count: 3,
+            retry_backoff_base_seconds: 30,
+            stalled_download_timeout_hours: 24,
         }
     }
 }

--- a/crates/syntaxis/Cargo.toml
+++ b/crates/syntaxis/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "syntaxis"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Download queue orchestration and post-processing for Harmonia"
+
+[dependencies]
+harmonia-common.workspace = true
+horismos.workspace = true
+harmonia-db.workspace = true
+ergasia.workspace = true
+snafu.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+serde.workspace = true
+uuid.workspace = true
+jiff.workspace = true
+sqlx.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tempfile = "3"

--- a/crates/syntaxis/src/dispatch.rs
+++ b/crates/syntaxis/src/dispatch.rs
@@ -1,0 +1,204 @@
+//! Slot allocator and mpsc channel dispatch to Ergasia.
+//!
+//! Tracks how many downloads are active per-tracker and globally, and sends
+//! `QueueItem`s to Ergasia when a slot opens.
+
+use std::collections::HashMap;
+
+use crate::types::{DownloadProtocol, QueueItem};
+
+/// Tracks active download slots globally and per tracker.
+///
+/// The slot allocator enforces:
+/// - `max_concurrent_downloads`: total active downloads across all protocols
+/// - `max_per_tracker`: per-indexer limit for torrent downloads
+#[derive(Debug)]
+pub(crate) struct SlotAllocator {
+    max_concurrent: usize,
+    max_per_tracker: usize,
+    /// Total active download count.
+    active_total: usize,
+    /// Active download count keyed by tracker_id (torrent only).
+    active_per_tracker: HashMap<i64, usize>,
+}
+
+impl SlotAllocator {
+    pub(crate) fn new(max_concurrent: usize, max_per_tracker: usize) -> Self {
+        Self {
+            max_concurrent,
+            max_per_tracker,
+            active_total: 0,
+            active_per_tracker: HashMap::new(),
+        }
+    }
+
+    /// Returns `true` if `item` can be dispatched given current slot state.
+    pub(crate) fn has_slot(&self, item: &QueueItem) -> bool {
+        if self.active_total >= self.max_concurrent {
+            return false;
+        }
+        // Per-tracker limit applies only to torrent downloads with a known tracker_id.
+        if item.protocol == DownloadProtocol::Torrent
+            && let Some(tracker_id) = item.tracker_id
+        {
+            let tracker_active = self
+                .active_per_tracker
+                .get(&tracker_id)
+                .copied()
+                .unwrap_or(0);
+            if tracker_active >= self.max_per_tracker {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Registers `item` as active, consuming a slot.
+    ///
+    /// Callers must verify `has_slot` returns `true` before calling this.
+    pub(crate) fn acquire(&mut self, item: &QueueItem) {
+        self.active_total += 1;
+        if item.protocol == DownloadProtocol::Torrent
+            && let Some(tracker_id) = item.tracker_id
+        {
+            *self.active_per_tracker.entry(tracker_id).or_insert(0) += 1;
+        }
+    }
+
+    /// Releases the slot held by a completed or failed download.
+    pub(crate) fn release(&mut self, protocol: DownloadProtocol, tracker_id: Option<i64>) {
+        if self.active_total > 0 {
+            self.active_total -= 1;
+        }
+        let Some(id) = tracker_id else { return };
+        if protocol != DownloadProtocol::Torrent {
+            return;
+        }
+        // Decrement the per-tracker count, removing the entry when it reaches zero.
+        let new_count = self
+            .active_per_tracker
+            .get(&id)
+            .copied()
+            .unwrap_or(0)
+            .saturating_sub(1);
+        if new_count == 0 {
+            self.active_per_tracker.remove(&id);
+        } else {
+            self.active_per_tracker.insert(id, new_count);
+        }
+    }
+
+    pub(crate) fn global_slot_available(&self) -> bool {
+        self.active_total < self.max_concurrent
+    }
+
+    /// Returns a snapshot of per-tracker active counts for use in closures
+    /// that cannot hold a reference to `self`.
+    pub(crate) fn per_tracker_snapshot(&self) -> HashMap<i64, usize> {
+        self.active_per_tracker.clone()
+    }
+}
+
+#[cfg(test)]
+impl SlotAllocator {
+    pub(crate) fn active_total(&self) -> usize {
+        self.active_total
+    }
+
+    pub(crate) fn active_for_tracker(&self, tracker_id: i64) -> usize {
+        self.active_per_tracker
+            .get(&tracker_id)
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DownloadProtocol;
+    use harmonia_common::ids::{ReleaseId, WantId};
+    use uuid::Uuid;
+
+    fn torrent_item(tracker_id: Option<i64>) -> QueueItem {
+        QueueItem {
+            id: Uuid::now_v7(),
+            want_id: WantId::new(),
+            release_id: ReleaseId::new(),
+            download_url: "magnet:?xt=urn:btih:test".to_string(),
+            protocol: DownloadProtocol::Torrent,
+            priority: 2,
+            tracker_id,
+            info_hash: None,
+        }
+    }
+
+    #[test]
+    fn has_slot_when_empty() {
+        let allocator = SlotAllocator::new(5, 3);
+        assert!(allocator.has_slot(&torrent_item(Some(1))));
+    }
+
+    #[test]
+    fn no_slot_when_global_limit_reached() {
+        let mut allocator = SlotAllocator::new(2, 3);
+        let item1 = torrent_item(Some(1));
+        let item2 = torrent_item(Some(2));
+        allocator.acquire(&item1);
+        allocator.acquire(&item2);
+        assert_eq!(allocator.active_total(), 2);
+        assert!(!allocator.has_slot(&torrent_item(Some(3))));
+    }
+
+    #[test]
+    fn no_slot_when_per_tracker_limit_reached() {
+        let mut allocator = SlotAllocator::new(10, 2);
+        let item1 = torrent_item(Some(1));
+        let item2 = torrent_item(Some(1));
+        allocator.acquire(&item1);
+        allocator.acquire(&item2);
+        assert_eq!(allocator.active_for_tracker(1), 2);
+        assert!(!allocator.has_slot(&torrent_item(Some(1))));
+        // Different tracker can still go
+        assert!(allocator.has_slot(&torrent_item(Some(2))));
+    }
+
+    #[test]
+    fn release_opens_slot() {
+        let mut allocator = SlotAllocator::new(1, 3);
+        let item = torrent_item(Some(1));
+        allocator.acquire(&item);
+        assert!(!allocator.global_slot_available());
+        allocator.release(DownloadProtocol::Torrent, Some(1));
+        assert!(allocator.global_slot_available());
+        assert_eq!(allocator.active_for_tracker(1), 0);
+    }
+
+    #[test]
+    fn release_removes_tracker_entry_when_zero() {
+        let mut allocator = SlotAllocator::new(5, 3);
+        let item = torrent_item(Some(99));
+        allocator.acquire(&item);
+        allocator.release(DownloadProtocol::Torrent, Some(99));
+        // Tracker entry removed; next call returns 0
+        assert_eq!(allocator.active_for_tracker(99), 0);
+    }
+
+    #[test]
+    fn no_per_tracker_limit_for_no_tracker_id() {
+        let mut allocator = SlotAllocator::new(5, 1);
+        // torrent with no tracker_id — no per-tracker limit applies
+        let item1 = torrent_item(None);
+        let item2 = torrent_item(None);
+        allocator.acquire(&item1);
+        assert!(allocator.has_slot(&item2));
+    }
+
+    #[test]
+    fn release_underflow_does_not_panic() {
+        let mut allocator = SlotAllocator::new(5, 3);
+        // Releasing when nothing is active should not panic
+        allocator.release(DownloadProtocol::Torrent, Some(1));
+        assert_eq!(allocator.active_total(), 0);
+    }
+}

--- a/crates/syntaxis/src/error.rs
+++ b/crates/syntaxis/src/error.rs
@@ -1,0 +1,71 @@
+//! Error types for the syntaxis crate.
+
+use harmonia_db::DbError;
+use snafu::Snafu;
+
+use ergasia::ErgasiaError;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum SyntaxisError {
+    #[snafu(display("failed to enqueue download: {reason}"))]
+    EnqueueFailed {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("download queue is full"))]
+    QueueFull {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("queue item not found: {id}"))]
+    ItemNotFound {
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("post-processing pipeline aborted: {reason}"))]
+    PipelineAborted {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("archive extraction failed"))]
+    ExtractionFailed {
+        source: ErgasiaError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("import failed: {reason}"))]
+    ImportFailed {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("retry budget exhausted after {attempts} attempts"))]
+    RetryExhausted {
+        attempts: u32,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("database error"))]
+    Database {
+        source: DbError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("failed to dispatch download to engine"))]
+    DispatchFailed {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -1,0 +1,587 @@
+//! Syntaxis: download queue orchestration and post-processing for Harmonia.
+//!
+//! Syntaxis owns the download queue, priority rules, concurrency control, and
+//! the post-processing pipeline that runs after each download completes.
+
+pub mod error;
+pub mod pipeline;
+pub mod types;
+
+pub(crate) mod dispatch;
+pub(crate) mod queue;
+pub(crate) mod recovery;
+pub(crate) mod repo;
+pub(crate) mod retry;
+
+pub use error::SyntaxisError;
+pub use pipeline::ImportService;
+pub use types::{CompletedDownload, DownloadProtocol, QueueItem, QueuePosition, QueueSnapshot};
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use sqlx::SqlitePool;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, error, info, instrument, warn};
+
+use harmonia_common::ids::DownloadId;
+use harmonia_common::{EventReceiver, HarmoniaEvent};
+use horismos::SyntaxisConfig;
+
+use ergasia::DownloadEngine;
+
+use crate::dispatch::SlotAllocator;
+use crate::pipeline::PipelineItem;
+use crate::queue::PriorityQueue;
+use crate::retry::{FailureKind, backoff_seconds, classify_failure};
+
+/// Public trait surface for queue management.
+pub trait QueueManager: Send + Sync {
+    fn enqueue(
+        &self,
+        item: QueueItem,
+    ) -> impl std::future::Future<Output = Result<QueuePosition, SyntaxisError>> + Send;
+
+    fn cancel(
+        &self,
+        download_id: DownloadId,
+    ) -> impl std::future::Future<Output = Result<(), SyntaxisError>> + Send;
+
+    fn reprioritize(
+        &self,
+        download_id: DownloadId,
+        new_priority: u8,
+    ) -> impl std::future::Future<Output = Result<(), SyntaxisError>> + Send;
+
+    fn get_queue_state(
+        &self,
+    ) -> impl std::future::Future<Output = Result<QueueSnapshot, SyntaxisError>> + Send;
+}
+
+/// Metadata for a dispatched download; needed for slot release and retry.
+#[derive(Debug, Clone)]
+struct ActiveEntry {
+    queue_id: uuid::Uuid,
+    protocol: DownloadProtocol,
+    tracker_id: Option<i64>,
+    want_id: harmonia_common::ids::WantId,
+    release_id: harmonia_common::ids::ReleaseId,
+    download_url: String,
+    retry_count: u32,
+}
+
+/// Internal mutable state guarded by a single Mutex.
+struct Inner {
+    queue: PriorityQueue,
+    allocator: SlotAllocator,
+    /// Active downloads keyed by DownloadId string representation.
+    active: HashMap<String, ActiveEntry>,
+    config: SyntaxisConfig,
+}
+
+/// The concrete Syntaxis service, generic over the download engine type.
+///
+/// Construct via `SyntaxisService::new`, then call `start` to launch the
+/// event-listener task that processes Ergasia broadcast events.
+pub struct SyntaxisService<E: DownloadEngine + 'static> {
+    pool: SqlitePool,
+    engine: Arc<E>,
+    import_svc: Arc<dyn ImportService>,
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl<E: DownloadEngine + 'static> SyntaxisService<E> {
+    /// Creates a new service and runs startup reconciliation.
+    pub async fn new(
+        pool: SqlitePool,
+        engine: Arc<E>,
+        import_svc: Arc<dyn ImportService>,
+        config: SyntaxisConfig,
+    ) -> Result<Self, SyntaxisError> {
+        let mut pq = PriorityQueue::new();
+        let recovered = recovery::reload_queue(&pool, &mut pq).await?;
+        if recovered > 0 {
+            info!(count = recovered, "recovered queue items from database");
+        }
+
+        let allocator = SlotAllocator::new(config.max_concurrent_downloads, config.max_per_tracker);
+
+        let inner = Arc::new(Mutex::new(Inner {
+            queue: pq,
+            allocator,
+            active: HashMap::new(),
+            config,
+        }));
+
+        Ok(Self {
+            pool,
+            engine,
+            import_svc,
+            inner,
+        })
+    }
+
+    /// Launches the event-listener task that processes `DownloadCompleted` and
+    /// `DownloadFailed` events from the Ergasia broadcast bus.
+    ///
+    /// The task runs until `shutdown` is cancelled.
+    pub fn start(self: &Arc<Self>, mut event_rx: EventReceiver, shutdown: CancellationToken) {
+        let svc = Arc::clone(self);
+        let span = tracing::Span::current();
+        tokio::spawn(
+            async move {
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = shutdown.cancelled() => break,
+                        result = event_rx.recv() => {
+                            match result {
+                                Ok(event) => svc.handle_event(event).await,
+                                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                    warn!(skipped = n, "event bus lagged; some events were dropped");
+                                }
+                                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                            }
+                        }
+                    }
+                }
+                info!("syntaxis event listener stopped");
+            }
+            .instrument(span),
+        );
+    }
+
+    async fn handle_event(&self, event: HarmoniaEvent) {
+        match event {
+            HarmoniaEvent::DownloadCompleted { download_id, path } => {
+                self.on_download_completed(download_id, path).await;
+            }
+            HarmoniaEvent::DownloadFailed {
+                download_id,
+                reason,
+            } => {
+                self.on_download_failed(download_id, reason).await;
+            }
+            _ => {}
+        }
+    }
+
+    async fn on_download_completed(&self, download_id: DownloadId, path: std::path::PathBuf) {
+        let entry = {
+            let mut inner = self.inner.lock().await;
+            let key = download_id.to_string();
+            if let Some(entry) = inner.active.remove(&key) {
+                inner.allocator.release(entry.protocol, entry.tracker_id);
+                Some(entry)
+            } else {
+                warn!(%download_id, "DownloadCompleted for unknown download_id");
+                None
+            }
+        };
+
+        if let Some(entry) = entry {
+            // Dispatch next eligible item now that a slot freed up.
+            self.try_dispatch_next().await;
+
+            let pool = self.pool.clone();
+            let engine = Arc::clone(&self.engine);
+            let import_svc = Arc::clone(&self.import_svc);
+            let span = tracing::Span::current();
+
+            tokio::spawn(
+                async move {
+                    if let Err(e) = pipeline::run_pipeline(
+                        &pool,
+                        &engine,
+                        &import_svc,
+                        download_id,
+                        &path,
+                        PipelineItem {
+                            queue_id: entry.queue_id,
+                            want_id: entry.want_id,
+                            release_id: entry.release_id,
+                            protocol: entry.protocol,
+                            tracker_id: entry.tracker_id,
+                        },
+                    )
+                    .await
+                    {
+                        error!(error = %e, "post-processing pipeline failed");
+                    }
+                }
+                .instrument(span),
+            );
+        }
+    }
+
+    async fn on_download_failed(&self, download_id: DownloadId, reason: String) {
+        let entry = {
+            let mut inner = self.inner.lock().await;
+            let key = download_id.to_string();
+            inner.active.remove(&key).inspect(|e| {
+                inner.allocator.release(e.protocol, e.tracker_id);
+            })
+        };
+
+        let Some(entry) = entry else {
+            warn!(%download_id, "DownloadFailed for unknown download_id");
+            return;
+        };
+
+        match classify_failure(&reason) {
+            FailureKind::Permanent => {
+                error!(%download_id, %reason, "permanent download failure");
+                if let Err(e) = repo::mark_failed(&self.pool, entry.queue_id, &reason).await {
+                    error!(error = %e, "failed to persist failure status");
+                }
+            }
+            FailureKind::Transient => {
+                let retry_count = entry.retry_count;
+                let (max_retries, backoff_base) = {
+                    let inner = self.inner.lock().await;
+                    (
+                        inner.config.retry_count,
+                        inner.config.retry_backoff_base_seconds,
+                    )
+                };
+
+                if retry_count >= max_retries {
+                    error!(%download_id, attempts = retry_count, "retry budget exhausted");
+                    if let Err(e) = repo::mark_failed(
+                        &self.pool,
+                        entry.queue_id,
+                        &format!("retry budget exhausted after {retry_count} attempts: {reason}"),
+                    )
+                    .await
+                    {
+                        error!(error = %e, "failed to persist exhausted retry status");
+                    }
+                } else {
+                    let backoff = backoff_seconds(retry_count, backoff_base);
+                    info!(
+                        %download_id,
+                        retry = retry_count + 1,
+                        backoff_secs = backoff,
+                        "scheduling retry"
+                    );
+
+                    if let Err(e) = repo::increment_retry_count(&self.pool, entry.queue_id).await {
+                        error!(error = %e, "failed to increment retry count");
+                    }
+                    if let Err(e) = repo::update_status(&self.pool, entry.queue_id, "queued").await
+                    {
+                        error!(error = %e, "failed to reset status for retry");
+                    }
+
+                    let inner = Arc::clone(&self.inner);
+                    let span = tracing::Span::current();
+                    let queue_item = QueueItem {
+                        id: entry.queue_id,
+                        want_id: entry.want_id,
+                        release_id: entry.release_id,
+                        download_url: entry.download_url,
+                        protocol: entry.protocol,
+                        priority: 2,
+                        tracker_id: entry.tracker_id,
+                        info_hash: None,
+                    };
+
+                    tokio::spawn(
+                        async move {
+                            tokio::time::sleep(tokio::time::Duration::from_secs(backoff)).await;
+                            inner.lock().await.queue.insert(queue_item);
+                        }
+                        .instrument(span),
+                    );
+                }
+            }
+        }
+
+        self.try_dispatch_next().await;
+    }
+
+    /// Attempts to dispatch the next eligible item from the queue to Ergasia.
+    async fn try_dispatch_next(&self) {
+        let item = {
+            let mut inner = self.inner.lock().await;
+            if !inner.allocator.global_slot_available() {
+                return;
+            }
+
+            let max_per_tracker = inner.config.max_per_tracker;
+            // WHY: Snapshot tracker counts before mutably borrowing the queue.
+            // The closure passed to dequeue_eligible cannot hold a reference into
+            // `inner` while `inner.queue` is mutably borrowed.
+            let tracker_counts = inner.allocator.per_tracker_snapshot();
+            let item = inner.queue.dequeue_eligible(|tracker_id| {
+                if let Some(id) = tracker_id {
+                    tracker_counts.get(&id).copied().unwrap_or(0) < max_per_tracker
+                } else {
+                    true
+                }
+            });
+
+            let Some(item) = item else {
+                return;
+            };
+
+            inner.allocator.acquire(&item);
+
+            let new_dl_id = DownloadId::new();
+            inner.active.insert(
+                new_dl_id.to_string(),
+                ActiveEntry {
+                    queue_id: item.id,
+                    protocol: item.protocol,
+                    tracker_id: item.tracker_id,
+                    want_id: item.want_id,
+                    release_id: item.release_id,
+                    download_url: item.download_url.clone(),
+                    retry_count: 0,
+                },
+            );
+
+            (item, new_dl_id)
+        };
+
+        let (queue_item, new_dl_id) = item;
+        let engine = Arc::clone(&self.engine);
+        let pool = self.pool.clone();
+        let span = tracing::Span::current();
+
+        tokio::spawn(
+            async move {
+                if let Err(e) = repo::update_status(&pool, queue_item.id, "downloading").await {
+                    error!(error = %e, "failed to update status to downloading");
+                }
+                let request = ergasia::DownloadRequest {
+                    download_url: queue_item.download_url,
+                    protocol: ergasia::DownloadProtocol::Torrent,
+                    download_id: new_dl_id,
+                    want_id: queue_item.want_id,
+                };
+                if let Err(e) = engine.start_download(request).await {
+                    error!(error = %e, "failed to dispatch download to engine");
+                }
+            }
+            .instrument(span),
+        );
+    }
+}
+
+impl<E: DownloadEngine + 'static> QueueManager for Arc<SyntaxisService<E>> {
+    #[instrument(skip(self))]
+    async fn enqueue(&self, item: QueueItem) -> Result<QueuePosition, SyntaxisError> {
+        // Persist to DB first for durability.
+        repo::insert_queue_item(
+            &self.pool,
+            item.id,
+            item.want_id.as_uuid().as_bytes(),
+            item.release_id.as_uuid().as_bytes(),
+            &item.download_url,
+            item.protocol.as_db_str(),
+            item.priority,
+            item.tracker_id,
+            item.info_hash.as_deref(),
+        )
+        .await
+        .map_err(|source| SyntaxisError::Database {
+            source,
+            location: snafu::location!(),
+        })?;
+
+        if item.priority == 4 {
+            // Interactive bypass: try to acquire a slot and dispatch immediately.
+            let slot_available = {
+                let inner = self.inner.lock().await;
+                inner.allocator.has_slot(&item)
+            };
+
+            if slot_available {
+                let new_dl_id = DownloadId::new();
+                {
+                    let mut inner = self.inner.lock().await;
+                    inner.allocator.acquire(&item);
+                    inner.active.insert(
+                        new_dl_id.to_string(),
+                        ActiveEntry {
+                            queue_id: item.id,
+                            protocol: item.protocol,
+                            tracker_id: item.tracker_id,
+                            want_id: item.want_id,
+                            release_id: item.release_id,
+                            download_url: item.download_url.clone(),
+                            retry_count: 0,
+                        },
+                    );
+                }
+
+                let pool = self.pool.clone();
+                let engine = Arc::clone(&self.engine);
+                let queue_id = item.id;
+                let span = tracing::Span::current();
+                tokio::spawn(
+                    async move {
+                        if let Err(e) = repo::update_status(&pool, queue_id, "downloading").await {
+                            error!(error = %e, "failed to update status");
+                        }
+                        let request = ergasia::DownloadRequest {
+                            download_url: item.download_url,
+                            protocol: ergasia::DownloadProtocol::Torrent,
+                            download_id: new_dl_id,
+                            want_id: item.want_id,
+                        };
+                        if let Err(e) = engine.start_download(request).await {
+                            error!(error = %e, "failed to dispatch interactive download");
+                        }
+                    }
+                    .instrument(span),
+                );
+
+                return Ok(QueuePosition {
+                    position: 0,
+                    estimated_wait_secs: Some(0),
+                });
+            }
+            // No slot available: fall through and queue at priority 3.
+        }
+
+        let position = {
+            let mut inner = self.inner.lock().await;
+            let pos = inner.queue.len();
+            inner.queue.insert(item);
+            pos
+        };
+
+        self.try_dispatch_next().await;
+
+        Ok(QueuePosition {
+            position,
+            estimated_wait_secs: None,
+        })
+    }
+
+    #[instrument(skip(self))]
+    async fn cancel(&self, download_id: DownloadId) -> Result<(), SyntaxisError> {
+        let key = download_id.to_string();
+        let entry = {
+            let mut inner = self.inner.lock().await;
+            inner.active.remove(&key).inspect(|e| {
+                inner.allocator.release(e.protocol, e.tracker_id);
+            })
+        };
+
+        if let Some(entry) = entry {
+            self.engine
+                .cancel_download(download_id)
+                .await
+                .map_err(|_| SyntaxisError::DispatchFailed {
+                    location: snafu::location!(),
+                })?;
+            repo::mark_failed(&self.pool, entry.queue_id, "cancelled by user")
+                .await
+                .map_err(|source| SyntaxisError::Database {
+                    source,
+                    location: snafu::location!(),
+                })?;
+            self.try_dispatch_next().await;
+            return Ok(());
+        }
+
+        Err(SyntaxisError::ItemNotFound {
+            id: key,
+            location: snafu::location!(),
+        })
+    }
+
+    #[instrument(skip(self))]
+    async fn reprioritize(
+        &self,
+        download_id: DownloadId,
+        new_priority: u8,
+    ) -> Result<(), SyntaxisError> {
+        let id_str = download_id.to_string();
+
+        {
+            let inner = self.inner.lock().await;
+            // If already active, re-prioritization is a no-op.
+            if inner.active.contains_key(&id_str) {
+                return Ok(());
+            }
+        }
+
+        // Try to parse as Uuid and find in queue.
+        let uuid = uuid::Uuid::parse_str(&id_str).map_err(|_| SyntaxisError::ItemNotFound {
+            id: id_str.clone(),
+            location: snafu::location!(),
+        })?;
+
+        let found = {
+            let mut inner = self.inner.lock().await;
+            inner.queue.reprioritize(uuid, new_priority)
+        };
+
+        if !found {
+            return Err(SyntaxisError::ItemNotFound {
+                id: id_str,
+                location: snafu::location!(),
+            });
+        }
+
+        repo::update_priority(&self.pool, uuid, new_priority)
+            .await
+            .map_err(|source| SyntaxisError::Database {
+                source,
+                location: snafu::location!(),
+            })?;
+
+        if new_priority == 4 {
+            self.try_dispatch_next().await;
+        }
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    async fn get_queue_state(&self) -> Result<QueueSnapshot, SyntaxisError> {
+        let (queued_items, active_downloads) = {
+            let inner = self.inner.lock().await;
+            let queued: Vec<QueueItem> = inner.queue.items().cloned().collect();
+            let active: Vec<QueueItem> = inner
+                .active
+                .values()
+                .map(|e| QueueItem {
+                    id: e.queue_id,
+                    want_id: e.want_id,
+                    release_id: e.release_id,
+                    download_url: e.download_url.clone(),
+                    protocol: e.protocol,
+                    priority: 4,
+                    tracker_id: e.tracker_id,
+                    info_hash: None,
+                })
+                .collect();
+            (queued, active)
+        };
+
+        let completed_count = repo::count_by_status(&self.pool, "completed")
+            .await
+            .map_err(|source| SyntaxisError::Database {
+                source,
+                location: snafu::location!(),
+            })?;
+        let failed_count = repo::count_by_status(&self.pool, "failed")
+            .await
+            .map_err(|source| SyntaxisError::Database {
+                source,
+                location: snafu::location!(),
+            })?;
+
+        Ok(QueueSnapshot {
+            active_downloads,
+            queued_items,
+            completed_count,
+            failed_count,
+        })
+    }
+}

--- a/crates/syntaxis/src/pipeline.rs
+++ b/crates/syntaxis/src/pipeline.rs
@@ -1,0 +1,357 @@
+//! Post-processing pipeline: archive scan → extraction → import trigger.
+//!
+//! Triggered by `DownloadCompleted` events from Ergasia. Each step is idempotent:
+//! if the service restarts mid-pipeline, re-processing produces the same result.
+
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use sqlx::SqlitePool;
+use tracing::{error, info, instrument};
+use uuid::Uuid;
+
+use ergasia::DownloadEngine;
+use harmonia_common::ids::{DownloadId, ReleaseId, WantId};
+
+use crate::error::SyntaxisError;
+use crate::repo;
+use crate::types::{CompletedDownload, DownloadProtocol};
+
+/// Trait boundary for the Taxis import service. Wired in P3-08.
+///
+/// Uses `Pin<Box<dyn Future>>` for dyn compatibility — callers can store
+/// `Arc<dyn ImportService>` without the object-safety issues of native async fn.
+pub trait ImportService: Send + Sync {
+    fn import(
+        &self,
+        completed: CompletedDownload,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>>;
+}
+
+/// Per-item metadata passed to the post-processing pipeline.
+///
+/// Groups the download-specific context that is known at dispatch time,
+/// keeping `run_pipeline`'s argument list under the Clippy limit.
+#[derive(Debug, Clone)]
+pub(crate) struct PipelineItem {
+    pub queue_id: Uuid,
+    pub want_id: WantId,
+    pub release_id: ReleaseId,
+    pub protocol: DownloadProtocol,
+    pub tracker_id: Option<i64>,
+}
+
+/// Runs the post-processing pipeline for a completed download.
+///
+/// Steps:
+/// 1. Mark status = 'post_processing'
+/// 2. Scan for archives; extract if found
+/// 3. Mark status = 'importing', call import service
+/// 4. Mark status = 'completed'
+#[instrument(skip_all, fields(download_id = %download_id))]
+pub(crate) async fn run_pipeline<E: DownloadEngine>(
+    pool: &SqlitePool,
+    engine: &Arc<E>,
+    import_svc: &Arc<dyn ImportService>,
+    download_id: DownloadId,
+    download_path: &Path,
+    item: PipelineItem,
+) -> Result<(), SyntaxisError> {
+    let PipelineItem {
+        queue_id,
+        want_id,
+        release_id,
+        protocol,
+        tracker_id: _tracker_id,
+    } = item;
+    repo::update_status(pool, queue_id, "post_processing")
+        .await
+        .map_err(|source| SyntaxisError::Database {
+            source,
+            location: snafu::location!(),
+        })?;
+
+    let source_path = download_path.to_path_buf();
+
+    // Step 1: try extraction. On failure, mark failed and return immediately.
+    let working_path = match engine.extract(download_path, download_path) {
+        Ok(Some(result)) => {
+            info!(extracted_path = %result.extracted_path.display(), "extracted archives");
+            result.extracted_path
+        }
+        Ok(None) => {
+            // No archives found — work with the original path.
+            download_path.to_path_buf()
+        }
+        Err(source) => {
+            let msg = source.to_string();
+            error!(error = %msg, "archive extraction failed");
+            repo::mark_failed(pool, queue_id, &format!("extraction failed: {msg}"))
+                .await
+                .map_err(|db_source| SyntaxisError::Database {
+                    source: db_source,
+                    location: snafu::location!(),
+                })?;
+            return Err(SyntaxisError::ExtractionFailed {
+                source,
+                location: snafu::location!(),
+            });
+        }
+    };
+
+    // Step 2: trigger import.
+    repo::update_status(pool, queue_id, "importing")
+        .await
+        .map_err(|source| SyntaxisError::Database {
+            source,
+            location: snafu::location!(),
+        })?;
+
+    let completed = CompletedDownload {
+        download_id,
+        download_path: working_path,
+        source_path,
+        want_id,
+        release_id,
+        protocol,
+        requires_copy: false,
+    };
+
+    if let Err(reason) = import_svc.import(completed).await {
+        error!(%reason, "import failed");
+        repo::mark_failed(pool, queue_id, &format!("import failed: {reason}"))
+            .await
+            .map_err(|source| SyntaxisError::Database {
+                source,
+                location: snafu::location!(),
+            })?;
+        return Err(SyntaxisError::ImportFailed {
+            reason,
+            location: snafu::location!(),
+        });
+    }
+
+    // Step 3: bookkeeping complete.
+    let now = jiff::Timestamp::now().to_string();
+    repo::mark_completed(pool, queue_id, &now)
+        .await
+        .map_err(|source| SyntaxisError::Database {
+            source,
+            location: snafu::location!(),
+        })?;
+
+    info!("post-processing pipeline complete");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    use ergasia::{DownloadProgress, ErgasiaError, ExtractionResult};
+    use harmonia_common::ids::{DownloadId, ReleaseId, WantId};
+    use harmonia_db::migrate::MIGRATOR;
+    use sqlx::SqlitePool;
+    use uuid::Uuid;
+
+    use super::PipelineItem;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn make_queue_row(pool: &SqlitePool, id: Uuid) {
+        let want_id = Uuid::now_v7().as_bytes().to_vec();
+        let release_id = Uuid::now_v7().as_bytes().to_vec();
+        repo::insert_queue_item(
+            pool,
+            id,
+            &want_id,
+            &release_id,
+            "magnet:?xt=urn:btih:test",
+            "torrent",
+            2,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    // --- mock engines ---
+
+    struct NoArchiveEngine;
+    impl DownloadEngine for NoArchiveEngine {
+        async fn start_download(
+            &self,
+            _req: ergasia::DownloadRequest,
+        ) -> Result<DownloadId, ErgasiaError> {
+            Ok(DownloadId::new())
+        }
+        async fn cancel_download(&self, _id: DownloadId) -> Result<(), ErgasiaError> {
+            Ok(())
+        }
+        async fn get_progress(&self, _id: DownloadId) -> Result<DownloadProgress, ErgasiaError> {
+            unimplemented!()
+        }
+        fn extract(
+            &self,
+            _path: &Path,
+            _out: &Path,
+        ) -> Result<Option<ExtractionResult>, ErgasiaError> {
+            Ok(None)
+        }
+    }
+
+    struct FailingExtractEngine;
+    impl DownloadEngine for FailingExtractEngine {
+        async fn start_download(
+            &self,
+            _req: ergasia::DownloadRequest,
+        ) -> Result<DownloadId, ErgasiaError> {
+            Ok(DownloadId::new())
+        }
+        async fn cancel_download(&self, _id: DownloadId) -> Result<(), ErgasiaError> {
+            Ok(())
+        }
+        async fn get_progress(&self, _id: DownloadId) -> Result<DownloadProgress, ErgasiaError> {
+            unimplemented!()
+        }
+        fn extract(
+            &self,
+            _path: &Path,
+            _out: &Path,
+        ) -> Result<Option<ExtractionResult>, ErgasiaError> {
+            Err(ErgasiaError::ExtractFile {
+                path: PathBuf::from("/tmp/corrupt.rar"),
+                error: "corrupt archive".to_string(),
+                location: snafu::location!(),
+            })
+        }
+    }
+
+    // --- mock import services ---
+
+    struct OkImportService;
+    impl ImportService for OkImportService {
+        fn import(
+            &self,
+            _c: CompletedDownload,
+        ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    struct FailImportService;
+    impl ImportService for FailImportService {
+        fn import(
+            &self,
+            _c: CompletedDownload,
+        ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>> {
+            Box::pin(async { Err("metadata not found".to_string()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_success_marks_completed() {
+        let pool = setup().await;
+        let queue_id = Uuid::now_v7();
+        make_queue_row(&pool, queue_id).await;
+
+        let engine: Arc<NoArchiveEngine> = Arc::new(NoArchiveEngine);
+        let import: Arc<dyn ImportService> = Arc::new(OkImportService);
+
+        let result = run_pipeline(
+            &pool,
+            &engine,
+            &import,
+            DownloadId::new(),
+            Path::new("/data/downloads/album"),
+            PipelineItem {
+                queue_id,
+                want_id: WantId::new(),
+                release_id: ReleaseId::new(),
+                protocol: DownloadProtocol::Torrent,
+                tracker_id: None,
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let row = repo::get_queue_item(&pool, queue_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, "completed");
+    }
+
+    #[tokio::test]
+    async fn pipeline_extraction_failure_marks_failed() {
+        let pool = setup().await;
+        let queue_id = Uuid::now_v7();
+        make_queue_row(&pool, queue_id).await;
+
+        let engine: Arc<FailingExtractEngine> = Arc::new(FailingExtractEngine);
+        let import: Arc<dyn ImportService> = Arc::new(OkImportService);
+
+        let result = run_pipeline(
+            &pool,
+            &engine,
+            &import,
+            DownloadId::new(),
+            Path::new("/data/downloads/album"),
+            PipelineItem {
+                queue_id,
+                want_id: WantId::new(),
+                release_id: ReleaseId::new(),
+                protocol: DownloadProtocol::Torrent,
+                tracker_id: None,
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        let row = repo::get_queue_item(&pool, queue_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, "failed");
+    }
+
+    #[tokio::test]
+    async fn pipeline_import_failure_marks_failed() {
+        let pool = setup().await;
+        let queue_id = Uuid::now_v7();
+        make_queue_row(&pool, queue_id).await;
+
+        let engine: Arc<NoArchiveEngine> = Arc::new(NoArchiveEngine);
+        let import: Arc<dyn ImportService> = Arc::new(FailImportService);
+
+        let result = run_pipeline(
+            &pool,
+            &engine,
+            &import,
+            DownloadId::new(),
+            Path::new("/data/downloads/album"),
+            PipelineItem {
+                queue_id,
+                want_id: WantId::new(),
+                release_id: ReleaseId::new(),
+                protocol: DownloadProtocol::Torrent,
+                tracker_id: None,
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        let row = repo::get_queue_item(&pool, queue_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, "failed");
+    }
+}

--- a/crates/syntaxis/src/queue.rs
+++ b/crates/syntaxis/src/queue.rs
@@ -1,0 +1,303 @@
+//! In-memory priority queue for download items.
+//!
+//! Priority tiers (higher = dispatched first). Within a tier, FIFO order is preserved.
+//! Priority 4 (interactive) items bypass the queue and go directly to the dispatcher.
+
+use std::collections::VecDeque;
+
+use uuid::Uuid;
+
+use crate::types::QueueItem;
+
+/// In-memory priority queue backed by tier buckets.
+///
+/// Tiers 1–3 are stored; tier 4 items are never inserted here — callers bypass
+/// this queue and send directly to Ergasia.
+#[derive(Debug, Default)]
+pub(crate) struct PriorityQueue {
+    // WHY: Three separate VecDeques give O(1) dequeue by priority without
+    // heap overhead. Tiers are small (typically < 100 items each).
+    tier3: VecDeque<QueueItem>,
+    tier2: VecDeque<QueueItem>,
+    tier1: VecDeque<QueueItem>,
+}
+
+impl PriorityQueue {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inserts `item` into the appropriate tier bucket.
+    ///
+    /// Priority must be 1, 2, or 3. Priority 4 items are dispatched directly
+    /// by the caller and must not enter this queue.
+    pub(crate) fn insert(&mut self, item: QueueItem) {
+        match item.priority {
+            3 => self.tier3.push_back(item),
+            2 => self.tier2.push_back(item),
+            1 => self.tier1.push_back(item),
+            _ => {
+                // WHY: Priority 4 is the interactive bypass tier — callers must
+                // not insert it here. Any other value is a programmer error.
+                debug_assert!(
+                    false,
+                    "priority {} is not a valid queue tier (1–3)",
+                    item.priority
+                );
+                self.tier1.push_back(item);
+            }
+        }
+    }
+
+    /// Returns the first item whose `tracker_id` satisfies `tracker_ok`, or
+    /// `None` if no eligible item exists.
+    ///
+    /// The item is removed from the queue.
+    pub(crate) fn dequeue_eligible(
+        &mut self,
+        tracker_ok: impl Fn(Option<i64>) -> bool,
+    ) -> Option<QueueItem> {
+        for tier in [&mut self.tier3, &mut self.tier2, &mut self.tier1] {
+            if let Some(pos) = tier.iter().position(|item| tracker_ok(item.tracker_id)) {
+                return tier.remove(pos);
+            }
+        }
+        None
+    }
+
+    /// Upgrades the item with `id` to priority 4 (interactive) and removes it
+    /// from the queue, returning it to the caller for direct dispatch.
+    ///
+    /// Returns `None` if no item with that id is present.
+    pub(crate) fn reprioritize_to_interactive(&mut self, id: Uuid) -> Option<QueueItem> {
+        for tier in [&mut self.tier3, &mut self.tier2, &mut self.tier1] {
+            if let Some(pos) = tier.iter().position(|item| item.id == id) {
+                let mut item = tier.remove(pos)?;
+                item.priority = 4;
+                return Some(item);
+            }
+        }
+        None
+    }
+
+    /// Updates the priority of the item with `id` in-place without removing it.
+    ///
+    /// Returns `true` if the item was found and re-bucketed.
+    pub(crate) fn reprioritize(&mut self, id: Uuid, new_priority: u8) -> bool {
+        if new_priority == 4 {
+            // Interactive bypass — remove from queue; caller dispatches directly.
+            return self.reprioritize_to_interactive(id).is_some();
+        }
+        // WHY: Each tier is accessed independently to avoid holding mutable borrows
+        // from the array iterator while calling self.insert().
+        let found = if let Some(pos) = self.tier3.iter().position(|i| i.id == id) {
+            let mut item = self.tier3.remove(pos).expect("position was valid");
+            item.priority = new_priority;
+            Some(item)
+        } else if let Some(pos) = self.tier2.iter().position(|i| i.id == id) {
+            let mut item = self.tier2.remove(pos).expect("position was valid");
+            item.priority = new_priority;
+            Some(item)
+        } else if let Some(pos) = self.tier1.iter().position(|i| i.id == id) {
+            let mut item = self.tier1.remove(pos).expect("position was valid");
+            item.priority = new_priority;
+            Some(item)
+        } else {
+            None
+        };
+
+        if let Some(item) = found {
+            self.insert(item);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Total items currently in the queue.
+    pub(crate) fn len(&self) -> usize {
+        self.tier3.len() + self.tier2.len() + self.tier1.len()
+    }
+
+    /// Returns an iterator over all items, highest priority first.
+    pub(crate) fn items(&self) -> impl Iterator<Item = &QueueItem> {
+        self.tier3
+            .iter()
+            .chain(self.tier2.iter())
+            .chain(self.tier1.iter())
+    }
+}
+
+#[cfg(test)]
+impl PriorityQueue {
+    /// Removes and returns the highest-priority item, or `None` if empty.
+    ///
+    /// Dequeues from tier 3 first, then 2, then 1 (FIFO within each tier).
+    pub(crate) fn dequeue(&mut self) -> Option<QueueItem> {
+        self.tier3
+            .pop_front()
+            .or_else(|| self.tier2.pop_front())
+            .or_else(|| self.tier1.pop_front())
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns `true` if any queued item has the given `id`.
+    pub(crate) fn contains(&self, id: Uuid) -> bool {
+        self.tier3.iter().any(|i| i.id == id)
+            || self.tier2.iter().any(|i| i.id == id)
+            || self.tier1.iter().any(|i| i.id == id)
+    }
+
+    /// Position (0-based) of the item with `id` in overall dispatch order.
+    pub(crate) fn position_of(&self, id: Uuid) -> Option<usize> {
+        self.items().position(|i| i.id == id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DownloadProtocol;
+    use harmonia_common::ids::{ReleaseId, WantId};
+
+    fn make_item(priority: u8) -> QueueItem {
+        QueueItem {
+            id: Uuid::now_v7(),
+            want_id: WantId::new(),
+            release_id: ReleaseId::new(),
+            download_url: "magnet:?xt=urn:btih:test".to_string(),
+            protocol: DownloadProtocol::Torrent,
+            priority,
+            tracker_id: None,
+            info_hash: None,
+        }
+    }
+
+    fn make_item_with_tracker(priority: u8, tracker_id: i64) -> QueueItem {
+        let mut item = make_item(priority);
+        item.tracker_id = Some(tracker_id);
+        item
+    }
+
+    #[test]
+    fn dequeues_empty_returns_none() {
+        let mut q = PriorityQueue::new();
+        assert!(q.dequeue().is_none());
+    }
+
+    #[test]
+    fn higher_priority_dequeued_first() {
+        let mut q = PriorityQueue::new();
+        q.insert(make_item(1));
+        q.insert(make_item(3));
+        q.insert(make_item(2));
+
+        assert_eq!(q.dequeue().unwrap().priority, 3);
+        assert_eq!(q.dequeue().unwrap().priority, 2);
+        assert_eq!(q.dequeue().unwrap().priority, 1);
+    }
+
+    #[test]
+    fn fifo_within_tier() {
+        let mut q = PriorityQueue::new();
+        let first = make_item(2);
+        let second = make_item(2);
+        let first_id = first.id;
+        let second_id = second.id;
+
+        q.insert(first);
+        q.insert(second);
+
+        assert_eq!(q.dequeue().unwrap().id, first_id);
+        assert_eq!(q.dequeue().unwrap().id, second_id);
+    }
+
+    #[test]
+    fn reprioritize_to_interactive_removes_from_queue() {
+        let mut q = PriorityQueue::new();
+        let item = make_item(2);
+        let id = item.id;
+        q.insert(item);
+
+        let upgraded = q.reprioritize_to_interactive(id).unwrap();
+        assert_eq!(upgraded.priority, 4);
+        assert!(!q.contains(id));
+        assert_eq!(q.len(), 0);
+    }
+
+    #[test]
+    fn reprioritize_to_interactive_nonexistent_returns_none() {
+        let mut q = PriorityQueue::new();
+        q.insert(make_item(1));
+        let result = q.reprioritize_to_interactive(Uuid::now_v7());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn reprioritize_moves_item_to_new_tier() {
+        let mut q = PriorityQueue::new();
+        let item = make_item(1);
+        let id = item.id;
+        q.insert(item);
+        q.insert(make_item(3));
+
+        let changed = q.reprioritize(id, 3);
+        assert!(changed);
+        // The original priority-3 item plus the re-bucketed one; order is FIFO
+        // within tier3. The original tier3 item was inserted first.
+        let first = q.dequeue().unwrap();
+        assert_eq!(first.priority, 3);
+        let second = q.dequeue().unwrap();
+        assert_eq!(second.id, id);
+        assert_eq!(second.priority, 3);
+    }
+
+    #[test]
+    fn dequeue_eligible_skips_ineligible_trackers() {
+        let mut q = PriorityQueue::new();
+        q.insert(make_item_with_tracker(3, 1)); // tracker 1 full
+        q.insert(make_item_with_tracker(3, 2)); // tracker 2 ok
+        q.insert(make_item_with_tracker(1, 3)); // tracker 3 ok
+
+        // Simulate tracker 1 at limit; only allow tracker_id != Some(1)
+        let item = q.dequeue_eligible(|t| t != Some(1)).unwrap();
+        assert_eq!(item.tracker_id, Some(2));
+    }
+
+    #[test]
+    fn dequeue_eligible_returns_none_when_all_ineligible() {
+        let mut q = PriorityQueue::new();
+        q.insert(make_item_with_tracker(3, 1));
+        q.insert(make_item_with_tracker(2, 1));
+
+        let item = q.dequeue_eligible(|t| t != Some(1));
+        assert!(item.is_none());
+        // Items remain in queue
+        assert_eq!(q.len(), 2);
+    }
+
+    #[test]
+    fn position_of_returns_zero_for_next_item() {
+        let mut q = PriorityQueue::new();
+        let item = make_item(3);
+        let id = item.id;
+        q.insert(make_item(1));
+        q.insert(item);
+
+        // tier3 first, so id is at position 0
+        assert_eq!(q.position_of(id), Some(0));
+    }
+
+    #[test]
+    fn len_and_is_empty() {
+        let mut q = PriorityQueue::new();
+        assert!(q.is_empty());
+        q.insert(make_item(2));
+        assert_eq!(q.len(), 1);
+        q.dequeue();
+        assert!(q.is_empty());
+    }
+}

--- a/crates/syntaxis/src/recovery.rs
+++ b/crates/syntaxis/src/recovery.rs
@@ -1,0 +1,202 @@
+//! Startup reconciliation: reload non-terminal queue rows into memory.
+//!
+//! At startup, any download not in a terminal state ('completed' or 'failed') is
+//! reloaded and re-queued. Items in 'downloading', 'post_processing', or
+//! 'importing' states are re-queued from the top so they can be retried.
+
+use sqlx::SqlitePool;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::error::SyntaxisError;
+use crate::queue::PriorityQueue;
+use crate::repo::{self, QueueRow};
+use crate::types::{DownloadProtocol, QueueItem};
+use harmonia_common::ids::{ReleaseId, WantId};
+
+fn parse_protocol(s: &str) -> DownloadProtocol {
+    match s {
+        "torrent" => DownloadProtocol::Torrent,
+        "nzb" => DownloadProtocol::Usenet,
+        other => {
+            warn!(
+                protocol = other,
+                "unknown protocol in download_queue; treating as torrent"
+            );
+            DownloadProtocol::Torrent
+        }
+    }
+}
+
+fn row_to_queue_item(row: &QueueRow) -> Option<QueueItem> {
+    let id = Uuid::from_slice(&row.id).ok()?;
+    let want_uuid = Uuid::from_slice(&row.want_id).ok()?;
+    let release_uuid = Uuid::from_slice(&row.release_id).ok()?;
+    Some(QueueItem {
+        id,
+        want_id: WantId::from_uuid(want_uuid),
+        release_id: ReleaseId::from_uuid(release_uuid),
+        download_url: row.download_url.clone(),
+        protocol: parse_protocol(&row.protocol),
+        // Clamp priority to 1–3 during recovery; interactive (4) items are re-queued
+        // at priority 3 so they don't re-bypass on restart.
+        priority: (row.priority as u8).clamp(1, 3),
+        tracker_id: row.tracker_id,
+        info_hash: row.info_hash.clone(),
+    })
+}
+
+/// Loads all non-terminal rows from the database and inserts them into `queue`.
+///
+/// Returns the number of items reloaded.
+pub(crate) async fn reload_queue(
+    pool: &SqlitePool,
+    queue: &mut PriorityQueue,
+) -> Result<usize, SyntaxisError> {
+    let non_terminal = ["queued", "downloading", "post_processing", "importing"];
+    let rows = repo::list_by_status(pool, &non_terminal)
+        .await
+        .map_err(|source| SyntaxisError::Database {
+            source,
+            location: snafu::location!(),
+        })?;
+
+    let mut count = 0usize;
+    for row in &rows {
+        match row_to_queue_item(row) {
+            Some(item) => {
+                // Re-queue all non-terminal items. Items in downloading/post_processing/
+                // importing are effectively re-queued from the start; Ergasia's
+                // persistence layer may allow resumption.
+                queue.insert(item);
+                count += 1;
+            }
+            None => {
+                warn!("could not parse download_queue row during recovery; skipping");
+            }
+        }
+    }
+
+    if count > 0 {
+        info!(recovered = count, "startup reconciliation complete");
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harmonia_db::migrate::MIGRATOR;
+    use sqlx::SqlitePool;
+    use uuid::Uuid;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_id_bytes(id: Uuid) -> Vec<u8> {
+        id.as_bytes().to_vec()
+    }
+
+    async fn insert(pool: &SqlitePool, id: Uuid, status: &str, priority: u8) {
+        let want_id = make_id_bytes(Uuid::now_v7());
+        let release_id = make_id_bytes(Uuid::now_v7());
+        repo::insert_queue_item(
+            pool,
+            id,
+            &want_id,
+            &release_id,
+            "magnet:?xt=urn:btih:test",
+            "torrent",
+            priority,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        if status != "queued" {
+            repo::update_status(pool, id, status).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn reloads_queued_items() {
+        let pool = setup().await;
+        insert(&pool, Uuid::now_v7(), "queued", 2).await;
+        insert(&pool, Uuid::now_v7(), "queued", 1).await;
+
+        let mut queue = PriorityQueue::new();
+        let count = reload_queue(&pool, &mut queue).await.unwrap();
+
+        assert_eq!(count, 2);
+        assert_eq!(queue.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn skips_terminal_items() {
+        let pool = setup().await;
+        insert(&pool, Uuid::now_v7(), "completed", 2).await;
+        insert(&pool, Uuid::now_v7(), "failed", 1).await;
+        insert(&pool, Uuid::now_v7(), "queued", 3).await;
+
+        let mut queue = PriorityQueue::new();
+        let count = reload_queue(&pool, &mut queue).await.unwrap();
+
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn reloads_in_progress_states() {
+        let pool = setup().await;
+        insert(&pool, Uuid::now_v7(), "downloading", 2).await;
+        insert(&pool, Uuid::now_v7(), "post_processing", 2).await;
+        insert(&pool, Uuid::now_v7(), "importing", 1).await;
+
+        let mut queue = PriorityQueue::new();
+        let count = reload_queue(&pool, &mut queue).await.unwrap();
+
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn empty_db_returns_zero() {
+        let pool = setup().await;
+        let mut queue = PriorityQueue::new();
+        let count = reload_queue(&pool, &mut queue).await.unwrap();
+        assert_eq!(count, 0);
+        assert!(queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn interactive_priority_clamped_to_three() {
+        let pool = setup().await;
+        // Insert with priority 4 directly in DB (simulating a pre-restart interactive item)
+        let id = Uuid::now_v7();
+        let want_id = make_id_bytes(Uuid::now_v7());
+        let release_id = make_id_bytes(Uuid::now_v7());
+        repo::insert_queue_item(
+            &pool,
+            id,
+            &want_id,
+            &release_id,
+            "magnet:?",
+            "torrent",
+            4,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut queue = PriorityQueue::new();
+        reload_queue(&pool, &mut queue).await.unwrap();
+
+        let item = queue.dequeue().unwrap();
+        assert_eq!(
+            item.priority, 3,
+            "priority 4 should be clamped to 3 on recovery"
+        );
+    }
+}

--- a/crates/syntaxis/src/repo.rs
+++ b/crates/syntaxis/src/repo.rs
@@ -1,0 +1,516 @@
+//! `download_queue` table operations.
+
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use harmonia_db::DbError;
+use snafu::ResultExt;
+
+use harmonia_db::error::QuerySnafu;
+
+/// A raw DB row from `download_queue`.
+///
+/// All columns are selected so that `sqlx::FromRow` can deserialise any query result.
+/// Some fields are only consumed in tests or future pipeline stages; suppressing the
+/// lint avoids forcing premature use of every column.
+#[derive(Debug, Clone, sqlx::FromRow)]
+#[allow(dead_code)]
+pub(crate) struct QueueRow {
+    pub id: Vec<u8>,
+    pub want_id: Vec<u8>,
+    pub release_id: Vec<u8>,
+    pub download_url: String,
+    pub protocol: String,
+    pub priority: i64,
+    pub tracker_id: Option<i64>,
+    pub info_hash: Option<String>,
+    pub status: String,
+    pub added_at: String,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub failed_reason: Option<String>,
+    pub retry_count: i64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn insert_queue_item(
+    pool: &SqlitePool,
+    id: Uuid,
+    want_id: &[u8],
+    release_id: &[u8],
+    download_url: &str,
+    protocol: &str,
+    priority: u8,
+    tracker_id: Option<i64>,
+    info_hash: Option<&str>,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "INSERT INTO download_queue
+         (id, want_id, release_id, download_url, protocol, priority, tracker_id, info_hash)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(id.as_bytes().as_slice())
+    .bind(want_id)
+    .bind(release_id)
+    .bind(download_url)
+    .bind(protocol)
+    .bind(priority as i64)
+    .bind(tracker_id)
+    .bind(info_hash)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "download_queue",
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) async fn get_queue_item(
+    pool: &SqlitePool,
+    id: Uuid,
+) -> Result<Option<QueueRow>, DbError> {
+    sqlx::query_as::<_, QueueRow>(
+        "SELECT id, want_id, release_id, download_url, protocol, priority,
+                tracker_id, info_hash, status, added_at, started_at,
+                completed_at, failed_reason, retry_count
+         FROM download_queue WHERE id = ?",
+    )
+    .bind(id.as_bytes().as_slice())
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu {
+        table: "download_queue",
+    })
+}
+
+pub(crate) async fn update_status(
+    pool: &SqlitePool,
+    id: Uuid,
+    status: &str,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE download_queue SET status = ? WHERE id = ?")
+        .bind(status)
+        .bind(id.as_bytes().as_slice())
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "download_queue",
+        })?;
+    Ok(())
+}
+
+pub(crate) async fn update_priority(
+    pool: &SqlitePool,
+    id: Uuid,
+    priority: u8,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE download_queue SET priority = ? WHERE id = ?")
+        .bind(priority as i64)
+        .bind(id.as_bytes().as_slice())
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "download_queue",
+        })?;
+    Ok(())
+}
+
+/// Returns all rows with any of the given statuses, ordered by priority DESC, added_at ASC.
+pub(crate) async fn list_by_status(
+    pool: &SqlitePool,
+    statuses: &[&str],
+) -> Result<Vec<QueueRow>, DbError> {
+    // WHY: sqlx doesn't support binding Vec<&str> to IN clauses directly.
+    // We build the placeholders dynamically and use a raw query string.
+    if statuses.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders: String = statuses
+        .iter()
+        .enumerate()
+        .map(|(i, _)| {
+            if i == 0 {
+                "?".to_string()
+            } else {
+                ",?".to_string()
+            }
+        })
+        .collect();
+    let sql = format!(
+        "SELECT id, want_id, release_id, download_url, protocol, priority,
+                tracker_id, info_hash, status, added_at, started_at,
+                completed_at, failed_reason, retry_count
+         FROM download_queue
+         WHERE status IN ({placeholders})
+         ORDER BY priority DESC, added_at ASC"
+    );
+    let mut query = sqlx::query_as::<_, QueueRow>(&sql);
+    for s in statuses {
+        query = query.bind(*s);
+    }
+    query.fetch_all(pool).await.context(QuerySnafu {
+        table: "download_queue",
+    })
+}
+
+/// Returns rows with status 'queued' or 'downloading', ordered by priority DESC.
+#[cfg(test)]
+pub(crate) async fn list_active(pool: &SqlitePool) -> Result<Vec<QueueRow>, DbError> {
+    sqlx::query_as::<_, QueueRow>(
+        "SELECT id, want_id, release_id, download_url, protocol, priority,
+                tracker_id, info_hash, status, added_at, started_at,
+                completed_at, failed_reason, retry_count
+         FROM download_queue
+         WHERE status IN ('queued', 'downloading')
+         ORDER BY priority DESC, added_at ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu {
+        table: "download_queue",
+    })
+}
+
+pub(crate) async fn mark_completed(
+    pool: &SqlitePool,
+    id: Uuid,
+    completed_at: &str,
+) -> Result<(), DbError> {
+    sqlx::query("UPDATE download_queue SET status = 'completed', completed_at = ? WHERE id = ?")
+        .bind(completed_at)
+        .bind(id.as_bytes().as_slice())
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "download_queue",
+        })?;
+    Ok(())
+}
+
+pub(crate) async fn mark_failed(pool: &SqlitePool, id: Uuid, reason: &str) -> Result<(), DbError> {
+    sqlx::query("UPDATE download_queue SET status = 'failed', failed_reason = ? WHERE id = ?")
+        .bind(reason)
+        .bind(id.as_bytes().as_slice())
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "download_queue",
+        })?;
+    Ok(())
+}
+
+pub(crate) async fn increment_retry_count(pool: &SqlitePool, id: Uuid) -> Result<(), DbError> {
+    sqlx::query("UPDATE download_queue SET retry_count = retry_count + 1 WHERE id = ?")
+        .bind(id.as_bytes().as_slice())
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "download_queue",
+        })?;
+    Ok(())
+}
+
+pub(crate) async fn count_by_status(pool: &SqlitePool, status: &str) -> Result<u64, DbError> {
+    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM download_queue WHERE status = ?")
+        .bind(status)
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu {
+            table: "download_queue",
+        })?;
+    Ok(row.0 as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harmonia_db::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn make_uuid() -> Uuid {
+        Uuid::now_v7()
+    }
+
+    fn make_id_bytes() -> Vec<u8> {
+        Uuid::now_v7().as_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_queue_item() {
+        let pool = setup().await;
+        let id = make_uuid();
+        let want_id = make_id_bytes();
+        let release_id = make_id_bytes();
+
+        insert_queue_item(
+            &pool,
+            id,
+            &want_id,
+            &release_id,
+            "magnet:?xt=urn:btih:abc",
+            "torrent",
+            3,
+            Some(1),
+            Some("abc123"),
+        )
+        .await
+        .unwrap();
+
+        let row = get_queue_item(&pool, id).await.unwrap().unwrap();
+        assert_eq!(row.status, "queued");
+        assert_eq!(row.priority, 3);
+        assert_eq!(row.protocol, "torrent");
+        assert_eq!(row.tracker_id, Some(1));
+        assert_eq!(row.info_hash, Some("abc123".to_string()));
+        assert_eq!(row.retry_count, 0);
+    }
+
+    #[tokio::test]
+    async fn update_status_changes_row() {
+        let pool = setup().await;
+        let id = make_uuid();
+        let want_id = make_id_bytes();
+        let release_id = make_id_bytes();
+
+        insert_queue_item(
+            &pool,
+            id,
+            &want_id,
+            &release_id,
+            "magnet:?xt=urn:btih:def",
+            "torrent",
+            1,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        update_status(&pool, id, "downloading").await.unwrap();
+        let row = get_queue_item(&pool, id).await.unwrap().unwrap();
+        assert_eq!(row.status, "downloading");
+    }
+
+    #[tokio::test]
+    async fn mark_failed_sets_reason() {
+        let pool = setup().await;
+        let id = make_uuid();
+        let want_id = make_id_bytes();
+        let release_id = make_id_bytes();
+
+        insert_queue_item(
+            &pool,
+            id,
+            &want_id,
+            &release_id,
+            "magnet:?xt=urn:btih:xyz",
+            "torrent",
+            2,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        mark_failed(&pool, id, "no seeders").await.unwrap();
+        let row = get_queue_item(&pool, id).await.unwrap().unwrap();
+        assert_eq!(row.status, "failed");
+        assert_eq!(row.failed_reason, Some("no seeders".to_string()));
+    }
+
+    #[tokio::test]
+    async fn mark_completed_sets_timestamp() {
+        let pool = setup().await;
+        let id = make_uuid();
+        let want_id = make_id_bytes();
+        let release_id = make_id_bytes();
+
+        insert_queue_item(
+            &pool,
+            id,
+            &want_id,
+            &release_id,
+            "magnet:?xt=urn:btih:zzz",
+            "torrent",
+            3,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        mark_completed(&pool, id, "2026-01-01T00:00:00Z")
+            .await
+            .unwrap();
+        let row = get_queue_item(&pool, id).await.unwrap().unwrap();
+        assert_eq!(row.status, "completed");
+        assert_eq!(row.completed_at, Some("2026-01-01T00:00:00Z".to_string()));
+    }
+
+    #[tokio::test]
+    async fn list_by_status_returns_matching_rows() {
+        let pool = setup().await;
+        let id1 = make_uuid();
+        let id2 = make_uuid();
+        let want_id = make_id_bytes();
+        let release_id = make_id_bytes();
+
+        insert_queue_item(
+            &pool,
+            id1,
+            &want_id,
+            &release_id,
+            "magnet:?xt=1",
+            "torrent",
+            3,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        insert_queue_item(
+            &pool,
+            id2,
+            &want_id,
+            &release_id,
+            "magnet:?xt=2",
+            "torrent",
+            1,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        mark_failed(&pool, id2, "timeout").await.unwrap();
+
+        let queued = list_by_status(&pool, &["queued"]).await.unwrap();
+        assert_eq!(queued.len(), 1);
+
+        let all = list_by_status(&pool, &["queued", "failed"]).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn list_by_status_empty_slice_returns_empty() {
+        let pool = setup().await;
+        let rows = list_by_status(&pool, &[]).await.unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_active_excludes_terminal_states() {
+        let pool = setup().await;
+        let id_queued = make_uuid();
+        let id_failed = make_uuid();
+        let want_id = make_id_bytes();
+        let release_id = make_id_bytes();
+
+        insert_queue_item(
+            &pool,
+            id_queued,
+            &want_id,
+            &release_id,
+            "magnet:?xt=a",
+            "torrent",
+            1,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        insert_queue_item(
+            &pool,
+            id_failed,
+            &want_id,
+            &release_id,
+            "magnet:?xt=b",
+            "torrent",
+            1,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        mark_failed(&pool, id_failed, "corrupt").await.unwrap();
+
+        let active = list_active(&pool).await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].status, "queued");
+    }
+
+    #[tokio::test]
+    async fn priority_ordering_in_list_by_status() {
+        let pool = setup().await;
+        let want_id = make_id_bytes();
+        let release_id = make_id_bytes();
+
+        let id_low = make_uuid();
+        let id_high = make_uuid();
+
+        // Insert low priority first
+        insert_queue_item(
+            &pool,
+            id_low,
+            &want_id,
+            &release_id,
+            "magnet:?xt=low",
+            "torrent",
+            1,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        insert_queue_item(
+            &pool,
+            id_high,
+            &want_id,
+            &release_id,
+            "magnet:?xt=high",
+            "torrent",
+            3,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let rows = list_by_status(&pool, &["queued"]).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        // First row should be the higher priority item
+        assert_eq!(rows[0].priority, 3);
+        assert_eq!(rows[1].priority, 1);
+    }
+
+    #[tokio::test]
+    async fn count_by_status_returns_correct_count() {
+        let pool = setup().await;
+        let want_id = make_id_bytes();
+        let release_id = make_id_bytes();
+
+        for _ in 0..3 {
+            insert_queue_item(
+                &pool,
+                make_uuid(),
+                &want_id,
+                &release_id,
+                "magnet:?xt=x",
+                "torrent",
+                1,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        let count = count_by_status(&pool, "queued").await.unwrap();
+        assert_eq!(count, 3);
+    }
+}

--- a/crates/syntaxis/src/retry.rs
+++ b/crates/syntaxis/src/retry.rs
@@ -1,0 +1,103 @@
+//! Retry logic and failure classification for download errors.
+
+/// Classification of a download failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FailureKind {
+    /// Network error, tracker timeout, or other condition that may resolve on retry.
+    Transient,
+    /// No seeders after stalled timeout, corrupt torrent, or other unrecoverable state.
+    Permanent,
+}
+
+/// Classifies a failure reason string into transient or permanent.
+///
+/// Permanent patterns are checked first; everything else is treated as transient.
+pub(crate) fn classify_failure(reason: &str) -> FailureKind {
+    let lower = reason.to_lowercase();
+    let permanent_patterns = [
+        "corrupt",
+        "no seeders",
+        "stalled",
+        "invalid torrent",
+        "magnet resolve failed",
+        "bad data",
+    ];
+    if permanent_patterns.iter().any(|p| lower.contains(p)) {
+        FailureKind::Permanent
+    } else {
+        FailureKind::Transient
+    }
+}
+
+/// Returns the backoff duration in seconds for a given retry attempt (0-indexed).
+///
+/// Backoff schedule: `base`, `base * 4`, `base * 20`.
+pub(crate) fn backoff_seconds(attempt: u32, base_seconds: u64) -> u64 {
+    match attempt {
+        0 => base_seconds,
+        1 => base_seconds * 4,
+        _ => base_seconds * 20,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn corrupt_torrent_is_permanent() {
+        assert_eq!(
+            classify_failure("corrupt torrent file"),
+            FailureKind::Permanent
+        );
+    }
+
+    #[test]
+    fn no_seeders_is_permanent() {
+        assert_eq!(
+            classify_failure("no seeders available"),
+            FailureKind::Permanent
+        );
+    }
+
+    #[test]
+    fn stalled_is_permanent() {
+        assert_eq!(classify_failure("stalled download"), FailureKind::Permanent);
+    }
+
+    #[test]
+    fn network_error_is_transient() {
+        assert_eq!(
+            classify_failure("network connection refused"),
+            FailureKind::Transient
+        );
+    }
+
+    #[test]
+    fn tracker_timeout_is_transient() {
+        assert_eq!(
+            classify_failure("tracker announce timeout"),
+            FailureKind::Transient
+        );
+    }
+
+    #[test]
+    fn backoff_first_attempt_is_base() {
+        assert_eq!(backoff_seconds(0, 30), 30);
+    }
+
+    #[test]
+    fn backoff_second_attempt_is_4x_base() {
+        assert_eq!(backoff_seconds(1, 30), 120);
+    }
+
+    #[test]
+    fn backoff_third_attempt_is_20x_base() {
+        assert_eq!(backoff_seconds(2, 30), 600);
+    }
+
+    #[test]
+    fn backoff_beyond_third_caps_at_20x() {
+        assert_eq!(backoff_seconds(5, 30), 600);
+    }
+}

--- a/crates/syntaxis/src/types.rs
+++ b/crates/syntaxis/src/types.rs
@@ -1,0 +1,125 @@
+//! Domain types for the download queue and post-processing pipeline.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use harmonia_common::ids::{DownloadId, ReleaseId, WantId};
+
+/// Protocol used to retrieve the release.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DownloadProtocol {
+    Torrent,
+    Usenet,
+}
+
+impl DownloadProtocol {
+    /// Canonical string representation stored in the database.
+    pub fn as_db_str(self) -> &'static str {
+        match self {
+            DownloadProtocol::Torrent => "torrent",
+            DownloadProtocol::Usenet => "nzb",
+        }
+    }
+}
+
+impl std::fmt::Display for DownloadProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_db_str())
+    }
+}
+
+/// A single entry waiting to be dispatched or actively downloading.
+#[derive(Debug, Clone)]
+pub struct QueueItem {
+    /// UUIDv7 identifier; also used as `download_queue.id` in the DB.
+    pub id: Uuid,
+    pub want_id: WantId,
+    pub release_id: ReleaseId,
+    pub download_url: String,
+    pub protocol: DownloadProtocol,
+    /// 1–4; see priority tier table in orchestration.md.
+    pub priority: u8,
+    /// FK to `indexers.id` (torrent only).
+    pub tracker_id: Option<i64>,
+    /// Torrent info hash (torrent only).
+    pub info_hash: Option<String>,
+}
+
+/// Passed from Syntaxis to the import service when post-processing is complete.
+#[derive(Debug, Clone)]
+pub struct CompletedDownload {
+    pub download_id: DownloadId,
+    /// Path to the completed download (or extracted files if archives were present).
+    pub download_path: PathBuf,
+    /// Original download directory; used for seeding cleanup and archive removal.
+    pub source_path: PathBuf,
+    pub want_id: WantId,
+    pub release_id: ReleaseId,
+    pub protocol: DownloadProtocol,
+    /// Set when `std::fs::hard_link` fails with `EXDEV`; Taxis copies instead.
+    pub requires_copy: bool,
+}
+
+/// Returned by `QueueManager::enqueue`.
+#[derive(Debug, Clone)]
+pub struct QueuePosition {
+    /// Zero-based position in the priority queue (0 = next to dispatch).
+    pub position: usize,
+    /// Rough estimate in seconds; `None` when the queue is empty.
+    pub estimated_wait_secs: Option<u64>,
+}
+
+/// Current queue state for API responses.
+#[derive(Debug, Clone)]
+pub struct QueueSnapshot {
+    pub active_downloads: Vec<QueueItem>,
+    pub queued_items: Vec<QueueItem>,
+    pub completed_count: u64,
+    pub failed_count: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_db_str_torrent() {
+        assert_eq!(DownloadProtocol::Torrent.as_db_str(), "torrent");
+    }
+
+    #[test]
+    fn protocol_db_str_usenet() {
+        assert_eq!(DownloadProtocol::Usenet.as_db_str(), "nzb");
+    }
+
+    #[test]
+    fn protocol_display_matches_db_str() {
+        assert_eq!(
+            DownloadProtocol::Torrent.to_string(),
+            DownloadProtocol::Torrent.as_db_str()
+        );
+        assert_eq!(
+            DownloadProtocol::Usenet.to_string(),
+            DownloadProtocol::Usenet.as_db_str()
+        );
+    }
+
+    #[test]
+    fn completed_download_carries_required_fields() {
+        let dl = CompletedDownload {
+            download_id: DownloadId::new(),
+            download_path: PathBuf::from("/data/downloads/album"),
+            source_path: PathBuf::from("/data/downloads/album"),
+            want_id: WantId::new(),
+            release_id: ReleaseId::new(),
+            protocol: DownloadProtocol::Torrent,
+            requires_copy: false,
+        };
+        assert!(!dl.requires_copy);
+        assert_eq!(dl.protocol, DownloadProtocol::Torrent);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `syntaxis` crate: download queue orchestration and post-processing pipeline
- Priority queue with 3 tiers (1–3) + interactive bypass tier (4); per-tracker concurrency limits via `SlotAllocator`
- Post-processing pipeline: archive extraction via Ergasia → import trigger via `ImportService` trait
- Startup reconciliation (`recovery::reload_queue`) reloads non-terminal rows on restart; priority-4 items clamped to 3
- Exponential-backoff retry with permanent-failure classification (`retry.rs`)
- Migration `006_download_queue.sql` adds the `download_queue` table

## Files changed

- `Cargo.toml` — added `syntaxis` to workspace members and `[workspace.dependencies]`
- `crates/horismos/src/subsystems.rs` — replaced `SyntaxisConfig` with design-doc fields
- `crates/harmonia-db/migrations/006_download_queue.sql` — new table + index
- `crates/syntaxis/` — new crate (9 source files, 47 tests)

## Validation

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p syntaxis -- -D warnings` ✓  
- `cargo test -p syntaxis` — 47/47 passed ✓

## Observations

- `DownloadEngine` uses native-async-trait returns (not dyn-compatible); `SyntaxisService` is generic over `E: DownloadEngine` rather than using `Arc<dyn DownloadEngine>`. `ImportService` uses `Pin<Box<dyn Future>>` for dyn-compatibility and is stored as `Arc<dyn ImportService>`.
- `per_tracker_snapshot()` on `SlotAllocator` returns an owned `HashMap` clone to break the borrow-checker conflict between `inner.allocator` (immutable read) and `inner.queue.dequeue_eligible()` (mutable borrow) inside the same `MutexGuard`.
- `ergasia::DownloadProtocol` is a separate type from `syntaxis::DownloadProtocol`; the dispatch path hard-codes `Torrent` when building `DownloadRequest`. This mapping should be made explicit in P3-08 when the Usenet engine is wired.