### PR TITLE
feat(akouo-core): extract audio engine into workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aitesis"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "harmonia-common",
  "harmonia-db",
@@ -44,6 +44,24 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "akouo-core"
+version = "0.1.2"
+dependencies = [
+ "cpal",
+ "ebur128",
+ "lofty",
+ "opus",
+ "rand 0.10.0",
+ "rstest",
+ "rubato",
+ "snafu",
+ "symphonia",
+ "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -66,6 +84,28 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "alsa"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "android_system_properties"
@@ -154,6 +194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +276,54 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25c5bb54993ad4693d8b68b6f29f872c5fd9f92a6469d0acb0cbaf80a13d0f9"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6af89882334c4e501faa08992888593ada468f9e1ab211635c32f9ada7786e0"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9a3d502fec0b21aa420febe0b110875cf8a7057c49e83a0cace1df6a73e03e"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
 
 [[package]]
 name = "autocfg"
@@ -405,6 +499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,10 +696,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "commoncrypto"
@@ -690,6 +818,50 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15c3c3cee7c087938f7ad1c3098840b3ef1f1bdc7f6e496336c3b1e7a6f3914"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
+dependencies = [
+ "alsa",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -859,6 +1031,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasp_frame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
+dependencies = [
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +1112,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +1143,18 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ebur128"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e227cc62d64d6fe01abbef48134b9c1f17d470cef1e7a56337ad05b1f81df7f9"
+dependencies = [
+ "bitflags 1.3.2",
+ "dasp_frame",
+ "dasp_sample",
+ "smallvec",
+]
 
 [[package]]
 name = "ecdsa"
@@ -1026,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "epignosis"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dashmap",
  "harmonia-common",
@@ -1049,7 +1258,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ergasia"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "dashmap",
@@ -1104,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "exousia"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "argon2",
  "axum",
@@ -1125,6 +1334,12 @@ dependencies = [
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -1470,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "harmonia-common"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "compact_str",
  "jiff",
@@ -1485,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "harmonia-db"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "harmonia-common",
  "jiff",
@@ -1501,9 +1716,10 @@ dependencies = [
 
 [[package]]
 name = "harmonia-host"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aitesis",
+ "akouo-core",
  "axum",
  "clap",
  "epignosis",
@@ -1624,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "horismos"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "figment",
  "harmonia-common",
@@ -2060,6 +2276,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "komide"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "feed-rs",
  "harmonia-common",
@@ -2143,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "kritike"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "harmonia-common",
  "harmonia-db",
@@ -2509,6 +2769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2888,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "network-interface"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,7 +2976,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
 dependencies = [
- "num-complex",
+ "num-complex 0.2.4",
  "num-integer",
  "num-iter",
  "num-rational",
@@ -2722,10 +3020,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-integer"
@@ -2766,6 +3084,117 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2840,6 +3269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "opus"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
+dependencies = [
+ "audiopus_sys",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "paroche"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "epignosis",
@@ -3096,6 +3534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "prostheke"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "harmonia-common",
  "harmonia-db",
@@ -3360,6 +3807,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,6 +4026,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rubato"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90173154a8a14e6adb109ea641743bc95ec81c093d94e70c6763565f7108ebeb"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-complex 0.4.6",
+ "num-integer",
+ "num-traits",
+ "realfft",
+ "visibility",
+ "windowfunctions",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,6 +4054,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex 0.4.6",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -4225,6 +4711,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4248,6 +4740,201 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,7 +4956,7 @@ dependencies = [
 
 [[package]]
 name = "syndesmos"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "harmonia-common",
  "harmonia-db",
@@ -4299,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "syntaxis"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ergasia",
  "harmonia-common",
@@ -4325,7 +5012,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taxis"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "harmonia-common",
  "harmonia-db",
@@ -4355,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "theatron-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -4772,6 +5459,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4967,6 +5664,17 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "walkdir"
@@ -5200,6 +5908,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5210,6 +5948,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5241,6 +5990,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5256,6 +6015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5292,6 +6060,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5343,6 +6126,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5362,6 +6160,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5377,6 +6181,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5410,6 +6220,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5425,6 +6241,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5446,6 +6268,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5461,6 +6289,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5703,7 +6537,7 @@ dependencies = [
 
 [[package]]
 name = "zetesis"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/harmonia-host",
     "crates/prostheke",
     "crates/theatron/core",
+    "crates/akouo-core",
 ]
 exclude = [
     "akouo/shared/akouo-core",
@@ -48,6 +49,7 @@ aitesis         = { path = "crates/aitesis" }
 syntaxis        = { path = "crates/syntaxis" }
 prostheke       = { path = "crates/prostheke" }
 theatron-core   = { path = "crates/theatron/core" }
+akouo-core      = { path = "crates/akouo-core" }
 
 # ── Async runtime ──────────────────────────────────────────────────────────────
 tokio           = { version = "1", features = ["full"] }

--- a/crates/akouo-core/Cargo.toml
+++ b/crates/akouo-core/Cargo.toml
@@ -1,0 +1,40 @@
+# crates/akouo-core — high-fidelity audio engine: decode, DSP, and output
+[package]
+name = "akouo-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "High-fidelity audio engine — decode, DSP, and output"
+
+[dependencies]
+# Audio decode
+symphonia.workspace = true
+opus.workspace = true
+lofty.workspace = true
+
+# Audio processing
+rubato.workspace = true
+ebur128.workspace = true
+
+# Audio output — requires ALSA on Linux; enable via "native-output" feature
+cpal = { workspace = true, optional = true }
+
+# Async runtime
+tokio.workspace = true
+
+# Error handling
+snafu.workspace = true
+
+# Logging
+tracing.workspace = true
+
+# Random (TPDF dither)
+rand.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true
+tempfile = "3"
+
+[features]
+# Native audio output via cpal (requires ALSA on Linux)
+native-output = ["cpal"]

--- a/crates/akouo-core/src/config.rs
+++ b/crates/akouo-core/src/config.rs
@@ -1,0 +1,327 @@
+use std::time::Duration;
+
+/// Top-level engine configuration.
+#[derive(Debug, Clone)]
+pub struct EngineConfig {
+    /// Ring buffer capacity in samples per channel.
+    pub ring_buffer_capacity: usize,
+    /// Pre-buffer threshold before playback starts.
+    pub prebuffer_threshold: Duration,
+    /// DSP pipeline configuration.
+    pub dsp: DspConfig,
+    /// Audio output configuration.
+    pub output: OutputConfig,
+}
+
+impl Default for EngineConfig {
+    fn default() -> Self {
+        Self {
+            ring_buffer_capacity: 65536,
+            prebuffer_threshold: Duration::from_millis(500),
+            dsp: DspConfig::default(),
+            output: OutputConfig::default(),
+        }
+    }
+}
+
+/// Configuration for the full DSP pipeline.
+#[derive(Debug, Clone, Default)]
+pub struct DspConfig {
+    pub skip_silence: SkipSilenceConfig,
+    pub eq: EqConfig,
+    pub crossfeed: CrossfeedConfig,
+    pub replaygain: ReplayGainConfig,
+    pub compressor: CompressorConfig,
+    pub convolution: ConvolutionConfig,
+    pub volume: VolumeConfig,
+}
+
+/// Skip-silence stage: trims silence below a threshold at track boundaries.
+#[derive(Debug, Clone)]
+pub struct SkipSilenceConfig {
+    pub enabled: bool,
+    /// Silence threshold in dBFS (negative). Samples below this level are considered silent.
+    pub threshold_db: f64,
+    /// Minimum consecutive silent frames before trimming begins.
+    pub min_silence_samples: usize,
+    /// Maximum consecutive silent frames to remove. Silence beyond this passes through
+    /// unchanged to preserve intentional pauses.
+    pub max_silence_samples: usize,
+}
+
+impl Default for SkipSilenceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            threshold_db: -60.0,
+            min_silence_samples: 441,    // 10 ms at 44.1 kHz
+            max_silence_samples: 132300, // 3 s at 44.1 kHz
+        }
+    }
+}
+
+/// Biquad filter type for a parametric EQ band.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum FilterType {
+    #[default]
+    Peaking,
+    LowShelf,
+    HighShelf,
+    LowPass,
+    HighPass,
+    Notch,
+    AllPass,
+}
+
+/// Parametric EQ stage.
+#[derive(Debug, Clone, Default)]
+pub struct EqConfig {
+    pub enabled: bool,
+    pub bands: Vec<EqBand>,
+}
+
+impl EqConfig {
+    /// Returns a 10-band EQ at ISO standard center frequencies, all gains at 0 dB.
+    pub fn iso_10_band_default() -> Self {
+        const ISO_FREQS: [f64; 10] = [
+            31.0, 63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0,
+        ];
+        Self {
+            enabled: false,
+            bands: ISO_FREQS
+                .iter()
+                .map(|&f| EqBand {
+                    frequency: f,
+                    gain_db: 0.0,
+                    q: 1.414,
+                    filter_type: FilterType::Peaking,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// A single parametric EQ band.
+#[derive(Debug, Clone)]
+pub struct EqBand {
+    /// Center frequency in Hz.
+    pub frequency: f64,
+    /// Gain in dB (negative = cut, positive = boost).
+    pub gain_db: f64,
+    /// Q factor (bandwidth).
+    pub q: f64,
+    /// Filter topology.
+    pub filter_type: FilterType,
+}
+
+/// Crossfeed stage: blends stereo channels for headphone listening.
+#[derive(Debug, Clone)]
+pub struct CrossfeedConfig {
+    pub enabled: bool,
+    /// Crossfeed strength 0.0–1.0.
+    pub strength: f64,
+}
+
+impl Default for CrossfeedConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            strength: 0.3,
+        }
+    }
+}
+
+/// ReplayGain / EBU R128 normalization stage.
+#[derive(Debug, Clone)]
+pub struct ReplayGainConfig {
+    pub enabled: bool,
+    pub mode: ReplayGainMode,
+    /// Pre-amplification gain in dB applied on top of the tag-based gain.
+    pub preamp_db: f64,
+    /// Fall back to track gain when album gain is unavailable.
+    pub fallback_to_track: bool,
+    /// Gain applied when no tags are found (default 0 dB = no change).
+    pub fallback_gain_db: f64,
+    /// Reduce gain if `peak * gain_linear > 1.0` to prevent clipping.
+    pub prevent_clipping: bool,
+    // Per-track metadata set by the engine when a new track starts.
+    pub track_gain_db: Option<f64>,
+    pub track_peak: Option<f64>,
+    pub album_gain_db: Option<f64>,
+    pub album_peak: Option<f64>,
+    /// EBU R128 track loudness offset (used by Opus tracks).
+    pub r128_track_gain: Option<f64>,
+    pub r128_album_gain: Option<f64>,
+}
+
+impl Default for ReplayGainConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mode: ReplayGainMode::Track,
+            preamp_db: 0.0,
+            fallback_to_track: true,
+            fallback_gain_db: 0.0,
+            prevent_clipping: true,
+            track_gain_db: None,
+            track_peak: None,
+            album_gain_db: None,
+            album_peak: None,
+            r128_track_gain: None,
+            r128_album_gain: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReplayGainMode {
+    Track,
+    Album,
+    /// EBU R128 integrated loudness normalization.
+    R128,
+}
+
+/// Dynamics compressor / limiter stage.
+#[derive(Debug, Clone)]
+pub struct CompressorConfig {
+    pub enabled: bool,
+    pub threshold_db: f64,
+    pub ratio: f64,
+    pub attack_ms: f64,
+    pub release_ms: f64,
+    /// Hard limiter ceiling in dBFS.
+    pub limiter_ceiling_db: f64,
+}
+
+impl Default for CompressorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            threshold_db: -6.0,
+            ratio: 4.0,
+            attack_ms: 5.0,
+            release_ms: 100.0,
+            limiter_ceiling_db: -0.1,
+        }
+    }
+}
+
+/// Convolution reverb / room correction stage.
+#[derive(Debug, Clone)]
+pub struct ConvolutionConfig {
+    pub enabled: bool,
+    /// Path to the impulse response file. `None` = passthrough.
+    pub ir_path: Option<std::path::PathBuf>,
+    /// Output gain in dB applied after convolution.
+    pub output_gain_db: f64,
+}
+
+impl Default for ConvolutionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ir_path: None,
+            output_gain_db: 0.0,
+        }
+    }
+}
+
+/// Volume control and TPDF dither stage.
+#[derive(Debug, Clone)]
+pub struct VolumeConfig {
+    /// Main volume in dB (0 dB = unity, negative = attenuation).
+    pub level_db: f64,
+    /// Enable TPDF dither when quantizing to output bit depth.
+    pub dither: bool,
+}
+
+impl Default for VolumeConfig {
+    fn default() -> Self {
+        Self {
+            level_db: 0.0,
+            dither: true,
+        }
+    }
+}
+
+/// Audio output configuration.
+#[derive(Debug, Clone)]
+pub struct OutputConfig {
+    /// Target output device name. `None` = system default.
+    pub device_name: Option<String>,
+    pub buffer_size: BufferSize,
+    /// Request exclusive mode from the OS (WASAPI/CoreAudio).
+    pub exclusive_mode: bool,
+    /// Target bit depth for output quantization.
+    pub bit_depth: u32,
+}
+
+impl Default for OutputConfig {
+    fn default() -> Self {
+        Self {
+            device_name: None,
+            buffer_size: BufferSize::default(),
+            exclusive_mode: false,
+            bit_depth: 24,
+        }
+    }
+}
+
+/// Output buffer size hint passed to the audio backend.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub enum BufferSize {
+    /// Let the backend choose the buffer size.
+    #[default]
+    Default,
+    /// Fixed buffer size in frames.
+    Fixed(u32),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_config_defaults() {
+        let cfg = EngineConfig::default();
+        assert_eq!(cfg.ring_buffer_capacity, 65536);
+        assert_eq!(cfg.prebuffer_threshold, Duration::from_millis(500));
+        assert_eq!(cfg.output.bit_depth, 24);
+    }
+
+    #[test]
+    fn dsp_config_stages_disabled_by_default() {
+        let dsp = DspConfig::default();
+        assert!(!dsp.skip_silence.enabled);
+        assert!(!dsp.eq.enabled);
+        assert!(!dsp.crossfeed.enabled);
+        assert!(!dsp.replaygain.enabled);
+        assert!(!dsp.compressor.enabled);
+        assert!(!dsp.convolution.enabled);
+    }
+
+    #[test]
+    fn volume_config_unity_gain_default() {
+        let vol = VolumeConfig::default();
+        assert_eq!(vol.level_db, 0.0);
+        assert!(vol.dither);
+    }
+
+    #[test]
+    fn compressor_config_reasonable_defaults() {
+        let comp = CompressorConfig::default();
+        assert!(comp.ratio > 1.0);
+        assert!(comp.threshold_db < 0.0);
+        assert!(comp.limiter_ceiling_db < 0.0);
+    }
+
+    #[test]
+    fn skip_silence_threshold_is_negative() {
+        let cfg = SkipSilenceConfig::default();
+        assert!(cfg.threshold_db < 0.0);
+        assert!(cfg.min_silence_samples > 0);
+    }
+}

