### PR TITLE
docs: rewrite root docs for Rust-only monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,33 +2,47 @@
 
 ## Repository
 
-Harmonia: unified self-hosted media platform. Monorepo containing backend and player.
+Harmonia: unified self-hosted media platform. Rust monorepo containing backend crates, audio core, and desktop app.
 
 ```
 harmonia/
-├── mouseion/       # Media management backend (.NET 10/C#, future Rust)
-├── akroasis/       # Media player (Android/Kotlin, Web/React, Rust audio core)
-├── standards/      # Universal coding standards (all languages)
-├── docs/           # Cross-cutting documentation
+├── crates/             # Rust workspace crates (backend subsystems)
+│   ├── harmonia-common/    # Shared types, IDs, domain primitives
+│   ├── harmonia-db/        # SQLite storage layer (sqlx)
+│   ├── harmonia-host/      # Axum HTTP server and binary entry point
+│   ├── horismos/           # Configuration (figment)
+│   ├── exousia/            # Authentication and authorization (JWT, argon2)
+│   ├── paroche/            # HTTP streaming and media serving
+│   ├── taxis/              # File import, renaming, directory structure
+│   ├── epignosis/          # Metadata enrichment (MusicBrainz, TMDB, etc.)
+│   ├── kritike/            # Library quality and integrity verification
+│   ├── komide/             # Library scanner and file watcher
+│   ├── zetesis/            # Indexer search (Torznab/Newznab)
+│   ├── ergasia/            # Download execution and archive extraction
+│   ├── syndesmos/          # External service integration (Plex, Last.fm, Tidal)
+│   ├── aitesis/            # Household media request management
+│   └── syntaxis/           # Download queue orchestration and post-processing
+├── akroasis/
+│   └── shared/
+│       └── akroasis-core/  # Rust audio engine (decode, DSP, output) — excluded from workspace
+├── desktop/            # Tauri 2 desktop app (Rust + webview)
+├── standards/          # Universal coding standards
+├── docs/               # Cross-cutting documentation
 │   ├── gnomon.md           # Greek naming methodology
 │   ├── lexicon.md          # Project name registry
 │   ├── LESSONS.md          # Operational rules (earned through failure)
 │   ├── CLAUDE_CODE.md      # Claude Code dispatch protocol
 │   ├── WORKING-AGREEMENT.md
 │   └── policy/             # Agent contribution, versioning, git history
-└── CLAUDE.md       # This file — project conventions for CC agents
+└── CLAUDE.md           # This file
 ```
 
-Component-specific guidelines live in `mouseion/CLAUDE.md` and `akroasis/CLAUDE.md`.
+Component-specific guidelines: `akroasis/CLAUDE.md`.
 
 ## Standards
 
 Universal: [standards/STANDARDS.md](standards/STANDARDS.md)
 Rust: [standards/RUST.md](standards/RUST.md)
-C#/.NET: [standards/CSHARP.md](standards/CSHARP.md)
-Kotlin: [standards/KOTLIN.md](standards/KOTLIN.md)
-TypeScript: [standards/TYPESCRIPT.md](standards/TYPESCRIPT.md)
-C++: [standards/CPP.md](standards/CPP.md)
 SQL: [standards/SQL.md](standards/SQL.md)
 Shell: [standards/SHELL.md](standards/SHELL.md)
 Writing: [standards/WRITING.md](standards/WRITING.md)
@@ -53,37 +67,33 @@ Writing: [standards/WRITING.md](standards/WRITING.md)
 `category(scope): description`
 
 Categories: feat, fix, docs, refactor, test, chore, style
-Scopes: `mouseion`, `akroasis`, `docs`, `infra`
+Scopes: crate name (`syntaxis`, `exousia`, etc.), `desktop`, `docs`, `infra`
 
 ## Build & test
 
 ```bash
-# Mouseion (backend)
-cd mouseion && dotnet build Mouseion.sln --configuration Release
-cd mouseion && dotnet test --configuration Release --verbosity minimal
-
-# Akroasis web
-cd akroasis/web && npm ci && npm run lint && npm run build && npx vitest run
-
-# Akroasis android
-cd akroasis/android && ./gradlew build && ./gradlew test
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
 ```
 
-## Architecture direction
+Targeted tests during development: `cargo test -p <crate>`
 
-**Backend (Mouseion):** Currently .NET 10/C#. Planned Rust rewrite: single static binary, Tokio, Axum, embedded DB. Eliminates multi-process *arr coordination overhead. See mouseion#225.
+## Architecture
 
