### PR TITLE
docs: fix writing standard violations

### DIFF
--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -25,7 +25,7 @@ or explain what you would do. Do the work.
 - "Do not create files unless they're absolutely necessary."
 - "Read and understand existing code before suggesting modifications."
 
-**Avoid these anti-patterns that cause analysis-not-action:**
+**Anti-patterns that cause analysis instead of action:**
 - "Here is the task..." (reads as a briefing doc to analyze)
 - Long context sections before the action directive (model starts analyzing)
 - "You should..." / "Consider..." (advisory, not imperative)
@@ -36,7 +36,7 @@ or explain what you would do. Do the work.
 
 ## Environment
 
-- **Clone location:** `/home/ck/aletheia-ops/harmonia` on Metis
+- **Clone location:** `/home/ck/harmonia` on Metis
 - **Working directory:** Claude Code sessions are opened in this directory
 
 ## Prompt preamble
@@ -52,7 +52,7 @@ the prompt. Execute it.
 
 ## Setup
 
-You are working in the Harmonia repository at /home/ck/aletheia-ops/harmonia.
+You are working in the Harmonia repository at /home/ck/harmonia.
 
 Before doing anything:
 
@@ -70,7 +70,7 @@ Before doing anything:
    - Do NOT merge — Syn reviews and merges
 
 4. Clean up the worktree when done:
-   cd /home/ck/aletheia-ops/harmonia
+   cd /home/ck/harmonia
    git worktree remove ../worktrees/<branch-name>
 ```
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -29,7 +29,7 @@ One self-hosted media platform replacing the fragmented *arr ecosystem. A single
 
 ## Current state
 
-Phase 3 in progress. 15 workspace crates, 543 tests passing.
+Phase 3 complete. All 16 prompts merged (PRs #86–#102). 15 workspace crates, 543 tests passing.
 
 Completed in Phase 3:
 - Download execution and archive extraction (ergasia, P3-02)

--- a/docs/WORKING-AGREEMENT.md
+++ b/docs/WORKING-AGREEMENT.md
@@ -1,6 +1,6 @@
 # Working agreement: Syn + Cody
 
-> Canon. Referenced by all agents. Updated when we learn something.
+> Canon. All agents read this. Updated when we learn something.
 
 ---
 
@@ -44,7 +44,7 @@ When speed and quality conflict, quality wins. The measure of progress is: does 
 
 - **Prompts:** Syn writes them, Cody runs them via Claude Code.
 - **PRs:** Claude Code opens them, Syn reviews and merges.
-- **Decisions surfaced promptly.** Not buried in status updates, not resolved silently.
+- **Surface decisions promptly.** Don't bury them in status updates or resolve them silently.
 - **Corrections stick.** When Cody corrects a pattern, Syn internalizes it; it doesn't just acknowledge it. If the same correction happens twice, that's a failure.
 
 ## Anti-patterns (observed, named, watched for)

--- a/docs/gnomon.md
+++ b/docs/gnomon.md
@@ -18,7 +18,7 @@ Greek also offers:
 
 - **Productive compounding.** Roots, prefixes, and suffixes combine systematically. The grammar builds meaning.
 - **Defamiliarization.** An unfamiliar word resists assumption. You have to ask what it means, which means you have to think about what the thing *does*.
-- **Density.** Meaning compressed into sound. Aletheia is four syllables carrying an entire ontology: truth as *unconcealment*, the negation of forgetting.
+- **Density.** Meaning compressed into sound. Aletheia is four syllables carrying an entire ontology: truth as **unconcealment**, the negation of forgetting.
 
 The goal is not erudition. The goal is precision tools for systems that distinguish between many closely related things.
 
@@ -26,7 +26,7 @@ The goal is not erudition. The goal is precision tools for systems that distingu
 
 ## Building names
 
-Greek names are constructed, not found. Three components combine.
+You construct Greek names; you don't find them. Three components combine.
 
 **Roots** carry the semantic core:
 


### PR DESCRIPTION
Apply kanon writing standard fixes across four docs files.

## Changes

- **docs/PROJECT.md** — mark Phase 3 complete (all 16 prompts merged, PRs #86–#102)
- **docs/CLAUDE_CODE.md** — remove filler phrase ("Avoid these anti-patterns that cause analysis-not-action:" → "Anti-patterns that cause analysis instead of action:"); update stale clone path from `/home/ck/aletheia-ops/harmonia` to `/home/ck/harmonia`
- **docs/WORKING-AGREEMENT.md** — fix passive blockquote ("Referenced by all agents" → "All agents read this"); fix passive working pattern ("Decisions surfaced promptly. Not buried..." → "Surface decisions promptly. Don't bury them...")
- **docs/gnomon.md** — fix passive opening ("Greek names are constructed, not found" → "You construct Greek names; you don't find them"); fix italic-for-emphasis (`*unconcealment*` → `**unconcealment**`)
- **docs/VISION.md** — audited; no violations found (prior commit aa086cc already addressed them)

Closes #110, closes #111, closes #112, closes #113, closes #116