--- a/crates/akouo-core/src/decode/metadata.rs
+++ b/crates/akouo-core/src/decode/metadata.rs
@@ -1,0 +1,232 @@
+// Tag and audio property metadata.
+
+use std::path::Path;
+use std::time::Duration;
+
+use lofty::prelude::{Accessor, AudioFile, ItemKey, TaggedFileExt};
+use tracing::instrument;
+
+use crate::decode::{Codec, GaplessInfo};
+use crate::error::DecodeError;
+
+/// Tag and audio property metadata read from a source file via lofty.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct TrackMetadata {
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub track_number: Option<u32>,
+    pub duration: Option<Duration>,
+
+    pub replaygain_track_gain: Option<f32>,
+    pub replaygain_track_peak: Option<f32>,
+    pub replaygain_album_gain: Option<f32>,
+    pub replaygain_album_peak: Option<f32>,
+
+    /// EBU R128 track loudness offset in 1/256 LU units (i16).
+    pub r128_track_gain: Option<i16>,
+    /// EBU R128 album loudness offset in 1/256 LU units (i16).
+    pub r128_album_gain: Option<i16>,
+}
+
+/// Reads gapless timing metadata for `path`.
+///
+/// Sources per codec:
+/// - **MP3**: Xing/LAME header (via symphonia codec params with `enable_gapless`)
+/// - **Vorbis**: 3456-sample pre-skip (hardcoded; symphonia issue #418)
+/// - **AAC / ALAC**: iTunSMPB / codec params from MP4 container
+/// - **Opus**: OGG header pre-skip via symphonia codec params
+/// - **FLAC / WAV / AIFF**: no encoder delay — returns `None`
+#[instrument]
+pub fn read_gapless_info(path: &Path, codec: &Codec) -> Option<GaplessInfo> {
+    use symphonia::core::codecs::CODEC_TYPE_NULL;
+    use symphonia::core::formats::FormatOptions;
+    use symphonia::core::io::MediaSourceStream;
+    use symphonia::core::meta::MetadataOptions;
+    use symphonia::core::probe::Hint;
+
+    if matches!(codec, Codec::Vorbis) {
+        return Some(GaplessInfo {
+            encoder_delay: 3456,
+            encoder_padding: 0,
+            total_samples: None,
+        });
+    }
+
+    if matches!(codec, Codec::Flac | Codec::Wav | Codec::Aiff) {
+        return None;
+    }
+
+    let file = std::fs::File::open(path).ok()?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+
+    let probed = symphonia::default::get_probe()
+        .format(
+            &hint,
+            mss,
+            &FormatOptions {
+                enable_gapless: true,
+                ..Default::default()
+            },
+            &MetadataOptions::default(),
+        )
+        .ok()?;
+
+    let track = probed
+        .format
+        .tracks()
+        .iter()
+        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)?;
+
+    let p = &track.codec_params;
+    if p.delay.is_some() || p.padding.is_some() {
+        Some(GaplessInfo {
+            encoder_delay: p.delay.unwrap_or(0),
+            encoder_padding: p.padding.unwrap_or(0),
+            total_samples: p.n_frames,
+        })
+    } else {
+        None
+    }
+}
+
+/// Reads tag and audio properties from `path` using lofty.
+///
+/// ReplayGain and R128 values are parsed from string tags. Missing or
+/// unparseable values are silently omitted — callers should apply sensible
+/// defaults.
+#[instrument]
+pub fn read_track_metadata(path: &Path) -> Result<TrackMetadata, DecodeError> {
+    let tagged = lofty::read_from_path(path).map_err(|e| DecodeError::Metadata {
+        message: format!("lofty read failed: {e}"),
+        location: snafu::location!(),
+    })?;
+
+    let duration = Some(tagged.properties().duration());
+
+    let (title, artist, album, track_number, rg_tg, rg_tp, rg_ag, rg_ap, r128_tg, r128_ag) =
+        if let Some(tag) = tagged.primary_tag() {
+            let rg_tg = tag
+                .get_string(ItemKey::ReplayGainTrackGain)
+                .and_then(parse_gain_db);
+            let rg_tp = tag
+                .get_string(ItemKey::ReplayGainTrackPeak)
+                .and_then(parse_float);
+            let rg_ag = tag
+                .get_string(ItemKey::ReplayGainAlbumGain)
+                .and_then(parse_gain_db);
+            let rg_ap = tag
+                .get_string(ItemKey::ReplayGainAlbumPeak)
+                .and_then(parse_float);
+
+            // R128 tags are not in lofty's ItemKey enum — search by raw key value.
+            let r128_tg = find_custom_tag_i16(tag, "R128_TRACK_GAIN");
+            let r128_ag = find_custom_tag_i16(tag, "R128_ALBUM_GAIN");
+
+            (
+                tag.title().map(|v| v.to_string()),
+                tag.artist().map(|v| v.to_string()),
+                tag.album().map(|v| v.to_string()),
+                tag.track(),
+                rg_tg,
+                rg_tp,
+                rg_ag,
+                rg_ap,
+                r128_tg,
+                r128_ag,
+            )
+        } else {
+            (None, None, None, None, None, None, None, None, None, None)
+        };
+
+    Ok(TrackMetadata {
+        title,
+        artist,
+        album,
+        track_number,
+        duration,
+        replaygain_track_gain: rg_tg,
+        replaygain_track_peak: rg_tp,
+        replaygain_album_gain: rg_ag,
+        replaygain_album_peak: rg_ap,
+        r128_track_gain: r128_tg,
+        r128_album_gain: r128_ag,
+    })
+}
+
+/// Searches tag items for a custom key and parses its value as i16.
+fn find_custom_tag_i16(tag: &lofty::tag::Tag, key_name: &str) -> Option<i16> {
+    for item in tag.items() {
+        if let Some(mapped) = item.key().map_key(tag.tag_type())
+            && mapped.eq_ignore_ascii_case(key_name)
+            && let lofty::tag::ItemValue::Text(ref s) = *item.value()
+        {
+            return s.trim().parse().ok();
+        }
+    }
+    None
+}
+
+/// Parses a ReplayGain dB string like `"-3.50 dB"` or `"-3.50"` to `f32`.
+fn parse_gain_db(s: &str) -> Option<f32> {
+    s.trim().trim_end_matches("dB").trim().parse().ok()
+}
+
+/// Parses a bare float string.
+fn parse_float(s: &str) -> Option<f32> {
+    s.trim().parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vorbis_gapless_hardcoded_3456() {
+        let info = read_gapless_info(Path::new("/dev/null"), &Codec::Vorbis);
+        assert!(info.is_some());
+        let info = info.expect("vorbis gapless should return Some");
+        assert_eq!(info.encoder_delay, 3456);
+        assert_eq!(info.encoder_padding, 0);
+    }
+
+    #[test]
+    fn flac_gapless_is_none() {
+        let info = read_gapless_info(Path::new("/dev/null"), &Codec::Flac);
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn wav_gapless_is_none() {
+        let info = read_gapless_info(Path::new("/dev/null"), &Codec::Wav);
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn aiff_gapless_is_none() {
+        let info = read_gapless_info(Path::new("/dev/null"), &Codec::Aiff);
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn parse_gain_db_with_suffix() {
+        let v = parse_gain_db("-3.50 dB").expect("should parse");
+        assert!((v - (-3.50f32)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn parse_gain_db_without_suffix() {
+        let v = parse_gain_db("-3.50").expect("should parse");
+        assert!((v - (-3.50f32)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn parse_gain_db_invalid_returns_none() {
+        assert!(parse_gain_db("not a number").is_none());
+    }
+}

--- a/crates/akouo-core/src/decode/mod.rs
+++ b/crates/akouo-core/src/decode/mod.rs
@@ -1,0 +1,90 @@
+pub mod metadata;
+pub mod opus;
+pub mod probe;
+pub mod symphonia;
+pub mod wavpack;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use crate::error::DecodeError;
+
+/// Identifies the codec of an audio stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Codec {
+    Flac,
+    Alac,
+    Wav,
+    Aiff,
+    Mp3,
+    Aac,
+    Vorbis,
+    Opus,
+    /// A codec not explicitly enumerated — carries a human-readable label.
+    Other(String),
+}
+
+/// Parameters describing a decoded audio stream.
+#[derive(Debug, Clone)]
+pub struct StreamParams {
+    pub codec: Codec,
+    pub sample_rate: u32,
+    pub channels: u16,
+    /// Bit depth of the source (e.g. 16, 24, 32). `None` for lossy codecs.
+    pub bit_depth: Option<u32>,
+    pub duration: Option<Duration>,
+    /// Bitrate in kbps. `None` when unavailable.
+    pub bitrate: Option<u32>,
+}
+
+/// Gapless playback metadata embedded in the source file.
+#[derive(Debug, Clone)]
+pub struct GaplessInfo {
+    /// Encoder delay in samples to skip at the start.
+    pub encoder_delay: u32,
+    /// Encoder padding in samples to skip at the end.
+    pub encoder_padding: u32,
+    /// Total PCM sample count after applying delay and padding, if known.
+    pub total_samples: Option<u64>,
+}
+
+/// A single decoded audio frame: interleaved f64 samples in [-1.0, 1.0].
+#[derive(Debug, Clone)]
+pub struct DecodedFrame {
+    /// Interleaved samples: for stereo, layout is [L, R, L, R, ...].
+    pub samples: Box<[f64]>,
+    pub channels: u16,
+    pub sample_rate: u32,
+    /// Sample offset from the start of the stream (before gapless trimming).
+    pub timestamp: u64,
+}
+
+/// An async audio decoder. Implementations drive symphonia, opus, or other backends.
+///
+/// Methods return `Pin<Box<dyn Future>>` so the trait is dyn-compatible and can be
+/// used as `Box<dyn AudioDecoder>` without the async-trait crate. Decoder state is
+/// mutably accessed only from the single decode task — no external locking needed.
+///
+/// The `Pin<Box<dyn Future>>` return types enable `Box<dyn AudioDecoder>` — necessary
+/// for probe.rs to return an erased decoder without knowing the concrete type at compile
+/// time. The `'_` lifetime binds the future's lifetime to the `&mut self` borrow.
+pub trait AudioDecoder: Send {
+    /// Returns the next decoded frame, or `None` at end of stream.
+    fn next_frame(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<DecodedFrame>, DecodeError>> + Send + '_>>;
+
+    /// Seeks to the requested position. Returns the actual position reached.
+    fn seek(
+        &mut self,
+        position: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Duration, DecodeError>> + Send + '_>>;
+
+    /// Stream parameters discovered during open/probe.
+    fn stream_params(&self) -> StreamParams;
+
+    /// Gapless metadata if present in the source.
+    fn gapless_info(&self) -> Option<GaplessInfo>;
+}

--- a/crates/akouo-core/src/decode/opus.rs
+++ b/crates/akouo-core/src/decode/opus.rs
@@ -1,0 +1,295 @@
+// P1-03: OpusDecoder — FFI bridge wrapping libopus via the `opus` crate.
+//
+// Symphonia's OGG demuxer extracts raw Opus packets; `opus::Decoder` decodes them.
+// When Symphonia's native Opus decoder reaches production readiness (PR #398), this
+// bridge can be removed without API change — it implements the same AudioDecoder trait.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use symphonia::core::codecs::{CODEC_TYPE_OPUS, CodecParameters};
+use symphonia::core::formats::{FormatReader, SeekMode, SeekTo};
+use symphonia::core::probe::ProbeResult;
+use symphonia::core::units::{Time, TimeBase};
+
+use crate::decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams};
+use crate::error::DecodeError;
+
+/// Opus is always 48 kHz internally.
+const OPUS_SAMPLE_RATE: u32 = 48_000;
+
+/// Maximum Opus frame size: 120 ms at 48 kHz per channel.
+const OPUS_MAX_FRAME_SAMPLES: usize = 5_760;
+
+/// Opus FFI decoder. Demuxes OGG via Symphonia, decodes packets via libopus.
+///
+/// All I/O is synchronous (std file reads); the `Pin<Box<dyn Future>>` wrappers
+/// return `std::future::ready(result)` so the caller can await without blocking.
+pub struct OpusDecoder {
+    decoder: opus::Decoder,
+    format_reader: Box<dyn FormatReader>,
+    track_id: u32,
+    params: StreamParams,
+    gapless: Option<GaplessInfo>,
+    time_base: TimeBase,
+    /// Pre-allocated f32 output from `opus::Decoder::decode_float` (interleaved channels).
+    decode_buf: Box<[f32]>,
+    /// Widened f64 copy for the internal pipeline.
+    output_buf: Box<[f64]>,
+}
+
+impl OpusDecoder {
+    /// Constructs an `OpusDecoder` from an already-probed Symphonia `ProbeResult`.
+    ///
+    /// The caller (probe.rs) does the format detection; this constructor takes
+    /// ownership and sets up the libopus decoder for the OGG/Opus track.
+    pub fn from_probed(probed: ProbeResult) -> Result<Box<dyn AudioDecoder>, DecodeError> {
+        let format = probed.format;
+
+        let track = format
+            .tracks()
+            .iter()
+            .find(|t| t.codec_params.codec == CODEC_TYPE_OPUS)
+            .ok_or_else(|| DecodeError::OpusDecode {
+                message: "no Opus track found in OGG container".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        let track_id = track.id;
+        let codec_params = track.codec_params.clone();
+
+        let channels = codec_params.channels.map(|c| c.count() as u16).unwrap_or(2);
+
+        let opus_channels = if channels == 1 {
+            opus::Channels::Mono
+        } else {
+            opus::Channels::Stereo
+        };
+
+        let decoder = opus::Decoder::new(OPUS_SAMPLE_RATE, opus_channels).map_err(|e| {
+            DecodeError::OpusDecode {
+                message: format!("failed to initialise libopus decoder: {e}"),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            }
+        })?;
+
+        let time_base = codec_params.time_base.unwrap_or(TimeBase {
+            numer: 1,
+            denom: OPUS_SAMPLE_RATE,
+        });
+
+        let duration = codec_params.n_frames.map(|n| {
+            let t = time_base.calc_time(n);
+            Duration::from_secs_f64(t.seconds as f64 + t.frac)
+        });
+
+        let params = StreamParams {
+            codec: Codec::Opus,
+            sample_rate: OPUS_SAMPLE_RATE,
+            channels,
+            bit_depth: None,
+            duration,
+            bitrate: codec_params.bits_per_coded_sample.map(|b| b / 1000),
+        };
+
+        let gapless = build_gapless_info(&codec_params);
+
+        let buf_samples = OPUS_MAX_FRAME_SAMPLES * channels as usize;
+        let decode_buf = vec![0.0f32; buf_samples].into_boxed_slice();
+        let output_buf = vec![0.0f64; buf_samples].into_boxed_slice();
+
+        Ok(Box::new(Self {
+            decoder,
+            format_reader: format,
+            track_id,
+            params,
+            gapless,
+            time_base,
+            decode_buf,
+            output_buf,
+        }))
+    }
+
+    fn decode_next_packet(&mut self) -> Result<Option<DecodedFrame>, DecodeError> {
+        loop {
+            let packet = match self.format_reader.next_packet() {
+                Ok(p) => p,
+                Err(symphonia::core::errors::Error::IoError(e))
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+                {
+                    return Ok(None);
+                }
+                Err(e) => {
+                    return Err(DecodeError::SymphoniaRead {
+                        message: format!("OGG read error: {e}"),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    });
+                }
+            };
+
+            if packet.track_id() != self.track_id {
+                continue;
+            }
+
+            let timestamp = packet.ts();
+
+            // An empty slice triggers Opus Packet Loss Concealment (PLC).
+            let n_samples_per_channel = self
+                .decoder
+                .decode_float(packet.buf(), &mut self.decode_buf, false)
+                .map_err(|e| DecodeError::OpusDecode {
+                    message: format!("decode_float failed: {e}"),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+
+            let channels = self.params.channels as usize;
+            let total = n_samples_per_channel * channels;
+
+            // Widen f32 → f64. Cast is lossless for audio-range values.
+            for (i, &s) in self.decode_buf[..total].iter().enumerate() {
+                self.output_buf[i] = s as f64;
+            }
+
+            return Ok(Some(DecodedFrame {
+                samples: self.output_buf[..total].to_vec().into_boxed_slice(),
+                channels: self.params.channels,
+                sample_rate: OPUS_SAMPLE_RATE,
+                timestamp,
+            }));
+        }
+    }
+
+    fn do_seek(&mut self, position: Duration) -> Result<Duration, DecodeError> {
+        let time = Time {
+            seconds: position.as_secs(),
+            frac: position.subsec_nanos() as f64 / 1e9,
+        };
+
+        let seeked = self
+            .format_reader
+            .seek(
+                SeekMode::Accurate,
+                SeekTo::Time {
+                    time,
+                    track_id: Some(self.track_id),
+                },
+            )
+            .map_err(|e| DecodeError::SymphoniaRead {
+                message: format!("seek failed: {e}"),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        // Recreate decoder to clear internal state after seek.
+        let opus_channels = if self.params.channels == 1 {
+            opus::Channels::Mono
+        } else {
+            opus::Channels::Stereo
+        };
+        self.decoder = opus::Decoder::new(OPUS_SAMPLE_RATE, opus_channels).map_err(|e| {
+            DecodeError::OpusDecode {
+                message: format!("decoder reset after seek failed: {e}"),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            }
+        })?;
+
+        let actual_time = self.time_base.calc_time(seeked.actual_ts);
+        Ok(Duration::from_secs_f64(
+            actual_time.seconds as f64 + actual_time.frac,
+        ))
+    }
+}
+
+impl AudioDecoder for OpusDecoder {
+    fn next_frame(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<DecodedFrame>, DecodeError>> + Send + '_>> {
+        Box::pin(std::future::ready(self.decode_next_packet()))
+    }
+
+    fn seek(
+        &mut self,
+        position: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Duration, DecodeError>> + Send + '_>> {
+        Box::pin(std::future::ready(self.do_seek(position)))
+    }
+
+    fn stream_params(&self) -> StreamParams {
+        self.params.clone()
+    }
+
+    fn gapless_info(&self) -> Option<GaplessInfo> {
+        self.gapless.clone()
+    }
+}
+
+fn build_gapless_info(params: &CodecParameters) -> Option<GaplessInfo> {
+    let delay = params.delay?;
+    let padding = params.padding.unwrap_or(0);
+    let total_samples = params
+        .n_frames
+        .map(|n| n.saturating_sub(u64::from(delay) + u64::from(padding)));
+    Some(GaplessInfo {
+        encoder_delay: delay,
+        encoder_padding: padding,
+        total_samples,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use symphonia::core::codecs::CodecParameters;
+
+    use super::*;
+
+    #[test]
+    fn f32_to_f64_conversion_is_lossless_for_audio_range() {
+        let samples: &[f32] = &[1.0, -1.0, 0.5, -0.5, 0.0, 0.123_456_79];
+        for &s in samples {
+            let widened = s as f64;
+            // The round-trip back to f32 must be identical.
+            assert_eq!(widened as f32, s, "cast must round-trip for {s}");
+        }
+    }
+
+    #[test]
+    fn build_gapless_info_extracts_pre_skip_and_padding() {
+        let mut params = CodecParameters::new();
+        params.delay = Some(3840);
+        params.padding = Some(120);
+        params.n_frames = Some(2_257_920);
+
+        let info = build_gapless_info(&params).expect("should build gapless info");
+        assert_eq!(info.encoder_delay, 3840);
+        assert_eq!(info.encoder_padding, 120);
+        assert_eq!(info.total_samples, Some(2_257_920 - 3840 - 120));
+    }
+
+    #[test]
+    fn build_gapless_info_returns_none_without_delay() {
+        let params = CodecParameters::new();
+        assert!(build_gapless_info(&params).is_none());
+    }
+
+    #[test]
+    fn build_gapless_info_padding_defaults_to_zero() {
+        let mut params = CodecParameters::new();
+        params.delay = Some(312);
+        // padding intentionally not set
+
+        let info = build_gapless_info(&params).expect("should build gapless info");
+        assert_eq!(info.encoder_padding, 0);
+        assert_eq!(info.total_samples, None); // n_frames not set
+    }
+
+    #[test]
+    fn opus_plc_decode_produces_concealment_audio() {
+        // Passing an empty slice to decode_float triggers Opus Packet Loss Concealment.
+        let mut dec =
+            opus::Decoder::new(48_000, opus::Channels::Stereo).expect("libopus must be available");
+        let mut buf = vec![0.0f32; OPUS_MAX_FRAME_SAMPLES * 2];
+        let result = dec.decode_float(&[], &mut buf, false);
+        assert!(result.is_ok(), "PLC decode must not error: {result:?}");
+        assert!(result.unwrap() > 0, "PLC must produce samples");
+    }
+}

--- a/crates/akouo-core/src/decode/probe.rs
+++ b/crates/akouo-core/src/decode/probe.rs
@@ -1,0 +1,167 @@
+// Format detection and decoder selection.
+//
+// P1-02 owns: SymphoniaDecoder path (all non-Opus formats).
+// P1-03 owns: Opus routing (OpusDecoder) + WavPack rejection.
+
+use std::path::Path;
+
+use symphonia::core::codecs::{CODEC_TYPE_NULL, CODEC_TYPE_OPUS, CODEC_TYPE_WAVPACK};
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+use crate::decode::opus::OpusDecoder;
+use crate::decode::symphonia::{SymphoniaDecoder, map_codec};
+use crate::decode::{AudioDecoder, Codec};
+use crate::error::DecodeError;
+
+/// Probes `path` and returns a boxed decoder appropriate for the detected format.
+///
+/// Routing:
+/// - OGG/Opus  → `OpusDecoder` (Symphonia OGG demux + libopus FFI)
+/// - WavPack   → `UnsupportedCodec` error (implement via wavpack-sys when needed)
+/// - All others (FLAC, WAV, ALAC, MP3, AAC, AIFF, Vorbis) → `SymphoniaDecoder` (P1-02)
+pub async fn open_decoder(path: &Path) -> Result<Box<dyn AudioDecoder>, DecodeError> {
+    let probed = probe_format(path)?;
+    let codec = probed.format.default_track().map(|t| t.codec_params.codec);
+
+    match codec {
+        Some(CODEC_TYPE_OPUS) => OpusDecoder::from_probed(probed),
+
+        Some(CODEC_TYPE_WAVPACK) => Err(DecodeError::UnsupportedCodec {
+            codec: Codec::Other("WavPack".to_string()),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        }),
+
+        _ => {
+            let mss = MediaSourceStream::new(
+                Box::new(
+                    std::fs::File::open(path).map_err(|e| DecodeError::SymphoniaRead {
+                        message: format!("failed to open {}: {e}", path.display()),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    })?,
+                ),
+                Default::default(),
+            );
+            let hint = hint_from_path(path);
+            let dec = SymphoniaDecoder::new(mss, &hint)?;
+            Ok(Box::new(dec) as Box<dyn AudioDecoder>)
+        }
+    }
+}
+
+/// Returns the codec for a file without fully opening a decoder. Useful for UI display.
+pub async fn probe_codec(path: &Path) -> Result<Codec, DecodeError> {
+    let probed = probe_format(path)?;
+
+    let codec_type = probed
+        .format
+        .default_track()
+        .map(|t| t.codec_params.codec)
+        .unwrap_or(CODEC_TYPE_NULL);
+
+    Ok(map_codec(codec_type))
+}
+
+/// Opens `path` and runs Symphonia's format probe. Shared by `open_decoder` and `probe_codec`.
+fn probe_format(path: &Path) -> Result<symphonia::core::probe::ProbeResult, DecodeError> {
+    let file = std::fs::File::open(path).map_err(|e| DecodeError::SymphoniaRead {
+        message: format!("failed to open {}: {e}", path.display()),
+        location: snafu::Location::new(file!(), line!(), column!()),
+    })?;
+
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+
+    let hint = hint_from_path(path);
+
+    symphonia::default::get_probe()
+        .format(
+            &hint,
+            mss,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .map_err(|e| DecodeError::SymphoniaRead {
+            message: format!("format probe failed for {}: {e}", path.display()),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })
+}
+
+fn hint_from_path(path: &Path) -> Hint {
+    let mut hint = Hint::new();
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+    hint
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    /// Builds a minimal valid WAV and writes it to a tempfile.
+    fn wav_tempfile(channels: u16, sample_rate: u32, samples: &[i16]) -> NamedTempFile {
+        let data_len = (samples.len() * 2) as u32;
+        let byte_rate = sample_rate * channels as u32 * 2;
+        let block_align = channels * 2;
+
+        let mut v = Vec::new();
+        v.extend_from_slice(b"RIFF");
+        v.extend_from_slice(&(36 + data_len).to_le_bytes());
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(b"fmt ");
+        v.extend_from_slice(&16u32.to_le_bytes());
+        v.extend_from_slice(&1u16.to_le_bytes());
+        v.extend_from_slice(&channels.to_le_bytes());
+        v.extend_from_slice(&sample_rate.to_le_bytes());
+        v.extend_from_slice(&byte_rate.to_le_bytes());
+        v.extend_from_slice(&block_align.to_le_bytes());
+        v.extend_from_slice(&16u16.to_le_bytes());
+        v.extend_from_slice(b"data");
+        v.extend_from_slice(&data_len.to_le_bytes());
+        for &s in samples {
+            v.extend_from_slice(&s.to_le_bytes());
+        }
+
+        let mut f = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
+        f.write_all(&v).unwrap();
+        f
+    }
+
+    #[tokio::test]
+    async fn probe_wav_returns_wav_codec() {
+        let f = wav_tempfile(2, 44100, &[0i16; 4]);
+        let codec = probe_codec(f.path()).await.expect("probe failed");
+        assert!(matches!(codec, Codec::Wav), "expected Wav, got {codec:?}");
+    }
+
+    #[tokio::test]
+    async fn open_decoder_wav_streams_frames() {
+        let f = wav_tempfile(2, 44100, &[0i16; 4]);
+        let mut dec = open_decoder(f.path()).await.expect("open failed");
+        let frame = dec.next_frame().await.expect("decode error");
+        assert!(
+            frame.is_some(),
+            "expected at least one frame from 4-sample WAV"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_decoder_empty_wav_returns_none() {
+        let f = wav_tempfile(2, 44100, &[]);
+        let mut dec = open_decoder(f.path()).await.expect("open failed");
+        let frame = dec.next_frame().await.expect("decode error");
+        assert!(frame.is_none(), "expected Ok(None) for empty WAV");
+    }
+
+    #[tokio::test]
+    async fn missing_file_returns_err() {
+        let result = open_decoder(Path::new("/nonexistent/file.wav")).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/akouo-core/src/decode/symphonia.rs
+++ b/crates/akouo-core/src/decode/symphonia.rs
@@ -1,0 +1,443 @@
+use std::io::ErrorKind;
+use std::pin::Pin;
+use std::time::Duration;
+
+use symphonia::core::audio::AudioBufferRef;
+use symphonia::core::codecs::{CODEC_TYPE_NULL, DecoderOptions};
+use symphonia::core::errors::Error as SymphErr;
+use symphonia::core::formats::{FormatOptions, SeekMode, SeekTo};
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+use symphonia::core::units::{Time, TimeBase};
+use tracing::{instrument, warn};
+
+use crate::decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams};
+use crate::error::DecodeError;
+
+pub struct SymphoniaDecoder {
+    format: Box<dyn symphonia::core::formats::FormatReader>,
+    decoder: Box<dyn symphonia::core::codecs::Decoder>,
+    track_id: u32,
+    time_base: TimeBase,
+    stream_params: StreamParams,
+    gapless_info: Option<GaplessInfo>,
+}
+
+impl SymphoniaDecoder {
+    /// Probes `mss` and creates a ready-to-decode instance.
+    #[instrument(skip(mss))]
+    pub fn new(mss: MediaSourceStream, hint: &Hint) -> Result<Self, DecodeError> {
+        let format_opts = FormatOptions {
+            enable_gapless: true,
+            ..Default::default()
+        };
+        let probed = symphonia::default::get_probe()
+            .format(hint, mss, &format_opts, &MetadataOptions::default())
+            .map_err(|e| DecodeError::SymphoniaRead {
+                message: format!("probe failed: {e}"),
+                location: snafu::location!(),
+            })?;
+
+        let format = probed.format;
+
+        let track = format
+            .tracks()
+            .iter()
+            .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+            .ok_or_else(|| DecodeError::SymphoniaRead {
+                message: "no audio track found".to_string(),
+                location: snafu::location!(),
+            })?;
+
+        let track_id = track.id;
+        let codec = map_codec(track.codec_params.codec);
+
+        let gapless_info = extract_gapless(track, &codec);
+
+        let p = &track.codec_params;
+        let sample_rate = p.sample_rate.unwrap_or(44100);
+        let channels = p.channels.map(|c| c.count() as u16).unwrap_or(2);
+        let duration = p
+            .n_frames
+            .map(|n| Duration::from_secs_f64(n as f64 / sample_rate as f64));
+
+        let stream_params = StreamParams {
+            codec,
+            sample_rate,
+            channels,
+            bit_depth: p.bits_per_sample.or(p.bits_per_coded_sample),
+            duration,
+            bitrate: None,
+        };
+
+        let time_base = p.time_base.unwrap_or(TimeBase {
+            numer: 1,
+            denom: sample_rate,
+        });
+
+        let decoder = symphonia::default::get_codecs()
+            .make(p, &DecoderOptions::default())
+            .map_err(|e| DecodeError::SymphoniaRead {
+                message: format!("decoder init failed: {e}"),
+                location: snafu::location!(),
+            })?;
+
+        Ok(Self {
+            format,
+            decoder,
+            track_id,
+            time_base,
+            stream_params,
+            gapless_info,
+        })
+    }
+}
+
+impl AudioDecoder for SymphoniaDecoder {
+    fn next_frame(
+        &mut self,
+    ) -> Pin<
+        Box<
+            dyn std::future::Future<Output = Result<Option<DecodedFrame>, DecodeError>> + Send + '_,
+        >,
+    > {
+        Box::pin(async move { self.decode_next_frame() })
+    }
+
+    fn seek(
+        &mut self,
+        position: Duration,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Duration, DecodeError>> + Send + '_>> {
+        Box::pin(async move { self.seek_to(position) })
+    }
+
+    fn stream_params(&self) -> StreamParams {
+        self.stream_params.clone()
+    }
+
+    fn gapless_info(&self) -> Option<GaplessInfo> {
+        self.gapless_info.clone()
+    }
+}
+
+impl SymphoniaDecoder {
+    fn decode_next_frame(&mut self) -> Result<Option<DecodedFrame>, DecodeError> {
+        loop {
+            let packet = match self.format.next_packet() {
+                Ok(p) => p,
+                Err(SymphErr::IoError(e)) if e.kind() == ErrorKind::UnexpectedEof => {
+                    return Ok(None);
+                }
+                Err(SymphErr::ResetRequired) => {
+                    self.decoder.reset();
+                    continue;
+                }
+                Err(e) => {
+                    return Err(DecodeError::SymphoniaRead {
+                        message: e.to_string(),
+                        location: snafu::location!(),
+                    });
+                }
+            };
+
+            if packet.track_id() != self.track_id {
+                continue;
+            }
+
+            let buffer = match self.decoder.decode(&packet) {
+                Ok(buf) => buf,
+                Err(SymphErr::DecodeError(msg)) => {
+                    warn!(message = %msg, "skipping corrupt frame");
+                    continue;
+                }
+                Err(e) => {
+                    return Err(DecodeError::SymphoniaDecode {
+                        message: e.to_string(),
+                        location: snafu::location!(),
+                    });
+                }
+            };
+
+            let timestamp = packet.ts;
+            let channels = self.stream_params.channels;
+            let sample_rate = self.stream_params.sample_rate;
+            let samples = buffer_to_f64_interleaved(&buffer);
+
+            return Ok(Some(DecodedFrame {
+                samples: samples.into_boxed_slice(),
+                channels,
+                sample_rate,
+                timestamp,
+            }));
+        }
+    }
+
+    fn seek_to(&mut self, position: Duration) -> Result<Duration, DecodeError> {
+        let seek_to = SeekTo::Time {
+            time: Time::from(position.as_secs_f64()),
+            track_id: Some(self.track_id),
+        };
+
+        let seeked = self.format.seek(SeekMode::Coarse, seek_to).map_err(|e| {
+            DecodeError::SymphoniaRead {
+                message: format!("seek failed: {e}"),
+                location: snafu::location!(),
+            }
+        })?;
+
+        self.decoder.reset();
+
+        let t = self.time_base.calc_time(seeked.actual_ts);
+        Ok(Duration::from_secs_f64(t.seconds as f64 + t.frac))
+    }
+}
+
+/// Maps a symphonia `CodecType` to the crate's `Codec` enum.
+pub(crate) fn map_codec(ct: symphonia::core::codecs::CodecType) -> Codec {
+    use symphonia::core::codecs::*;
+    match ct {
+        CODEC_TYPE_FLAC => Codec::Flac,
+        CODEC_TYPE_MP3 => Codec::Mp3,
+        CODEC_TYPE_AAC => Codec::Aac,
+        CODEC_TYPE_VORBIS => Codec::Vorbis,
+        CODEC_TYPE_OPUS => Codec::Opus,
+        CODEC_TYPE_ALAC => Codec::Alac,
+        CODEC_TYPE_PCM_S16LE | CODEC_TYPE_PCM_S24LE | CODEC_TYPE_PCM_S32LE
+        | CODEC_TYPE_PCM_F32LE | CODEC_TYPE_PCM_S16BE | CODEC_TYPE_PCM_S24BE
+        | CODEC_TYPE_PCM_S32BE => Codec::Wav,
+        _ => Codec::Other(format!("{ct:?}")),
+    }
+}
+
+fn extract_gapless(track: &symphonia::core::formats::Track, codec: &Codec) -> Option<GaplessInfo> {
+    // Symphonia issue #418: Vorbis pre-skip is not parsed — hardcode the standard value.
+    if matches!(codec, Codec::Vorbis) {
+        return Some(GaplessInfo {
+            encoder_delay: 3456,
+            encoder_padding: 0,
+            total_samples: track.codec_params.n_frames,
+        });
+    }
+
+    // Lossless codecs have no encoder delay.
+    if matches!(codec, Codec::Flac | Codec::Wav | Codec::Aiff) {
+        return None;
+    }
+
+    let p = &track.codec_params;
+    if p.delay.is_some() || p.padding.is_some() {
+        Some(GaplessInfo {
+            encoder_delay: p.delay.unwrap_or(0),
+            encoder_padding: p.padding.unwrap_or(0),
+            total_samples: p.n_frames,
+        })
+    } else {
+        None
+    }
+}
+
+fn buffer_to_f64_interleaved(buf: &AudioBufferRef<'_>) -> Vec<f64> {
+    let n_channels = buf.spec().channels.count();
+    let n_frames = buf.frames();
+    let mut out = vec![0.0f64; n_frames * n_channels];
+
+    macro_rules! interleave {
+        ($b:expr, $convert:expr) => {{
+            for (ch, plane) in $b.planes().planes().iter().enumerate() {
+                for (frame, &s) in plane.iter().enumerate() {
+                    out[frame * n_channels + ch] = $convert(s);
+                }
+            }
+        }};
+    }
+
+    match buf {
+        AudioBufferRef::U8(b) => interleave!(b, |s: u8| (s as f64 - 128.0) / 128.0),
+        AudioBufferRef::U16(b) => interleave!(b, |s: u16| (s as f64 - 32768.0) / 32768.0),
+        AudioBufferRef::U24(b) => {
+            interleave!(b, |s: symphonia::core::sample::u24| {
+                (s.inner() as f64 - 8_388_608.0) / 8_388_608.0
+            })
+        }
+        AudioBufferRef::U32(b) => {
+            interleave!(b, |s: u32| (s as f64 - 2_147_483_648.0) / 2_147_483_648.0)
+        }
+        AudioBufferRef::S8(b) => interleave!(b, |s: i8| s as f64 / 128.0),
+        AudioBufferRef::S16(b) => interleave!(b, |s: i16| s as f64 / 32_768.0),
+        AudioBufferRef::S24(b) => {
+            interleave!(b, |s: symphonia::core::sample::i24| {
+                s.inner() as f64 / 8_388_608.0
+            })
+        }
+        AudioBufferRef::S32(b) => interleave!(b, |s: i32| s as f64 / 2_147_483_648.0),
+        AudioBufferRef::F32(b) => interleave!(b, |s: f32| s as f64),
+        AudioBufferRef::F64(b) => interleave!(b, |s: f64| s),
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use symphonia::core::io::ReadOnlySource;
+
+    use super::*;
+
+    /// Builds a minimal valid WAV in memory.
+    fn wav_bytes(channels: u16, sample_rate: u32, samples_i16: &[i16]) -> Vec<u8> {
+        let data_len = (samples_i16.len() * 2) as u32;
+        let byte_rate = sample_rate * channels as u32 * 2;
+        let block_align = channels * 2;
+        let mut v = Vec::new();
+        v.extend_from_slice(b"RIFF");
+        v.extend_from_slice(&(36 + data_len).to_le_bytes());
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(b"fmt ");
+        v.extend_from_slice(&16u32.to_le_bytes());
+        v.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        v.extend_from_slice(&channels.to_le_bytes());
+        v.extend_from_slice(&sample_rate.to_le_bytes());
+        v.extend_from_slice(&byte_rate.to_le_bytes());
+        v.extend_from_slice(&block_align.to_le_bytes());
+        v.extend_from_slice(&16u16.to_le_bytes());
+        v.extend_from_slice(b"data");
+        v.extend_from_slice(&data_len.to_le_bytes());
+        for &s in samples_i16 {
+            v.extend_from_slice(&s.to_le_bytes());
+        }
+        v
+    }
+
+    fn decoder_from_wav(wav: Vec<u8>) -> SymphoniaDecoder {
+        let cursor = Cursor::new(wav);
+        let source = ReadOnlySource::new(cursor);
+        let mss = MediaSourceStream::new(Box::new(source), Default::default());
+        let mut hint = Hint::new();
+        hint.with_extension("wav");
+        SymphoniaDecoder::new(mss, &hint).expect("WAV decode init failed")
+    }
+
+    // --- Normalization unit tests (no I/O needed) ---
+
+    #[test]
+    fn normalize_i16_zero() {
+        assert_eq!(0i16 as f64 / 32_768.0, 0.0);
+    }
+
+    #[test]
+    fn normalize_i16_min_is_neg_one() {
+        let v = i16::MIN as f64 / 32_768.0;
+        assert_eq!(v, -1.0);
+    }
+
+    #[test]
+    fn normalize_i16_max_near_one() {
+        let v = i16::MAX as f64 / 32_768.0;
+        assert!(v > 0.999 && v <= 1.0, "i16 max normalized = {v}");
+    }
+
+    #[test]
+    fn normalize_i32_min_is_neg_one() {
+        let v = i32::MIN as f64 / 2_147_483_648.0;
+        assert_eq!(v, -1.0);
+    }
+
+    #[test]
+    fn normalize_i32_max_near_one() {
+        let v = i32::MAX as f64 / 2_147_483_648.0;
+        assert!(v > 0.999 && v <= 1.0, "i32 max normalized = {v}");
+    }
+
+    #[test]
+    fn normalize_i32_quarter_scale() {
+        // 2^29 / 2^31 = 0.25
+        let v = (1i32 << 29) as f64 / 2_147_483_648.0;
+        assert!((v - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn normalize_f32_passthrough() {
+        let v: f64 = 0.5f32 as f64;
+        assert!((v - 0.5).abs() < f64::EPSILON);
+    }
+
+    // --- Decode loop tests ---
+
+    #[tokio::test]
+    async fn empty_wav_returns_ok_none() {
+        let wav = wav_bytes(2, 44100, &[]);
+        let mut dec = decoder_from_wav(wav);
+        let result = dec.next_frame().await.expect("decode error");
+        assert!(result.is_none(), "expected Ok(None) for empty stream");
+    }
+
+    #[tokio::test]
+    async fn wav_stream_params_populated() {
+        let wav = wav_bytes(2, 44100, &[0i16; 4]);
+        let dec = decoder_from_wav(wav);
+        let p = dec.stream_params();
+        assert_eq!(p.sample_rate, 44100);
+        assert_eq!(p.channels, 2);
+        assert_eq!(p.bit_depth, Some(16));
+        assert!(matches!(p.codec, Codec::Wav));
+    }
+
+    #[tokio::test]
+    async fn wav_decodes_first_frame() {
+        // 4 interleaved stereo samples: [0x7FFF, 0x7FFF, 0, 0]
+        let samples: &[i16] = &[i16::MAX, i16::MAX, 0, 0];
+        let wav = wav_bytes(2, 44100, samples);
+        let mut dec = decoder_from_wav(wav);
+        let frame = dec
+            .next_frame()
+            .await
+            .expect("decode error")
+            .expect("expected a frame");
+        assert_eq!(frame.channels, 2);
+        assert_eq!(frame.sample_rate, 44100);
+        assert!(!frame.samples.is_empty());
+        // First sample pair should be near +1.0
+        let l = frame.samples[0];
+        let r = frame.samples[1];
+        assert!(l > 0.999, "left channel = {l}");
+        assert!(r > 0.999, "right channel = {r}");
+    }
+
+    #[tokio::test]
+    async fn interleave_ordering_l_then_r() {
+        // Left = i16::MIN (-1.0), Right = i16::MAX (~1.0)
+        let samples: &[i16] = &[i16::MIN, i16::MAX];
+        let wav = wav_bytes(2, 44100, samples);
+        let mut dec = decoder_from_wav(wav);
+        let frame = dec
+            .next_frame()
+            .await
+            .expect("decode error")
+            .expect("expected a frame");
+        let l = frame.samples[0];
+        let r = frame.samples[1];
+        assert!(l < -0.999, "left should be ≈ -1.0, got {l}");
+        assert!(r > 0.999, "right should be ≈ +1.0, got {r}");
+    }
+
+    #[tokio::test]
+    async fn seek_returns_duration() {
+        let samples: Vec<i16> = vec![0i16; 44100 * 2 * 2]; // 1s stereo
+        let wav = wav_bytes(2, 44100, &samples);
+        let mut dec = decoder_from_wav(wav);
+        let target = Duration::from_millis(500);
+        let actual = dec.seek(target).await.expect("seek failed");
+        // Coarse seek — should be within 500ms of requested
+        assert!(actual.as_millis() < 600, "seek overshot: {actual:?}");
+    }
+
+    #[tokio::test]
+    async fn gapless_none_for_wav() {
+        let wav = wav_bytes(2, 44100, &[]);
+        let dec = decoder_from_wav(wav);
+        assert!(dec.gapless_info().is_none());
+    }
+}

--- a/crates/akouo-core/src/decode/wavpack.rs
+++ b/crates/akouo-core/src/decode/wavpack.rs
@@ -1,0 +1,63 @@
+// P1-03: WavPackDecoder skeleton.
+//
+// WavPack is extremely rare in real music libraries. This skeleton satisfies the
+// AudioDecoder trait so probe.rs can reject WavPack files cleanly. Implement via
+// wavpack-sys = "0.4" when there is genuine user demand.
+//
+// Tracking: uncomment `wavpack-sys = "0.4"` in Cargo.toml and fill in the bodies below.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use crate::decode::{AudioDecoder, DecodedFrame, GaplessInfo, StreamParams};
+use crate::error::DecodeError;
+
+/// WavPack decoder — not yet implemented.
+///
+/// Probe routing rejects WavPack files with `UnsupportedCodec` before this type
+/// is instantiated. The struct exists to hold the future implementation once
+/// wavpack-sys is added.
+pub struct WavPackDecoder;
+
+impl AudioDecoder for WavPackDecoder {
+    fn next_frame(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<DecodedFrame>, DecodeError>> + Send + '_>> {
+        todo!("WavPack decode not yet implemented — extremely rare codec")
+    }
+
+    fn seek(
+        &mut self,
+        _position: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Duration, DecodeError>> + Send + '_>> {
+        todo!("WavPack seek not yet implemented — extremely rare codec")
+    }
+
+    fn stream_params(&self) -> StreamParams {
+        todo!("WavPack stream_params not yet implemented — extremely rare codec")
+    }
+
+    fn gapless_info(&self) -> Option<GaplessInfo> {
+        todo!("WavPack gapless_info not yet implemented — extremely rare codec")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::decode::Codec;
+    use crate::error::DecodeError;
+
+    #[test]
+    fn wavpack_unsupported_codec_error_contains_codec_name() {
+        // probe.rs returns UnsupportedCodec for WavPack before WavPackDecoder is instantiated.
+        let err = DecodeError::UnsupportedCodec {
+            codec: Codec::Other("WavPack".to_string()),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        };
+        assert!(
+            err.to_string().contains("WavPack"),
+            "error must name the codec: {err}"
+        );
+    }
+}

--- a/crates/akouo-core/src/dsp/compressor.rs
+++ b/crates/akouo-core/src/dsp/compressor.rs
@@ -1,0 +1,265 @@
+// Stage 5: Dynamics compressor / limiter.
+
+use crate::config::CompressorConfig;
+use crate::dsp::{DspStage, StageResult};
+use crate::signal_path::{QualityTier, SignalStageInfo, StageParams};
+
+fn db_to_linear(db: f64) -> f64 {
+    10.0_f64.powf(db / 20.0)
+}
+
+/// One-pole RC coefficient from a time constant in milliseconds.
+fn time_coeff(time_ms: f64, sample_rate: u32) -> f64 {
+    if time_ms <= 0.0 {
+        return 0.0;
+    }
+    (-1.0_f64 / (time_ms * sample_rate as f64 / 1000.0)).exp()
+}
+
+pub struct Compressor {
+    config: CompressorConfig,
+    /// Current smoothed gain reduction in dB (always >= 0).
+    gain_reduction_db: f64,
+    attack_coeff: f64,
+    release_coeff: f64,
+    last_sample_rate: u32,
+}
+
+impl Compressor {
+    pub fn new(config: CompressorConfig) -> Self {
+        Self {
+            config,
+            gain_reduction_db: 0.0,
+            attack_coeff: 0.0,
+            release_coeff: 0.0,
+            last_sample_rate: 0,
+        }
+    }
+
+    fn update_coeffs(&mut self, sample_rate: u32) {
+        if sample_rate != self.last_sample_rate {
+            self.attack_coeff = time_coeff(self.config.attack_ms, sample_rate);
+            self.release_coeff = time_coeff(self.config.release_ms, sample_rate);
+            self.last_sample_rate = sample_rate;
+        }
+    }
+}
+
+impl DspStage for Compressor {
+    fn name(&self) -> &str {
+        "compressor"
+    }
+
+    fn process(&mut self, samples: &mut [f64], channels: u16, sample_rate: u32) -> StageResult {
+        if !self.config.enabled || channels == 0 {
+            return StageResult {
+                meta: self.signal_stage_meta(),
+            };
+        }
+
+        self.update_coeffs(sample_rate);
+
+        let ch = channels as usize;
+        let limiter_ceiling = db_to_linear(self.config.limiter_ceiling_db);
+
+        for frame in samples.chunks_mut(ch) {
+            // Peak detection across all channels preserves stereo image.
+            let peak = frame.iter().map(|s| s.abs()).fold(0.0_f64, f64::max);
+
+            let peak_db = if peak > 1e-10 {
+                20.0 * peak.log10()
+            } else {
+                -200.0
+            };
+
+            // Target gain reduction (dB, always >= 0).
+            let target_gr = if peak_db > self.config.threshold_db {
+                (peak_db - self.config.threshold_db) * (1.0 - 1.0 / self.config.ratio)
+            } else {
+                0.0
+            };
+
+            // Attack when gain reduction is increasing; release when decreasing.
+            let coeff = if target_gr > self.gain_reduction_db {
+                self.attack_coeff
+            } else {
+                self.release_coeff
+            };
+            self.gain_reduction_db = coeff * self.gain_reduction_db + (1.0 - coeff) * target_gr;
+
+            let gain = db_to_linear(-self.gain_reduction_db);
+
+            for s in frame.iter_mut() {
+                *s *= gain;
+                // Brick-wall limiter ceiling.
+                *s = s.clamp(-limiter_ceiling, limiter_ceiling);
+            }
+        }
+
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
+    }
+
+    fn signal_stage_meta(&self) -> SignalStageInfo {
+        SignalStageInfo {
+            name: self.name().to_owned(),
+            enabled: self.config.enabled,
+            params: StageParams::Compressor {
+                threshold_db: self.config.threshold_db,
+                ratio: self.config.ratio,
+            },
+            // Compression reduces dynamic range — lowers tier from BitPerfect to Lossless.
+            tier_impact: self.config.enabled.then_some(QualityTier::Lossless),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressorConfig;
+
+    fn config_enabled(
+        threshold_db: f64,
+        ratio: f64,
+        attack_ms: f64,
+        release_ms: f64,
+    ) -> CompressorConfig {
+        CompressorConfig {
+            enabled: true,
+            threshold_db,
+            ratio,
+            attack_ms,
+            release_ms,
+            limiter_ceiling_db: 0.0,
+        }
+    }
+
+    fn run_mono(comp: &mut Compressor, amplitude: f64, n_samples: usize, sr: u32) -> Vec<f64> {
+        let mut out = Vec::with_capacity(n_samples);
+        for _ in 0..n_samples {
+            let mut frame = [amplitude];
+            comp.process(&mut frame, 1, sr);
+            out.push(frame[0]);
+        }
+        out
+    }
+
+    #[test]
+    fn below_threshold_passes_through() {
+        let cfg = config_enabled(-20.0, 4.0, 1.0, 10.0);
+        let mut comp = Compressor::new(cfg);
+
+        // Signal at -40 dBFS, well below -20 dB threshold.
+        let amplitude = db_to_linear(-40.0);
+        let out = run_mono(&mut comp, amplitude, 200, 44100);
+
+        for s in &out {
+            let diff = (s.abs() - amplitude).abs();
+            assert!(diff < 1e-6, "expected passthrough, got diff {diff}");
+        }
+    }
+
+    #[test]
+    fn above_threshold_gain_reduced() {
+        // 0 dBFS input, threshold -6 dB, ratio 4:1. After settling:
+        // excess = 6 dB, gain reduction = 6 * (1 - 1/4) = 4.5 dB.
+        let cfg = config_enabled(-6.0, 4.0, 1.0, 1000.0);
+        let mut comp = Compressor::new(cfg);
+
+        let amplitude = 1.0_f64; // 0 dBFS
+        // Run enough samples to fully settle (>> attack time).
+        let out = run_mono(&mut comp, amplitude, 5000, 44100);
+
+        let final_level_db = 20.0
+            * out
+                .last()
+                .expect("output should not be empty")
+                .abs()
+                .log10();
+        let expected_db = -4.5_f64;
+        assert!(
+            (final_level_db - expected_db).abs() < 0.1,
+            "expected ~{expected_db:.1} dB, got {final_level_db:.2} dB"
+        );
+    }
+
+    #[test]
+    fn attack_ramps_over_attack_time() {
+        // After one time constant the gain reduction should be ~63.2% of target.
+        let attack_ms = 10.0;
+        let sr = 44100_u32;
+        let cfg = config_enabled(-6.0, 100.0, attack_ms, 1000.0);
+        let mut comp = Compressor::new(cfg);
+
+        // Target gain reduction for 0 dBFS → threshold -6 dB, ratio 100 ≈ ∞:
+        // gr_target ≈ (0 - (-6)) * (1 - 1/100) ≈ 5.94 dB.
+        let target_gr = 6.0 * (1.0 - 1.0 / 100.0);
+        let n_tc = (attack_ms * sr as f64 / 1000.0).round() as usize;
+
+        let amplitude = 1.0_f64;
+        let out = run_mono(&mut comp, amplitude, n_tc, sr);
+
+        // Output amplitude after one time constant; gain reduction ≈ 63.2% of target.
+        let actual_output = out.last().expect("output should not be empty").abs();
+        let actual_gr = -20.0 * actual_output.log10();
+        let expected_gr_at_tc = target_gr * (1.0 - (-1.0_f64).exp()); // = target * 0.632
+
+        let ratio = actual_gr / expected_gr_at_tc;
+        assert!(
+            (ratio - 1.0).abs() < 0.05,
+            "gain reduction after 1 TC should be ~63.2% of target; ratio={ratio:.3}"
+        );
+    }
+
+    #[test]
+    fn limiter_ceiling_clamps_output() {
+        let cfg = CompressorConfig {
+            enabled: true,
+            threshold_db: -60.0, // very low threshold
+            ratio: 1.0,          // no compression
+            attack_ms: 0.0,
+            release_ms: 0.0,
+            limiter_ceiling_db: -6.0, // ceiling at ~0.5 linear
+        };
+        let mut comp = Compressor::new(cfg);
+        let ceiling = db_to_linear(-6.0);
+
+        let mut frame = [1.0_f64, -1.0]; // stereo, full scale
+        comp.process(&mut frame, 2, 44100);
+
+        assert!(frame[0] <= ceiling + 1e-10, "positive sample not clamped");
+        assert!(frame[1] >= -ceiling - 1e-10, "negative sample not clamped");
+    }
+
+    #[test]
+    fn disabled_passes_through() {
+        let cfg = CompressorConfig {
+            enabled: false,
+            ..CompressorConfig::default()
+        };
+        let mut comp = Compressor::new(cfg);
+        let mut samples = [0.9_f64, -0.8, 0.7];
+        let original = samples;
+        comp.process(&mut samples, 1, 44100);
+        assert_eq!(samples, original);
+    }
+
+    #[test]
+    fn signal_stage_meta_tier_impact() {
+        let mut cfg = CompressorConfig {
+            enabled: true,
+            ..CompressorConfig::default()
+        };
+        let comp = Compressor::new(cfg.clone());
+        assert_eq!(
+            comp.signal_stage_meta().tier_impact,
+            Some(QualityTier::Lossless)
+        );
+
+        cfg.enabled = false;
+        let comp = Compressor::new(cfg);
+        assert_eq!(comp.signal_stage_meta().tier_impact, None);
+    }
+}

--- a/crates/akouo-core/src/dsp/convolution.rs
+++ b/crates/akouo-core/src/dsp/convolution.rs
@@ -1,0 +1,101 @@
+// Stage 6: Convolution reverb / room-correction — Phase 5 passthrough.
+
+use crate::config::ConvolutionConfig;
+use crate::dsp::{DspStage, StageResult};
+use crate::signal_path::{QualityTier, SignalStageInfo, StageParams};
+
+pub struct Convolution {
+    config: ConvolutionConfig,
+}
+
+impl Convolution {
+    pub fn new(config: ConvolutionConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl DspStage for Convolution {
+    fn name(&self) -> &str {
+        "convolution"
+    }
+
+    fn process(&mut self, _samples: &mut [f64], _channels: u16, _sample_rate: u32) -> StageResult {
+        // Partition-overlap-save FFT convolution is a Phase 5 feature.
+        // Passthrough: samples are unmodified regardless of enabled state.
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
+    }
+
+    fn signal_stage_meta(&self) -> SignalStageInfo {
+        let ir_name = self
+            .config
+            .ir_path
+            .as_ref()
+            .and_then(|p| p.file_name())
+            .map(|n| n.to_string_lossy().into_owned());
+        SignalStageInfo {
+            name: self.name().to_owned(),
+            enabled: self.config.enabled,
+            params: StageParams::Convolution { ir_name },
+            // Convolution with a room IR lowers quality tier to HighQuality.
+            tier_impact: self.config.enabled.then_some(QualityTier::HighQuality),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ConvolutionConfig;
+
+    #[test]
+    fn passthrough_disabled() {
+        let mut conv = Convolution::new(ConvolutionConfig::default());
+        let original = [0.1_f64, -0.5, 0.9, -0.3];
+        let mut samples = original;
+        conv.process(&mut samples, 2, 44100);
+        assert_eq!(
+            samples, original,
+            "disabled convolution must not modify samples"
+        );
+    }
+
+    #[test]
+    fn passthrough_enabled() {
+        let cfg = ConvolutionConfig {
+            enabled: true,
+            ir_path: Some("/tmp/room.wav".into()),
+            output_gain_db: 0.0,
+        };
+        let mut conv = Convolution::new(cfg);
+        let original = [0.2_f64, -0.4, 0.6];
+        let mut samples = original;
+        conv.process(&mut samples, 1, 48000);
+        assert_eq!(
+            samples, original,
+            "enabled convolution passthrough must not modify samples"
+        );
+    }
+
+    #[test]
+    fn signal_path_reports_inactive() {
+        let conv = Convolution::new(ConvolutionConfig::default());
+        let meta = conv.signal_stage_meta();
+        assert!(!meta.enabled);
+        assert_eq!(meta.tier_impact, None);
+    }
+
+    #[test]
+    fn signal_path_enabled_reports_high_quality_tier() {
+        let cfg = ConvolutionConfig {
+            enabled: true,
+            ir_path: None,
+            output_gain_db: 0.0,
+        };
+        let conv = Convolution::new(cfg);
+        let meta = conv.signal_stage_meta();
+        assert!(meta.enabled);
+        assert_eq!(meta.tier_impact, Some(QualityTier::HighQuality));
+    }
+}

--- a/crates/akouo-core/src/dsp/crossfeed.rs
+++ b/crates/akouo-core/src/dsp/crossfeed.rs
@@ -1,0 +1,222 @@
+use std::f64::consts::PI;
+
+use crate::config::CrossfeedConfig;
+use crate::dsp::{DspStage, StageResult};
+use crate::signal_path::{QualityTier, SignalStageInfo, StageParams};
+
+/// bs2b preset parameters derived from `strength` via linear interpolation.
+///
+/// strength 0.0 → Easy  (700 Hz, −4.5 dB)
+/// strength 0.5 → Normal (650 Hz, −6.0 dB) — Bauer default
+/// strength 1.0 → Extreme (500 Hz, −9.0 dB)
+fn preset_params(strength: f64) -> (f64, f64) {
+    let s = strength.clamp(0.0, 1.0);
+    let (cutoff, level_db) = if s <= 0.5 {
+        let t = s * 2.0;
+        (700.0 + t * (650.0 - 700.0), -4.5 + t * (-6.0 - -4.5))
+    } else {
+        let t = (s - 0.5) * 2.0;
+        (650.0 + t * (500.0 - 650.0), -6.0 + t * (-9.0 - -6.0))
+    };
+    (cutoff, level_db)
+}
+
+/// Normalized 2nd-order Butterworth low-pass biquad coefficients.
+fn butterworth_lp(cutoff_hz: f64, sample_rate: u32) -> [f64; 5] {
+    let q = 1.0 / 2f64.sqrt(); // Butterworth Q
+    let w0 = 2.0 * PI * cutoff_hz / sample_rate as f64;
+    let cos_w0 = w0.cos();
+    let alpha = w0.sin() / (2.0 * q);
+    let b0 = (1.0 - cos_w0) / 2.0;
+    let b1 = 1.0 - cos_w0;
+    let b2 = (1.0 - cos_w0) / 2.0;
+    let a0 = 1.0 + alpha;
+    let a1 = -2.0 * cos_w0;
+    let a2 = 1.0 - alpha;
+    [b0 / a0, b1 / a0, b2 / a0, a1 / a0, a2 / a0]
+}
+
+pub struct Crossfeed {
+    config: CrossfeedConfig,
+    /// Direct Form II Transposed state [z1, z2] for each channel's LP filter.
+    /// Index: [channel][delay element]  (0 = L→cross-into-R, 1 = R→cross-into-L)
+    lp_state: [[f64; 2]; 2],
+    /// 1-sample delay of the LP-filtered signal per channel, modeling ~23 µs ITD.
+    lp_delayed: [f64; 2],
+    /// Cached filter coefficients: [b0, b1, b2, a1, a2].
+    lp_coeffs: [f64; 5],
+    cross_gain: f64,
+    last_sample_rate: u32,
+}
+
+impl Crossfeed {
+    pub fn new(config: CrossfeedConfig) -> Self {
+        Self {
+            config,
+            lp_state: [[0.0; 2]; 2],
+            lp_delayed: [0.0; 2],
+            lp_coeffs: [1.0, 0.0, 0.0, 0.0, 0.0], // passthrough until first process()
+            cross_gain: 0.0,
+            last_sample_rate: 0,
+        }
+    }
+
+    fn recompute(&mut self, sample_rate: u32) {
+        self.last_sample_rate = sample_rate;
+        let (cutoff, level_db) = preset_params(self.config.strength);
+        self.lp_coeffs = butterworth_lp(cutoff, sample_rate);
+        self.cross_gain = 10f64.powf(level_db / 20.0);
+        // Reset filter and delay state when parameters change.
+        self.lp_state = [[0.0; 2]; 2];
+        self.lp_delayed = [0.0; 2];
+    }
+
+    #[inline]
+    fn lp_sample(&mut self, x: f64, ch: usize) -> f64 {
+        let [b0, b1, b2, a1, a2] = self.lp_coeffs;
+        let [z1, z2] = self.lp_state[ch];
+        let y = b0 * x + z1;
+        self.lp_state[ch] = [b1 * x - a1 * y + z2, b2 * x - a2 * y];
+        y
+    }
+}
+
+impl DspStage for Crossfeed {
+    fn name(&self) -> &str {
+        "crossfeed"
+    }
+
+    fn process(&mut self, samples: &mut [f64], channels: u16, sample_rate: u32) -> StageResult {
+        if !self.config.enabled || channels != 2 {
+            return StageResult {
+                meta: self.signal_stage_meta(),
+            };
+        }
+
+        if self.last_sample_rate != sample_rate {
+            self.recompute(sample_rate);
+        }
+
+        for frame in samples.chunks_mut(2) {
+            let l = frame[0];
+            let r = frame[1];
+
+            // LP-filter each channel (models the spectral shaping of head diffraction).
+            let lp_l = self.lp_sample(l, 0);
+            let lp_r = self.lp_sample(r, 1);
+
+            // Mix: direct signal + 1-sample-delayed LP-filtered opposite channel.
+            // The 1-sample delay (~22 µs at 44.1 kHz) models the interaural time difference.
+            frame[0] = l + self.cross_gain * self.lp_delayed[1];
+            frame[1] = r + self.cross_gain * self.lp_delayed[0];
+
+            self.lp_delayed = [lp_l, lp_r];
+        }
+
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
+    }
+
+    fn signal_stage_meta(&self) -> SignalStageInfo {
+        SignalStageInfo {
+            name: self.name().to_owned(),
+            enabled: self.config.enabled,
+            params: StageParams::Crossfeed {
+                strength: self.config.strength,
+            },
+            // Crossfeed modifies the stereo image; no longer bit-perfect when active.
+            tier_impact: self.config.enabled.then_some(QualityTier::Lossless),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make(strength: f64) -> Crossfeed {
+        Crossfeed::new(CrossfeedConfig {
+            enabled: true,
+            strength,
+        })
+    }
+
+    fn measure_cross(strength: f64) -> f64 {
+        let mut stage = make(strength);
+        // Hard-panned left signal: [1.0, 0.0] repeated
+        let frames = 4410usize; // 100 ms at 44.1 kHz
+        let mut samples: Vec<f64> = (0..frames).flat_map(|_| [0.5_f64, 0.0_f64]).collect();
+        stage.process(&mut samples, 2, 44100);
+
+        // Measure energy in the right channel after settling (last 50 ms)
+        let skip = frames / 2 * 2;
+        let right_energy: f64 = samples[skip..].chunks(2).map(|f| f[1] * f[1]).sum();
+        right_energy.sqrt()
+    }
+
+    #[test]
+    fn mono_signal_unchanged() {
+        // L == R → crossfeed is identity in the sense that the mix is symmetric
+        let mut stage = make(0.5);
+        let signal = 0.5_f64;
+        let original: Vec<f64> = (0..100).flat_map(|_| [signal, signal]).collect();
+        let mut buf = original.clone();
+        stage.process(&mut buf, 2, 44100);
+
+        // After crossfeed, L and R should remain equal (symmetric signal stays symmetric).
+        for frame in buf.chunks(2) {
+            assert!(
+                (frame[0] - frame[1]).abs() < 1e-9,
+                "L and R should remain equal for mono signal"
+            );
+        }
+    }
+
+    #[test]
+    fn hard_panned_left_appears_in_right() {
+        let cross = measure_cross(0.5);
+        assert!(
+            cross > 0.0,
+            "crossfeed signal should appear in opposite channel"
+        );
+    }
+
+    #[test]
+    fn three_presets_produce_different_levels() {
+        let s_easy = measure_cross(0.0); // Easy:    cutoff 700 Hz, level −4.5 dB
+        let s_normal = measure_cross(0.5); // Normal:  cutoff 650 Hz, level −6.0 dB
+        let s_extreme = measure_cross(1.0); // Extreme: cutoff 500 Hz, level −9.0 dB
+
+        // −4.5 dB > −6 dB > −9 dB in linear gain, so Easy mixes the most raw energy.
+        // The important property is that all three are distinct.
+        assert!(
+            s_easy > s_normal && s_normal > s_extreme,
+            "each preset should produce a distinct crossfeed level: \
+             easy={s_easy:.4} normal={s_normal:.4} extreme={s_extreme:.4}"
+        );
+    }
+
+    #[test]
+    fn disabled_passes_through_unchanged() {
+        let mut stage = Crossfeed::new(CrossfeedConfig {
+            enabled: false,
+            strength: 1.0,
+        });
+        let input: Vec<f64> = (0..200)
+            .flat_map(|i| [i as f64 * 0.01, -(i as f64 * 0.01)])
+            .collect();
+        let mut buf = input.clone();
+        stage.process(&mut buf, 2, 44100);
+        assert_eq!(buf, input);
+    }
+
+    #[test]
+    fn mono_channel_count_passes_through() {
+        let mut stage = make(0.5);
+        let input: Vec<f64> = (0..100).map(|i| i as f64 * 0.01).collect();
+        let mut buf = input.clone();
+        stage.process(&mut buf, 1, 44100);
+        assert_eq!(buf, input, "mono (1 channel) should be a passthrough");
+    }
+}

--- a/crates/akouo-core/src/dsp/eq.rs
+++ b/crates/akouo-core/src/dsp/eq.rs
@@ -1,0 +1,426 @@
+use std::f64::consts::PI;
+
+use crate::config::{EqBand, EqConfig, FilterType};
+use crate::dsp::{DspStage, StageResult};
+use crate::signal_path::{SignalStageInfo, StageParams};
+
+/// Normalized biquad coefficients (b0, b1, b2 divided by a0; a1, a2 divided by a0).
+/// Direct Form II Transposed: y = b0·x + z1; z1 = b1·x − a1·y + z2; z2 = b2·x − a2·y
+#[derive(Clone, Copy)]
+struct Coeffs {
+    b0: f64,
+    b1: f64,
+    b2: f64,
+    a1: f64,
+    a2: f64,
+}
+
+impl Coeffs {
+    fn passthrough() -> Self {
+        Self {
+            b0: 1.0,
+            b1: 0.0,
+            b2: 0.0,
+            a1: 0.0,
+            a2: 0.0,
+        }
+    }
+
+    /// Compute RBJ Audio EQ Cookbook coefficients for the given band and sample rate.
+    fn from_band(band: &EqBand, sample_rate: u32) -> Self {
+        if band.q <= 0.0 || !band.frequency.is_finite() || !band.gain_db.is_finite() {
+            return Self::passthrough();
+        }
+
+        let w0 = 2.0 * PI * band.frequency / sample_rate as f64;
+        let cos_w0 = w0.cos();
+        let sin_w0 = w0.sin();
+        let alpha = sin_w0 / (2.0 * band.q);
+
+        let (b0, b1, b2, a0, a1, a2) = match band.filter_type {
+            FilterType::Peaking => {
+                let a = 10f64.powf(band.gain_db / 40.0);
+                (
+                    1.0 + alpha * a,
+                    -2.0 * cos_w0,
+                    1.0 - alpha * a,
+                    1.0 + alpha / a,
+                    -2.0 * cos_w0,
+                    1.0 - alpha / a,
+                )
+            }
+            FilterType::LowShelf => {
+                let a = 10f64.powf(band.gain_db / 40.0);
+                let two_sqrt_a_alpha = 2.0 * a.sqrt() * alpha;
+                (
+                    a * ((a + 1.0) - (a - 1.0) * cos_w0 + two_sqrt_a_alpha),
+                    2.0 * a * ((a - 1.0) - (a + 1.0) * cos_w0),
+                    a * ((a + 1.0) - (a - 1.0) * cos_w0 - two_sqrt_a_alpha),
+                    (a + 1.0) + (a - 1.0) * cos_w0 + two_sqrt_a_alpha,
+                    -2.0 * ((a - 1.0) + (a + 1.0) * cos_w0),
+                    (a + 1.0) + (a - 1.0) * cos_w0 - two_sqrt_a_alpha,
+                )
+            }
+            FilterType::HighShelf => {
+                let a = 10f64.powf(band.gain_db / 40.0);
+                let two_sqrt_a_alpha = 2.0 * a.sqrt() * alpha;
+                (
+                    a * ((a + 1.0) + (a - 1.0) * cos_w0 + two_sqrt_a_alpha),
+                    -2.0 * a * ((a - 1.0) + (a + 1.0) * cos_w0),
+                    a * ((a + 1.0) + (a - 1.0) * cos_w0 - two_sqrt_a_alpha),
+                    (a + 1.0) - (a - 1.0) * cos_w0 + two_sqrt_a_alpha,
+                    2.0 * ((a - 1.0) - (a + 1.0) * cos_w0),
+                    (a + 1.0) - (a - 1.0) * cos_w0 - two_sqrt_a_alpha,
+                )
+            }
+            FilterType::LowPass => (
+                (1.0 - cos_w0) / 2.0,
+                1.0 - cos_w0,
+                (1.0 - cos_w0) / 2.0,
+                1.0 + alpha,
+                -2.0 * cos_w0,
+                1.0 - alpha,
+            ),
+            FilterType::HighPass => (
+                (1.0 + cos_w0) / 2.0,
+                -(1.0 + cos_w0),
+                (1.0 + cos_w0) / 2.0,
+                1.0 + alpha,
+                -2.0 * cos_w0,
+                1.0 - alpha,
+            ),
+            FilterType::Notch => (
+                1.0,
+                -2.0 * cos_w0,
+                1.0,
+                1.0 + alpha,
+                -2.0 * cos_w0,
+                1.0 - alpha,
+            ),
+            FilterType::AllPass => (
+                1.0 - alpha,
+                -2.0 * cos_w0,
+                1.0 + alpha,
+                1.0 + alpha,
+                -2.0 * cos_w0,
+                1.0 - alpha,
+            ),
+        };
+
+        if a0.abs() < f64::EPSILON {
+            return Self::passthrough();
+        }
+
+        Self {
+            b0: b0 / a0,
+            b1: b1 / a0,
+            b2: b2 / a0,
+            a1: a1 / a0,
+            a2: a2 / a0,
+        }
+    }
+}
+
+/// Per-channel delay elements for one biquad (Direct Form II Transposed).
+#[derive(Clone, Copy, Default)]
+struct Chan {
+    z1: f64,
+    z2: f64,
+}
+
+struct BiquadBand {
+    coeffs: Coeffs,
+    chans: Vec<Chan>,
+}
+
+impl BiquadBand {
+    fn new(band: &EqBand, num_channels: usize, sample_rate: u32) -> Self {
+        Self {
+            coeffs: Coeffs::from_band(band, sample_rate),
+            chans: vec![Chan::default(); num_channels],
+        }
+    }
+
+    fn ensure_channels(&mut self, n: usize) {
+        if self.chans.len() < n {
+            self.chans.resize(n, Chan::default());
+        }
+    }
+
+    #[inline]
+    fn process_sample(&mut self, x: f64, ch: usize) -> f64 {
+        let c = &self.chans[ch];
+        let y = self.coeffs.b0 * x + c.z1;
+        let z1_next = self.coeffs.b1 * x - self.coeffs.a1 * y + c.z2;
+        let z2_next = self.coeffs.b2 * x - self.coeffs.a2 * y;
+        self.chans[ch] = Chan {
+            z1: z1_next,
+            z2: z2_next,
+        };
+        y
+    }
+}
+
+pub struct ParametricEq {
+    config: EqConfig,
+    bands: Vec<BiquadBand>,
+    last_sample_rate: u32,
+}
+
+impl ParametricEq {
+    pub fn new(config: EqConfig) -> Self {
+        Self {
+            config,
+            bands: Vec::new(),
+            last_sample_rate: 0,
+        }
+    }
+
+    fn rebuild(&mut self, channels: u16, sample_rate: u32) {
+        self.last_sample_rate = sample_rate;
+        self.bands = self
+            .config
+            .bands
+            .iter()
+            .map(|b| BiquadBand::new(b, channels as usize, sample_rate))
+            .collect();
+    }
+}
+
+impl DspStage for ParametricEq {
+    fn name(&self) -> &str {
+        "parametric-eq"
+    }
+
+    fn process(&mut self, samples: &mut [f64], channels: u16, sample_rate: u32) -> StageResult {
+        if !self.config.enabled || self.config.bands.is_empty() {
+            return StageResult {
+                meta: self.signal_stage_meta(),
+            };
+        }
+
+        if self.last_sample_rate != sample_rate || self.bands.len() != self.config.bands.len() {
+            self.rebuild(channels, sample_rate);
+        }
+
+        let ch_count = channels.max(1) as usize;
+        for band in &mut self.bands {
+            band.ensure_channels(ch_count);
+        }
+
+        for (i, sample) in samples.iter_mut().enumerate() {
+            let ch = i % ch_count;
+            for band in &mut self.bands {
+                *sample = band.process_sample(*sample, ch);
+            }
+        }
+
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
+    }
+
+    fn signal_stage_meta(&self) -> SignalStageInfo {
+        let bands = self
+            .config
+            .bands
+            .iter()
+            .map(|b| (b.frequency, b.gain_db, b.q))
+            .collect();
+        SignalStageInfo {
+            name: self.name().to_owned(),
+            enabled: self.config.enabled,
+            params: StageParams::Eq { bands },
+            tier_impact: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::EqBand;
+
+    const SR: u32 = 44100;
+
+    fn peaking(freq: f64, gain_db: f64, q: f64) -> EqBand {
+        EqBand {
+            frequency: freq,
+            gain_db,
+            q,
+            filter_type: FilterType::Peaking,
+        }
+    }
+
+    fn make_eq(band: EqBand) -> ParametricEq {
+        ParametricEq::new(EqConfig {
+            enabled: true,
+            bands: vec![band],
+        })
+    }
+
+    /// Measure steady-state gain (dB) at `freq_hz` by driving the filter with a sinusoid
+    /// and measuring RMS of the last cycle after settling.
+    fn measure_gain_db(eq: &mut ParametricEq, freq_hz: f64, input_amplitude: f64) -> f64 {
+        let period = (SR as f64 / freq_hz).round() as usize;
+        let warmup_cycles = 200usize;
+        let measure_cycles = 4usize;
+        let total = (warmup_cycles + measure_cycles) * period;
+
+        let mut samples: Vec<f64> = (0..total)
+            .map(|i| input_amplitude * (2.0 * PI * freq_hz * i as f64 / SR as f64).sin())
+            .collect();
+
+        // Process in frames of one period at a time.
+        for chunk in samples.chunks_mut(period) {
+            eq.process(chunk, 1, SR);
+        }
+
+        // Measure RMS over the last `measure_cycles` periods.
+        let measure_start = warmup_cycles * period;
+        let segment = &samples[measure_start..];
+        let rms_out = (segment.iter().map(|s| s * s).sum::<f64>() / segment.len() as f64).sqrt();
+        let rms_in = input_amplitude / 2f64.sqrt();
+        20.0 * (rms_out / rms_in).log10()
+    }
+
+    #[test]
+    fn bypass_when_disabled() {
+        let mut eq = ParametricEq::new(EqConfig {
+            enabled: false,
+            bands: vec![peaking(1000.0, 12.0, 1.414)],
+        });
+        let input: Vec<f64> = (0..1024).map(|i| (i as f64 * 0.01).sin()).collect();
+        let mut buf = input.clone();
+        eq.process(&mut buf, 1, SR);
+        assert_eq!(buf, input);
+    }
+
+    #[test]
+    fn bypass_when_all_gains_zero() {
+        let mut eq = make_eq(peaking(1000.0, 0.0, 1.414));
+        let input: Vec<f64> = (0..2048).map(|i| (i as f64 * 0.01).sin() * 0.5).collect();
+        let mut buf = input.clone();
+        eq.process(&mut buf, 1, SR);
+        for (a, b) in buf.iter().zip(input.iter()) {
+            assert!(
+                (a - b).abs() < 1e-10,
+                "zero-gain peaking should be transparent"
+            );
+        }
+    }
+
+    #[test]
+    fn peaking_boost_at_center_frequency() {
+        let gain_db = 6.0;
+        let mut eq = make_eq(peaking(1000.0, gain_db, 1.414));
+        let measured = measure_gain_db(&mut eq, 1000.0, 0.5);
+        assert!(
+            (measured - gain_db).abs() < 1.0,
+            "peaking: measured {measured:.2} dB, expected ~{gain_db} dB at 1 kHz"
+        );
+    }
+
+    #[test]
+    fn peaking_unity_two_octaves_away() {
+        let mut eq = make_eq(peaking(1000.0, 12.0, 1.414));
+        for &freq in &[250.0_f64, 4000.0_f64] {
+            let measured = measure_gain_db(&mut eq, freq, 0.5);
+            assert!(
+                measured.abs() < 3.0,
+                "peaking at 1 kHz: {freq} Hz should be near unity, got {measured:.2} dB"
+            );
+        }
+    }
+
+    #[test]
+    fn low_shelf_boosts_below_cutoff() {
+        let mut eq = make_eq(EqBand {
+            frequency: 200.0,
+            gain_db: 9.0,
+            q: 0.707,
+            filter_type: FilterType::LowShelf,
+        });
+        let low = measure_gain_db(&mut eq, 50.0, 0.5);
+        let high = measure_gain_db(&mut eq, 4000.0, 0.5);
+        assert!(
+            low > 5.0,
+            "low shelf should boost low frequencies, got {low:.2} dB at 50 Hz"
+        );
+        assert!(
+            high.abs() < 2.0,
+            "low shelf should leave highs flat, got {high:.2} dB at 4 kHz"
+        );
+    }
+
+    #[test]
+    fn high_shelf_boosts_above_cutoff() {
+        let mut eq = make_eq(EqBand {
+            frequency: 4000.0,
+            gain_db: 9.0,
+            q: 0.707,
+            filter_type: FilterType::HighShelf,
+        });
+        let low = measure_gain_db(&mut eq, 200.0, 0.5);
+        let high = measure_gain_db(&mut eq, 16000.0, 0.5);
+        assert!(
+            low.abs() < 2.0,
+            "high shelf should leave lows flat, got {low:.2} dB at 200 Hz"
+        );
+        assert!(
+            high > 5.0,
+            "high shelf should boost highs, got {high:.2} dB at 16 kHz"
+        );
+    }
+
+    #[test]
+    fn no_nan_or_inf_at_extreme_q() {
+        for &q in &[0.1_f64, 100.0_f64] {
+            let mut eq = make_eq(peaking(1000.0, 6.0, q));
+            let mut buf: Vec<f64> = (0..1024).map(|i| (i as f64 * 0.01).sin()).collect();
+            eq.process(&mut buf, 1, SR);
+            assert!(buf.iter().all(|s| s.is_finite()), "NaN/Inf at Q={q}");
+        }
+    }
+
+    #[test]
+    fn iso_10_band_default_all_zero_gain_is_transparent() {
+        let cfg = EqConfig {
+            enabled: true,
+            ..EqConfig::iso_10_band_default()
+        };
+        let mut eq = ParametricEq::new(cfg);
+        let input: Vec<f64> = (0..4096).map(|i| (i as f64 * 0.01).sin() * 0.5).collect();
+        let mut buf = input.clone();
+        eq.process(&mut buf, 1, SR);
+        for (a, b) in buf.iter().zip(input.iter()) {
+            assert!(
+                (a - b).abs() < 1e-9,
+                "10-band ISO default should be transparent at 0 dB gains"
+            );
+        }
+    }
+
+    #[test]
+    fn stereo_independent_channels() {
+        let mut eq = make_eq(peaking(1000.0, 6.0, 1.414));
+        // Stereo: ch0 = sine, ch1 = silence. After EQ, ch1 should remain near-zero.
+        let mut buf: Vec<f64> = (0..2048)
+            .map(|i| {
+                if i % 2 == 0 {
+                    (i as f64 * 0.1).sin() * 0.5
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        eq.process(&mut buf, 2, SR);
+        for i in (1..2048).step_by(2) {
+            assert!(
+                buf[i].abs() < 1e-10,
+                "silent channel should stay silent, got {}",
+                buf[i]
+            );
+        }
+    }
+}

--- a/crates/akouo-core/src/dsp/mod.rs
+++ b/crates/akouo-core/src/dsp/mod.rs
@@ -1,0 +1,97 @@
+pub mod compressor;
+pub mod convolution;
+pub mod crossfeed;
+pub mod eq;
+pub mod replaygain;
+pub mod silence;
+pub mod volume;
+
+use tokio::sync::watch;
+
+use crate::config::DspConfig;
+use crate::signal_path::{SignalPathSnapshot, SignalStageInfo};
+
+/// Result returned by `DspStage::process` after each frame.
+pub struct StageResult {
+    /// Metadata snapshot for this stage, used to build the signal path.
+    pub meta: SignalStageInfo,
+}
+
+/// A single processing stage in the DSP pipeline.
+///
+/// Implementations must be `Send + Sync` for use in the audio task.
+/// `process` takes `&mut self` because stages maintain internal state (filters, gain
+/// smoothing, lookahead buffers). Frame data is modified in place.
+pub trait DspStage: Send + Sync {
+    /// Short human-readable name used in signal path display.
+    fn name(&self) -> &str;
+
+    /// Processes `samples` in place (interleaved, f64, channel-major order).
+    /// Returns metadata about this processing step.
+    fn process(&mut self, samples: &mut [f64], channels: u16, sample_rate: u32) -> StageResult;
+
+    /// Returns the current signal path metadata for this stage.
+    fn signal_stage_meta(&self) -> SignalStageInfo;
+}
+
+/// The full DSP pipeline: an ordered list of stages with live config updates.
+pub struct DspPipeline {
+    stages: Vec<Box<dyn DspStage>>,
+    config_rx: watch::Receiver<DspConfig>,
+}
+
+impl DspPipeline {
+    /// Constructs the pipeline from the initial config. The `config_rx` channel is polled
+    /// each frame so DSP settings can be updated without stopping playback.
+    pub fn new(initial_config: DspConfig, config_rx: watch::Receiver<DspConfig>) -> Self {
+        let stages = Self::build_stages(&initial_config);
+        Self { stages, config_rx }
+    }
+
+    /// Processes one frame through all stages in order. Returns a snapshot of the signal path
+    /// state after this frame, including per-stage metadata.
+    pub fn process_frame(
+        &mut self,
+        samples: &mut [f64],
+        channels: u16,
+        sample_rate: u32,
+    ) -> Vec<SignalStageInfo> {
+        // Apply any pending config update.
+        if self.config_rx.has_changed().unwrap_or(false) {
+            let config = self.config_rx.borrow_and_update().clone();
+            self.stages = Self::build_stages(&config);
+        }
+
+        self.stages
+            .iter_mut()
+            .map(|stage| {
+                let result = stage.process(samples, channels, sample_rate);
+                result.meta
+            })
+            .collect()
+    }
+
+    /// Returns the current signal path metadata for all stages without processing audio.
+    pub fn stage_metas(&self) -> Vec<SignalStageInfo> {
+        self.stages.iter().map(|s| s.signal_stage_meta()).collect()
+    }
+
+    /// Rebuilds the stage list from a config snapshot.
+    fn build_stages(config: &DspConfig) -> Vec<Box<dyn DspStage>> {
+        vec![
+            Box::new(silence::SkipSilence::new(config.skip_silence.clone())),
+            Box::new(eq::ParametricEq::new(config.eq.clone())),
+            Box::new(crossfeed::Crossfeed::new(config.crossfeed.clone())),
+            Box::new(replaygain::ReplayGainStage::new(config.replaygain.clone())),
+            Box::new(compressor::Compressor::new(config.compressor.clone())),
+            Box::new(convolution::Convolution::new(config.convolution.clone())),
+            Box::new(volume::Volume::new(config.volume.clone())),
+        ]
+    }
+
+    /// Convenience: build a snapshot from the current stage metadata.
+    pub fn build_snapshot(&self, source_snapshot: &SignalPathSnapshot) -> Vec<SignalStageInfo> {
+        let _ = source_snapshot; // used by callers to merge; pipeline provides stage list only
+        self.stage_metas()
+    }
+}

--- a/crates/akouo-core/src/dsp/replaygain.rs
+++ b/crates/akouo-core/src/dsp/replaygain.rs
@@ -1,0 +1,319 @@
+use crate::config::{ReplayGainConfig, ReplayGainMode};
+use crate::dsp::{DspStage, StageResult};
+use crate::signal_path::{SignalStageInfo, StageParams};
+
+pub struct ReplayGainStage {
+    config: ReplayGainConfig,
+    /// Gain actually applied to the current track, in dB. Stored for signal path display.
+    applied_gain_db: f64,
+}
+
+impl ReplayGainStage {
+    pub fn new(config: ReplayGainConfig) -> Self {
+        let applied_gain_db = Self::compute_gain_db(&config);
+        Self {
+            config,
+            applied_gain_db,
+        }
+    }
+
+    /// Select the base gain (dB) from tag metadata according to the configured mode.
+    fn selected_gain_db(config: &ReplayGainConfig) -> f64 {
+        match config.mode {
+            ReplayGainMode::Track => config.track_gain_db.unwrap_or(config.fallback_gain_db),
+            ReplayGainMode::Album => config
+                .album_gain_db
+                .or_else(|| {
+                    config
+                        .fallback_to_track
+                        .then_some(config.track_gain_db)
+                        .flatten()
+                })
+                .unwrap_or(config.fallback_gain_db),
+            ReplayGainMode::R128 => {
+                // Prefer R128 track gain, fall back to legacy track gain, then fallback.
+                config
+                    .r128_track_gain
+                    .or(config.track_gain_db)
+                    .unwrap_or(config.fallback_gain_db)
+            }
+        }
+    }
+
+    /// Select the peak value corresponding to the active gain mode.
+    fn selected_peak(config: &ReplayGainConfig) -> Option<f64> {
+        match config.mode {
+            ReplayGainMode::Album => config.album_peak.or(config.track_peak),
+            _ => config.track_peak,
+        }
+    }
+
+    /// Compute the total gain (dB) including preamp and clipping prevention.
+    fn compute_gain_db(config: &ReplayGainConfig) -> f64 {
+        let base_db = Self::selected_gain_db(config) + config.preamp_db;
+        let mut gain_linear = 10f64.powf(base_db / 20.0);
+
+        if config.prevent_clipping
+            && let Some(peak) = Self::selected_peak(config)
+        {
+            let peak = peak.abs();
+            if peak > 0.0 && peak * gain_linear > 1.0 {
+                gain_linear = 1.0 / peak;
+            }
+        }
+
+        20.0 * gain_linear.log10()
+    }
+}
+
+impl DspStage for ReplayGainStage {
+    fn name(&self) -> &str {
+        "replaygain"
+    }
+
+    fn process(&mut self, samples: &mut [f64], _channels: u16, _sample_rate: u32) -> StageResult {
+        if self.config.enabled {
+            // Recompute in case config was hot-swapped (pipeline rebuild resets state anyway,
+            // but computing here keeps applied_gain_db accurate for signal_stage_meta).
+            self.applied_gain_db = Self::compute_gain_db(&self.config);
+            let gain_linear = 10f64.powf(self.applied_gain_db / 20.0);
+
+            for s in samples.iter_mut() {
+                *s *= gain_linear;
+            }
+        }
+
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
+    }
+
+    fn signal_stage_meta(&self) -> SignalStageInfo {
+        SignalStageInfo {
+            name: self.name().to_owned(),
+            enabled: self.config.enabled,
+            params: StageParams::ReplayGain {
+                mode: format!("{:?}", self.config.mode),
+                gain_db: self.applied_gain_db,
+            },
+            tier_impact: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ReplayGainMode;
+
+    fn cfg_with_track(track_gain_db: f64, track_peak: f64) -> ReplayGainConfig {
+        ReplayGainConfig {
+            enabled: true,
+            mode: ReplayGainMode::Track,
+            preamp_db: 0.0,
+            fallback_to_track: true,
+            fallback_gain_db: 0.0,
+            prevent_clipping: false,
+            track_gain_db: Some(track_gain_db),
+            track_peak: Some(track_peak),
+            album_gain_db: None,
+            album_peak: None,
+            r128_track_gain: None,
+            r128_album_gain: None,
+        }
+    }
+
+    fn apply(config: ReplayGainConfig, input: f64) -> f64 {
+        let mut stage = ReplayGainStage::new(config);
+        let mut buf = vec![input];
+        stage.process(&mut buf, 1, 44100);
+        buf[0]
+    }
+
+    #[test]
+    fn track_mode_applies_track_gain() {
+        let gain_db = -6.0_f64;
+        let gain_linear = 10f64.powf(gain_db / 20.0);
+        let result = apply(cfg_with_track(gain_db, 0.5), 1.0);
+        assert!((result - gain_linear).abs() < 1e-10);
+    }
+
+    #[test]
+    fn album_mode_applies_album_gain() {
+        let config = ReplayGainConfig {
+            enabled: true,
+            mode: ReplayGainMode::Album,
+            preamp_db: 0.0,
+            fallback_to_track: true,
+            fallback_gain_db: 0.0,
+            prevent_clipping: false,
+            track_gain_db: Some(-3.0),
+            track_peak: Some(0.5),
+            album_gain_db: Some(-9.0),
+            album_peak: Some(0.8),
+            r128_track_gain: None,
+            r128_album_gain: None,
+        };
+        let expected = 10f64.powf(-9.0_f64 / 20.0);
+        let result = apply(config, 1.0);
+        assert!((result - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn album_mode_falls_back_to_track_when_no_album_gain() {
+        let config = ReplayGainConfig {
+            enabled: true,
+            mode: ReplayGainMode::Album,
+            preamp_db: 0.0,
+            fallback_to_track: true,
+            fallback_gain_db: 0.0,
+            prevent_clipping: false,
+            track_gain_db: Some(-5.0),
+            track_peak: Some(0.5),
+            album_gain_db: None,
+            album_peak: None,
+            r128_track_gain: None,
+            r128_album_gain: None,
+        };
+        let expected = 10f64.powf(-5.0_f64 / 20.0);
+        let result = apply(config, 1.0);
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "should fall back to track gain"
+        );
+    }
+
+    #[test]
+    fn no_tags_fallback_zero_db_leaves_signal_unchanged() {
+        let config = ReplayGainConfig {
+            enabled: true,
+            mode: ReplayGainMode::Track,
+            preamp_db: 0.0,
+            fallback_to_track: true,
+            fallback_gain_db: 0.0,
+            prevent_clipping: false,
+            track_gain_db: None,
+            track_peak: None,
+            album_gain_db: None,
+            album_peak: None,
+            r128_track_gain: None,
+            r128_album_gain: None,
+        };
+        let result = apply(config, 0.7);
+        assert!(
+            (result - 0.7).abs() < 1e-10,
+            "no tags + 0 dB fallback should be transparent"
+        );
+    }
+
+    #[test]
+    fn clipping_prevention_limits_gain() {
+        // gain = +20 dB (linear 10×), peak = 0.5 → 10 × 0.5 = 5.0 > 1.0 → should limit
+        let config = ReplayGainConfig {
+            enabled: true,
+            mode: ReplayGainMode::Track,
+            preamp_db: 0.0,
+            fallback_to_track: true,
+            fallback_gain_db: 0.0,
+            prevent_clipping: true,
+            track_gain_db: Some(20.0),
+            track_peak: Some(0.5),
+            album_gain_db: None,
+            album_peak: None,
+            r128_track_gain: None,
+            r128_album_gain: None,
+        };
+        let result = apply(config, 0.5);
+        assert!(
+            result <= 1.0 + 1e-9,
+            "clipping prevention should keep output ≤ 1.0, got {result}"
+        );
+        // The actual gain should be 1/peak = 2.0×
+        assert!(
+            (result - 1.0).abs() < 1e-9,
+            "peak sample should be brought to exactly 1.0"
+        );
+    }
+
+    #[test]
+    fn clipping_prevention_no_effect_when_gain_safe() {
+        // gain = -6 dB, peak = 0.9 → gain_linear ≈ 0.501, 0.501 × 0.9 ≈ 0.451 < 1.0
+        let config = ReplayGainConfig {
+            enabled: true,
+            mode: ReplayGainMode::Track,
+            preamp_db: 0.0,
+            fallback_to_track: true,
+            fallback_gain_db: 0.0,
+            prevent_clipping: true,
+            track_gain_db: Some(-6.0),
+            track_peak: Some(0.9),
+            album_gain_db: None,
+            album_peak: None,
+            r128_track_gain: None,
+            r128_album_gain: None,
+        };
+        let expected = 10f64.powf(-6.0_f64 / 20.0);
+        let result = apply(config, 1.0);
+        assert!(
+            (result - expected).abs() < 1e-9,
+            "no clipping risk → gain should be applied as-is"
+        );
+    }
+
+    #[test]
+    fn r128_gain_applied() {
+        let r128_gain = -8.0_f64;
+        let config = ReplayGainConfig {
+            enabled: true,
+            mode: ReplayGainMode::R128,
+            preamp_db: 0.0,
+            fallback_to_track: true,
+            fallback_gain_db: 0.0,
+            prevent_clipping: false,
+            track_gain_db: Some(-3.0),
+            track_peak: Some(0.5),
+            album_gain_db: None,
+            album_peak: None,
+            r128_track_gain: Some(r128_gain),
+            r128_album_gain: None,
+        };
+        let expected = 10f64.powf(r128_gain / 20.0);
+        let result = apply(config, 1.0);
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "R128 mode should use r128_track_gain"
+        );
+    }
+
+    #[test]
+    fn disabled_passes_through() {
+        let mut config = cfg_with_track(-12.0, 0.5);
+        config.enabled = false;
+        let result = apply(config, 0.8);
+        assert!((result - 0.8).abs() < 1e-10);
+    }
+
+    #[test]
+    fn preamp_added_to_gain() {
+        let config = ReplayGainConfig {
+            enabled: true,
+            mode: ReplayGainMode::Track,
+            preamp_db: 3.0,
+            fallback_to_track: true,
+            fallback_gain_db: 0.0,
+            prevent_clipping: false,
+            track_gain_db: Some(-6.0),
+            track_peak: Some(0.1),
+            album_gain_db: None,
+            album_peak: None,
+            r128_track_gain: None,
+            r128_album_gain: None,
+        };
+        let expected = 10f64.powf((-6.0_f64 + 3.0) / 20.0);
+        let result = apply(config, 1.0);
+        assert!(
+            (result - expected).abs() < 1e-9,
+            "preamp should be added to track gain"
+        );
+    }
+}

--- a/crates/akouo-core/src/dsp/silence.rs
+++ b/crates/akouo-core/src/dsp/silence.rs
@@ -1,0 +1,200 @@
+use crate::config::SkipSilenceConfig;
+use crate::dsp::{DspStage, StageResult};
+use crate::signal_path::{SignalStageInfo, StageParams};
+
+pub struct SkipSilence {
+    config: SkipSilenceConfig,
+    /// Consecutive silent frames seen so far (reset on any non-silent frame).
+    consecutive_silent: usize,
+}
+
+impl SkipSilence {
+    pub fn new(config: SkipSilenceConfig) -> Self {
+        Self {
+            config,
+            consecutive_silent: 0,
+        }
+    }
+
+    fn rms_db(samples: &[f64]) -> f64 {
+        if samples.is_empty() {
+            return f64::NEG_INFINITY;
+        }
+        let mean_sq = samples.iter().map(|s| s * s).sum::<f64>() / samples.len() as f64;
+        if mean_sq == 0.0 {
+            return f64::NEG_INFINITY;
+        }
+        20.0 * mean_sq.sqrt().log10()
+    }
+}
+
+impl DspStage for SkipSilence {
+    fn name(&self) -> &str {
+        "skip-silence"
+    }
+
+    fn process(&mut self, samples: &mut [f64], channels: u16, _sample_rate: u32) -> StageResult {
+        if self.config.enabled {
+            let frame_count = samples.len() / channels.max(1) as usize;
+            let is_silent = Self::rms_db(samples) < self.config.threshold_db;
+
+            if is_silent {
+                let prev_silent = self.consecutive_silent;
+                self.consecutive_silent = self.consecutive_silent.saturating_add(frame_count);
+
+                // Zero the frame while we are in [min, max) of consecutive silence.
+                // Frames beyond max_silence_samples pass through to preserve intentional pauses.
+                if self.consecutive_silent >= self.config.min_silence_samples
+                    && prev_silent < self.config.max_silence_samples
+                {
+                    samples.fill(0.0);
+                }
+            } else {
+                self.consecutive_silent = 0;
+            }
+        }
+
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
+    }
+
+    fn signal_stage_meta(&self) -> SignalStageInfo {
+        SignalStageInfo {
+            name: self.name().to_owned(),
+            enabled: self.config.enabled,
+            params: StageParams::SkipSilence {
+                threshold_db: self.config.threshold_db,
+            },
+            tier_impact: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(enabled: bool, threshold_db: f64, min_ms: f64, max_ms: f64) -> SkipSilenceConfig {
+        let sr = 44100.0_f64;
+        SkipSilenceConfig {
+            enabled,
+            threshold_db,
+            min_silence_samples: (min_ms * sr / 1000.0) as usize,
+            max_silence_samples: (max_ms * sr / 1000.0) as usize,
+        }
+    }
+
+    /// A whisper-quiet signal well below any reasonable threshold (-160 dBFS).
+    fn near_silence(len: usize) -> Vec<f64> {
+        vec![1e-8_f64; len]
+    }
+
+    fn audible_tone(len: usize) -> Vec<f64> {
+        (0..len)
+            .map(|i| (i as f64 * std::f64::consts::TAU / 100.0).sin() * 0.5)
+            .collect()
+    }
+
+    fn process_all(stage: &mut SkipSilence, samples: &mut [f64], frame_size: usize) {
+        for chunk in samples.chunks_mut(frame_size) {
+            stage.process(chunk, 1, 44100);
+        }
+    }
+
+    #[test]
+    fn detects_silence_region() {
+        let sr = 44100_usize;
+        let frame = 1024;
+        // min 200 ms, max 3 s — sustained 1 s silence should be removed
+        let mut stage = SkipSilence::new(cfg(true, -50.0, 200.0, 3000.0));
+
+        // Process 1 s of near-silence.
+        let mut silence = near_silence(sr);
+        process_all(&mut stage, &mut silence, frame);
+
+        // After >200 ms of accumulated silence, frames should be zeroed.
+        let mut extra = near_silence(frame);
+        stage.process(&mut extra, 1, 44100);
+        assert!(
+            extra.iter().all(|&s| s == 0.0),
+            "silence should be zeroed after min threshold"
+        );
+    }
+
+    #[test]
+    fn passes_tone_unchanged() {
+        let frame = 1024;
+        let mut stage = SkipSilence::new(cfg(true, -50.0, 200.0, 3000.0));
+        let tone = audible_tone(frame);
+        let mut buf = tone.clone();
+        stage.process(&mut buf, 1, 44100);
+        assert_eq!(buf, tone, "audible tone should pass through unchanged");
+    }
+
+    #[test]
+    fn respects_min_silence_ms() {
+        // min = 200 ms → 8820 frames at 44.1 kHz
+        // A 10 ms burst of near-silence is too short to be removed.
+        let mut stage = SkipSilence::new(cfg(true, -50.0, 200.0, 3000.0));
+        let mut short = near_silence(441); // 10 ms
+        let original = short.clone();
+        stage.process(&mut short, 1, 44100);
+        assert_eq!(
+            short, original,
+            "short silence should pass through (below min threshold)"
+        );
+    }
+
+    #[test]
+    fn respects_max_silence_ms() {
+        // max = 500 ms → 22050 frames at 44.1 kHz
+        let frame = 1024;
+        let mut stage = SkipSilence::new(cfg(true, -50.0, 10.0, 500.0));
+
+        // Drain well past 500 ms worth of frames.
+        let mut bulk = near_silence(44100); // 1 s
+        process_all(&mut stage, &mut bulk, frame);
+
+        // At this point consecutive_silent >> max; further silence passes through.
+        let original = near_silence(frame);
+        let mut extra = original.clone();
+        stage.process(&mut extra, 1, 44100);
+        assert_eq!(
+            extra, original,
+            "silence beyond max should pass through unchanged"
+        );
+    }
+
+    #[test]
+    fn resets_on_tone() {
+        let frame = 1024;
+        // min = 200 ms (8820 frames at 44.1 kHz)
+        let mut stage = SkipSilence::new(cfg(true, -50.0, 200.0, 3000.0));
+
+        // Build up enough consecutive silence to be well into the removal region.
+        let mut silence = near_silence(44100);
+        process_all(&mut stage, &mut silence, frame);
+
+        // Interrupt with a tone — should reset the counter to zero.
+        let mut tone_buf = audible_tone(frame);
+        stage.process(&mut tone_buf, 1, 44100);
+
+        // Following silence of only 10 ms (441 frames) should NOT be zeroed:
+        // consecutive_silent just reset and 441 < 8820 (min).
+        let short = near_silence(441); // 10 ms << 200 ms min
+        let original = short.clone();
+        let mut buf = short;
+        stage.process(&mut buf, 1, 44100);
+        assert_eq!(buf, original, "silence counter should reset after tone");
+    }
+
+    #[test]
+    fn disabled_passes_all() {
+        let mut stage = SkipSilence::new(cfg(false, -50.0, 10.0, 3000.0));
+        let near = near_silence(1024);
+        let mut buf = near.clone();
+        stage.process(&mut buf, 1, 44100);
+        assert_eq!(buf, near);
+    }
+}

--- a/crates/akouo-core/src/dsp/volume.rs
+++ b/crates/akouo-core/src/dsp/volume.rs
@@ -1,0 +1,339 @@
+// Stage 7: Volume control + TPDF dither.
+
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+use crate::config::VolumeConfig;
+use crate::dsp::{DspStage, StageResult};
+use crate::signal_path::{SignalStageInfo, StageParams};
+
+fn db_to_linear(db: f64) -> f64 {
+    if db <= -200.0 {
+        return 0.0;
+    }
+    10.0_f64.powf(db / 20.0)
+}
+
+/// Maps a UI slider value (0–100) to a linear gain.
+///
+/// Slider 0 → 0.0 (mute), slider 50 → ~0.1 (−20 dB), slider 100 → 1.0 (0 dB).
+/// Uses a 60 dB dynamic range.
+pub fn slider_to_gain(slider: f64) -> f64 {
+    // 40 dB range: slider 50 → −20 dB (0.1 linear), slider 100 → 0 dB (1.0 linear).
+    const RANGE_DB: f64 = 40.0;
+    if slider <= 0.0 {
+        return 0.0;
+    }
+    let db = (slider.min(100.0) / 100.0) * RANGE_DB - RANGE_DB;
+    db_to_linear(db)
+}
+
+pub struct Volume {
+    config: VolumeConfig,
+    rng: SmallRng,
+}
+
+impl Volume {
+    pub fn new(config: VolumeConfig) -> Self {
+        Self {
+            config,
+            rng: SmallRng::from_rng(&mut rand::rng()),
+        }
+    }
+
+    /// Constructs a deterministic instance for testing.
+    pub fn new_seeded(config: VolumeConfig, seed: u64) -> Self {
+        Self {
+            config,
+            rng: SmallRng::seed_from_u64(seed),
+        }
+    }
+
+    fn tpdf_noise(&mut self, amplitude: f64) -> f64 {
+        use rand::RngExt;
+        let u1: f64 = self.rng.random();
+        let u2: f64 = self.rng.random();
+        // Two uniform [0, 1) values → triangular distribution in [-amplitude, amplitude].
+        (u1 - u2) * amplitude
+    }
+
+    /// Applies TPDF dither (if enabled) and quantizes to i16.
+    pub fn dither_and_quantize_i16(&mut self, sample: f64) -> i16 {
+        const AMPLITUDE: f64 = 1.0 / 32_768.0;
+        let s = if self.config.dither {
+            sample + self.tpdf_noise(AMPLITUDE)
+        } else {
+            sample
+        };
+        quantize_i16(s)
+    }
+
+    /// Applies TPDF dither (if enabled) and quantizes to i24 (returned as i32).
+    pub fn dither_and_quantize_i24(&mut self, sample: f64) -> i32 {
+        const AMPLITUDE: f64 = 1.0 / 8_388_608.0;
+        let s = if self.config.dither {
+            sample + self.tpdf_noise(AMPLITUDE)
+        } else {
+            sample
+        };
+        quantize_i24(s)
+    }
+
+    /// Applies TPDF dither (if enabled) and quantizes to i32.
+    pub fn dither_and_quantize_i32(&mut self, sample: f64) -> i32 {
+        const AMPLITUDE: f64 = 1.0 / 2_147_483_648.0;
+        let s = if self.config.dither {
+            sample + self.tpdf_noise(AMPLITUDE)
+        } else {
+            sample
+        };
+        quantize_i32(s)
+    }
+
+    /// Converts to f32 — no dither required.
+    pub fn dither_and_quantize_f32(&self, sample: f64) -> f32 {
+        quantize_f32(sample)
+    }
+}
+
+impl DspStage for Volume {
+    fn name(&self) -> &str {
+        "volume"
+    }
+
+    fn process(&mut self, samples: &mut [f64], _channels: u16, _sample_rate: u32) -> StageResult {
+        let gain = db_to_linear(self.config.level_db);
+        for s in samples.iter_mut() {
+            *s *= gain;
+        }
+        StageResult {
+            meta: self.signal_stage_meta(),
+        }
+    }
+
+    fn signal_stage_meta(&self) -> SignalStageInfo {
+        SignalStageInfo {
+            name: self.name().to_owned(),
+            enabled: true, // volume is always active
+            params: StageParams::Volume {
+                level_db: self.config.level_db,
+                dither: self.config.dither,
+            },
+            tier_impact: None,
+        }
+    }
+}
+
+/// Clamps and scales a f64 sample to i16 range.
+pub fn quantize_i16(sample: f64) -> i16 {
+    let clamped = sample.clamp(-1.0, 1.0);
+    (clamped * 32_767.0).round() as i16
+}
+
+/// Clamps and scales a f64 sample to i24 range (returned as i32).
+pub fn quantize_i24(sample: f64) -> i32 {
+    let clamped = sample.clamp(-1.0, 1.0);
+    (clamped * 8_388_607.0).round() as i32
+}
+
+/// Clamps and scales a f64 sample to i32 range.
+pub fn quantize_i32(sample: f64) -> i32 {
+    let clamped = sample.clamp(-1.0, 1.0);
+    (clamped * 2_147_483_647.0).round() as i32
+}
+
+/// Converts a f64 sample to f32 — no quantization noise for float output.
+pub fn quantize_f32(sample: f64) -> f32 {
+    sample as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::VolumeConfig;
+
+    fn vol(level_db: f64, dither: bool) -> Volume {
+        Volume::new_seeded(VolumeConfig { level_db, dither }, 0xdeadbeef)
+    }
+
+    // ── process() ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn unity_gain_passes_through() {
+        let mut v = vol(0.0, false);
+        let mut samples = [0.5_f64, -0.3, 0.9];
+        let original = samples;
+        v.process(&mut samples, 1, 44100);
+        for (a, b) in samples.iter().zip(original.iter()) {
+            assert!((a - b).abs() < 1e-12, "unity gain must not alter samples");
+        }
+    }
+
+    #[test]
+    fn zero_gain_produces_silence() {
+        let mut v = vol(-200.0, false);
+        let mut samples = [0.5_f64, -0.9, 1.0];
+        v.process(&mut samples, 1, 44100);
+        for s in samples {
+            assert_eq!(s, 0.0, "muted volume must produce silence");
+        }
+    }
+
+    #[test]
+    fn half_amplitude() {
+        let mut v = vol(-6.0206, false); // ≈ -6 dB → linear 0.5
+        let mut samples = [1.0_f64, 0.5, -0.8];
+        let original = samples;
+        v.process(&mut samples, 1, 44100);
+        for (out, &inp) in samples.iter().zip(original.iter()) {
+            let ratio = out / inp;
+            assert!(
+                (ratio - 0.5).abs() < 0.001,
+                "expected ~0.5 gain, got {ratio}"
+            );
+        }
+    }
+
+    // ── slider_to_gain ────────────────────────────────────────────────────────
+
+    #[test]
+    fn slider_zero_is_silence() {
+        assert_eq!(slider_to_gain(0.0), 0.0);
+    }
+
+    #[test]
+    fn slider_100_is_unity() {
+        let gain = slider_to_gain(100.0);
+        assert!(
+            (gain - 1.0).abs() < 1e-10,
+            "slider 100 should be unity gain, got {gain}"
+        );
+    }
+
+    #[test]
+    fn slider_50_is_minus_20db() {
+        let gain = slider_to_gain(50.0);
+        let db = 20.0 * gain.log10();
+        assert!(
+            (db - (-20.0)).abs() < 0.01,
+            "slider 50 should be ~-20 dB, got {db:.2} dB"
+        );
+    }
+
+    // ── quantize_* free functions ─────────────────────────────────────────────
+
+    #[test]
+    fn quantize_i16_full_scale() {
+        assert_eq!(quantize_i16(1.0), 32767);
+        assert_eq!(quantize_i16(-1.0), -32767);
+    }
+
+    #[test]
+    fn quantize_i16_clamps_overflow() {
+        assert_eq!(quantize_i16(1.5), 32767);
+        assert_eq!(quantize_i16(-1.5), -32767);
+    }
+
+    #[test]
+    fn quantize_i24_full_scale() {
+        assert_eq!(quantize_i24(1.0), 8_388_607);
+        assert_eq!(quantize_i24(-1.0), -8_388_607);
+    }
+
+    #[test]
+    fn quantize_i32_full_scale() {
+        assert_eq!(quantize_i32(1.0), 2_147_483_647);
+        assert_eq!(quantize_i32(-1.0), -2_147_483_647);
+    }
+
+    #[test]
+    fn quantize_f32_round_trips() {
+        let x = 0.12345_f64;
+        let out = quantize_f32(x);
+        let diff = (out as f64 - x).abs();
+        assert!(
+            diff < 1e-7,
+            "f32 round-trip error {diff} exceeds f32 precision"
+        );
+    }
+
+    // ── TPDF dither ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn dither_i16_deterministic_with_seed() {
+        let cfg = VolumeConfig {
+            level_db: 0.0,
+            dither: true,
+        };
+        let mut v1 = Volume::new_seeded(cfg.clone(), 42);
+        let mut v2 = Volume::new_seeded(cfg, 42);
+
+        let sample = 0.0_f64;
+        assert_eq!(
+            v1.dither_and_quantize_i16(sample),
+            v2.dither_and_quantize_i16(sample),
+            "same seed must produce same output"
+        );
+    }
+
+    #[test]
+    fn dither_tpdf_distribution_is_triangular() {
+        // Collect raw dither values by subtracting the un-dithered output.
+        // The dither amplitude for i16 is 1/32768; collect enough samples
+        // to verify the distribution is triangular (mean ~0, ends taper).
+        const N: usize = 50_000;
+        const AMPLITUDE: f64 = 1.0 / 32_768.0;
+
+        let cfg = VolumeConfig {
+            level_db: 0.0,
+            dither: true,
+        };
+        let mut v = Volume::new_seeded(cfg, 12345);
+
+        // Fixed input → variation in output is purely dither noise.
+        let input = 0.0_f64;
+        let mut values: Vec<f64> = Vec::with_capacity(N);
+        for _ in 0..N {
+            let dithered = v.dither_and_quantize_i16(input) as f64 / 32_767.0;
+            values.push(dithered);
+        }
+
+        // TPDF: mean ≈ 0, all values within ±1 LSB.
+        let mean = values.iter().sum::<f64>() / N as f64;
+        assert!(
+            mean.abs() < AMPLITUDE * 5.0,
+            "TPDF mean should be ~0, got {mean}"
+        );
+
+        let max_abs = values.iter().map(|v| v.abs()).fold(0.0_f64, f64::max);
+        assert!(
+            max_abs <= AMPLITUDE * 1.5,
+            "TPDF values should stay within ±1 LSB, max={max_abs}"
+        );
+    }
+
+    #[test]
+    fn f32_output_is_deterministic() {
+        // f32 quantization requires no RNG — same input always yields same output.
+        let cfg = VolumeConfig {
+            level_db: 0.0,
+            dither: true,
+        };
+        let v = Volume::new_seeded(cfg, 0);
+        let out1 = v.dither_and_quantize_f32(0.5);
+        let out2 = v.dither_and_quantize_f32(0.5);
+        assert_eq!(out1, out2, "f32 output must be deterministic (no dither)");
+    }
+
+    #[test]
+    fn no_dither_quantize_is_deterministic() {
+        let cfg = VolumeConfig {
+            level_db: 0.0,
+            dither: false,
+        };
+        let mut v = Volume::new_seeded(cfg, 99);
+        let a = v.dither_and_quantize_i16(0.123);
+        let b = v.dither_and_quantize_i16(0.123);
+        assert_eq!(a, b, "without dither, same input must give same output");
+    }
+}

--- a/crates/akouo-core/src/engine.rs
+++ b/crates/akouo-core/src/engine.rs
@@ -1,0 +1,741 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::sync::{broadcast, mpsc, watch};
+use tokio::task::JoinHandle;
+use tracing::{instrument, warn};
+
+use crate::config::{DspConfig, EngineConfig};
+use crate::decode::DecodedFrame;
+use tracing::Instrument;
+
+use crate::decode::probe::open_decoder;
+use crate::dsp::DspPipeline;
+use crate::error::EngineError;
+use crate::output::OutputDevice;
+use crate::ring_buffer::RingBuffer;
+use crate::signal_path::{QualityTier, SignalPathSnapshot, SignalStageInfo, SourceInfo};
+
+const STATE_STOPPED: u8 = 0;
+const STATE_PLAYING: u8 = 1;
+const STATE_PAUSED: u8 = 2;
+
+/// An audio source to be played back by the engine.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum AudioSource {
+    /// A local file path.
+    File(PathBuf),
+}
+
+/// Events emitted by the engine during playback. Subscribe via `Engine::subscribe_events`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum EngineEvent {
+    /// Playback started for a new source.
+    PlaybackStarted { source: AudioSource },
+    /// Playback stopped (either via `stop()` or natural track end with no next track).
+    PlaybackStopped,
+    /// Playback paused.
+    PlaybackPaused,
+    /// Playback resumed after pause.
+    PlaybackResumed,
+    /// The current track reached its natural end.
+    TrackEnded { source: AudioSource },
+    /// The engine transitioned from one track to the next (gapless / crossfade).
+    TrackChanged { from: AudioSource, to: AudioSource },
+    /// A seek completed; contains the actual position reached.
+    SeekCompleted { position: Duration },
+    /// The signal path configuration changed (DSP stage enabled/disabled, source changed).
+    SignalPathChanged(SignalPathSnapshot),
+    /// The output device changed.
+    OutputDeviceChanged { device: OutputDevice },
+    /// A non-fatal error occurred during playback.
+    Error { message: String },
+    /// The output ring buffer underran; `count` is the cumulative underrun count.
+    Underrun { count: u64 },
+}
+
+struct PlaybackSession {
+    decode_task: JoinHandle<()>,
+    dsp_task: JoinHandle<()>,
+}
+
+/// The audio engine: owns the decode → DSP → output pipeline.
+///
+/// Construct via `Engine::new`, wrap in `Arc<Engine>` for multi-task access.
+/// All public methods take `&self` and use internal synchronisation.
+///
+/// **Runtime requirement:** `play()` calls `tokio::spawn` internally. The engine must be
+/// used within a Tokio runtime context; calling `play()` outside a runtime panics.
+pub struct Engine {
+    config: EngineConfig,
+    state: Arc<AtomicU8>,
+    dsp_config_tx: Arc<watch::Sender<DspConfig>>,
+    signal_path_tx: Arc<watch::Sender<SignalPathSnapshot>>,
+    event_tx: broadcast::Sender<EngineEvent>,
+    session: Mutex<Option<PlaybackSession>>,
+}
+
+// SAFETY: All fields are Send+Sync. Mutex<Option<PlaybackSession>> is Sync because
+// JoinHandle<()> and AudioSource are Send.
+unsafe impl Send for Engine {}
+unsafe impl Sync for Engine {}
+
+impl Engine {
+    /// Creates a new engine with the given configuration.
+    ///
+    /// Does not start playback or open audio devices. Safe to call outside a Tokio runtime.
+    #[instrument]
+    pub fn new(config: EngineConfig) -> Result<Self, EngineError> {
+        let state = Arc::new(AtomicU8::new(STATE_STOPPED));
+        let (dsp_config_tx, _dsp_rx) = watch::channel(config.dsp.clone());
+        let (signal_path_tx, _sp_rx) = watch::channel(SignalPathSnapshot::idle());
+        let (event_tx, _) = broadcast::channel(256);
+
+        Ok(Self {
+            config,
+            state,
+            dsp_config_tx: Arc::new(dsp_config_tx),
+            signal_path_tx: Arc::new(signal_path_tx),
+            event_tx,
+            session: Mutex::new(None),
+        })
+    }
+
+    /// Begins playback of `source`. Returns `EngineError::AlreadyPlaying` if a track is
+    /// currently playing — call `stop()` first.
+    ///
+    /// Spawns decode and DSP tasks via `tokio::spawn`; must be called within a Tokio runtime.
+    #[instrument(skip(self))]
+    pub fn play(&self, source: AudioSource) -> Result<(), EngineError> {
+        // Atomically transition STOPPED → PLAYING.
+        self.state
+            .compare_exchange(
+                STATE_STOPPED,
+                STATE_PLAYING,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .map_err(|_| EngineError::AlreadyPlaying)?;
+
+        // Build fresh decode→DSP channel and output ring buffer.
+        let (frame_tx, frame_rx) = mpsc::channel::<Option<DecodedFrame>>(256);
+        let ring = Arc::new(RingBuffer::new(self.config.ring_buffer_capacity));
+
+        // Clone shared handles for the tasks.
+        let state = Arc::clone(&self.state);
+        let event_tx = self.event_tx.clone();
+        let dsp_config_rx = self.dsp_config_tx.subscribe();
+        let signal_path_tx = Arc::clone(&self.signal_path_tx);
+        let engine_config = self.config.clone();
+        let initial_dsp_config = self.config.dsp.clone();
+        let source_for_dsp = source.clone();
+        let ring_for_dsp = Arc::clone(&ring);
+
+        let AudioSource::File(ref path) = source;
+        let path = path.clone();
+
+        // Decode task: read file, send DecodedFrame to DSP channel.
+        let state_dec = Arc::clone(&state);
+        let event_dec = event_tx.clone();
+        let decode_task = tokio::spawn(
+            async move {
+                decode_task_fn(path, frame_tx, state_dec, event_dec).await;
+            }
+            .instrument(tracing::info_span!("decode_task")),
+        );
+
+        // DSP+output task: receive frames, run DSP pipeline, push to ring buffer,
+        // open cpal stream and feed audio hardware (when native-output feature is enabled).
+        let state_dsp = Arc::clone(&state);
+        let event_dsp = event_tx.clone();
+        let dsp_task = tokio::spawn(
+            async move {
+                dsp_task_fn(
+                    source_for_dsp,
+                    frame_rx,
+                    dsp_config_rx,
+                    initial_dsp_config,
+                    engine_config,
+                    ring_for_dsp,
+                    signal_path_tx,
+                    state_dsp,
+                    event_dsp,
+                )
+                .await;
+            }
+            .instrument(tracing::info_span!("dsp_task")),
+        );
+
+        // Store session.
+        let mut guard = self.session.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(PlaybackSession {
+            decode_task,
+            dsp_task,
+        });
+        drop(guard);
+
+        let _ = self.event_tx.send(EngineEvent::PlaybackStarted { source });
+        Ok(())
+    }
+
+    /// Pauses playback at the current position. Safe to call if already paused.
+    #[instrument(skip(self))]
+    pub fn pause(&self) -> Result<(), EngineError> {
+        let prev = self.state.compare_exchange(
+            STATE_PLAYING,
+            STATE_PAUSED,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
+        if prev.is_ok() {
+            let _ = self.event_tx.send(EngineEvent::PlaybackPaused);
+        }
+        Ok(())
+    }
+
+    /// Resumes paused playback.
+    #[instrument(skip(self))]
+    pub fn resume(&self) -> Result<(), EngineError> {
+        let prev = self.state.compare_exchange(
+            STATE_PAUSED,
+            STATE_PLAYING,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
+        if prev.is_ok() {
+            let _ = self.event_tx.send(EngineEvent::PlaybackResumed);
+        }
+        Ok(())
+    }
+
+    /// Stops playback and resets the engine to idle.
+    #[instrument(skip(self))]
+    pub fn stop(&self) -> Result<(), EngineError> {
+        self.state.store(STATE_STOPPED, Ordering::SeqCst);
+
+        let mut guard = self.session.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(session) = guard.take() {
+            session.decode_task.abort();
+            session.dsp_task.abort();
+        }
+        drop(guard);
+
+        let _ = self.event_tx.send(EngineEvent::PlaybackStopped);
+        Ok(())
+    }
+
+    /// Seeks to `position` within the current track. Returns the actual position reached.
+    ///
+    /// The seek flushes DSP state and signals the decode task to reposition. In this
+    /// implementation the position is accepted as-is and a `SeekCompleted` event is emitted.
+    /// Full inter-task seek coordination is completed in a subsequent pass.
+    #[instrument(skip(self))]
+    pub fn seek(&self, position: Duration) -> Result<Duration, EngineError> {
+        if self
+            .session
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_none()
+        {
+            return Err(EngineError::SeekOutOfBounds {
+                position_secs: position.as_secs_f64(),
+                duration_secs: 0.0,
+            });
+        }
+        let _ = self.event_tx.send(EngineEvent::SeekCompleted { position });
+        Ok(position)
+    }
+
+    /// Applies a new DSP configuration to the running pipeline without interrupting playback.
+    ///
+    /// The DSP task picks up the new config on the next frame via a `watch` channel.
+    #[instrument(skip(self))]
+    pub fn configure_dsp(&self, config: DspConfig) {
+        let _ = self.dsp_config_tx.send(config);
+    }
+
+    /// Returns the current signal path snapshot.
+    pub fn signal_path(&self) -> SignalPathSnapshot {
+        self.signal_path_tx.borrow().clone()
+    }
+
+    /// Returns a watch receiver that emits a new `SignalPathSnapshot` whenever the signal
+    /// path changes (DSP config updated, source changed, output opened/closed).
+    pub fn signal_path_stream(&self) -> watch::Receiver<SignalPathSnapshot> {
+        self.signal_path_tx.subscribe()
+    }
+
+    /// Returns a broadcast receiver for engine events.
+    pub fn subscribe_events(&self) -> broadcast::Receiver<EngineEvent> {
+        self.event_tx.subscribe()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decode task
+// ---------------------------------------------------------------------------
+
+async fn decode_task_fn(
+    path: PathBuf,
+    frame_tx: mpsc::Sender<Option<DecodedFrame>>,
+    state: Arc<AtomicU8>,
+    event_tx: broadcast::Sender<EngineEvent>,
+) {
+    let mut decoder = match open_decoder(&path).await {
+        Ok(d) => d,
+        Err(e) => {
+            let _ = event_tx.send(EngineEvent::Error {
+                message: e.to_string(),
+            });
+            let _ = frame_tx.send(None).await;
+            return;
+        }
+    };
+
+    loop {
+        if state.load(Ordering::Relaxed) == STATE_STOPPED {
+            break;
+        }
+
+        // Pause: yield until resumed or stopped.
+        if state.load(Ordering::Relaxed) == STATE_PAUSED {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            continue;
+        }
+
+        match decoder.next_frame().await {
+            Ok(Some(frame)) => {
+                if frame_tx.send(Some(frame)).await.is_err() {
+                    break; // DSP task dropped receiver
+                }
+            }
+            Ok(None) => {
+                let _ = frame_tx.send(None).await;
+                break;
+            }
+            Err(e) => {
+                let _ = event_tx.send(EngineEvent::Error {
+                    message: e.to_string(),
+                });
+                let _ = frame_tx.send(None).await;
+                break;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DSP + output task
+// ---------------------------------------------------------------------------
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "DSP task receives all pipeline components; splitting further would require wrapper structs"
+)]
+#[cfg_attr(
+    not(feature = "native-output"),
+    expect(
+        unused_variables,
+        reason = "several parameters are used only when native-output feature is enabled"
+    )
+)]
+async fn dsp_task_fn(
+    source: AudioSource,
+    mut frame_rx: mpsc::Receiver<Option<DecodedFrame>>,
+    dsp_config_rx: watch::Receiver<DspConfig>,
+    initial_dsp_config: DspConfig,
+    engine_config: EngineConfig,
+    ring: Arc<RingBuffer>,
+    signal_path_tx: Arc<watch::Sender<SignalPathSnapshot>>,
+    state: Arc<AtomicU8>,
+    event_tx: broadcast::Sender<EngineEvent>,
+) {
+    let mut dsp = DspPipeline::new(initial_dsp_config, dsp_config_rx);
+    let mut output_opened = false;
+    let mut last_snapshot_update = Instant::now();
+
+    #[cfg(feature = "native-output")]
+    let mut backend: Option<crate::output::cpal::CpalOutputBackend> = None;
+
+    loop {
+        if state.load(Ordering::Relaxed) == STATE_STOPPED {
+            break;
+        }
+
+        if state.load(Ordering::Relaxed) == STATE_PAUSED {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            continue;
+        }
+
+        let opt_frame = match frame_rx.recv().await {
+            Some(v) => v,
+            None => break, // decode task dropped sender
+        };
+
+        let Some(frame) = opt_frame else {
+            // End of stream: allow ring buffer to drain before stopping.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            let prev = state.swap(STATE_STOPPED, Ordering::SeqCst);
+            if prev != STATE_STOPPED {
+                let _ = event_tx.send(EngineEvent::TrackEnded {
+                    source: source.clone(),
+                });
+                let _ = event_tx.send(EngineEvent::PlaybackStopped);
+            }
+            break;
+        };
+
+        // Open output on first frame (now that we know sample rate and channels).
+        if !output_opened {
+            output_opened = true;
+
+            #[cfg(feature = "native-output")]
+            {
+                use crate::output::{AudioDataCallback, OutputBackend, OutputParams};
+                let ring_cb = Arc::clone(&ring);
+                let callback: AudioDataCallback = Box::new(move |buf: &mut [f64]| {
+                    if !ring_cb.pop_frame(buf) {
+                        buf.fill(0.0);
+                    }
+                });
+                let params = OutputParams {
+                    sample_rate: frame.sample_rate,
+                    channels: frame.channels,
+                    bit_depth: engine_config.output.bit_depth,
+                    exclusive_mode: engine_config.output.exclusive_mode,
+                    needs_resample: false,
+                    source_sample_rate: frame.sample_rate,
+                    quality_tier: QualityTier::Lossless,
+                };
+                let mut b = crate::output::cpal::CpalOutputBackend::new();
+                match b
+                    .open(
+                        engine_config.output.device_name.as_deref(),
+                        params,
+                        callback,
+                    )
+                    .await
+                {
+                    Ok(()) => match b.start().await {
+                        Ok(()) => backend = Some(b),
+                        Err(e) => {
+                            let _ = event_tx.send(EngineEvent::Error {
+                                message: e.to_string(),
+                            });
+                            state.store(STATE_STOPPED, Ordering::SeqCst);
+                            let _ = event_tx.send(EngineEvent::PlaybackStopped);
+                            return;
+                        }
+                    },
+                    Err(e) => {
+                        let _ = event_tx.send(EngineEvent::Error {
+                            message: e.to_string(),
+                        });
+                        state.store(STATE_STOPPED, Ordering::SeqCst);
+                        let _ = event_tx.send(EngineEvent::PlaybackStopped);
+                        return;
+                    }
+                }
+            }
+
+            // Publish initial signal path snapshot.
+            let source_info = build_source_info(&source, frame.sample_rate, frame.channels);
+            let stages = dsp.stage_metas();
+            let tier = compute_tier(&source_info, &stages);
+            let snap = SignalPathSnapshot {
+                tier,
+                source: Some(source_info),
+                stages: stages.clone(),
+                output: None,
+                timestamp: Instant::now(),
+            };
+            let _ = signal_path_tx.send(snap.clone());
+            let _ = event_tx.send(EngineEvent::SignalPathChanged(snap));
+        }
+
+        // Process frame through DSP pipeline.
+        let mut samples = frame.samples.to_vec();
+        let stage_metas = dsp.process_frame(&mut samples, frame.channels, frame.sample_rate);
+
+        // Push processed samples to ring buffer with yield-based backpressure.
+        loop {
+            if state.load(Ordering::Relaxed) == STATE_STOPPED {
+                break;
+            }
+            if ring.push_frame(&samples) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        // Throttle signal path updates to avoid watch channel spam (~4 Hz).
+        if last_snapshot_update.elapsed() >= Duration::from_millis(250) {
+            last_snapshot_update = Instant::now();
+            let source_info = build_source_info(&source, frame.sample_rate, frame.channels);
+            let tier = compute_tier(&source_info, &stage_metas);
+            let snap = SignalPathSnapshot {
+                tier,
+                source: Some(source_info),
+                stages: stage_metas,
+                output: None,
+                timestamp: Instant::now(),
+            };
+            let _ = signal_path_tx.send(snap);
+        }
+    }
+
+    // Close output backend.
+    #[cfg(feature = "native-output")]
+    if let Some(mut b) = backend {
+        use crate::output::OutputBackend;
+        let _ = b.close().await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_source_info(source: &AudioSource, sample_rate: u32, channels: u16) -> SourceInfo {
+    let codec_str = match source {
+        AudioSource::File(p) => p
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|s| s.to_uppercase())
+            .unwrap_or_else(|| "Unknown".into()),
+    };
+    SourceInfo {
+        codec: codec_str,
+        sample_rate,
+        channels,
+        bit_depth: None,
+        tier: QualityTier::Lossless,
+    }
+}
+
+fn compute_tier(source: &SourceInfo, stages: &[SignalStageInfo]) -> QualityTier {
+    let base = source.tier;
+    stages
+        .iter()
+        .filter(|s| s.enabled)
+        .filter_map(|s| s.tier_impact)
+        .fold(base, QualityTier::min)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::time::Duration;
+
+    use tempfile::NamedTempFile;
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::config::EngineConfig;
+
+    /// Builds a minimal valid WAV file with enough samples to keep the decode task alive
+    /// for a few hundred milliseconds.
+    fn make_wav(channels: u16, sample_rate: u32, duration_secs: f32) -> NamedTempFile {
+        let n_samples = (sample_rate as f32 * duration_secs) as u32 * channels as u32;
+        let data_len = n_samples * 2;
+        let byte_rate = sample_rate * channels as u32 * 2;
+        let block_align = channels * 2;
+
+        let mut v: Vec<u8> = Vec::new();
+        v.extend_from_slice(b"RIFF");
+        v.extend_from_slice(&(36 + data_len).to_le_bytes());
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(b"fmt ");
+        v.extend_from_slice(&16u32.to_le_bytes());
+        v.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        v.extend_from_slice(&channels.to_le_bytes());
+        v.extend_from_slice(&sample_rate.to_le_bytes());
+        v.extend_from_slice(&byte_rate.to_le_bytes());
+        v.extend_from_slice(&block_align.to_le_bytes());
+        v.extend_from_slice(&16u16.to_le_bytes());
+        v.extend_from_slice(b"data");
+        v.extend_from_slice(&data_len.to_le_bytes());
+        v.extend(std::iter::repeat_n(0u8, data_len as usize));
+
+        let mut f = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
+        f.write_all(&v).unwrap();
+        f
+    }
+
+    #[test]
+    fn engine_new_succeeds_with_default_config() {
+        let engine = Engine::new(EngineConfig::default());
+        assert!(engine.is_ok());
+    }
+
+    #[test]
+    fn engine_initial_signal_path_is_idle() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let snap = engine.signal_path();
+        assert!(snap.source.is_none());
+        assert!(snap.output.is_none());
+    }
+
+    #[tokio::test]
+    async fn engine_play_emits_playback_started() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let mut events = engine.subscribe_events();
+        let wav = make_wav(2, 44100, 2.0);
+
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+
+        let evt = timeout(Duration::from_secs(5), events.recv())
+            .await
+            .expect("timeout waiting for PlaybackStarted")
+            .expect("broadcast recv error");
+
+        assert!(
+            matches!(evt, EngineEvent::PlaybackStarted { .. }),
+            "expected PlaybackStarted, got {evt:?}"
+        );
+
+        engine.stop().unwrap();
+    }
+
+    #[tokio::test]
+    async fn engine_play_rejects_already_playing() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let wav = make_wav(2, 44100, 2.0);
+
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+
+        let second = engine.play(AudioSource::File(wav.path().to_path_buf()));
+        assert!(
+            matches!(second, Err(EngineError::AlreadyPlaying)),
+            "expected AlreadyPlaying"
+        );
+
+        engine.stop().unwrap();
+    }
+
+    #[tokio::test]
+    async fn engine_stop_emits_playback_stopped() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let mut events = engine.subscribe_events();
+        let wav = make_wav(2, 44100, 2.0);
+
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+
+        // Drain PlaybackStarted (and possibly SignalPathChanged).
+        loop {
+            let evt = timeout(Duration::from_secs(5), events.recv())
+                .await
+                .expect("timeout")
+                .expect("recv error");
+            if matches!(evt, EngineEvent::PlaybackStarted { .. }) {
+                break;
+            }
+        }
+
+        engine.stop().unwrap();
+
+        // Collect events, expect PlaybackStopped.
+        let mut saw_stopped = false;
+        for _ in 0..10 {
+            match timeout(Duration::from_millis(500), events.recv()).await {
+                Ok(Ok(EngineEvent::PlaybackStopped)) => {
+                    saw_stopped = true;
+                    break;
+                }
+                Ok(Ok(_)) => continue,
+                _ => break,
+            }
+        }
+        assert!(saw_stopped, "expected PlaybackStopped event");
+    }
+
+    #[tokio::test]
+    async fn engine_configure_dsp_mid_playback_does_not_crash() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let wav = make_wav(2, 44100, 2.0);
+
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+
+        // Reconfigure DSP while playing — must not panic.
+        for _ in 0..5 {
+            engine.configure_dsp(crate::config::DspConfig::default());
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        engine.stop().unwrap();
+    }
+
+    #[tokio::test]
+    async fn engine_signal_path_updated_during_playback() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let wav = make_wav(2, 44100, 1.0);
+
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+
+        // Give the DSP task time to process the first frame and publish a snapshot.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let snap = engine.signal_path();
+        // After playback starts, the snapshot should have been updated from idle.
+        // The DSP task publishes source info on the first frame.
+        // (With native-output disabled the DSP task still processes frames.)
+        let _ = snap; // no assertion on content — just must not panic
+
+        engine.stop().unwrap();
+    }
+
+    #[tokio::test]
+    async fn engine_pause_resume_cycle() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let mut events = engine.subscribe_events();
+        let wav = make_wav(2, 44100, 2.0);
+
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+        let _ = timeout(Duration::from_secs(2), events.recv()).await; // PlaybackStarted
+
+        engine.pause().unwrap();
+        let evt = timeout(Duration::from_millis(500), events.recv())
+            .await
+            .expect("timeout after pause")
+            .expect("recv error");
+        assert!(matches!(evt, EngineEvent::PlaybackPaused));
+
+        engine.resume().unwrap();
+        let evt = timeout(Duration::from_millis(500), events.recv())
+            .await
+            .expect("timeout after resume")
+            .expect("recv error");
+        assert!(matches!(evt, EngineEvent::PlaybackResumed));
+
+        engine.stop().unwrap();
+    }
+
+    #[tokio::test]
+    async fn engine_signal_path_stream_returns_receiver() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let rx = engine.signal_path_stream();
+        // Receiver should hold the initial idle snapshot.
+        let snap = rx.borrow().clone();
+        assert!(snap.source.is_none());
+    }
+}

--- a/crates/akouo-core/src/error.rs
+++ b/crates/akouo-core/src/error.rs
@@ -1,0 +1,120 @@
+// Error types for the akouo-core engine.
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum EngineError {
+    #[snafu(display("decode error"))]
+    Decode { source: DecodeError },
+
+    #[snafu(display("DSP error"))]
+    Dsp { source: DspError },
+
+    #[snafu(display("output error"))]
+    Output { source: OutputError },
+
+    #[snafu(display("playback already in progress"))]
+    AlreadyPlaying,
+
+    #[snafu(display(
+        "seek position {position_secs:.3}s out of bounds (duration: {duration_secs:.3}s)"
+    ))]
+    SeekOutOfBounds {
+        position_secs: f64,
+        duration_secs: f64,
+    },
+}
+
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum DecodeError {
+    #[snafu(display("symphonia read failed: {message}"))]
+    SymphoniaRead {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("symphonia decode failed: {message}"))]
+    SymphoniaDecode {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("opus decode failed: {message}"))]
+    OpusDecode {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("unsupported codec: {codec:?}"))]
+    UnsupportedCodec {
+        codec: crate::decode::Codec,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("metadata error: {message}"))]
+    Metadata {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum DspError {
+    #[snafu(display("DSP stage '{stage}' failed: {message}"))]
+    StageFailed { stage: String, message: String },
+
+    #[snafu(display("invalid DSP configuration: {message}"))]
+    InvalidConfig { message: String },
+}
+
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum OutputError {
+    #[snafu(display("no audio output device available"))]
+    NoDevice,
+
+    #[snafu(display("failed to open output device '{device}': {message}"))]
+    DeviceOpen { device: String, message: String },
+
+    #[snafu(display("output format not supported: {message}"))]
+    FormatUnsupported { message: String },
+
+    #[snafu(display("output stream error: {message}"))]
+    StreamError { message: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_error_already_playing_display() {
+        let e = EngineError::AlreadyPlaying;
+        assert!(e.to_string().contains("already in progress"));
+    }
+
+    #[test]
+    fn engine_error_seek_out_of_bounds_display() {
+        let e = EngineError::SeekOutOfBounds {
+            position_secs: 10.5,
+            duration_secs: 5.0,
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("10.500"));
+        assert!(msg.contains("5.000"));
+    }
+
+    #[test]
+    fn output_error_no_device_display() {
+        let e = OutputError::NoDevice;
+        assert!(e.to_string().contains("no audio output device"));
+    }
+}

--- a/crates/akouo-core/src/gapless/mod.rs
+++ b/crates/akouo-core/src/gapless/mod.rs
@@ -1,0 +1,689 @@
+pub mod prebuffer;
+
+use std::collections::VecDeque;
+use std::f64::consts::FRAC_PI_2;
+
+use tracing::instrument;
+
+use crate::decode::{GaplessInfo, metadata::TrackMetadata};
+use crate::gapless::prebuffer::PreBuffer;
+
+/// Transition mode between two tracks in gapless playback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TransitionMode {
+    /// True gapless: the next track's pre-buffer is spliced immediately after the last sample
+    /// of the current track (after gapless trimming).
+    Gapless,
+    /// Cross-fade: the tail of the current track and the head of the next are mixed over
+    /// `duration_ms` milliseconds.
+    Crossfade { duration_ms: u32 },
+    /// A hard gap (silence) is inserted between tracks.
+    Gap { duration_ms: u32 },
+}
+
+impl Default for TransitionMode {
+    fn default() -> Self {
+        TransitionMode::Crossfade { duration_ms: 3000 }
+    }
+}
+
+/// Which end of the frame buffer to trim encoder delay from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrimPosition {
+    /// Trim encoder priming samples from the start of the track.
+    Start,
+    /// Trim encoder padding samples from the end of the track.
+    End,
+}
+
+/// Trims encoder delay or padding samples from a frame buffer.
+///
+/// `encoder_delay` and `encoder_padding` in `GaplessInfo` are in per-channel samples.
+/// This function accounts for interleaved layout by multiplying by `channels`.
+///
+/// A zero delay or padding value is a no-op.
+#[instrument(skip(frames, gapless_info))]
+pub fn trim_codec_delay(
+    frames: &mut VecDeque<Box<[f64]>>,
+    gapless_info: &GaplessInfo,
+    position: TrimPosition,
+    channels: u16,
+) {
+    let samples_to_trim = match position {
+        TrimPosition::Start => gapless_info.encoder_delay as usize * channels as usize,
+        TrimPosition::End => gapless_info.encoder_padding as usize * channels as usize,
+    };
+
+    if samples_to_trim == 0 {
+        return;
+    }
+
+    match position {
+        TrimPosition::Start => trim_from_start(frames, samples_to_trim),
+        TrimPosition::End => trim_from_end(frames, samples_to_trim),
+    }
+}
+
+fn trim_from_start(frames: &mut VecDeque<Box<[f64]>>, mut remaining: usize) {
+    while remaining > 0 {
+        let frame_len = match frames.front() {
+            Some(f) => f.len(),
+            None => break,
+        };
+        if frame_len <= remaining {
+            remaining -= frame_len;
+            frames.pop_front();
+        } else {
+            let frame = frames
+                .pop_front()
+                .unwrap_or_else(|| unreachable!("frames.front() returned Some above"));
+            let trimmed = frame[remaining..].to_vec().into_boxed_slice();
+            frames.push_front(trimmed);
+            remaining = 0;
+        }
+    }
+}
+
+fn trim_from_end(frames: &mut VecDeque<Box<[f64]>>, mut remaining: usize) {
+    while remaining > 0 {
+        let frame_len = match frames.back() {
+            Some(f) => f.len(),
+            None => break,
+        };
+        if frame_len <= remaining {
+            remaining -= frame_len;
+            frames.pop_back();
+        } else {
+            let frame = frames
+                .pop_back()
+                .unwrap_or_else(|| unreachable!("frames.back() returned Some above"));
+            let keep = frame.len() - remaining;
+            let trimmed = frame[..keep].to_vec().into_boxed_slice();
+            frames.push_back(trimmed);
+            remaining = 0;
+        }
+    }
+}
+
+/// Produces an equal-power crossfade blend of `outgoing` and `incoming` at `position`.
+///
+/// `position` is in `[0.0, 1.0]`: `0.0` yields only the outgoing signal, `1.0` only
+/// the incoming signal. The equal-power curve (`cos`/`sin`) preserves perceived loudness
+/// across the blend window.
+///
+/// `outgoing` and `incoming` must have the same length. If they differ in debug builds
+/// this panics; in release builds the shorter length is used.
+pub fn crossfade_frame(outgoing: &[f64], incoming: &[f64], position: f64) -> Box<[f64]> {
+    debug_assert_eq!(
+        outgoing.len(),
+        incoming.len(),
+        "crossfade_frame: frame length mismatch"
+    );
+
+    let angle = position.clamp(0.0, 1.0) * FRAC_PI_2;
+    let out_gain = angle.cos();
+    let in_gain = angle.sin();
+
+    outgoing
+        .iter()
+        .zip(incoming.iter())
+        .map(|(&o, &i)| o * out_gain + i * in_gain)
+        .collect::<Vec<f64>>()
+        .into_boxed_slice()
+}
+
+/// Detects whether two consecutive tracks belong to the same album.
+pub struct AlbumDetector;
+
+impl AlbumDetector {
+    /// Returns `true` when `current` and `next` share the same album and artist.
+    ///
+    /// Comparison is case-insensitive ASCII. If either album or artist is missing from
+    /// either track, returns `false`.
+    pub fn is_same_album(current: &TrackMetadata, next: &TrackMetadata) -> bool {
+        let same_album = match (&current.album, &next.album) {
+            (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
+            _ => false,
+        };
+        let same_artist = match (&current.artist, &next.artist) {
+            (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
+            _ => false,
+        };
+        same_album && same_artist
+    }
+
+    /// Selects the appropriate transition mode for moving from `current` to `next`.
+    ///
+    /// Returns `Gapless` when both tracks are on the same album. Falls back to
+    /// `TransitionMode::default()` otherwise.
+    pub fn should_gapless(current: &TrackMetadata, next: &TrackMetadata) -> TransitionMode {
+        if Self::is_same_album(current, next) {
+            TransitionMode::Gapless
+        } else {
+            TransitionMode::default()
+        }
+    }
+}
+
+/// The overlap region where the ending track's tail meets the starting track's head.
+///
+/// For a gapless splice this is empty; for a crossfade it holds both sides of the
+/// window so `crossfade_frame` can blend them frame-by-frame.
+pub struct CarryBuffer {
+    /// Remaining samples from the ending track.
+    pub outgoing: VecDeque<Box<[f64]>>,
+    /// First samples from the starting track.
+    pub incoming: VecDeque<Box<[f64]>>,
+    /// Pre-computed equal-power fade positions, one per interleaved frame.
+    pub fade_curve: Option<Box<[f64]>>,
+}
+
+impl CarryBuffer {
+    pub fn new() -> Self {
+        Self {
+            outgoing: VecDeque::new(),
+            incoming: VecDeque::new(),
+            fade_curve: None,
+        }
+    }
+
+    /// Creates a carry buffer pre-loaded with the fade curve for a crossfade of
+    /// `duration_samples` per-channel samples at the given `sample_rate`.
+    pub fn with_crossfade(duration_ms: u32, sample_rate: u32) -> Self {
+        let duration_samples = (duration_ms as f64 / 1000.0 * sample_rate as f64) as usize;
+        let fade_curve = (0..duration_samples)
+            .map(|i| i as f64 / duration_samples.max(1) as f64)
+            .collect::<Vec<f64>>()
+            .into_boxed_slice();
+        Self {
+            outgoing: VecDeque::new(),
+            incoming: VecDeque::new(),
+            fade_curve: Some(fade_curve),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.outgoing.is_empty() && self.incoming.is_empty()
+    }
+}
+
+impl Default for CarryBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Coordinates pre-buffering and scheduling of the next track.
+///
+/// The scheduler watches the current track's remaining sample count and begins
+/// decoding the next track when the ring buffer drops below `prebuffer_threshold`.
+/// Transition logic (gapless splice, crossfade, or silence gap) is applied at
+/// track boundaries by the engine (P1-10).
+pub struct GaplessScheduler {
+    pre_buffer: PreBuffer,
+    carry_buffer: Option<CarryBuffer>,
+    transition_mode: TransitionMode,
+    prefetch_active: bool,
+}
+
+impl GaplessScheduler {
+    pub fn new(pre_buffer: PreBuffer, transition_mode: TransitionMode) -> Self {
+        Self {
+            pre_buffer,
+            carry_buffer: None,
+            transition_mode,
+            prefetch_active: false,
+        }
+    }
+
+    /// Returns `true` when remaining playback time has dropped below the pre-buffer
+    /// threshold and prefetching should begin.
+    ///
+    /// Once prefetching is active this returns `false` until `cancel_prefetch` is called.
+    pub fn should_start_prefetch(&self, samples_remaining: u64, sample_rate: u32) -> bool {
+        if self.prefetch_active {
+            return false;
+        }
+        let threshold = (self.pre_buffer.threshold_secs() * sample_rate as f64) as u64;
+        samples_remaining <= threshold
+    }
+
+    /// Marks the pre-buffer task as active. Call after spawning the decode task.
+    pub fn mark_prefetch_started(&mut self) {
+        self.prefetch_active = true;
+    }
+
+    /// Returns `true` when a prefetch task is running.
+    pub fn is_prefetch_active(&self) -> bool {
+        self.prefetch_active
+    }
+
+    /// Cancels the running prefetch task and resets state. Call on stop or skip.
+    #[instrument(skip(self))]
+    pub fn cancel_prefetch(&mut self) {
+        self.pre_buffer.cancel();
+        self.pre_buffer.clear();
+        self.prefetch_active = false;
+        self.carry_buffer = None;
+    }
+
+    /// Selects the transition mode for moving from `current` to `next`.
+    ///
+    /// Uses album detection to pick gapless automatically; falls back to
+    /// `self.transition_mode` only when overriding user preference takes precedence
+    /// (i.e., the user has explicitly set Gap or Crossfade in settings — the caller
+    /// is responsible for deciding when to honour that over album detection).
+    pub fn select_transition_mode(
+        &self,
+        current: &TrackMetadata,
+        next: &TrackMetadata,
+    ) -> TransitionMode {
+        AlbumDetector::should_gapless(current, next)
+    }
+
+    /// Overrides the default transition mode (used when the user changes settings).
+    pub fn set_transition_mode(&mut self, mode: TransitionMode) {
+        self.transition_mode = mode;
+    }
+
+    pub fn transition_mode(&self) -> &TransitionMode {
+        &self.transition_mode
+    }
+
+    pub fn pre_buffer(&self) -> &PreBuffer {
+        &self.pre_buffer
+    }
+
+    pub fn pre_buffer_mut(&mut self) -> &mut PreBuffer {
+        &mut self.pre_buffer
+    }
+
+    pub fn carry_buffer(&self) -> Option<&CarryBuffer> {
+        self.carry_buffer.as_ref()
+    }
+
+    pub fn carry_buffer_mut(&mut self) -> Option<&mut CarryBuffer> {
+        self.carry_buffer.as_mut()
+    }
+
+    pub fn set_carry_buffer(&mut self, buf: CarryBuffer) {
+        self.carry_buffer = Some(buf);
+    }
+
+    pub fn take_carry_buffer(&mut self) -> Option<CarryBuffer> {
+        self.carry_buffer.take()
+    }
+}
+
+impl Default for GaplessScheduler {
+    fn default() -> Self {
+        Self::new(
+            PreBuffer::new(10.0, 44100 * 10 * 2),
+            TransitionMode::default(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decode::GaplessInfo;
+    use crate::decode::metadata::TrackMetadata;
+
+    // ── crossfade_frame ──────────────────────────────────────────────────────
+
+    #[test]
+    fn crossfade_position_zero_is_all_outgoing() {
+        let out: Vec<f64> = vec![1.0, 0.5, -0.5, -1.0];
+        let inc: Vec<f64> = vec![0.2, 0.3, 0.4, 0.5];
+        let result = crossfade_frame(&out, &inc, 0.0);
+        for (r, &o) in result.iter().zip(out.iter()) {
+            assert!(
+                (r - o).abs() < 1e-12,
+                "at position 0 output should equal outgoing"
+            );
+        }
+    }
+
+    #[test]
+    fn crossfade_position_one_is_all_incoming() {
+        let out: Vec<f64> = vec![1.0, 0.5, -0.5, -1.0];
+        let inc: Vec<f64> = vec![0.2, 0.3, 0.4, 0.5];
+        let result = crossfade_frame(&out, &inc, 1.0);
+        for (r, &i) in result.iter().zip(inc.iter()) {
+            assert!(
+                (r - i).abs() < 1e-12,
+                "at position 1 output should equal incoming"
+            );
+        }
+    }
+
+    #[test]
+    fn crossfade_position_half_equal_power_blend() {
+        // At 0.5 both gains should be cos(π/4) = sin(π/4) ≈ 0.7071
+        let out: Vec<f64> = vec![1.0, 1.0];
+        let inc: Vec<f64> = vec![0.0, 0.0];
+        let result = crossfade_frame(&out, &inc, 0.5);
+        let expected_gain = (FRAC_PI_2 * 0.5_f64).cos();
+        for &r in result.iter() {
+            assert!((r - expected_gain).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn crossfade_energy_conservation() {
+        // Equal-power property: out_gain² + in_gain² = 1 at any position
+        let out: Vec<f64> = vec![1.0];
+        let inc: Vec<f64> = vec![1.0];
+        for i in 0..=100 {
+            let pos = i as f64 / 100.0;
+            let result = crossfade_frame(&out, &inc, pos);
+            let angle = pos * FRAC_PI_2;
+            // The result for unit inputs: cos(angle) + sin(angle)
+            // Power of output signal = result² compared to ideal constant-power:
+            // out_gain² + in_gain² = 1, so total power across both channels is preserved
+            let out_gain = angle.cos();
+            let in_gain = angle.sin();
+            let power = out_gain * out_gain + in_gain * in_gain;
+            assert!(
+                (power - 1.0).abs() < 1e-12,
+                "power conservation failed at pos={pos}"
+            );
+            // Verify the blended value matches formula
+            let expected = out_gain * out[0] + in_gain * inc[0];
+            assert!((result[0] - expected).abs() < 1e-12);
+        }
+    }
+
+    // ── trim_codec_delay ─────────────────────────────────────────────────────
+
+    fn make_frames(samples_per_frame: usize, num_frames: usize) -> VecDeque<Box<[f64]>> {
+        let mut q = VecDeque::new();
+        let mut counter = 0.0_f64;
+        for _ in 0..num_frames {
+            let frame: Box<[f64]> = (0..samples_per_frame)
+                .map(|_| {
+                    let v = counter;
+                    counter += 1.0;
+                    v
+                })
+                .collect::<Vec<f64>>()
+                .into_boxed_slice();
+            q.push_back(frame);
+        }
+        q
+    }
+
+    fn total_samples(frames: &VecDeque<Box<[f64]>>) -> usize {
+        frames.iter().map(|f| f.len()).sum()
+    }
+
+    #[test]
+    fn trim_mp3_encoder_delay_removes_start_samples() {
+        // Simulate MP3 with 576 samples encoder delay, stereo (channels=2)
+        let encoder_delay = 576_u32;
+        let channels = 2_u16;
+        // 4 frames of 1024 stereo samples = 4096 interleaved values
+        let mut frames = make_frames(1024, 4);
+        let before = total_samples(&frames);
+
+        let info = GaplessInfo {
+            encoder_delay,
+            encoder_padding: 0,
+            total_samples: None,
+        };
+        trim_codec_delay(&mut frames, &info, TrimPosition::Start, channels);
+
+        let after = total_samples(&frames);
+        let removed = before - after;
+        assert_eq!(removed, encoder_delay as usize * channels as usize);
+        // First remaining sample should be value 1152 (576 * 2)
+        assert_eq!(
+            frames[0][0],
+            (encoder_delay as usize * channels as usize) as f64
+        );
+    }
+
+    #[test]
+    fn trim_mp3_encoder_padding_removes_end_samples() {
+        let encoder_padding = 576_u32;
+        let channels = 2_u16;
+        let mut frames = make_frames(1024, 4);
+        let before = total_samples(&frames);
+
+        let info = GaplessInfo {
+            encoder_delay: 0,
+            encoder_padding,
+            total_samples: None,
+        };
+        trim_codec_delay(&mut frames, &info, TrimPosition::End, channels);
+
+        let after = total_samples(&frames);
+        let removed = before - after;
+        assert_eq!(removed, encoder_padding as usize * channels as usize);
+    }
+
+    #[test]
+    fn trim_flac_zero_delay_no_change() {
+        // FLAC returns None for GaplessInfo; if called with zero delay, nothing changes
+        let channels = 2_u16;
+        let mut frames = make_frames(512, 2);
+        let before = total_samples(&frames);
+
+        let info = GaplessInfo {
+            encoder_delay: 0,
+            encoder_padding: 0,
+            total_samples: None,
+        };
+        trim_codec_delay(&mut frames, &info, TrimPosition::Start, channels);
+        trim_codec_delay(&mut frames, &info, TrimPosition::End, channels);
+
+        assert_eq!(total_samples(&frames), before);
+    }
+
+    #[test]
+    fn trim_opus_preskip_removes_correct_samples() {
+        // Opus standard pre-skip is 3840 samples (80ms at 48 kHz), channels=2
+        let encoder_delay = 3840_u32;
+        let channels = 2_u16;
+        // 8 frames of 960 stereo samples (one Opus frame worth per frame)
+        let mut frames = make_frames(960 * channels as usize, 8);
+        let before = total_samples(&frames);
+
+        let info = GaplessInfo {
+            encoder_delay,
+            encoder_padding: 0,
+            total_samples: None,
+        };
+        trim_codec_delay(&mut frames, &info, TrimPosition::Start, channels);
+
+        let after = total_samples(&frames);
+        let removed = before - after;
+        assert_eq!(removed, encoder_delay as usize * channels as usize);
+    }
+
+    #[test]
+    fn trim_delay_spanning_multiple_frames() {
+        // Delay larger than a single frame — must consume multiple frames
+        let encoder_delay = 1500_u32;
+        let channels = 1_u16;
+        let mut frames = make_frames(1024, 4); // 4 * 1024 = 4096 samples mono
+        let before = total_samples(&frames);
+
+        let info = GaplessInfo {
+            encoder_delay,
+            encoder_padding: 0,
+            total_samples: None,
+        };
+        trim_codec_delay(&mut frames, &info, TrimPosition::Start, channels);
+
+        let after = total_samples(&frames);
+        assert_eq!(before - after, encoder_delay as usize);
+        // After removing 1500 samples from 4*1024=4096, we have 2596 left
+        assert_eq!(after, 4096 - 1500);
+    }
+
+    // ── AlbumDetector ────────────────────────────────────────────────────────
+
+    fn track(
+        album: Option<&str>,
+        artist: Option<&str>,
+        track_number: Option<u32>,
+    ) -> TrackMetadata {
+        TrackMetadata {
+            album: album.map(str::to_string),
+            artist: artist.map(str::to_string),
+            track_number,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn same_album_consecutive_tracks_is_gapless() {
+        let current = track(Some("Dark Side of the Moon"), Some("Pink Floyd"), Some(1));
+        let next = track(Some("Dark Side of the Moon"), Some("Pink Floyd"), Some(2));
+        assert!(AlbumDetector::is_same_album(&current, &next));
+        assert_eq!(
+            AlbumDetector::should_gapless(&current, &next),
+            TransitionMode::Gapless
+        );
+    }
+
+    #[test]
+    fn same_album_nonconsecutive_tracks_is_still_gapless() {
+        let current = track(Some("Dark Side of the Moon"), Some("Pink Floyd"), Some(1));
+        let next = track(Some("Dark Side of the Moon"), Some("Pink Floyd"), Some(5));
+        assert!(AlbumDetector::is_same_album(&current, &next));
+        assert_eq!(
+            AlbumDetector::should_gapless(&current, &next),
+            TransitionMode::Gapless
+        );
+    }
+
+    #[test]
+    fn different_albums_returns_user_default() {
+        let current = track(Some("Dark Side of the Moon"), Some("Pink Floyd"), Some(1));
+        let next = track(Some("Wish You Were Here"), Some("Pink Floyd"), Some(1));
+        assert!(!AlbumDetector::is_same_album(&current, &next));
+        assert_eq!(
+            AlbumDetector::should_gapless(&current, &next),
+            TransitionMode::default()
+        );
+    }
+
+    #[test]
+    fn missing_metadata_returns_user_default() {
+        let current = track(None, None, None);
+        let next = track(None, None, None);
+        assert!(!AlbumDetector::is_same_album(&current, &next));
+        assert_eq!(
+            AlbumDetector::should_gapless(&current, &next),
+            TransitionMode::default()
+        );
+    }
+
+    #[test]
+    fn album_match_is_case_insensitive() {
+        let current = track(Some("dark side of the moon"), Some("pink floyd"), Some(1));
+        let next = track(Some("Dark Side of the Moon"), Some("Pink Floyd"), Some(2));
+        assert!(AlbumDetector::is_same_album(&current, &next));
+    }
+
+    #[test]
+    fn missing_artist_on_next_is_not_same_album() {
+        let current = track(Some("Abbey Road"), Some("The Beatles"), Some(1));
+        let next = track(Some("Abbey Road"), None, Some(2));
+        assert!(!AlbumDetector::is_same_album(&current, &next));
+    }
+
+    // ── GaplessScheduler ─────────────────────────────────────────────────────
+
+    fn scheduler_with_threshold(threshold_secs: f64) -> GaplessScheduler {
+        GaplessScheduler::new(
+            PreBuffer::new(threshold_secs, 1000),
+            TransitionMode::default(),
+        )
+    }
+
+    #[test]
+    fn prefetch_starts_when_threshold_reached() {
+        let sched = scheduler_with_threshold(10.0);
+        let sample_rate = 44100_u32;
+        // 9 seconds remaining → below 10-second threshold → should start
+        let below = (9.0 * sample_rate as f64) as u64;
+        assert!(sched.should_start_prefetch(below, sample_rate));
+    }
+
+    #[test]
+    fn prefetch_does_not_start_when_above_threshold() {
+        let sched = scheduler_with_threshold(10.0);
+        let sample_rate = 44100_u32;
+        // 11 seconds remaining → above threshold → should not start
+        let above = (11.0 * sample_rate as f64) as u64;
+        assert!(!sched.should_start_prefetch(above, sample_rate));
+    }
+
+    #[test]
+    fn prefetch_does_not_repeat_when_already_active() {
+        let mut sched = scheduler_with_threshold(10.0);
+        let sample_rate = 44100_u32;
+        let below = (5.0 * sample_rate as f64) as u64;
+        assert!(sched.should_start_prefetch(below, sample_rate));
+        sched.mark_prefetch_started();
+        // Even though we're still below threshold, should not start again
+        assert!(!sched.should_start_prefetch(below, sample_rate));
+    }
+
+    #[test]
+    fn cancel_prefetch_resets_active_state() {
+        let mut sched = scheduler_with_threshold(10.0);
+        let sample_rate = 44100_u32;
+        sched.mark_prefetch_started();
+        assert!(sched.is_prefetch_active());
+        sched.cancel_prefetch();
+        assert!(!sched.is_prefetch_active());
+        // After cancel, should be able to start again
+        let below = (5.0 * sample_rate as f64) as u64;
+        assert!(sched.should_start_prefetch(below, sample_rate));
+    }
+
+    #[test]
+    fn transition_mode_selection_same_album_gapless() {
+        let sched = scheduler_with_threshold(10.0);
+        let current = track(Some("OK Computer"), Some("Radiohead"), Some(1));
+        let next = track(Some("OK Computer"), Some("Radiohead"), Some(2));
+        assert_eq!(
+            sched.select_transition_mode(&current, &next),
+            TransitionMode::Gapless
+        );
+    }
+
+    #[test]
+    fn transition_mode_selection_different_album_is_default() {
+        let sched = scheduler_with_threshold(10.0);
+        let current = track(Some("OK Computer"), Some("Radiohead"), Some(1));
+        let next = track(Some("Kid A"), Some("Radiohead"), Some(1));
+        assert_eq!(
+            sched.select_transition_mode(&current, &next),
+            TransitionMode::default()
+        );
+    }
+
+    // ── CarryBuffer ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn carry_buffer_crossfade_fade_curve_has_correct_length() {
+        let buf = CarryBuffer::with_crossfade(3000, 44100);
+        let curve = buf.fade_curve.as_ref().unwrap();
+        // 3 seconds at 44100 Hz = 132300 per-channel positions
+        assert_eq!(curve.len(), 132300);
+    }
+
+    #[test]
+    fn carry_buffer_default_is_empty() {
+        let buf = CarryBuffer::new();
+        assert!(buf.is_empty());
+        assert!(buf.fade_curve.is_none());
+    }
+}

--- a/crates/akouo-core/src/gapless/prebuffer.rs
+++ b/crates/akouo-core/src/gapless/prebuffer.rs
@@ -1,0 +1,121 @@
+use std::collections::VecDeque;
+
+use tokio::task::JoinHandle;
+use tracing::instrument;
+
+/// Pre-decoded frame buffer for the upcoming track.
+///
+/// When the current track's remaining samples fall below `threshold_secs`, the engine
+/// spawns a decode task (P1-10) that fills this buffer ahead of time so the transition
+/// is seamless. Frames are stored as interleaved f64 slices, already processed by the
+/// DSP pipeline.
+pub struct PreBuffer {
+    frames: VecDeque<Box<[f64]>>,
+    threshold_secs: f64,
+    max_frames: usize,
+    task: Option<JoinHandle<()>>,
+}
+
+impl PreBuffer {
+    pub fn new(threshold_secs: f64, max_frames: usize) -> Self {
+        Self {
+            frames: VecDeque::new(),
+            threshold_secs,
+            max_frames,
+            task: None,
+        }
+    }
+
+    /// Returns how many seconds before track end to begin pre-buffering.
+    pub fn threshold_secs(&self) -> f64 {
+        self.threshold_secs
+    }
+
+    /// Returns the maximum number of frames this buffer will hold.
+    pub fn max_frames(&self) -> usize {
+        self.max_frames
+    }
+
+    /// Pushes a decoded frame into the buffer. Returns `false` if the buffer is full.
+    pub fn push_frame(&mut self, frame: Box<[f64]>) -> bool {
+        if self.frames.len() >= self.max_frames {
+            return false;
+        }
+        self.frames.push_back(frame);
+        true
+    }
+
+    /// Pops the next pre-buffered frame. Returns `None` when the buffer is empty.
+    pub fn pop_frame(&mut self) -> Option<Box<[f64]>> {
+        self.frames.pop_front()
+    }
+
+    /// Number of frames currently in the buffer.
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    /// Registers the background decode task handle so it can be cancelled later.
+    pub fn set_task(&mut self, handle: JoinHandle<()>) {
+        self.task = Some(handle);
+    }
+
+    /// Cancels the background decode task if one is running.
+    #[instrument(skip(self))]
+    pub fn cancel(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+
+    /// Cancels any background task and discards all buffered frames.
+    pub fn clear(&mut self) {
+        self.cancel();
+        self.frames.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_and_pop_frames() {
+        let mut buf = PreBuffer::new(10.0, 4);
+        let frame: Box<[f64]> = vec![0.1, 0.2, 0.3, 0.4].into_boxed_slice();
+        assert!(buf.push_frame(frame.clone()));
+        assert_eq!(buf.len(), 1);
+        let out = buf.pop_frame().unwrap();
+        assert_eq!(&*out, &[0.1, 0.2, 0.3, 0.4]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn buffer_respects_max_frames() {
+        let mut buf = PreBuffer::new(10.0, 2);
+        let frame: Box<[f64]> = vec![0.0].into_boxed_slice();
+        assert!(buf.push_frame(frame.clone()));
+        assert!(buf.push_frame(frame.clone()));
+        assert!(!buf.push_frame(frame)); // full
+        assert_eq!(buf.len(), 2);
+    }
+
+    #[test]
+    fn clear_empties_buffer() {
+        let mut buf = PreBuffer::new(10.0, 8);
+        buf.push_frame(vec![1.0, 2.0].into_boxed_slice());
+        buf.push_frame(vec![3.0, 4.0].into_boxed_slice());
+        buf.clear();
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn pop_from_empty_returns_none() {
+        let mut buf = PreBuffer::new(10.0, 8);
+        assert!(buf.pop_frame().is_none());
+    }
+}

--- a/crates/akouo-core/src/lib.rs
+++ b/crates/akouo-core/src/lib.rs
@@ -1,0 +1,53 @@
+// Public API surface for akouo-core.
+
+pub mod config;
+pub mod decode;
+pub mod dsp;
+pub mod engine;
+pub mod error;
+pub mod gapless;
+pub mod output;
+pub mod queue;
+pub(crate) mod ring_buffer;
+pub mod signal_path;
+
+// Config
+pub use config::{
+    BufferSize, CompressorConfig, ConvolutionConfig, CrossfeedConfig, DspConfig, EngineConfig,
+    EqBand, EqConfig, OutputConfig, ReplayGainConfig, ReplayGainMode, SkipSilenceConfig,
+    VolumeConfig,
+};
+
+// Decode types
+pub use decode::metadata::TrackMetadata;
+pub use decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams};
+
+// Engine
+pub use engine::{AudioSource, Engine, EngineEvent};
+
+// Queue
+pub use queue::PlayQueue;
+
+// Errors
+pub use error::{DecodeError, DspError, EngineError, OutputError};
+
+// Output
+pub use output::format::Quantization;
+pub use output::resample::Resampler;
+pub use output::{DeviceCapabilities, OutputBackend, OutputDevice, OutputParams};
+
+// Signal path
+pub use signal_path::tier::{propagate_tier, source_tier};
+pub use signal_path::{
+    OutputInfo, QualityTier, SignalPathSnapshot, SignalStageInfo, SourceInfo, StageParams,
+};
+
+// DSP pipeline (for embedding in custom engine implementations)
+pub use dsp::{DspPipeline, DspStage, StageResult};
+
+// Gapless
+pub use gapless::prebuffer::PreBuffer;
+pub use gapless::{
+    AlbumDetector, CarryBuffer, GaplessScheduler, TransitionMode, TrimPosition, crossfade_frame,
+    trim_codec_delay,
+};

--- a/crates/akouo-core/src/output/cpal.rs
+++ b/crates/akouo-core/src/output/cpal.rs
@@ -1,0 +1,399 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use tracing::warn;
+
+use crate::error::OutputError;
+use crate::output::{
+    AudioDataCallback, DeviceCapabilities, OutputBackend, OutputDevice, OutputParams,
+};
+
+/// cpal-backed audio output: Linux (ALSA/PulseAudio/PipeWire), macOS, and Windows.
+pub struct CpalOutputBackend {
+    host: cpal::Host,
+    stream: Mutex<Option<cpal::Stream>>,
+}
+
+impl CpalOutputBackend {
+    pub fn new() -> Self {
+        Self {
+            host: cpal::default_host(),
+            stream: Mutex::new(None),
+        }
+    }
+}
+
+impl Default for CpalOutputBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// SAFETY: cpal::Host is Send on all supported platforms (ALSA unit struct on Linux).
+// cpal::Stream is Send; wrapped in Mutex for Sync.
+unsafe impl Send for CpalOutputBackend {}
+unsafe impl Sync for CpalOutputBackend {}
+
+impl OutputBackend for CpalOutputBackend {
+    fn available_devices(&self) -> Result<Vec<OutputDevice>, OutputError> {
+        let default_name = self
+            .host
+            .default_output_device()
+            .and_then(|d| d.name().ok());
+
+        let devices = self
+            .host
+            .output_devices()
+            .map_err(|e| OutputError::StreamError {
+                message: e.to_string(),
+            })?;
+
+        let mut result = Vec::new();
+        for device in devices {
+            let name = match device.name() {
+                Ok(n) => n,
+                Err(e) => {
+                    warn!("skipping device with unreadable name: {e}");
+                    continue;
+                }
+            };
+            let is_default = default_name.as_deref() == Some(&name);
+            result.push(OutputDevice {
+                id: name.clone(),
+                name,
+                is_default,
+            });
+        }
+
+        if result.is_empty() {
+            return Err(OutputError::NoDevice);
+        }
+        Ok(result)
+    }
+
+    fn device_capabilities(
+        &self,
+        device_id: Option<&str>,
+    ) -> Result<DeviceCapabilities, OutputError> {
+        let device = resolve_device(&self.host, device_id)?;
+        let device_name = device.name().unwrap_or_else(|_| "<unknown>".into());
+
+        let supported = device
+            .supported_output_configs()
+            .map_err(|e| OutputError::DeviceOpen {
+                device: device_name,
+                message: e.to_string(),
+            })?;
+
+        // Common sample rates to probe (each SupportedStreamConfigRange is a continuous range)
+        const PROBE_RATES: &[u32] = &[
+            8000, 11025, 16000, 22050, 44100, 48000, 88200, 96000, 176400, 192000,
+        ];
+
+        let mut sample_rates = std::collections::BTreeSet::new();
+        let mut bit_depths = std::collections::BTreeSet::new();
+        let mut max_channels = 0u16;
+
+        for range in supported {
+            let min = range.min_sample_rate();
+            let max = range.max_sample_rate();
+
+            for &rate in PROBE_RATES {
+                if rate >= min && rate <= max {
+                    sample_rates.insert(rate);
+                }
+            }
+
+            max_channels = max_channels.max(range.channels());
+
+            // Map cpal format to bit depths we can service
+            match range.sample_format() {
+                cpal::SampleFormat::F32 => {
+                    bit_depths.insert(32u32);
+                }
+                cpal::SampleFormat::I32 => {
+                    // i32 container can carry 24-bit and 32-bit audio
+                    bit_depths.insert(24u32);
+                    bit_depths.insert(32u32);
+                }
+                cpal::SampleFormat::I16 => {
+                    bit_depths.insert(16u32);
+                }
+                _ => {}
+            }
+        }
+
+        Ok(DeviceCapabilities {
+            supported_sample_rates: sample_rates.into_iter().collect(),
+            supported_bit_depths: bit_depths.into_iter().collect(),
+            max_channels,
+            // ALSA direct hardware access bypasses PulseAudio/PipeWire
+            supports_exclusive_mode: cfg!(target_os = "linux"),
+        })
+    }
+
+    async fn open(
+        &mut self,
+        device_id: Option<&str>,
+        params: OutputParams,
+        data_callback: AudioDataCallback,
+    ) -> Result<(), OutputError> {
+        let device = resolve_device(&self.host, device_id)?;
+        let device_name = device.name().unwrap_or_else(|_| "<unknown>".into());
+
+        let (stream_config, sample_format) =
+            find_stream_config(&device, &params).map_err(|e| OutputError::DeviceOpen {
+                device: device_name.clone(),
+                message: e.to_string(),
+            })?;
+
+        let channels = params.channels as usize;
+        // Pre-allocate f64 working buffer large enough for any callback invocation.
+        // Fixed buffer size is requested; 8 192 samples covers 4 096 stereo frames.
+        const MAX_SAMPLES: usize = 8192;
+        let mut f64_buf = vec![0.0f64; MAX_SAMPLES];
+        let mut callback = data_callback;
+        let underruns = Arc::new(AtomicU64::new(0));
+        let underruns_rt = Arc::clone(&underruns);
+
+        let error_cb = {
+            let device_name = device_name.clone();
+            move |err: cpal::StreamError| {
+                warn!("audio stream error on '{device_name}': {err}");
+            }
+        };
+
+        let stream = device
+            .build_output_stream_raw(
+                &stream_config,
+                sample_format,
+                move |data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {
+                    let n_samples = data.len();
+                    // Use the pre-allocated buffer; if callback asks for more than we have
+                    // (shouldn't happen with fixed buffer), fill the rest with silence.
+                    let fill = n_samples.min(f64_buf.len());
+                    callback(&mut f64_buf[..fill]);
+
+                    // Track underruns: cpal asked for more samples than we could provide
+                    if fill < n_samples {
+                        underruns_rt.fetch_add(1, Ordering::Relaxed);
+                    }
+
+                    write_to_data(data, &f64_buf[..fill], n_samples, channels);
+                },
+                error_cb,
+                None,
+            )
+            .map_err(|e| OutputError::DeviceOpen {
+                device: device_name,
+                message: e.to_string(),
+            })?;
+
+        *self.stream.lock().unwrap_or_else(|e| e.into_inner()) = Some(stream);
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), OutputError> {
+        let guard = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        match guard.as_ref() {
+            Some(stream) => stream.play().map_err(|e| OutputError::StreamError {
+                message: e.to_string(),
+            }),
+            None => Err(OutputError::StreamError {
+                message: "no stream open".into(),
+            }),
+        }
+    }
+
+    async fn pause(&mut self) -> Result<(), OutputError> {
+        let guard = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        match guard.as_ref() {
+            Some(stream) => stream.pause().map_err(|e| OutputError::StreamError {
+                message: e.to_string(),
+            }),
+            None => Err(OutputError::StreamError {
+                message: "no stream open".into(),
+            }),
+        }
+    }
+
+    async fn close(&mut self) -> Result<(), OutputError> {
+        // Dropping the cpal::Stream stops playback and releases the device handle.
+        *self.stream.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn resolve_device(host: &cpal::Host, device_id: Option<&str>) -> Result<cpal::Device, OutputError> {
+    match device_id {
+        None => host.default_output_device().ok_or(OutputError::NoDevice),
+        Some(id) => {
+            let devices = host
+                .output_devices()
+                .map_err(|e| OutputError::StreamError {
+                    message: e.to_string(),
+                })?;
+
+            for device in devices {
+                if device.name().as_deref() == Ok(id) {
+                    return Ok(device);
+                }
+            }
+            Err(OutputError::DeviceOpen {
+                device: id.into(),
+                message: "device not found".into(),
+            })
+        }
+    }
+}
+
+/// Finds the best matching cpal `StreamConfig` and `SampleFormat` for the requested params.
+///
+/// Format preference (highest quality first): F32 > I32 > I16.
+fn find_stream_config(
+    device: &cpal::Device,
+    params: &OutputParams,
+) -> Result<(cpal::StreamConfig, cpal::SampleFormat), OutputError> {
+    let supported: Vec<_> = device
+        .supported_output_configs()
+        .map_err(|e| OutputError::StreamError {
+            message: e.to_string(),
+        })?
+        .filter(|c| {
+            c.channels() >= params.channels
+                && c.min_sample_rate() <= params.sample_rate
+                && c.max_sample_rate() >= params.sample_rate
+        })
+        .collect();
+
+    if supported.is_empty() {
+        return Err(OutputError::FormatUnsupported {
+            message: format!(
+                "no config supports {}Hz {}ch",
+                params.sample_rate, params.channels
+            ),
+        });
+    }
+
+    // Prefer f32 (no quantization needed) > i32 > i16
+    let format_rank = |f: cpal::SampleFormat| match f {
+        cpal::SampleFormat::F32 => 0u8,
+        cpal::SampleFormat::I32 => 1,
+        cpal::SampleFormat::I16 => 2,
+        _ => 3,
+    };
+
+    let best = supported
+        .into_iter()
+        .min_by_key(|c| format_rank(c.sample_format()))
+        .unwrap_or_else(|| unreachable!("supported is non-empty; checked above"));
+
+    let sample_format = best.sample_format();
+    let config = cpal::StreamConfig {
+        channels: params.channels,
+        sample_rate: params.sample_rate,
+        buffer_size: cpal::BufferSize::Default,
+    };
+
+    Ok((config, sample_format))
+}
+
+/// Writes quantized f64 samples into the cpal output buffer.
+///
+/// Silence is written for any output samples beyond `filled`.
+fn write_to_data(data: &mut cpal::Data, f64_src: &[f64], total_samples: usize, _channels: usize) {
+    match data.sample_format() {
+        cpal::SampleFormat::F32 => {
+            if let Some(out) = data.as_slice_mut::<f32>() {
+                for (o, &s) in out[..f64_src.len()].iter_mut().zip(f64_src) {
+                    *o = s as f32;
+                }
+                out[f64_src.len()..total_samples].fill(0.0);
+            }
+        }
+        cpal::SampleFormat::I32 => {
+            if let Some(out) = data.as_slice_mut::<i32>() {
+                for (o, &s) in out[..f64_src.len()].iter_mut().zip(f64_src) {
+                    *o = quantize_i32(s);
+                }
+                out[f64_src.len()..total_samples].fill(0);
+            }
+        }
+        cpal::SampleFormat::I16 => {
+            if let Some(out) = data.as_slice_mut::<i16>() {
+                for (o, &s) in out[..f64_src.len()].iter_mut().zip(f64_src) {
+                    *o = quantize_i16(s);
+                }
+                out[f64_src.len()..total_samples].fill(0);
+            }
+        }
+        _ => {
+            // Unsupported format: write silence to avoid undefined output
+            warn!("unsupported cpal sample format {:?}", data.sample_format());
+        }
+    }
+}
+
+#[inline(always)]
+fn quantize_i32(s: f64) -> i32 {
+    (s * 2_147_483_648.0).clamp(-2_147_483_648.0, 2_147_483_647.0) as i32
+}
+
+#[inline(always)]
+fn quantize_i16(s: f64) -> i16 {
+    (s * 32_768.0).clamp(-32_768.0, 32_767.0) as i16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires audio hardware"]
+    fn available_devices_includes_default() {
+        let backend = CpalOutputBackend::new();
+        let devices = backend.available_devices().unwrap();
+        assert!(!devices.is_empty());
+        assert!(devices.iter().any(|d| d.is_default));
+    }
+
+    #[test]
+    #[ignore = "requires audio hardware"]
+    fn device_capabilities_returns_sample_rates() {
+        let backend = CpalOutputBackend::new();
+        let caps = backend.device_capabilities(None).unwrap();
+        assert!(!caps.supported_sample_rates.is_empty());
+        assert!(caps.max_channels >= 2);
+    }
+
+    #[test]
+    fn quantize_i32_full_scale() {
+        assert_eq!(quantize_i32(1.0), i32::MAX);
+        assert_eq!(quantize_i32(-1.0), i32::MIN);
+        assert_eq!(quantize_i32(0.0), 0);
+    }
+
+    #[test]
+    fn quantize_i32_clips() {
+        assert_eq!(quantize_i32(2.0), i32::MAX);
+        assert_eq!(quantize_i32(-2.0), i32::MIN);
+    }
+
+    #[test]
+    fn quantize_i16_full_scale() {
+        assert_eq!(quantize_i16(1.0), i16::MAX);
+        assert_eq!(quantize_i16(-1.0), i16::MIN);
+        assert_eq!(quantize_i16(0.0), 0);
+    }
+
+    #[test]
+    fn quantize_i16_clips() {
+        assert_eq!(quantize_i16(2.0), i16::MAX);
+        assert_eq!(quantize_i16(-2.0), i16::MIN);
+    }
+}

--- a/crates/akouo-core/src/output/format.rs
+++ b/crates/akouo-core/src/output/format.rs
@@ -1,0 +1,341 @@
+use crate::config::OutputConfig;
+use crate::decode::StreamParams;
+use crate::error::OutputError;
+use crate::output::{DeviceCapabilities, OutputParams};
+use crate::signal_path::QualityTier;
+use crate::signal_path::tier::{propagate_tier, source_tier};
+
+/// Quantization target for the output stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Quantization {
+    /// 16-bit signed integer (CD quality).
+    I16,
+    /// 24-bit signed integer packed in 32-bit (most DACs).
+    I24,
+    /// 32-bit signed integer.
+    I32,
+    /// 32-bit float.
+    F32,
+}
+
+impl Quantization {
+    pub fn bit_depth(self) -> u32 {
+        match self {
+            Quantization::I16 => 16,
+            Quantization::I24 => 24,
+            Quantization::I32 | Quantization::F32 => 32,
+        }
+    }
+
+    /// Returns the quantization format matching a bit depth. Prefers float for 32-bit.
+    pub fn from_bit_depth(depth: u32) -> Option<Self> {
+        match depth {
+            16 => Some(Quantization::I16),
+            24 => Some(Quantization::I24),
+            32 => Some(Quantization::F32),
+            _ => None,
+        }
+    }
+}
+
+/// Negotiates the best output format from device capabilities, stream parameters, and config.
+///
+/// Decision tree:
+/// 1. If device supports source sample rate -> use it (no resample)
+/// 2. Else pick highest supported rate <= 192 kHz
+/// 3. Prefer config bit depth if supported, else highest available
+/// 4. Grant exclusive mode only when device reports support
+pub fn negotiate_format(
+    caps: &DeviceCapabilities,
+    stream_params: &StreamParams,
+    config: &OutputConfig,
+) -> Result<OutputParams, OutputError> {
+    if caps.supported_sample_rates.is_empty() {
+        return Err(OutputError::FormatUnsupported {
+            message: "device reports no supported sample rates".into(),
+        });
+    }
+
+    let (sample_rate, needs_resample) = select_sample_rate(caps, stream_params.sample_rate);
+    let bit_depth = select_bit_depth(caps, config.bit_depth);
+    let exclusive_mode = config.exclusive_mode && caps.supports_exclusive_mode;
+
+    let src_tier = source_tier(
+        &stream_params.codec,
+        stream_params.sample_rate,
+        stream_params.bit_depth,
+    );
+    let resample_tier = QualityTier::HighQuality;
+    let depth_reduction = stream_params.bit_depth.is_some_and(|d| bit_depth < d);
+    let depth_tier = QualityTier::Lossless;
+    let quality_tier = propagate_tier(
+        src_tier,
+        [
+            (needs_resample, resample_tier),
+            (depth_reduction, depth_tier),
+        ],
+    );
+
+    Ok(OutputParams {
+        sample_rate,
+        channels: stream_params.channels.min(caps.max_channels),
+        bit_depth,
+        exclusive_mode,
+        needs_resample,
+        source_sample_rate: stream_params.sample_rate,
+        quality_tier,
+    })
+}
+
+fn select_sample_rate(caps: &DeviceCapabilities, source_rate: u32) -> (u32, bool) {
+    if caps.supported_sample_rates.contains(&source_rate) {
+        return (source_rate, false);
+    }
+    // Pick highest supported rate at or below 192 kHz
+    let target = caps
+        .supported_sample_rates
+        .iter()
+        .filter(|&&r| r <= 192_000)
+        .max()
+        .copied()
+        .unwrap_or(source_rate);
+    (target, target != source_rate)
+}
+
+fn select_bit_depth(caps: &DeviceCapabilities, requested: u32) -> u32 {
+    if caps.supported_bit_depths.contains(&requested) {
+        return requested;
+    }
+    // Fall back to highest supported depth
+    caps.supported_bit_depths
+        .iter()
+        .max()
+        .copied()
+        .unwrap_or(requested)
+}
+
+/// Converts interleaved f64 samples in `[-1.0, 1.0]` to the target quantization format.
+///
+/// Output bytes are in little-endian order. I24 writes 3 bytes per sample (packed in i32).
+pub fn quantize(samples: &[f64], target: Quantization) -> Vec<u8> {
+    let bytes_per_sample: usize = match target {
+        Quantization::I16 => 2,
+        Quantization::I24 => 3,
+        Quantization::I32 | Quantization::F32 => 4,
+    };
+    let mut out = vec![0u8; samples.len() * bytes_per_sample];
+    quantize_into(samples, target, &mut out);
+    out
+}
+
+/// Non-allocating quantization. `out` must have length `samples.len() * bytes_per_sample(target)`.
+pub fn quantize_into(samples: &[f64], target: Quantization, out: &mut [u8]) {
+    match target {
+        Quantization::F32 => {
+            for (chunk, &s) in out.chunks_exact_mut(4).zip(samples) {
+                chunk.copy_from_slice(&(s as f32).to_le_bytes());
+            }
+        }
+        Quantization::I32 => {
+            for (chunk, &s) in out.chunks_exact_mut(4).zip(samples) {
+                let v = (s * 2_147_483_648.0).clamp(-2_147_483_648.0, 2_147_483_647.0) as i32;
+                chunk.copy_from_slice(&v.to_le_bytes());
+            }
+        }
+        Quantization::I24 => {
+            for (chunk, &s) in out.chunks_exact_mut(3).zip(samples) {
+                let v = (s * 8_388_608.0).clamp(-8_388_608.0, 8_388_607.0) as i32;
+                let bytes = v.to_le_bytes();
+                chunk.copy_from_slice(&bytes[..3]);
+            }
+        }
+        Quantization::I16 => {
+            for (chunk, &s) in out.chunks_exact_mut(2).zip(samples) {
+                let v = (s * 32_768.0).clamp(-32_768.0, 32_767.0) as i16;
+                chunk.copy_from_slice(&v.to_le_bytes());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decode::Codec;
+
+    fn caps(rates: &[u32], depths: &[u32]) -> DeviceCapabilities {
+        DeviceCapabilities {
+            supported_sample_rates: rates.to_vec(),
+            supported_bit_depths: depths.to_vec(),
+            max_channels: 2,
+            supports_exclusive_mode: false,
+        }
+    }
+
+    fn stream(sample_rate: u32) -> StreamParams {
+        StreamParams {
+            codec: Codec::Flac,
+            sample_rate,
+            channels: 2,
+            bit_depth: Some(24),
+            duration: None,
+            bitrate: None,
+        }
+    }
+
+    #[test]
+    fn negotiate_no_resample_when_rates_match() {
+        let params = negotiate_format(
+            &caps(&[44100, 48000, 96000], &[16, 24, 32]),
+            &stream(44100),
+            &OutputConfig::default(),
+        )
+        .unwrap();
+        assert!(!params.needs_resample);
+        assert_eq!(params.sample_rate, 44100);
+        assert_eq!(params.source_sample_rate, 44100);
+    }
+
+    #[test]
+    fn negotiate_resample_when_source_rate_unsupported() {
+        let params = negotiate_format(
+            &caps(&[48000], &[16, 24, 32]),
+            &stream(96000),
+            &OutputConfig::default(),
+        )
+        .unwrap();
+        assert!(params.needs_resample);
+        assert_eq!(params.sample_rate, 48000);
+        assert_eq!(params.source_sample_rate, 96000);
+    }
+
+    #[test]
+    fn negotiate_highest_rate_below_192k() {
+        let params = negotiate_format(
+            &caps(&[44100, 48000], &[16, 24]),
+            &stream(96000),
+            &OutputConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(params.sample_rate, 48000);
+        assert!(params.needs_resample);
+    }
+
+    #[test]
+    fn negotiate_uses_config_bit_depth_when_supported() {
+        let config = OutputConfig {
+            bit_depth: 16,
+            ..OutputConfig::default()
+        };
+        let params =
+            negotiate_format(&caps(&[44100], &[16, 24, 32]), &stream(44100), &config).unwrap();
+        assert_eq!(params.bit_depth, 16);
+    }
+
+    #[test]
+    fn negotiate_falls_back_to_highest_bit_depth() {
+        let config = OutputConfig {
+            bit_depth: 32,
+            ..OutputConfig::default()
+        };
+        // Device only supports up to 24-bit
+        let params = negotiate_format(&caps(&[44100], &[16, 24]), &stream(44100), &config).unwrap();
+        assert_eq!(params.bit_depth, 24);
+    }
+
+    #[test]
+    fn negotiate_quality_tier_lossless_no_resample() {
+        let params = negotiate_format(
+            &caps(&[44100], &[16, 24, 32]),
+            &stream(44100),
+            &OutputConfig::default(),
+        )
+        .unwrap();
+        // FLAC 24-bit, no resample, 24-bit output -> BitPerfect
+        assert_eq!(params.quality_tier, QualityTier::BitPerfect);
+    }
+
+    #[test]
+    fn negotiate_quality_tier_high_quality_on_resample() {
+        let params = negotiate_format(
+            &caps(&[48000], &[16, 24, 32]),
+            &stream(96000),
+            &OutputConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(params.quality_tier, QualityTier::HighQuality);
+    }
+
+    #[test]
+    fn negotiate_error_on_empty_caps() {
+        let result = negotiate_format(&caps(&[], &[16]), &stream(44100), &OutputConfig::default());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn quantize_f32_roundtrip() {
+        let samples = [0.0f64, 1.0, -1.0, 0.5, -0.5];
+        let bytes = quantize(&samples, Quantization::F32);
+        assert_eq!(bytes.len(), samples.len() * 4);
+        for (chunk, &expected) in bytes.chunks_exact(4).zip(&samples) {
+            let v = f32::from_le_bytes(chunk.try_into().unwrap());
+            assert!(
+                (v as f64 - expected).abs() < 1e-6,
+                "f32 mismatch: {v} != {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn quantize_i16_full_scale() {
+        let bytes = quantize(&[1.0f64, -1.0, 0.0], Quantization::I16);
+        assert_eq!(bytes.len(), 6);
+        let vals: Vec<i16> = bytes
+            .chunks_exact(2)
+            .map(|b| i16::from_le_bytes(b.try_into().unwrap()))
+            .collect();
+        assert_eq!(vals[0], i16::MAX);
+        assert_eq!(vals[1], i16::MIN);
+        assert_eq!(vals[2], 0);
+    }
+
+    #[test]
+    fn quantize_i16_clips_above_1() {
+        let bytes = quantize(&[2.0f64, -2.0], Quantization::I16);
+        let vals: Vec<i16> = bytes
+            .chunks_exact(2)
+            .map(|b| i16::from_le_bytes(b.try_into().unwrap()))
+            .collect();
+        assert_eq!(vals[0], i16::MAX);
+        assert_eq!(vals[1], i16::MIN);
+    }
+
+    #[test]
+    fn quantize_i24_full_scale() {
+        let bytes = quantize(&[1.0f64, -1.0], Quantization::I24);
+        assert_eq!(bytes.len(), 6);
+        // 1.0 -> 8_388_607 (0x7FFFFF), LE 3-byte: [0xFF, 0xFF, 0x7F]
+        assert_eq!(&bytes[0..3], &[0xFF_u8, 0xFF, 0x7F]);
+        // -1.0 -> -8_388_608 (0xFF800000), LE 3-byte: [0x00, 0x00, 0x80]
+        assert_eq!(&bytes[3..6], &[0x00_u8, 0x00, 0x80]);
+    }
+
+    #[test]
+    fn quantize_i32_full_scale() {
+        let bytes = quantize(&[1.0f64, -1.0], Quantization::I32);
+        assert_eq!(bytes.len(), 8);
+        let pos = i32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let neg = i32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert_eq!(pos, i32::MAX);
+        assert_eq!(neg, i32::MIN);
+    }
+
+    #[test]
+    fn quantization_bit_depth() {
+        assert_eq!(Quantization::I16.bit_depth(), 16);
+        assert_eq!(Quantization::I24.bit_depth(), 24);
+        assert_eq!(Quantization::I32.bit_depth(), 32);
+        assert_eq!(Quantization::F32.bit_depth(), 32);
+    }
+}

--- a/crates/akouo-core/src/output/mod.rs
+++ b/crates/akouo-core/src/output/mod.rs
@@ -1,0 +1,88 @@
+#[cfg(feature = "native-output")]
+#[expect(
+    deprecated,
+    reason = "cpal 0.17 deprecated name() in favour of description(); migration deferred until cpal 0.18 stabilizes"
+)]
+pub mod cpal;
+pub mod format;
+pub mod resample;
+
+use crate::error::OutputError;
+use crate::signal_path::QualityTier;
+
+/// Callback type supplied to `OutputBackend::open`. Called by the audio backend whenever
+/// it needs samples; must fill the provided buffer within the real-time deadline.
+pub type AudioDataCallback = Box<dyn FnMut(&mut [f64]) + Send + 'static>;
+
+/// Describes an enumerated audio output device.
+///
+/// `Clone` + no lifetimes: safe to pass across FFI/UniFFI boundaries in Phase 6.
+#[derive(Debug, Clone)]
+pub struct OutputDevice {
+    /// OS-assigned device identifier (e.g. WASAPI device GUID, CoreAudio UID).
+    pub id: String,
+    pub name: String,
+    pub is_default: bool,
+}
+
+/// Capabilities reported by an `OutputBackend` for a specific device.
+#[derive(Debug, Clone)]
+pub struct DeviceCapabilities {
+    pub supported_sample_rates: Vec<u32>,
+    pub supported_bit_depths: Vec<u32>,
+    pub max_channels: u16,
+    pub supports_exclusive_mode: bool,
+}
+
+/// Parameters for an output stream, as determined by format negotiation.
+#[derive(Debug, Clone)]
+pub struct OutputParams {
+    /// Hardware output sample rate in Hz.
+    pub sample_rate: u32,
+    /// Number of output channels.
+    pub channels: u16,
+    /// Output bit depth (16, 24, or 32).
+    pub bit_depth: u32,
+    /// Request exclusive device access (ALSA, WASAPI, CoreAudio).
+    pub exclusive_mode: bool,
+    /// True if the output sample rate differs from the source and resampling is needed.
+    pub needs_resample: bool,
+    /// Source sample rate before resampling. Equals `sample_rate` when `needs_resample` is false.
+    pub source_sample_rate: u32,
+    /// Signal quality tier after output negotiation.
+    pub quality_tier: QualityTier,
+}
+
+/// Abstraction over platform audio backends (cpal, AAudio, CoreAudio, WASAPI).
+///
+/// Implementations are `Send + Sync` so they can be shared between the audio task and
+/// the engine control task via `Arc<Mutex<dyn OutputBackend>>`.
+pub trait OutputBackend: Send + Sync {
+    /// Returns all available output devices.
+    fn available_devices(&self) -> Result<Vec<OutputDevice>, OutputError>;
+
+    /// Returns capabilities for the named device (or the default if `None`).
+    fn device_capabilities(
+        &self,
+        device_id: Option<&str>,
+    ) -> Result<DeviceCapabilities, OutputError>;
+
+    /// Opens an output stream with the given parameters. The backend calls `data_callback`
+    /// whenever it needs audio samples. `data_callback` receives a mutable interleaved f64
+    /// buffer; it must fill it within the real-time deadline.
+    fn open(
+        &mut self,
+        device_id: Option<&str>,
+        params: OutputParams,
+        data_callback: AudioDataCallback,
+    ) -> impl std::future::Future<Output = Result<(), OutputError>> + Send;
+
+    /// Starts the audio stream (begins calling `data_callback`).
+    fn start(&mut self) -> impl std::future::Future<Output = Result<(), OutputError>> + Send;
+
+    /// Pauses the stream without closing it.
+    fn pause(&mut self) -> impl std::future::Future<Output = Result<(), OutputError>> + Send;
+
+    /// Closes the stream and releases device resources.
+    fn close(&mut self) -> impl std::future::Future<Output = Result<(), OutputError>> + Send;
+}

--- a/crates/akouo-core/src/output/resample.rs
+++ b/crates/akouo-core/src/output/resample.rs
@@ -1,0 +1,233 @@
+use rubato::audioadapter::{Adapter, AdapterMut};
+use rubato::{
+    Async, FixedAsync, Resampler as _, SincInterpolationParameters, SincInterpolationType,
+    WindowFunction,
+};
+
+use crate::error::OutputError;
+
+// ---------------------------------------------------------------------------
+// Lightweight audioadapter wrappers for interleaved f64 slices
+// ---------------------------------------------------------------------------
+
+struct InterleavedIn<'a> {
+    data: &'a [f64],
+    channels: usize,
+    frames: usize,
+}
+
+impl<'a> Adapter<'a, f64> for InterleavedIn<'a> {
+    unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> f64 {
+        // SAFETY: caller guarantees channel < channels and frame < frames
+        unsafe { *self.data.get_unchecked(frame * self.channels + channel) }
+    }
+    fn channels(&self) -> usize {
+        self.channels
+    }
+    fn frames(&self) -> usize {
+        self.frames
+    }
+}
+
+struct InterleavedOut<'a> {
+    data: &'a mut [f64],
+    channels: usize,
+    frames: usize,
+}
+
+impl<'a> Adapter<'a, f64> for InterleavedOut<'a> {
+    unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> f64 {
+        // SAFETY: caller guarantees channel < channels and frame < frames
+        unsafe { *self.data.get_unchecked(frame * self.channels + channel) }
+    }
+    fn channels(&self) -> usize {
+        self.channels
+    }
+    fn frames(&self) -> usize {
+        self.frames
+    }
+}
+
+impl<'a> AdapterMut<'a, f64> for InterleavedOut<'a> {
+    unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &f64) -> bool {
+        // SAFETY: caller guarantees channel < channels and frame < frames
+        unsafe { *self.data.get_unchecked_mut(frame * self.channels + channel) = *value };
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resampler
+// ---------------------------------------------------------------------------
+
+/// Sinc resampler for converting interleaved f64 audio between sample rates.
+///
+/// Wraps rubato's `Async` sinc resampler with pre-allocated interleaved buffers so
+/// that `process_interleaved` is allocation-free after construction.
+pub struct Resampler {
+    inner: Async<f64>,
+    channels: usize,
+    /// Pre-allocated interleaved output buffer; capacity = `output_frames_max * channels`.
+    output_buf: Vec<f64>,
+}
+
+impl Resampler {
+    /// Creates a sinc resampler converting from `source_rate` to `target_rate`.
+    ///
+    /// `chunk_frames` is the fixed number of input frames per call to
+    /// `process_interleaved`. The output buffer is pre-allocated to the worst-case
+    /// output size.
+    pub fn new(
+        source_rate: u32,
+        target_rate: u32,
+        channels: usize,
+        chunk_frames: usize,
+    ) -> Result<Self, OutputError> {
+        let ratio = target_rate as f64 / source_rate as f64;
+
+        let params = SincInterpolationParameters {
+            sinc_len: 256,
+            f_cutoff: 0.95,
+            interpolation: SincInterpolationType::Linear,
+            oversampling_factor: 256,
+            window: WindowFunction::BlackmanHarris2,
+        };
+
+        let inner = Async::<f64>::new_sinc(
+            ratio,
+            2.0,
+            &params,
+            chunk_frames,
+            channels,
+            FixedAsync::Input,
+        )
+        .map_err(|e| OutputError::FormatUnsupported {
+            message: format!("resampler init failed: {e}"),
+        })?;
+
+        let max_output = inner.output_frames_max();
+        let output_buf = vec![0.0f64; max_output * channels];
+
+        Ok(Self {
+            inner,
+            channels,
+            output_buf,
+        })
+    }
+
+    /// Number of input frames expected by the next `process_interleaved` call.
+    pub fn input_frames_next(&self) -> usize {
+        self.inner.input_frames_next()
+    }
+
+    /// Maximum number of output frames the next `process_interleaved` call may produce.
+    pub fn output_frames_max(&self) -> usize {
+        self.inner.output_frames_max()
+    }
+
+    /// Resamples `input` (interleaved, `input_frames_next() * channels` samples) and
+    /// writes resampled interleaved audio into `output`.
+    ///
+    /// Returns the number of output frames written. `output` must have capacity for at
+    /// least `output_frames_max() * channels` samples.
+    ///
+    /// No allocation occurs after construction.
+    pub fn process_interleaved(
+        &mut self,
+        input: &[f64],
+        output: &mut [f64],
+    ) -> Result<usize, OutputError> {
+        let in_frames = input.len() / self.channels;
+        let out_capacity = output.len() / self.channels;
+        let max_out = self.inner.output_frames_max();
+
+        if out_capacity < max_out {
+            return Err(OutputError::StreamError {
+                message: format!(
+                    "output buffer too small: need {max_out} frames ({} samples), got {out_capacity} frames",
+                    max_out * self.channels
+                ),
+            });
+        }
+
+        let buf_in = InterleavedIn {
+            data: input,
+            channels: self.channels,
+            frames: in_frames,
+        };
+        let mut buf_out = InterleavedOut {
+            data: &mut self.output_buf,
+            channels: self.channels,
+            frames: max_out,
+        };
+
+        let (_, out_frames) = self
+            .inner
+            .process_into_buffer(&buf_in, &mut buf_out, None)
+            .map_err(|e| OutputError::StreamError {
+                message: format!("resample failed: {e}"),
+            })?;
+
+        // Copy resampled data from staging buffer into the caller's output
+        let out_samples = out_frames * self.channels;
+        output[..out_samples].copy_from_slice(&self.output_buf[..out_samples]);
+
+        Ok(out_frames)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resampler_new_same_rate() {
+        let r = Resampler::new(44100, 44100, 2, 512);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn resampler_new_upsample() {
+        let r = Resampler::new(44100, 48000, 2, 441);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn resampler_new_downsample() {
+        let r = Resampler::new(96000, 48000, 2, 1024);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn resampler_produces_output_frames() {
+        let chunk = 441;
+        let channels = 2;
+        let mut r = Resampler::new(44100, 48000, channels, chunk).unwrap();
+
+        let input = vec![0.0f64; r.input_frames_next() * channels];
+        let max_out = r.output_frames_max();
+        let mut output = vec![0.0f64; max_out * channels];
+
+        let out_frames = r.process_interleaved(&input, &mut output).unwrap();
+        // 44100 -> 48000 at 441 input frames ~ 480 output frames
+        assert!(out_frames > 0);
+        assert!(out_frames <= max_out);
+    }
+
+    #[test]
+    fn resampler_output_too_small_returns_error() {
+        let chunk = 441;
+        let channels = 2;
+        let mut r = Resampler::new(44100, 48000, channels, chunk).unwrap();
+        let input = vec![0.0f64; r.input_frames_next() * channels];
+        // Deliberately undersized output
+        let mut output = vec![0.0f64; 2];
+        assert!(r.process_interleaved(&input, &mut output).is_err());
+    }
+
+    #[test]
+    #[ignore = "requires hardware timing; verifies freq content below Nyquist"]
+    fn resampler_preserves_frequency_content() {
+        // Full FFT verification of sinc quality is an integration test
+    }
+}

--- a/crates/akouo-core/src/queue.rs
+++ b/crates/akouo-core/src/queue.rs
@@ -1,0 +1,202 @@
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+
+/// Sequential play queue with forward/backward navigation.
+///
+/// Phase 1: no shuffle, no repeat. Both are added in Phase 2.
+pub struct PlayQueue {
+    tracks: VecDeque<PathBuf>,
+    current_index: usize,
+    history: Vec<PathBuf>,
+}
+
+impl PlayQueue {
+    /// Creates an empty queue.
+    pub fn new() -> Self {
+        Self {
+            tracks: VecDeque::new(),
+            current_index: 0,
+            history: Vec::new(),
+        }
+    }
+
+    /// Creates a queue pre-loaded with `tracks`.
+    pub fn from_tracks(tracks: impl IntoIterator<Item = PathBuf>) -> Self {
+        Self {
+            tracks: tracks.into_iter().collect(),
+            current_index: 0,
+            history: Vec::new(),
+        }
+    }
+
+    /// Appends a track to the end of the queue.
+    pub fn push(&mut self, path: PathBuf) {
+        self.tracks.push_back(path);
+    }
+
+    /// Returns the currently active track path, or `None` when the queue is empty.
+    pub fn current(&self) -> Option<&Path> {
+        self.tracks.get(self.current_index).map(PathBuf::as_path)
+    }
+
+    /// Advances to the next track and returns its path.
+    ///
+    /// Returns `None` when there is no next track (end of queue).
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "PlayQueue::next() advances the queue and returns the track; naming matches domain language, not Iterator"
+    )]
+    pub fn next(&mut self) -> Option<PathBuf> {
+        if let Some(current) = self.current().map(PathBuf::from) {
+            self.history.push(current);
+        }
+        let next_index = self.current_index + 1;
+        if next_index < self.tracks.len() {
+            self.current_index = next_index;
+            self.current().map(PathBuf::from)
+        } else {
+            None
+        }
+    }
+
+    /// Moves to the previous track and returns its path.
+    ///
+    /// If `current_elapsed_secs` > 3.0, restarts the current track instead of going
+    /// back one track. Returns `None` only when the queue is empty.
+    pub fn previous(&mut self, current_elapsed_secs: f64) -> Option<PathBuf> {
+        if current_elapsed_secs > 3.0 {
+            // Restart current track.
+            return self.current().map(PathBuf::from);
+        }
+        if self.current_index > 0 {
+            self.current_index -= 1;
+        }
+        self.current().map(PathBuf::from)
+    }
+
+    /// Returns the number of tracks in the queue.
+    pub fn len(&self) -> usize {
+        self.tracks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tracks.is_empty()
+    }
+
+    /// Returns the current track index (0-based).
+    pub fn current_index(&self) -> usize {
+        self.current_index
+    }
+
+    /// Returns the playback history (tracks played before the current).
+    pub fn history(&self) -> &[PathBuf] {
+        &self.history
+    }
+}
+
+impl Default for PlayQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(names: &[&str]) -> Vec<PathBuf> {
+        names.iter().map(PathBuf::from).collect()
+    }
+
+    #[test]
+    fn empty_queue_current_is_none() {
+        let q = PlayQueue::new();
+        assert!(q.current().is_none());
+    }
+
+    #[test]
+    fn empty_queue_next_is_none() {
+        let mut q = PlayQueue::new();
+        assert!(q.next().is_none());
+    }
+
+    #[test]
+    fn single_track_current_returns_it() {
+        let q = PlayQueue::from_tracks(paths(&["a.flac"]));
+        assert_eq!(q.current(), Some(Path::new("a.flac")));
+    }
+
+    #[test]
+    fn sequential_three_files() {
+        let mut q = PlayQueue::from_tracks(paths(&["a.flac", "b.flac", "c.flac"]));
+
+        assert_eq!(q.current(), Some(Path::new("a.flac")));
+
+        let n = q.next();
+        assert_eq!(n.as_deref(), Some(Path::new("b.flac")));
+        assert_eq!(q.current(), Some(Path::new("b.flac")));
+
+        let n = q.next();
+        assert_eq!(n.as_deref(), Some(Path::new("c.flac")));
+        assert_eq!(q.current(), Some(Path::new("c.flac")));
+
+        let n = q.next();
+        assert!(n.is_none(), "should return None at end of queue");
+    }
+
+    #[test]
+    fn previous_at_start_stays_at_first_track() {
+        let mut q = PlayQueue::from_tracks(paths(&["a.flac", "b.flac"]));
+        let prev = q.previous(0.0);
+        assert_eq!(prev.as_deref(), Some(Path::new("a.flac")));
+        assert_eq!(q.current_index(), 0);
+    }
+
+    #[test]
+    fn previous_after_next_goes_back() {
+        let mut q = PlayQueue::from_tracks(paths(&["a.flac", "b.flac", "c.flac"]));
+        q.next();
+        q.next();
+        // At c.flac, elapsed < 3s → go to b.flac
+        let prev = q.previous(1.0);
+        assert_eq!(prev.as_deref(), Some(Path::new("b.flac")));
+    }
+
+    #[test]
+    fn previous_with_elapsed_over_3s_restarts_current() {
+        let mut q = PlayQueue::from_tracks(paths(&["a.flac", "b.flac"]));
+        q.next(); // at b.flac
+        // elapsed > 3s → restart b.flac
+        let prev = q.previous(5.0);
+        assert_eq!(prev.as_deref(), Some(Path::new("b.flac")));
+        assert_eq!(q.current_index(), 1, "index should not change");
+    }
+
+    #[test]
+    fn history_tracks_played_tracks() {
+        let mut q = PlayQueue::from_tracks(paths(&["a.flac", "b.flac", "c.flac"]));
+        q.next();
+        q.next();
+        assert_eq!(q.history().len(), 2);
+        assert_eq!(q.history()[0], PathBuf::from("a.flac"));
+        assert_eq!(q.history()[1], PathBuf::from("b.flac"));
+    }
+
+    #[test]
+    fn push_appends_to_queue() {
+        let mut q = PlayQueue::new();
+        q.push(PathBuf::from("a.flac"));
+        q.push(PathBuf::from("b.flac"));
+        assert_eq!(q.len(), 2);
+        assert_eq!(q.current(), Some(Path::new("a.flac")));
+    }
+
+    #[test]
+    fn len_and_is_empty() {
+        let mut q = PlayQueue::new();
+        assert!(q.is_empty());
+        q.push(PathBuf::from("x.flac"));
+        assert_eq!(q.len(), 1);
+        assert!(!q.is_empty());
+    }
+}

--- a/crates/akouo-core/src/ring_buffer.rs
+++ b/crates/akouo-core/src/ring_buffer.rs
@@ -1,0 +1,217 @@
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Lock-free SPSC (single-producer, single-consumer) ring buffer for f64 audio samples.
+///
+/// # Safety
+///
+/// The buffer is safe only when used with exactly one producer calling `push_frame` and
+/// exactly one consumer calling `pop_frame`, never concurrently on the same side. This is
+/// the standard SPSC contract: separate `&RingBuffer` references held by producer and
+/// consumer threads are safe because the atomic read/write positions coordinate access to
+/// non-overlapping slots.
+///
+/// The backing store uses `UnsafeCell<f64>` per slot. The producer exclusively writes into
+/// slots in the range `[write_pos, write_pos + count)` and publishes via a Release store to
+/// `write_pos`. The consumer exclusively reads from slots in `[read_pos, read_pos + count)`
+/// after an Acquire load of `write_pos` to synchronise.
+pub struct RingBuffer {
+    data: Box<[UnsafeCell<f64>]>,
+    /// Capacity, always a power of two, so `& (capacity - 1)` replaces modulo.
+    capacity: usize,
+    /// Monotonically increasing read position. Only advanced by the consumer.
+    read_pos: AtomicUsize,
+    /// Monotonically increasing write position. Only advanced by the producer.
+    write_pos: AtomicUsize,
+}
+
+// SPSC contract: one producer + one consumer, never same-side concurrent access.
+unsafe impl Send for RingBuffer {}
+unsafe impl Sync for RingBuffer {}
+
+#[expect(dead_code)]
+impl RingBuffer {
+    /// Allocates a ring buffer with at least `min_capacity` slots, rounded up to the next
+    /// power of two. No allocation occurs after this call.
+    pub fn new(min_capacity: usize) -> Self {
+        let capacity = min_capacity.next_power_of_two().max(2);
+        let data = (0..capacity)
+            .map(|_| UnsafeCell::new(0.0_f64))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            data,
+            capacity,
+            read_pos: AtomicUsize::new(0),
+            write_pos: AtomicUsize::new(0),
+        }
+    }
+
+    /// Returns the number of slots currently available for writing.
+    #[inline]
+    pub fn available_to_write(&self) -> usize {
+        let read = self.read_pos.load(Ordering::Acquire);
+        let write = self.write_pos.load(Ordering::Relaxed);
+        // One slot is kept empty to distinguish full from empty.
+        (self.capacity - 1 - write.wrapping_sub(read)) & (self.capacity - 1)
+    }
+
+    /// Returns the number of samples currently available for reading.
+    #[inline]
+    pub fn available_to_read(&self) -> usize {
+        let write = self.write_pos.load(Ordering::Acquire);
+        let read = self.read_pos.load(Ordering::Relaxed);
+        write.wrapping_sub(read) & (self.capacity - 1)
+    }
+
+    /// Writes `samples` into the buffer. Returns `true` on success, `false` if the buffer
+    /// does not have enough space (backpressure — caller should retry later).
+    ///
+    /// Must only be called from the single producer thread.
+    pub fn push_frame(&self, samples: &[f64]) -> bool {
+        let n = samples.len();
+        if n == 0 {
+            return true;
+        }
+
+        let write = self.write_pos.load(Ordering::Relaxed);
+        let read = self.read_pos.load(Ordering::Acquire);
+        let used = write.wrapping_sub(read) & (self.capacity - 1);
+        if used + n >= self.capacity {
+            return false; // backpressure
+        }
+
+        let mask = self.capacity - 1;
+        for (i, &sample) in samples.iter().enumerate() {
+            let idx = (write + i) & mask;
+            // SAFETY: We are the sole writer. The slot at `idx` is not being read because
+            // `used + n < capacity` ensures no overlap with the consumer window.
+            unsafe { *self.data[idx].get() = sample };
+        }
+
+        // Release: make written data visible to the consumer before advancing write_pos.
+        self.write_pos
+            .store(write.wrapping_add(n) & usize::MAX, Ordering::Release);
+        true
+    }
+
+    /// Reads the next frame of `out.len()` samples into `out`. Returns `true` on success,
+    /// `false` if the buffer does not have enough data.
+    ///
+    /// Must only be called from the single consumer thread.
+    pub fn pop_frame(&self, out: &mut [f64]) -> bool {
+        let n = out.len();
+        if n == 0 {
+            return true;
+        }
+
+        let read = self.read_pos.load(Ordering::Relaxed);
+        let write = self.write_pos.load(Ordering::Acquire);
+        let available = write.wrapping_sub(read) & (self.capacity - 1);
+        if available < n {
+            return false;
+        }
+
+        let mask = self.capacity - 1;
+        for (i, slot) in out.iter_mut().enumerate() {
+            let idx = (read + i) & mask;
+            // SAFETY: We are the sole reader. The write_pos Acquire load above synchronises
+            // with the producer's Release store, guaranteeing the data is fully written.
+            *slot = unsafe { *self.data[idx].get() };
+        }
+
+        // Release: make read_pos advance visible to the producer.
+        self.read_pos
+            .store(read.wrapping_add(n) & usize::MAX, Ordering::Release);
+        true
+    }
+
+    /// Resets both positions to zero, discarding all buffered data.
+    /// Call only when no other thread is concurrently accessing the buffer.
+    pub fn clear(&self) {
+        self.read_pos.store(0, Ordering::SeqCst);
+        self.write_pos.store(0, Ordering::SeqCst);
+    }
+
+    /// Buffer capacity in samples (always a power of two).
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_capacity_rounds_to_power_of_two() {
+        let rb = RingBuffer::new(100);
+        assert!(rb.capacity().is_power_of_two());
+        assert!(rb.capacity() >= 100);
+    }
+
+    #[test]
+    fn empty_buffer_reports_zero_available_to_read() {
+        let rb = RingBuffer::new(64);
+        assert_eq!(rb.available_to_read(), 0);
+    }
+
+    #[test]
+    fn push_and_pop_single_frame() {
+        let rb = RingBuffer::new(16);
+        let input = [1.0_f64, 2.0, 3.0, 4.0];
+        assert!(rb.push_frame(&input));
+        assert_eq!(rb.available_to_read(), 4);
+
+        let mut output = [0.0_f64; 4];
+        assert!(rb.pop_frame(&mut output));
+        assert_eq!(output, input);
+        assert_eq!(rb.available_to_read(), 0);
+    }
+
+    #[test]
+    fn push_returns_false_when_full() {
+        let rb = RingBuffer::new(4); // capacity = 4, usable = 3
+        let frame = [0.5_f64; 3];
+        assert!(rb.push_frame(&frame));
+        assert!(!rb.push_frame(&[0.5])); // no space
+    }
+
+    #[test]
+    fn pop_returns_false_when_empty() {
+        let rb = RingBuffer::new(16);
+        let mut out = [0.0_f64; 4];
+        assert!(!rb.pop_frame(&mut out));
+    }
+
+    #[test]
+    fn multiple_push_pop_cycles() {
+        let rb = RingBuffer::new(32);
+        for i in 0..10_u32 {
+            let frame = [i as f64, i as f64 + 0.5];
+            assert!(rb.push_frame(&frame));
+            let mut out = [0.0_f64; 2];
+            assert!(rb.pop_frame(&mut out));
+            assert_eq!(out[0], i as f64);
+            assert_eq!(out[1], i as f64 + 0.5);
+        }
+    }
+
+    #[test]
+    fn clear_resets_positions() {
+        let rb = RingBuffer::new(16);
+        assert!(rb.push_frame(&[1.0, 2.0, 3.0]));
+        assert_eq!(rb.available_to_read(), 3);
+        rb.clear();
+        assert_eq!(rb.available_to_read(), 0);
+    }
+
+    #[test]
+    fn empty_slice_push_and_pop_are_no_ops() {
+        let rb = RingBuffer::new(16);
+        assert!(rb.push_frame(&[]));
+        let mut out: [f64; 0] = [];
+        assert!(rb.pop_frame(&mut out));
+        assert_eq!(rb.available_to_read(), 0);
+    }
+}

--- a/crates/akouo-core/src/signal_path/mod.rs
+++ b/crates/akouo-core/src/signal_path/mod.rs
@@ -1,0 +1,105 @@
+pub mod tier;
+
+pub use tier::{QualityTier, source_tier};
+
+use std::time::Instant;
+
+/// A snapshot of the signal path state at a point in time.
+/// Sent via `watch::Sender<SignalPathSnapshot>` whenever any stage changes.
+#[derive(Debug, Clone)]
+pub struct SignalPathSnapshot {
+    /// Aggregate quality tier for the entire path (minimum across all stages).
+    pub tier: QualityTier,
+    pub source: Option<SourceInfo>,
+    pub stages: Vec<SignalStageInfo>,
+    pub output: Option<OutputInfo>,
+    pub timestamp: Instant,
+}
+
+impl SignalPathSnapshot {
+    /// Constructs an idle snapshot with no source or output.
+    pub fn idle() -> Self {
+        Self {
+            tier: QualityTier::Lossless,
+            source: None,
+            stages: Vec::new(),
+            output: None,
+            timestamp: Instant::now(),
+        }
+    }
+}
+
+/// Describes the source audio stream in the signal path.
+#[derive(Debug, Clone)]
+pub struct SourceInfo {
+    pub codec: String,
+    pub sample_rate: u32,
+    pub channels: u16,
+    /// Original bit depth of the source. `None` for lossy codecs.
+    pub bit_depth: Option<u32>,
+    pub tier: QualityTier,
+}
+
+/// Describes one DSP stage's contribution to the signal path.
+#[derive(Debug, Clone)]
+pub struct SignalStageInfo {
+    pub name: String,
+    pub enabled: bool,
+    pub params: StageParams,
+    /// The tier impact of this stage when enabled. `None` = no impact.
+    pub tier_impact: Option<QualityTier>,
+}
+
+/// Describes the audio output in the signal path.
+#[derive(Debug, Clone)]
+pub struct OutputInfo {
+    pub device_name: String,
+    pub sample_rate: u32,
+    pub bit_depth: u32,
+    pub channels: u16,
+    pub exclusive_mode: bool,
+}
+
+/// Parameters captured for display / logging from a DSP stage.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum StageParams {
+    SkipSilence {
+        threshold_db: f64,
+    },
+    Eq {
+        /// (frequency_hz, gain_db, q) per band.
+        bands: Vec<(f64, f64, f64)>,
+    },
+    Crossfeed {
+        strength: f64,
+    },
+    ReplayGain {
+        mode: String,
+        gain_db: f64,
+    },
+    Compressor {
+        threshold_db: f64,
+        ratio: f64,
+    },
+    Convolution {
+        ir_name: Option<String>,
+    },
+    Volume {
+        level_db: f64,
+        dither: bool,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_snapshot_has_no_source_or_output() {
+        let snap = SignalPathSnapshot::idle();
+        assert!(snap.source.is_none());
+        assert!(snap.output.is_none());
+        assert!(snap.stages.is_empty());
+    }
+}

--- a/crates/akouo-core/src/signal_path/tier.rs
+++ b/crates/akouo-core/src/signal_path/tier.rs
@@ -1,0 +1,161 @@
+use crate::decode::Codec;
+
+/// Quality tier for the audio signal path, from lowest to highest.
+///
+/// The `Ord` ordering is ascending quality: `Degraded < Standard < HighQuality < Lossless < BitPerfect`.
+/// Tier propagation takes the `min` across all active stages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum QualityTier {
+    /// Significant processing artifacts or lossy re-encoding applied.
+    Degraded = 0,
+    /// Standard lossy source (MP3, AAC < 192 kbps) with no additional degradation.
+    Standard = 1,
+    /// High-quality lossy source (Opus, Vorbis, AAC ≥ 192 kbps) or resampled lossless.
+    HighQuality = 2,
+    /// Losslessly decoded, DSP applied (EQ, crossfeed, ReplayGain).
+    Lossless = 3,
+    /// Bit-perfect: lossless source, no resampling, no DSP, output matches source depth.
+    BitPerfect = 4,
+}
+
+impl std::fmt::Display for QualityTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QualityTier::Degraded => f.write_str("Degraded"),
+            QualityTier::Standard => f.write_str("Standard"),
+            QualityTier::HighQuality => f.write_str("High Quality"),
+            QualityTier::Lossless => f.write_str("Lossless"),
+            QualityTier::BitPerfect => f.write_str("Bit-Perfect"),
+        }
+    }
+}
+
+/// Determines the quality tier ceiling of a source based on codec, sample rate, and bit depth.
+/// DSP stages may only lower the tier below this ceiling via `tier.min(stage_tier)`.
+pub fn source_tier(codec: &Codec, sample_rate: u32, bit_depth: Option<u32>) -> QualityTier {
+    match codec {
+        Codec::Flac | Codec::Alac | Codec::Wav | Codec::Aiff => {
+            // High-resolution lossless (Hi-Res Audio spec: > 44.1 kHz or > 16-bit).
+            if bit_depth.is_some_and(|d| d >= 24) || sample_rate > 44100 {
+                QualityTier::BitPerfect
+            } else {
+                QualityTier::Lossless
+            }
+        }
+        Codec::Vorbis | Codec::Opus => QualityTier::HighQuality,
+        Codec::Aac => QualityTier::HighQuality,
+        Codec::Mp3 | Codec::Other(_) => QualityTier::Standard,
+    }
+}
+
+/// Propagates the tier through a sequence of (enabled, stage_tier) pairs.
+/// Disabled stages do not affect the tier.
+pub fn propagate_tier(
+    source: QualityTier,
+    stages: impl IntoIterator<Item = (bool, QualityTier)>,
+) -> QualityTier {
+    stages
+        .into_iter()
+        .filter(|(enabled, _)| *enabled)
+        .map(|(_, tier)| tier)
+        .fold(source, QualityTier::min)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quality_tier_ordering() {
+        assert!(QualityTier::Degraded < QualityTier::Standard);
+        assert!(QualityTier::Standard < QualityTier::HighQuality);
+        assert!(QualityTier::HighQuality < QualityTier::Lossless);
+        assert!(QualityTier::Lossless < QualityTier::BitPerfect);
+    }
+
+    #[test]
+    fn source_tier_flac_16bit_44k_is_lossless() {
+        assert_eq!(
+            source_tier(&Codec::Flac, 44100, Some(16)),
+            QualityTier::Lossless
+        );
+    }
+
+    #[test]
+    fn source_tier_flac_24bit_96k_is_bitperfect() {
+        assert_eq!(
+            source_tier(&Codec::Flac, 96000, Some(24)),
+            QualityTier::BitPerfect
+        );
+    }
+
+    #[test]
+    fn source_tier_wav_hires_sample_rate_is_bitperfect() {
+        assert_eq!(
+            source_tier(&Codec::Wav, 88200, Some(16)),
+            QualityTier::BitPerfect
+        );
+    }
+
+    #[test]
+    fn source_tier_mp3_is_standard() {
+        assert_eq!(source_tier(&Codec::Mp3, 44100, None), QualityTier::Standard);
+    }
+
+    #[test]
+    fn source_tier_opus_is_high_quality() {
+        assert_eq!(
+            source_tier(&Codec::Opus, 48000, None),
+            QualityTier::HighQuality
+        );
+    }
+
+    #[test]
+    fn source_tier_alac_24bit_is_bitperfect() {
+        assert_eq!(
+            source_tier(&Codec::Alac, 44100, Some(24)),
+            QualityTier::BitPerfect
+        );
+    }
+
+    #[test]
+    fn propagate_tier_no_active_stages_preserves_source() {
+        let tier = propagate_tier(
+            QualityTier::BitPerfect,
+            [
+                (false, QualityTier::Degraded),
+                (false, QualityTier::Standard),
+            ],
+        );
+        assert_eq!(tier, QualityTier::BitPerfect);
+    }
+
+    #[test]
+    fn propagate_tier_active_stage_lowers_tier() {
+        let tier = propagate_tier(QualityTier::BitPerfect, [(true, QualityTier::Lossless)]);
+        assert_eq!(tier, QualityTier::Lossless);
+    }
+
+    #[test]
+    fn propagate_tier_takes_minimum() {
+        let tier = propagate_tier(
+            QualityTier::BitPerfect,
+            [
+                (true, QualityTier::Lossless),
+                (true, QualityTier::HighQuality),
+                (true, QualityTier::Lossless),
+            ],
+        );
+        assert_eq!(tier, QualityTier::HighQuality);
+    }
+
+    #[test]
+    fn quality_tier_display() {
+        assert_eq!(QualityTier::BitPerfect.to_string(), "Bit-Perfect");
+        assert_eq!(QualityTier::Lossless.to_string(), "Lossless");
+        assert_eq!(QualityTier::HighQuality.to_string(), "High Quality");
+        assert_eq!(QualityTier::Standard.to_string(), "Standard");
+        assert_eq!(QualityTier::Degraded.to_string(), "Degraded");
+    }
+}

--- a/crates/harmonia-host/Cargo.toml
+++ b/crates/harmonia-host/Cargo.toml
@@ -25,6 +25,7 @@ syntaxis.workspace = true
 aitesis.workspace = true
 syndesmos.workspace = true
 prostheke.workspace = true
+akouo-core = { workspace = true, features = ["native-output"] }
 clap.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/crates/harmonia-host/src/cli.rs
+++ b/crates/harmonia-host/src/cli.rs
@@ -15,6 +15,8 @@ pub enum Command {
     Serve(ServeArgs),
     /// Database management
     Db(DbArgs),
+    /// Play a local audio file
+    Play(PlayArgs),
 }
 
 #[derive(Args)]
@@ -37,6 +39,16 @@ pub struct DbArgs {
     /// Database subcommand
     #[command(subcommand)]
     pub command: DbCommand,
+}
+
+#[derive(Args)]
+pub struct PlayArgs {
+    /// Path to an audio file
+    pub file: PathBuf,
+
+    /// Audio output device name (uses default if omitted)
+    #[arg(long)]
+    pub device: Option<String>,
 }
 
 #[derive(Subcommand)]

--- a/crates/harmonia-host/src/error.rs
+++ b/crates/harmonia-host/src/error.rs
@@ -103,4 +103,12 @@ pub enum HostError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    #[snafu(display("audio engine error: {source}"))]
+    AudioEngine {
+        #[snafu(source(from(akouo_core::EngineError, Box::new)))]
+        source: Box<akouo_core::EngineError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }

--- a/crates/harmonia-host/src/main.rs
+++ b/crates/harmonia-host/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod error;
+mod play;
 mod serve;
 mod shutdown;
 mod startup;
@@ -19,6 +20,7 @@ async fn main() {
                 Ok(())
             }
         },
+        Command::Play(args) => play::run_play(args).await,
     };
 
     if let Err(e) = result {

--- a/crates/harmonia-host/src/play.rs
+++ b/crates/harmonia-host/src/play.rs
@@ -1,0 +1,34 @@
+// Play subcommand — plays a local audio file via akouo-core.
+
+use std::sync::Arc;
+
+use akouo_core::{AudioSource, Engine, EngineConfig, EngineEvent};
+use snafu::ResultExt;
+
+use crate::cli::PlayArgs;
+use crate::error::{AudioEngineSnafu, HostError};
+
+pub async fn run_play(args: PlayArgs) -> Result<(), HostError> {
+    let config = EngineConfig::default();
+    let engine = Arc::new(Engine::new(config).context(AudioEngineSnafu)?);
+    let mut events = engine.subscribe_events();
+
+    let source = AudioSource::File(args.file);
+    engine.play(source).context(AudioEngineSnafu)?;
+
+    // WHY: block until playback finishes or an error occurs.
+    loop {
+        match events.recv().await {
+            Ok(EngineEvent::PlaybackStopped | EngineEvent::TrackEnded { .. }) => break,
+            Ok(EngineEvent::Error { message }) => {
+                eprintln!("playback error: {message}");
+                break;
+            }
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+
+    engine.stop().context(AudioEngineSnafu)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #121.

- Ports the `akouo/shared/akouo-core` prototype into `crates/akouo-core` as a workspace member
- Full audio pipeline: decode (symphonia multi-codec + opus FFI), 7-stage DSP (skip-silence, parametric EQ, crossfeed, ReplayGain, compressor, convolution stub, volume+TPDF dither), output (format negotiation, rubato resampler, cpal backend behind `native-output` feature), gapless playback (codec delay trimming, equal-power crossfade, album detection, prebuffer), engine state machine, play queue, lock-free SPSC ring buffer, signal path quality tier tracking
- Adds `harmonia play <file>` subcommand to harmonia-host for local audio playback
- 177 akouo-core tests passing; full workspace green

## Key adaptations from prototype

- lofty 0.22 → 0.23: `get_string` takes `ItemKey` by value; R128 tag lookup via `tag.items()` iteration
- rand 0.10: `SmallRng::from_rng(&mut rand::rng())`, `use rand::RngExt`
- Feature-gated `#[expect(unused_variables)]` via `cfg_attr` for `native-output`

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (177 akouo-core tests, full workspace green)
- [ ] CI gate workflow validates Gate-Passed trailer