-**Player (Akroasis):** Kotlin + Jetpack Compose (Android), React 19 + TypeScript (Web), Tauri 2 (Desktop, planned). Rust audio core shared via JNI/FFI: bit-perfect FLAC, gapless playback, ReplayGain.
+Harmonia is a Rust platform. Single static binary (Tokio, Axum, SQLite) replacing the *arr ecosystem. 15 workspace crates covering the full media lifecycle: discovery, search, download, extraction, import, organization, metadata enrichment, quality management, serving, and household requests.
+
+The audio engine (`akroasis-core`) is built independently and shared via FFI with the Tauri desktop app. It handles bit-perfect decode, DSP (EQ, crossfeed, ReplayGain), and native audio output.
 
 ## CI
 
-Path-based triggers:
-- `mouseion/` changes: backend CI (dotnet build/test/format)
-- `akroasis/` changes: player CI (android build, web lint/test)
+GitHub Actions workflows:
+- `rust.yml`: format, clippy, test, MSRV check, rustdoc, coverage (triggers on `crates/`, `Cargo.toml`, `Cargo.lock`)
+- `security.yml`: cargo-audit, cargo-deny, gitleaks, TruffleHog (triggers on all pushes/PRs + weekly schedule)
+- `desktop.yml`: desktop app build pipeline
 
 ## What not to do
 
-- Don't mix mouseion/ and akroasis/ changes in the same PR unless tightly coupled
 - Don't add dependencies without justification
 - Don't modify CI workflows without understanding the full pipeline
 - No AI attribution, no "Co-authored-by: Claude", no emoji indicators

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -2,34 +2,44 @@
 
 ## Vision
 
-One self-hosted media platform replacing the fragmented *arr ecosystem. Mouseion manages all media types (movies, TV, music, books, audiobooks, podcasts, manga, comics, news). Akroasis plays them across Android, Web, and Desktop.
+One self-hosted media platform replacing the fragmented *arr ecosystem. A single Rust binary manages all media types (movies, TV, music, books, audiobooks, podcasts, manga, comics, news). Akroasis plays them across desktop (Tauri) and eventually Android and web. Video playback stays with Plex; everything else plays through Harmonia's own clients.
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────┐
 │              Akroasis                   │
-│  ┌───────────┐ ┌──────┐ ┌───────────┐  │
-│  │  Android   │ │ Web  │ │  Desktop  │  │
-│  │  Kotlin    │ │React │ │  Tauri 2  │  │
-│  └─────┬─────┘ └──┬───┘ └─────┬─────┘  │
-│        └──────────┼──────────┘          │
-│              Rust Audio Core            │
-│         (FLAC, gapless, ReplayGain)     │
+│  ┌───────────┐ ┌───────────┐           │
+│  │  Desktop  │ │  Android  │           │
+│  │  Tauri 2  │ │  (future) │           │
+│  └─────┬─────┘ └─────┬─────┘           │
+│        └──────┬───────┘                 │
+│         akroasis-core                   │
+│    (decode, DSP, ReplayGain)            │
 └────────────────┬────────────────────────┘
-                 │ REST API v3
+                 │ REST API
 ┌────────────────┴────────────────────────┐
-│              Mouseion                   │
-│  Media management, metadata, indexers,  │
-│  quality profiles, download clients     │
-│  (.NET 10 → Rust rewrite planned)       │
+│         Harmonia backend                │
+│  15 Rust crates: media management,      │
+│  metadata, indexers, quality profiles,  │
+│  downloads, serving, requests           │
+│  (Tokio, Axum, SQLite)                  │
 └─────────────────────────────────────────┘
 ```
 
-## Open issues
+## Current state
 
-- **mouseion#225:** Rust rewrite evaluation. Decision: proceed. Single static binary (Tokio, Axum, embedded DB). Same toolchain as Aletheia. Eliminates multi-process coordination overhead and ~4-8GB runtime footprint.
+Phase 3 in progress. 15 workspace crates, 543 tests passing.
+
+Completed in Phase 3:
+- Download execution and archive extraction (ergasia, P3-02)
+- Queue orchestration and post-processing (syntaxis, P3-03)
+- Request management (aitesis, P3-05)
+- External service integration (syndesmos, P3-06)
+- Desktop: now playing, audiobook player, podcast player, EQ/DSP, media management UI, MPRIS/tray (P3-11 through P3-16)
+
+Foundation (pre-Phase 3): harmonia-common, harmonia-db, harmonia-host, horismos, exousia, paroche, taxis, epignosis, kritike, komide, zetesis.
 
 ## Why monorepo
 
-Mouseion and Akroasis are one product with two deployment targets. Separate repos created coordination overhead for API changes, shared specs, and release timing. Harmonia unifies them while preserving independent build/CI pipelines.
+Backend crates and the desktop app are one product. Separate repos would create coordination overhead for API changes, shared types, and release timing. Independent CI pipelines per path keep builds fast.

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -11,10 +11,10 @@
 
 | Layer | Reading |
 |-------|---------|
-| L1 | Unified media platform: backend, player, audio core |
+| L1 | Unified media platform: backend crates, audio core, desktop app |
 | L2 | The integration layer that makes disparate media components work as one |
 | L3 | The fitting-together of parts, not mere compatibility but active concordance, each part finding its place within a whole |
-| L4 | The platform harmonizes: Mouseion (collection) and Akroasis (listening) joined into a coherent whole. The name describes its own architecture |
+| L4 | The platform harmonizes: backend subsystems and Akroasis (listening) joined into a coherent whole. The name describes its own architecture |
 
 ---
 
@@ -23,80 +23,73 @@
 | Name | Greek | Pronunciation | L3 Essential Nature |
 |------|-------|--------------|---------------------|
 | **Harmonia** | ἁρμονία | har-MOH-nee-ah | The platform as a whole: the fitting-together |
-| **Mouseion** | Μουσεῖον | moo-SAY-on | The place where the Muses dwell, custodianship of collected arts. The Rust backend. |
-| **Akroasis** | ἀκρόασις | ah-kroh-AH-sis | Attentive reception: the player. Android (Kotlin/Compose), web (React), desktop (Tauri). |
+| **Akroasis** | ἀκρόασις | ah-kroh-AH-sis | Attentive reception: the player. Desktop (Tauri), with Android and web planned. |
 
 ---
 
-## Backend subsystems (Mouseion)
+## Backend crates
+
+### Infrastructure
+
+| Crate | Greek | Pronunciation | Over | L3 Essential Nature |
+|-------|-------|--------------|------|---------------------|
+| **harmonia-common** | — | — | "shared types" | Domain primitives, IDs, and shared types used across all crates. |
+| **harmonia-db** | — | — | "storage" | SQLite storage layer, migrations, and query interface. |
+| **harmonia-host** | — | — | "server" | Axum HTTP server and binary entry point. The process boundary. |
+| **horismos** | ὁρισμός | hor-is-MOS | "config" | Definition, delimitation: the act of setting boundaries. All system configuration as the single parameterized source of truth. |
+| **exousia** | ἐξουσία | ex-oo-SEE-ah | "auth" | Authority: the power that comes from legitimate standing. Identity, authentication, authorization for household users. |
 
 ### Acquisition pipeline
 
-| Subsystem | Greek | Pronunciation | Over | L3 Essential Nature |
-|-----------|-------|--------------|------|---------------------|
-| **Episkope** | ἐπισκοπή | ep-ee-sko-PAY | "monitoring" | Oversight, superintendence: the episcopal function of watching over a domain. Monitors wanted media, triggers acquisition when gaps are found. |
-| **Zetesis** | ζήτησις | zay-TAY-sis | "indexer search" | The act of seeking, of inquiry: Socratic inquiry is zetesis. Queries Torznab/Newznab indexers, handles Cloudflare bypass. |
-| **Ergasia** | ἐργασία | er-GAH-see-ah | "download" | Working, operation, from ἔργον (the deed). Pure execution. Torrent downloads and archive extraction. |
-| **Syntaxis** | σύνταξις | syn-TAK-sis | "queue" | Arrangement-together, coordination: the ordering of parts into a whole. Download queue, priority, post-processing pipeline. |
+| Crate | Greek | Pronunciation | Over | L3 Essential Nature |
+|-------|-------|--------------|------|---------------------|
+| **zetesis** | ζήτησις | zay-TAY-sis | "indexer search" | The act of seeking, of inquiry: Socratic inquiry is zetesis. Queries Torznab/Newznab indexers, handles Cloudflare bypass. |
+| **ergasia** | ἐργασία | er-GAH-see-ah | "download" | Working, operation, from ἔργον (the deed). Pure execution. Torrent downloads and archive extraction. |
+| **syntaxis** | σύνταξις | syn-TAK-sis | "queue" | Arrangement-together, coordination: the ordering of parts into a whole. Download queue, priority, post-processing pipeline. |
 
 ### Recognition & organization
 
-| Subsystem | Greek | Pronunciation | Over | L3 Essential Nature |
-|-----------|-------|--------------|------|---------------------|
-| **Epignosis** | ἐπίγνωσις | ep-ee-GNOH-sis | "metadata" | Precise knowledge, recognition: knowing in full, not mere acquaintance. Metadata enrichment from MusicBrainz, TMDB, TVDB, Audnexus. |
-| **Taxis** | τάξις | TAK-sis | "import" | Arrangement, order: bringing things into their proper place. File import, renaming, directory structure. |
+| Crate | Greek | Pronunciation | Over | L3 Essential Nature |
+|-------|-------|--------------|------|---------------------|
+| **epignosis** | ἐπίγνωσις | ep-ee-GNOH-sis | "metadata" | Precise knowledge, recognition: knowing in full, not mere acquaintance. Metadata enrichment from MusicBrainz, TMDB, TVDB, Audnexus. |
+| **taxis** | τάξις | TAK-sis | "import" | Arrangement, order: bringing things into their proper place. File import, renaming, directory structure. |
+| **komide** | κομιδή | ko-mee-DAY | "feeds" | Care, tending: the faithful attendance to what arrives. RSS/Atom feed aggregation for podcasts and news. |
 
-### Quality & supplements
+### Quality
 
-| Subsystem | Greek | Pronunciation | Over | L3 Essential Nature |
-|-----------|-------|--------------|------|---------------------|
-| **Kritike** | κριτική | kree-tee-KAY | "curation" | The critical faculty: the art of separating the excellent from the merely adequate. Library quality, integrity verification, cleanup rules. |
-| **Prostheke** | προσθήκη | pros-THAY-kay | "subtitles" | The supplement, the addition: that which is added to make something more. Subtitle acquisition, sync, and storage. |
+| Crate | Greek | Pronunciation | Over | L3 Essential Nature |
+|-------|-------|--------------|------|---------------------|
+| **kritike** | κριτική | kree-tee-KAY | "curation" | The critical faculty: the art of separating the excellent from the merely adequate. Library quality, integrity verification, cleanup rules. |
 
-### Serving
+### Serving & integration
 
-| Subsystem | Greek | Pronunciation | Over | L3 Essential Nature |
-|-----------|-------|--------------|------|---------------------|
-| **Paroche** | παροχή | pah-ro-KAY | "streaming" | Provision, supply: the act of making available. HTTP streaming, OPDS feeds, transcoding. |
-| **Syndesis** | σύνδεσις | syn-DEH-sis | "QUIC transport" | Binding together: server-to-renderer audio transport, multi-room clock sync, renderer discovery. |
+| Crate | Greek | Pronunciation | Over | L3 Essential Nature |
+|-------|-------|--------------|------|---------------------|
+| **paroche** | παροχή | pah-ro-KAY | "streaming" | Provision, supply: the act of making available. HTTP streaming, OPDS feeds, transcoding. |
+| **syndesmos** | σύνδεσμος | syn-DES-mos | "external APIs" | The ligament, the bond: that which connects distinct bodies. Single integration boundary for Plex, Last.fm, Tidal. |
 
 ### Household
 
-| Subsystem | Greek | Pronunciation | Over | L3 Essential Nature |
-|-----------|-------|--------------|------|---------------------|
-| **Aitesis** | αἴτησις | eye-TAY-sis | "requests" | The act of asking: a formal request, not casual speech. Household media request workflow: submission, approval, tracking. |
-
-### Cross-cutting
-
-| Subsystem | Greek | Pronunciation | Over | L3 Essential Nature |
-|-----------|-------|--------------|------|---------------------|
-| **Horismos** | ὁρισμός | hor-is-MOS | "config" | Definition, delimitation: the act of setting boundaries. All system configuration as the single parameterized source of truth. |
-| **Exousia** | ἐξουσία | ex-oo-SEE-ah | "auth" | Authority: the power that comes from legitimate standing. Identity, authentication, authorization for household users. |
-| **Aggelia** | ἀγγελία | an-geh-LEE-ah | "events" | The message, the announcement: past-tense facts about what has occurred. Internal event bus between subsystems. |
-| **Syndesmos** | σύνδεσμος | syn-DES-mos | "external APIs" | The ligament, the bond: that which connects distinct bodies. Single integration boundary for Plex, Last.fm, Tidal. |
+| Crate | Greek | Pronunciation | Over | L3 Essential Nature |
+|-------|-------|--------------|------|---------------------|
+| **aitesis** | αἴτησις | eye-TAY-sis | "requests" | The act of asking: a formal request, not casual speech. Household media request workflow: submission, approval, tracking. |
 
 ---
 
-## Frontend domains (Akroasis)
+## Audio engine
 
-| Domain | Greek | Pronunciation | Over | L3 Essential Nature |
-|--------|-------|--------------|------|---------------------|
-| **Prosopon** | πρόσωπον | PROS-oh-pon | "now-playing" | The face, the mask: the persona turned toward the listener. Playback interface, controls, queue. |
-| **Theoria** | θεωρία | theh-oh-REE-ah | "library" | Contemplative beholding: seeing that involves the whole mind. Library browsing and search. |
-| **Heuresis** | εὕρεσις | hew-REH-sis | "discovery" | Finding, discovery: the moment of encounter with something not previously known. Recommendations, related artists, unplayed items. |
-| **Boulesis** | βούλησις | boo-LAY-sis | "requests" | Rational, deliberate desire: wanting that involves will and judgment. Request submission and tracking. |
-| **Diatheesis** | διάθεσις | dee-AH-theh-sis | "settings" | Disposition, arrangement: how one is arranged to respond. User preferences, playback configuration. |
+| Crate | Greek | Pronunciation | Over | L3 Essential Nature |
+|-------|-------|--------------|------|---------------------|
+| **akroasis-core** | ἀκρόασις | ah-kroh-AH-sis | "audio engine" | The core listening apparatus: decode, DSP, and native audio output. Shared via FFI with the desktop app. Built independently (excluded from workspace). |
 
 ---
 
 ## Key topological relationships
 
-- **Mouseion ↔ Akroasis:** Collection and listening. Neither suffices alone. Harmonia is the claim that both are necessary.
-- **Episkope → Zetesis → Ergasia → Syntaxis → Taxis:** The acquisition pipeline: watch → seek → work → coordinate → arrange.
-- **Kritike → Episkope:** The only upward feedback edge. Quality assessment re-enters the acquisition pipeline for upgrades.
-- **Aitesis ↔ Boulesis:** Backend receives what frontend wills. Together they constitute the full request arc.
-- **Paroche ↔ Syndesis:** Parallel serving layers. HTTP for catalog clients, QUIC for native audio renderers.
-- **Horismos ← (all):** Configuration is the ground on which all subsystems stand.
+- **Backend → Akroasis:** Backend manages media, Akroasis plays it. Neither suffices alone. Harmonia is the claim that both are necessary.
+- **Zetesis → Ergasia → Syntaxis → Taxis:** The acquisition pipeline: seek → work → coordinate → arrange.
+- **Kritike → Zetesis:** Quality assessment re-enters the acquisition pipeline for upgrades.
+- **Horismos ← (all):** Configuration is the ground on which all crates stand.
 
 See [architecture/subsystems.md](architecture/subsystems.md) for the full dependency graph with mermaid diagrams.
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Updated repo tree to show `crates/`, `akroasis/shared/`, `desktop/`, removed mouseion/ and multi-language references. Build commands are cargo-only. Architecture describes the Rust platform as current. CI references `rust.yml` and `security.yml`.
- **PROJECT.md**: Architecture diagram reflects 15 Rust crates and Tauri desktop. Current state shows Phase 3 in progress with 543 tests. Removed mouseion/.NET references and open issues section.
- **lexicon.md**: Entries match actual Cargo.toml workspace members. Added `komide`, `harmonia-common`, `harmonia-db`, `harmonia-host`. Removed entries for crates that don't exist yet (`episkope`, `prostheke`, `aggelia`, `syndesis`) and frontend domains. Removed Mouseion as a named component.

No references to mouseion, .NET, dotnet, Kotlin, Jetpack Compose, React, npm, or TypeScript remain in the three files.

## Observations

- **Doc gap**: `docs/CLAUDE_CODE.md` still references mouseion, legacy/, dotnet, npm, and gradlew commands. Needs a similar rewrite.
- **Doc gap**: `akroasis/CLAUDE.md` still describes Android/Kotlin, Web/React/TS architecture that no longer exists in this repo.
- **Doc gap**: `docs/README.md` links to `roadmap/migration.md` ("Migration from C# backend") which is stale.
- **Idea**: The `desktop/` directory has its own package.json/vite.config.ts but no CLAUDE.md or build docs for the Tauri app.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (543 tests)
- [x] `git diff --stat` shows only the 3 target files changed
- [x] `grep -cinE 'mouseion|\.NET|dotnet|kotlin|jetpack|react|npm|typescript'` returns 0 for all 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)