### PR TITLE
feat(syndesis): QUIC streaming protocol with clock sync and jitter buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -1053,9 +1053,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deflate64"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "der"
@@ -1340,6 +1340,18 @@ name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.2",
+ "siphasher",
+]
 
 [[package]]
 name = "fastrand"
@@ -2205,9 +2217,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -2230,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -3486,9 +3498,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -3557,7 +3569,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.4+spec-1.1.0",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -3666,6 +3678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
+ "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
@@ -3673,6 +3686,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3804,6 +3818,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -4098,6 +4125,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,10 +4147,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.103.9"
+name = "rustls-platform-verifier"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4955,6 +5021,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "syndesis"
+version = "0.1.2"
+dependencies = [
+ "bytes",
+ "quinn",
+ "rand 0.10.0",
+ "rcgen",
+ "rstest",
+ "rustls",
+ "serde",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "syndesmos"
 version = "0.1.2"
 dependencies = [
@@ -5144,9 +5226,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5278,9 +5360,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -5296,28 +5378,28 @@ dependencies = [
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -5852,6 +5934,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6324,6 +6415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6433,6 +6533,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6457,18 +6566,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6561,9 +6670,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.3.1"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c546feb4481b0fbafb4ef0d79b6204fc41c6f9884b1b73b1d73f82442fc0845"
+checksum = "7756d0206d058333667493c4014f545f4b9603c4330ccd6d9b3f86dcab59f7d9"
 dependencies = [
  "aes",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/prostheke",
     "crates/theatron/core",
     "crates/akouo-core",
+    "crates/syndesis",
 ]
 exclude = [
     "akouo/shared/akouo-core",
@@ -50,6 +51,7 @@ syntaxis        = { path = "crates/syntaxis" }
 prostheke       = { path = "crates/prostheke" }
 theatron-core   = { path = "crates/theatron/core" }
 akouo-core      = { path = "crates/akouo-core" }
+syndesis        = { path = "crates/syndesis" }
 
 # ── Async runtime ──────────────────────────────────────────────────────────────
 tokio           = { version = "1", features = ["full"] }

--- a/crates/syndesis/Cargo.toml
+++ b/crates/syndesis/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "syndesis"
+description = "QUIC streaming protocol for multi-room audio"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+bytes.workspace = true
+quinn.workspace = true
+rand.workspace = true
+rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
+rcgen = "0.13"
+serde.workspace = true
+snafu.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/syndesis/src/client/buffer.rs
+++ b/crates/syndesis/src/client/buffer.rs
@@ -1,0 +1,197 @@
+/// Jitter buffer: reorder, buffer, and emit audio frames at playout time.
+use std::collections::BTreeMap;
+
+use crate::protocol::frame::AudioFrame;
+
+const DEFAULT_DEPTH_MS: u64 = 100;
+
+#[derive(Debug)]
+pub struct JitterBuffer {
+    frames: BTreeMap<u64, AudioFrame>,
+    depth_us: u64,
+    next_sequence: u64,
+    clock_offset_us: i64,
+    gap_count: u64,
+}
+
+impl JitterBuffer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            frames: BTreeMap::new(),
+            depth_us: DEFAULT_DEPTH_MS * 1000,
+            next_sequence: 0,
+            clock_offset_us: 0,
+            gap_count: 0,
+        }
+    }
+
+    #[must_use]
+    pub fn with_depth_ms(depth_ms: u64) -> Self {
+        Self {
+            depth_us: depth_ms * 1000,
+            ..Self::new()
+        }
+    }
+
+    /// Update the clock offset used for playout timing.
+    pub fn set_clock_offset(&mut self, offset_us: i64) {
+        self.clock_offset_us = offset_us;
+    }
+
+    /// Insert a received frame into the buffer.
+    pub fn insert(&mut self, frame: AudioFrame) {
+        self.frames.insert(frame.sequence, frame);
+    }
+
+    /// Try to emit the next frame in sequence order, respecting the jitter buffer depth.
+    ///
+    /// `now_us` is the local clock time in microseconds.
+    /// Returns the frame if it is ready for playout.
+    pub fn pop_ready(&mut self, now_us: u64) -> Option<AudioFrame> {
+        let (&seq, frame) = self.frames.first_key_value()?;
+
+        // Adjust the frame timestamp by clock offset to convert to local time
+        let local_playout =
+            (frame.timestamp_us as i64 + self.clock_offset_us) as u64 + self.depth_us;
+
+        if now_us >= local_playout {
+            let frame = self.frames.remove(&seq).expect("frame exists in map");
+
+            if seq > self.next_sequence {
+                self.gap_count += seq - self.next_sequence;
+            }
+            self.next_sequence = seq + 1;
+
+            Some(frame)
+        } else {
+            None
+        }
+    }
+
+    /// Drain all frames that are past their playout deadline (for catchup).
+    pub fn drain_ready(&mut self, now_us: u64) -> Vec<AudioFrame> {
+        let mut ready = Vec::new();
+        while let Some(frame) = self.pop_ready(now_us) {
+            ready.push(frame);
+        }
+        ready
+    }
+
+    /// Current buffer depth in frames.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Whether the buffer is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    /// Number of sequence gaps detected (potential lost frames).
+    #[must_use]
+    pub fn gap_count(&self) -> u64 {
+        self.gap_count
+    }
+
+    /// Estimated buffer depth in milliseconds based on timestamp span.
+    #[must_use]
+    pub fn depth_ms(&self) -> u16 {
+        if self.frames.len() < 2 {
+            return 0;
+        }
+        let first_ts = self
+            .frames
+            .values()
+            .next()
+            .expect("checked len >= 2")
+            .timestamp_us;
+        let last_ts = self
+            .frames
+            .values()
+            .next_back()
+            .expect("checked len >= 2")
+            .timestamp_us;
+        ((last_ts.saturating_sub(first_ts)) / 1000) as u16
+    }
+}
+
+impl Default for JitterBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::protocol::AudioCodec;
+
+    fn test_frame(seq: u64, timestamp_us: u64) -> AudioFrame {
+        AudioFrame {
+            sequence: seq,
+            timestamp_us,
+            codec: AudioCodec::Pcm,
+            channels: 2,
+            sample_rate: 48000,
+            payload: Bytes::from_static(b"test"),
+        }
+    }
+
+    #[test]
+    fn emits_frames_in_sequence_order() {
+        let mut buf = JitterBuffer::with_depth_ms(0);
+        buf.insert(test_frame(2, 2000));
+        buf.insert(test_frame(0, 0));
+        buf.insert(test_frame(1, 1000));
+
+        let frames = buf.drain_ready(u64::MAX);
+        let seqs: Vec<u64> = frames.iter().map(|f| f.sequence).collect();
+        assert_eq!(seqs, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn respects_jitter_depth() {
+        let mut buf = JitterBuffer::with_depth_ms(100);
+        buf.insert(test_frame(0, 1_000_000));
+
+        assert!(buf.pop_ready(1_000_000).is_none(), "too early for playout");
+        assert!(
+            buf.pop_ready(1_100_000).is_some(),
+            "should be ready after depth"
+        );
+    }
+
+    #[test]
+    fn detects_sequence_gaps() {
+        let mut buf = JitterBuffer::with_depth_ms(0);
+        buf.insert(test_frame(0, 0));
+        buf.insert(test_frame(3, 3000));
+
+        buf.drain_ready(u64::MAX);
+        assert_eq!(buf.gap_count(), 2, "missed sequences 1 and 2");
+    }
+
+    #[test]
+    fn reports_buffer_depth() {
+        let mut buf = JitterBuffer::new();
+        buf.insert(test_frame(0, 0));
+        buf.insert(test_frame(1, 50_000));
+        assert_eq!(buf.depth_ms(), 50);
+    }
+
+    #[test]
+    fn applies_clock_offset() {
+        let mut buf = JitterBuffer::with_depth_ms(0);
+        buf.set_clock_offset(-500_000);
+        buf.insert(test_frame(0, 1_000_000));
+
+        // Frame timestamp 1_000_000 - offset 500_000 = local playout at 500_000
+        assert!(buf.pop_ready(499_999).is_none());
+        assert!(buf.pop_ready(500_000).is_some());
+    }
+}

--- a/crates/syndesis/src/client/mod.rs
+++ b/crates/syndesis/src/client/mod.rs
@@ -1,0 +1,63 @@
+/// QUIC streaming client: connects to server and receives audio frames.
+pub mod buffer;
+pub mod session;
+
+use std::net::SocketAddr;
+
+use snafu::ResultExt;
+use tracing::{info, instrument};
+
+use crate::error::{self, SyndesisError};
+use crate::tls;
+
+pub use buffer::JitterBuffer;
+pub use session::ClientSession;
+
+pub struct StreamClient {
+    endpoint: quinn::Endpoint,
+}
+
+impl StreamClient {
+    /// Create a new QUIC client bound to a local address.
+    #[instrument(skip_all)]
+    pub fn new(bind_addr: SocketAddr) -> Result<Self, SyndesisError> {
+        let client_config = tls::build_client_config()?;
+        let mut endpoint = quinn::Endpoint::client(bind_addr).context(error::BindSnafu)?;
+        endpoint.set_default_client_config(client_config);
+        Ok(Self { endpoint })
+    }
+
+    /// Create with a pre-built client config.
+    pub fn with_config(
+        bind_addr: SocketAddr,
+        client_config: quinn::ClientConfig,
+    ) -> Result<Self, SyndesisError> {
+        let mut endpoint = quinn::Endpoint::client(bind_addr).context(error::BindSnafu)?;
+        endpoint.set_default_client_config(client_config);
+        Ok(Self { endpoint })
+    }
+
+    /// Connect to a streaming server and return a session.
+    #[instrument(skip_all, fields(%server_addr))]
+    pub async fn connect(
+        &self,
+        server_addr: SocketAddr,
+        server_name: &str,
+    ) -> Result<ClientSession, SyndesisError> {
+        let conn = self
+            .endpoint
+            .connect(server_addr, server_name)
+            .context(error::ConnectSnafu)?
+            .await
+            .context(error::ConnectionSnafu)?;
+
+        info!("connected to streaming server");
+        Ok(ClientSession::new(conn))
+    }
+}
+
+impl Drop for StreamClient {
+    fn drop(&mut self) {
+        self.endpoint.close(0u32.into(), b"client closed");
+    }
+}

--- a/crates/syndesis/src/client/session.rs
+++ b/crates/syndesis/src/client/session.rs
@@ -1,0 +1,260 @@
+/// Client session: negotiation, frame reception, clock sync, status reporting.
+use bytes::Bytes;
+use snafu::ResultExt;
+use tracing::{debug, instrument, trace};
+
+use crate::client::buffer::JitterBuffer;
+use crate::clock::ClockEstimator;
+use crate::error::{self, SyndesisError};
+use crate::protocol::codec::{decode_datagram, decode_frame, encode_datagram, encode_frame};
+use crate::protocol::frame::{
+    AudioFrame, ClockSync, ClockSyncReply, Frame, SessionAccept, SessionInit, StatusReport,
+};
+use crate::protocol::{AudioCodec, DeviceState, PROTOCOL_VERSION};
+use crate::server::session::current_time_us;
+
+const STATUS_REPORT_INTERVAL_MS: u64 = 1000;
+
+pub struct ClientSession {
+    conn: quinn::Connection,
+    pub(crate) session_id: u64,
+    pub(crate) buffer: JitterBuffer,
+    clock: ClockEstimator,
+    renderer_id: Vec<u8>,
+    negotiated_codec: AudioCodec,
+    negotiated_sample_rate: u32,
+    negotiated_channels: u8,
+}
+
+impl ClientSession {
+    pub(crate) fn new(conn: quinn::Connection) -> Self {
+        Self {
+            conn,
+            session_id: 0,
+            buffer: JitterBuffer::new(),
+            clock: ClockEstimator::new(),
+            renderer_id: b"default".to_vec(),
+            negotiated_codec: AudioCodec::Flac,
+            negotiated_sample_rate: 48000,
+            negotiated_channels: 2,
+        }
+    }
+
+    /// Negotiate a session with the server.
+    #[instrument(skip_all)]
+    pub async fn negotiate(
+        &mut self,
+        codecs: Vec<AudioCodec>,
+        sample_rates: Vec<u32>,
+        channel_configs: Vec<u8>,
+    ) -> Result<SessionAccept, SyndesisError> {
+        let init = Frame::SessionInit(SessionInit {
+            protocol_version: PROTOCOL_VERSION,
+            supported_codecs: codecs,
+            sample_rates,
+            channel_configs,
+        });
+
+        let (mut send, mut recv) = self.conn.open_bi().await.context(error::ConnectionSnafu)?;
+
+        let encoded = encode_frame(&init);
+        send.write_all(&encoded)
+            .await
+            .context(error::WriteStreamSnafu)?;
+        let _ = send.finish();
+
+        let resp_data = recv
+            .read_to_end(4096)
+            .await
+            .context(error::ReadToEndSnafu)?;
+        let mut resp_bytes = Bytes::from(resp_data);
+        let frame = decode_frame(&mut resp_bytes)?;
+
+        let Frame::SessionAccept(accept) = frame else {
+            return Err(error::NegotiationSnafu {
+                reason: "expected SessionAccept frame",
+            }
+            .build());
+        };
+
+        self.session_id = accept.session_id;
+        self.negotiated_codec = accept.codec;
+        self.negotiated_sample_rate = accept.sample_rate;
+        self.negotiated_channels = accept.channels;
+
+        debug!(
+            session_id = self.session_id,
+            ?accept.codec,
+            accept.sample_rate,
+            accept.channels,
+            "session established"
+        );
+
+        Ok(accept)
+    }
+
+    /// Receive audio frames and handle clock sync. Runs until the stream ends or cancel fires.
+    /// Received frames are placed in the jitter buffer.
+    #[instrument(skip_all, fields(session_id = self.session_id))]
+    pub async fn run(
+        &mut self,
+        cancel: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<Vec<AudioFrame>, SyndesisError> {
+        let mut recv_stream = self
+            .conn
+            .accept_uni()
+            .await
+            .context(error::ConnectionSnafu)?;
+        let mut collected = Vec::new();
+
+        let mut status_interval =
+            tokio::time::interval(std::time::Duration::from_millis(STATUS_REPORT_INTERVAL_MS));
+        status_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        let mut read_buf = vec![0u8; 65536];
+
+        loop {
+            tokio::select! {
+                biased;
+
+                _ = wait_for_cancel(&cancel) => {
+                    debug!("client session cancelled");
+                    break;
+                }
+
+                datagram = self.conn.read_datagram() => {
+                    match datagram {
+                        Ok(data) => {
+                            self.handle_datagram(data)?;
+                        }
+                        Err(e) => {
+                            debug!(error = %e, "datagram read error, continuing");
+                            break;
+                        }
+                    }
+                }
+
+                _ = status_interval.tick() => {
+                    self.send_status_report()?;
+                }
+
+                result = recv_stream.read(&mut read_buf) => {
+                    match result {
+                        Ok(Some(n)) => {
+                            let mut data = Bytes::copy_from_slice(&read_buf[..n]);
+                            while data.len() >= 4 {
+                                match decode_frame(&mut data) {
+                                    Ok(Frame::Audio(frame)) => {
+                                        self.buffer.insert(frame.clone());
+                                        collected.push(frame);
+                                    }
+                                    Ok(other) => {
+                                        debug!(?other, "unexpected frame on audio stream");
+                                    }
+                                    Err(e) => {
+                                        trace!(error = %e, "partial frame in read buffer");
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            debug!("audio stream finished");
+                            break;
+                        }
+                        Err(e) => {
+                            return Err(e).context(error::ReadStreamSnafu);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(collected)
+    }
+
+    fn handle_datagram(&mut self, data: Bytes) -> Result<(), SyndesisError> {
+        let mut buf = data;
+        let frame = decode_datagram(&mut buf)?;
+
+        match frame {
+            Frame::ClockSync(sync) => {
+                self.handle_clock_sync(&sync)?;
+            }
+            Frame::Command(cmd) => {
+                debug!(?cmd, "received command");
+            }
+            other => {
+                debug!(?other, "unexpected datagram frame");
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_clock_sync(&mut self, sync: &ClockSync) -> Result<(), SyndesisError> {
+        let now = current_time_us();
+        let reply = Frame::ClockSyncReply(ClockSyncReply {
+            originate_ts: sync.originate_ts,
+            receive_ts: now,
+            transmit_ts: current_time_us(),
+            destination_ts: 0,
+        });
+        let data = encode_datagram(&reply);
+        self.conn.send_datagram(data).map_err(|e| {
+            error::DatagramSnafu {
+                reason: e.to_string(),
+            }
+            .build()
+        })?;
+        trace!("sent clock sync reply");
+        Ok(())
+    }
+
+    fn send_status_report(&self) -> Result<(), SyndesisError> {
+        let report = Frame::StatusReport(StatusReport {
+            buffer_depth_ms: self.buffer.depth_ms(),
+            latency_ms: self.clock.offset_us().unsigned_abs().min(u16::MAX as u64) as u16,
+            device_state: DeviceState::Active,
+            renderer_id: self.renderer_id.clone(),
+        });
+        let data = encode_datagram(&report);
+        self.conn.send_datagram(data).map_err(|e| {
+            error::DatagramSnafu {
+                reason: e.to_string(),
+            }
+            .build()
+        })?;
+        trace!(buffer_ms = self.buffer.depth_ms(), "sent status report");
+        Ok(())
+    }
+
+    /// The negotiated codec for this session.
+    #[must_use]
+    pub fn codec(&self) -> AudioCodec {
+        self.negotiated_codec
+    }
+
+    /// The negotiated sample rate for this session.
+    #[must_use]
+    pub fn sample_rate(&self) -> u32 {
+        self.negotiated_sample_rate
+    }
+
+    /// The negotiated channel count for this session.
+    #[must_use]
+    pub fn channels(&self) -> u8 {
+        self.negotiated_channels
+    }
+}
+
+async fn wait_for_cancel(cancel: &tokio::sync::watch::Receiver<bool>) {
+    let mut cancel = cancel.clone();
+    loop {
+        if *cancel.borrow() {
+            return;
+        }
+        if cancel.changed().await.is_err() {
+            return;
+        }
+    }
+}

--- a/crates/syndesis/src/clock/estimator.rs
+++ b/crates/syndesis/src/clock/estimator.rs
@@ -1,0 +1,230 @@
+/// NTP-style round-trip clock offset estimator.
+use std::collections::VecDeque;
+
+const WINDOW_SIZE: usize = 20;
+const OUTLIER_FACTOR: u64 = 2;
+
+#[derive(Debug)]
+pub struct ClockEstimator {
+    samples: VecDeque<Sample>,
+    current_offset: i64,
+    is_stable: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Sample {
+    offset: i64,
+    rtt: u64,
+}
+
+impl ClockEstimator {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            samples: VecDeque::with_capacity(WINDOW_SIZE),
+            current_offset: 0,
+            is_stable: false,
+        }
+    }
+
+    /// Process a complete clock sync exchange and update the offset estimate.
+    ///
+    /// Timestamps are in microseconds:
+    /// - `originate`: server sent the probe
+    /// - `receive`: renderer received the probe
+    /// - `transmit`: renderer sent the reply
+    /// - `destination`: server received the reply
+    pub fn record_exchange(
+        &mut self,
+        originate: u64,
+        receive: u64,
+        transmit: u64,
+        destination: u64,
+    ) {
+        let rtt = destination.saturating_sub(originate);
+        // WHY: NTP offset formula. Positive offset means renderer clock is ahead.
+        let offset =
+            ((receive as i128 - originate as i128) + (transmit as i128 - destination as i128)) / 2;
+        let offset = offset as i64;
+
+        let sample = Sample { offset, rtt };
+
+        if self.samples.len() >= WINDOW_SIZE {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(sample);
+
+        self.recompute();
+    }
+
+    fn recompute(&mut self) {
+        if self.samples.is_empty() {
+            return;
+        }
+
+        let median_rtt = self.median_rtt();
+        let threshold = median_rtt.saturating_mul(OUTLIER_FACTOR);
+
+        let mut filtered_offsets: Vec<i64> = self
+            .samples
+            .iter()
+            .filter(|s| s.rtt <= threshold)
+            .map(|s| s.offset)
+            .collect();
+
+        if filtered_offsets.is_empty() {
+            filtered_offsets = self.samples.iter().map(|s| s.offset).collect();
+        }
+
+        filtered_offsets.sort_unstable();
+        self.current_offset = median_of_sorted(&filtered_offsets);
+
+        self.is_stable = self.samples.len() >= 5 && self.offset_spread(&filtered_offsets) < 1000;
+    }
+
+    fn median_rtt(&self) -> u64 {
+        let mut rtts: Vec<u64> = self.samples.iter().map(|s| s.rtt).collect();
+        rtts.sort_unstable();
+        median_of_sorted_u64(&rtts)
+    }
+
+    fn offset_spread(&self, offsets: &[i64]) -> u64 {
+        if offsets.len() < 2 {
+            return 0;
+        }
+        let min = offsets[0];
+        let max = offsets[offsets.len() - 1];
+        (max - min).unsigned_abs()
+    }
+
+    /// Current estimated clock offset in microseconds.
+    /// Positive means the remote clock is ahead of local.
+    #[must_use]
+    pub fn offset_us(&self) -> i64 {
+        self.current_offset
+    }
+
+    /// Whether the estimator has converged to a stable offset.
+    #[must_use]
+    pub fn is_stable(&self) -> bool {
+        self.is_stable
+    }
+
+    /// Number of samples in the sliding window.
+    #[must_use]
+    pub fn sample_count(&self) -> usize {
+        self.samples.len()
+    }
+}
+
+impl Default for ClockEstimator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn median_of_sorted(values: &[i64]) -> i64 {
+    let len = values.len();
+    if len == 0 {
+        return 0;
+    }
+    if len % 2 == 1 {
+        values[len / 2]
+    } else {
+        (values[len / 2 - 1] + values[len / 2]) / 2
+    }
+}
+
+fn median_of_sorted_u64(values: &[u64]) -> u64 {
+    let len = values.len();
+    if len == 0 {
+        return 0;
+    }
+    if len % 2 == 1 {
+        values[len / 2]
+    } else {
+        (values[len / 2 - 1] + values[len / 2]) / 2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converges_to_zero_on_symmetric_loopback() {
+        let mut est = ClockEstimator::new();
+        for i in 0..20 {
+            let base = i * 100_000;
+            let originate = base;
+            let receive = base + 500;
+            let transmit = base + 600;
+            let destination = base + 1100;
+            est.record_exchange(originate, receive, transmit, destination);
+        }
+        assert!(
+            est.offset_us().unsigned_abs() < 1000,
+            "offset should be near zero on loopback, got {}us",
+            est.offset_us()
+        );
+        assert!(est.is_stable());
+    }
+
+    #[test]
+    fn detects_fixed_offset() {
+        let mut est = ClockEstimator::new();
+        let clock_offset: i64 = 5000;
+        for i in 0..20 {
+            let base = i * 100_000u64;
+            let originate = base;
+            // WHY: renderer clock is ahead by clock_offset, so receive = originate + one_way_delay + offset
+            let receive = (base as i64 + 500 + clock_offset) as u64;
+            let transmit = (base as i64 + 600 + clock_offset) as u64;
+            let destination = base + 1100;
+            est.record_exchange(originate, receive, transmit, destination);
+        }
+        let measured = est.offset_us();
+        assert!(
+            (measured - clock_offset).unsigned_abs() < 100,
+            "expected offset ~{clock_offset}, got {measured}"
+        );
+    }
+
+    #[test]
+    fn rejects_outliers() {
+        let mut est = ClockEstimator::new();
+        for i in 0..15 {
+            let base = i * 100_000;
+            est.record_exchange(base, base + 500, base + 600, base + 1100);
+        }
+        // Inject an outlier with huge RTT
+        est.record_exchange(2_000_000, 2_500_000, 2_500_100, 3_000_000);
+
+        for i in 16..20 {
+            let base = i * 100_000;
+            est.record_exchange(base, base + 500, base + 600, base + 1100);
+        }
+        assert!(
+            est.offset_us().unsigned_abs() < 1000,
+            "outlier should be rejected, got {}us",
+            est.offset_us()
+        );
+    }
+
+    #[test]
+    fn not_stable_with_few_samples() {
+        let mut est = ClockEstimator::new();
+        est.record_exchange(0, 500, 600, 1100);
+        assert!(!est.is_stable());
+    }
+
+    #[test]
+    fn sliding_window_evicts_old_samples() {
+        let mut est = ClockEstimator::new();
+        for i in 0..30 {
+            let base = i * 100_000;
+            est.record_exchange(base, base + 500, base + 600, base + 1100);
+        }
+        assert_eq!(est.sample_count(), WINDOW_SIZE);
+    }
+}

--- a/crates/syndesis/src/clock/mod.rs
+++ b/crates/syndesis/src/clock/mod.rs
@@ -1,0 +1,6 @@
+/// Clock synchronization for multi-room streaming.
+pub mod estimator;
+pub mod scheduler;
+
+pub use estimator::ClockEstimator;
+pub use scheduler::SyncScheduler;

--- a/crates/syndesis/src/clock/scheduler.rs
+++ b/crates/syndesis/src/clock/scheduler.rs
@@ -1,0 +1,109 @@
+/// Periodic clock sync probe scheduler with adaptive interval.
+use std::time::Duration;
+
+use super::ClockEstimator;
+
+const INITIAL_INTERVAL: Duration = Duration::from_secs(5);
+const STABLE_INTERVAL: Duration = Duration::from_secs(30);
+const DRIFT_THRESHOLD_US: i64 = 500;
+
+#[derive(Debug)]
+pub struct SyncScheduler {
+    interval: Duration,
+    last_stable_offset: i64,
+}
+
+impl SyncScheduler {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            interval: INITIAL_INTERVAL,
+            last_stable_offset: 0,
+        }
+    }
+
+    /// Update the scheduler based on the current estimator state.
+    /// Returns the interval to use before the next probe.
+    #[must_use]
+    pub fn update(&mut self, estimator: &ClockEstimator) -> Duration {
+        if estimator.is_stable() {
+            let drift = (estimator.offset_us() - self.last_stable_offset).unsigned_abs() as i64;
+            if drift > DRIFT_THRESHOLD_US {
+                self.interval = INITIAL_INTERVAL;
+            } else {
+                self.interval = self.interval.min(STABLE_INTERVAL).max(INITIAL_INTERVAL);
+                // WHY: Gradually increase toward stable interval when offset is steady.
+                let step = Duration::from_secs(5);
+                if self.interval < STABLE_INTERVAL {
+                    self.interval = (self.interval + step).min(STABLE_INTERVAL);
+                }
+            }
+            self.last_stable_offset = estimator.offset_us();
+        } else {
+            self.interval = INITIAL_INTERVAL;
+        }
+        self.interval
+    }
+
+    /// Current probe interval.
+    #[must_use]
+    pub fn interval(&self) -> Duration {
+        self.interval
+    }
+}
+
+impl Default for SyncScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_at_initial_interval() {
+        let sched = SyncScheduler::new();
+        assert_eq!(sched.interval(), INITIAL_INTERVAL);
+    }
+
+    #[test]
+    fn backs_off_when_stable() {
+        let mut sched = SyncScheduler::new();
+        let mut est = ClockEstimator::new();
+        for i in 0..10 {
+            let base = i * 100_000;
+            est.record_exchange(base, base + 500, base + 600, base + 1100);
+        }
+        let mut prev = sched.update(&est);
+        for _ in 0..10 {
+            let next = sched.update(&est);
+            assert!(next >= prev, "interval should not decrease when stable");
+            prev = next;
+        }
+        assert_eq!(prev, STABLE_INTERVAL);
+    }
+
+    #[test]
+    fn re_accelerates_on_drift() {
+        let mut sched = SyncScheduler::new();
+        let mut est = ClockEstimator::new();
+        for i in 0..10 {
+            let base = i * 100_000;
+            est.record_exchange(base, base + 500, base + 600, base + 1100);
+        }
+        for _ in 0..10 {
+            let _ = sched.update(&est);
+        }
+        assert_eq!(sched.interval(), STABLE_INTERVAL);
+
+        // Inject drift: offset jumps by a large amount
+        for i in 10..20 {
+            let base = i * 100_000;
+            est.record_exchange(base, base + 5500, base + 5600, base + 1100);
+        }
+        let interval = sched.update(&est);
+        assert_eq!(interval, INITIAL_INTERVAL, "should re-accelerate on drift");
+    }
+}

--- a/crates/syndesis/src/error.rs
+++ b/crates/syndesis/src/error.rs
@@ -1,0 +1,83 @@
+/// Error types for the syndesis streaming protocol.
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum SyndesisError {
+    #[snafu(display("protocol error: {reason}"))]
+    Protocol {
+        reason: &'static str,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("QUIC connection error: {source}"))]
+    Connection {
+        source: quinn::ConnectionError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("QUIC write error: {source}"))]
+    WriteStream {
+        source: quinn::WriteError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("QUIC read error: {source}"))]
+    ReadStream {
+        source: quinn::ReadError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("QUIC read-to-end error: {source}"))]
+    ReadToEnd {
+        source: quinn::ReadToEndError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("QUIC datagram send error: {reason}"))]
+    Datagram {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("TLS error: {reason}"))]
+    Tls {
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("session negotiation failed: {reason}"))]
+    Negotiation {
+        reason: &'static str,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("I/O error: {source}"))]
+    Io {
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("endpoint bind failed: {source}"))]
+    Bind {
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("QUIC connect error: {source}"))]
+    Connect {
+        source: quinn::ConnectError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/syndesis/src/lib.rs
+++ b/crates/syndesis/src/lib.rs
@@ -1,0 +1,9 @@
+/// QUIC streaming protocol for multi-room audio transport.
+pub mod client;
+pub mod clock;
+pub mod error;
+pub mod protocol;
+pub mod server;
+pub mod tls;
+
+pub use error::SyndesisError;

--- a/crates/syndesis/src/protocol/codec.rs
+++ b/crates/syndesis/src/protocol/codec.rs
@@ -1,0 +1,534 @@
+/// Zero-copy binary codec for wire frames.
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use snafu::ensure;
+
+use super::frame::{
+    AudioFrame, ClockSync, ClockSyncReply, Command, Frame, SessionAccept, SessionInit, StatusReport,
+};
+use super::{AudioCodec, CommandKind, DeviceState, FrameType};
+use crate::error;
+
+// WHY: Length-prefixed framing allows receivers to delimit frames on QUIC streams
+// without relying on stream boundaries. DATAGRAMs are already delimited by QUIC.
+const LENGTH_PREFIX_SIZE: usize = 4;
+
+/// Encode a frame into a length-prefixed byte buffer.
+#[must_use]
+pub fn encode_frame(frame: &Frame) -> Bytes {
+    let mut buf = BytesMut::new();
+    // Reserve space for length prefix
+    buf.put_u32(0);
+
+    match frame {
+        Frame::Audio(f) => encode_audio_frame(&mut buf, f),
+        Frame::ClockSync(f) => encode_clock_sync(&mut buf, f),
+        Frame::ClockSyncReply(f) => encode_clock_sync_reply(&mut buf, f),
+        Frame::SessionInit(f) => encode_session_init(&mut buf, f),
+        Frame::SessionAccept(f) => encode_session_accept(&mut buf, f),
+        Frame::StatusReport(f) => encode_status_report(&mut buf, f),
+        Frame::Command(f) => encode_command(&mut buf, f),
+    }
+
+    let frame_len = (buf.len() - LENGTH_PREFIX_SIZE) as u32;
+    buf[..LENGTH_PREFIX_SIZE].copy_from_slice(&frame_len.to_be_bytes());
+
+    buf.freeze()
+}
+
+/// Encode a frame without length prefix (for DATAGRAMs which are already delimited).
+#[must_use]
+pub fn encode_datagram(frame: &Frame) -> Bytes {
+    let mut buf = BytesMut::new();
+    match frame {
+        Frame::ClockSync(f) => encode_clock_sync(&mut buf, f),
+        Frame::ClockSyncReply(f) => encode_clock_sync_reply(&mut buf, f),
+        Frame::StatusReport(f) => encode_status_report(&mut buf, f),
+        Frame::Command(f) => encode_command(&mut buf, f),
+        Frame::Audio(f) => encode_audio_frame(&mut buf, f),
+        Frame::SessionInit(f) => encode_session_init(&mut buf, f),
+        Frame::SessionAccept(f) => encode_session_accept(&mut buf, f),
+    }
+    buf.freeze()
+}
+
+/// Decode a length-prefixed frame from a buffer.
+pub fn decode_frame(data: &mut Bytes) -> Result<Frame, error::SyndesisError> {
+    ensure!(
+        data.remaining() >= LENGTH_PREFIX_SIZE,
+        error::ProtocolSnafu {
+            reason: "buffer too short for length prefix"
+        }
+    );
+
+    let frame_len = data.get_u32() as usize;
+    ensure!(
+        data.remaining() >= frame_len,
+        error::ProtocolSnafu {
+            reason: "buffer shorter than declared frame length"
+        }
+    );
+
+    let mut frame_data = data.split_to(frame_len);
+    decode_frame_body(&mut frame_data)
+}
+
+/// Decode a frame from raw bytes (no length prefix, for DATAGRAMs).
+pub fn decode_datagram(data: &mut Bytes) -> Result<Frame, error::SyndesisError> {
+    decode_frame_body(data)
+}
+
+fn decode_frame_body(buf: &mut Bytes) -> Result<Frame, error::SyndesisError> {
+    ensure!(
+        buf.has_remaining(),
+        error::ProtocolSnafu {
+            reason: "empty frame body"
+        }
+    );
+
+    let type_byte = buf.get_u8();
+    let frame_type = FrameType::from_u8(type_byte).ok_or_else(|| {
+        error::ProtocolSnafu {
+            reason: "unknown frame type",
+        }
+        .build()
+    })?;
+
+    match frame_type {
+        FrameType::AudioFrame => decode_audio_frame(buf).map(Frame::Audio),
+        FrameType::ClockSync => decode_clock_sync(buf).map(Frame::ClockSync),
+        FrameType::ClockSyncReply => decode_clock_sync_reply(buf).map(Frame::ClockSyncReply),
+        FrameType::SessionInit => decode_session_init(buf).map(Frame::SessionInit),
+        FrameType::SessionAccept => decode_session_accept(buf).map(Frame::SessionAccept),
+        FrameType::StatusReport => decode_status_report(buf).map(Frame::StatusReport),
+        FrameType::Command => decode_command(buf).map(Frame::Command),
+    }
+}
+
+fn encode_audio_frame(buf: &mut BytesMut, f: &AudioFrame) {
+    buf.put_u8(FrameType::AudioFrame as u8);
+    buf.put_u64(f.sequence);
+    buf.put_u64(f.timestamp_us);
+    buf.put_u8(f.codec as u8);
+    buf.put_u8(f.channels);
+    buf.put_u32(f.sample_rate);
+    buf.put_u32(f.payload.len() as u32);
+    buf.put_slice(&f.payload);
+}
+
+fn decode_audio_frame(buf: &mut Bytes) -> Result<AudioFrame, error::SyndesisError> {
+    ensure!(
+        buf.remaining() >= 8 + 8 + 1 + 1 + 4 + 4,
+        error::ProtocolSnafu {
+            reason: "audio frame header too short"
+        }
+    );
+
+    let sequence = buf.get_u64();
+    let timestamp_us = buf.get_u64();
+    let codec_byte = buf.get_u8();
+    let channels = buf.get_u8();
+    let sample_rate = buf.get_u32();
+    let payload_len = buf.get_u32() as usize;
+
+    let codec = AudioCodec::from_u8(codec_byte).ok_or_else(|| {
+        error::ProtocolSnafu {
+            reason: "unknown audio codec",
+        }
+        .build()
+    })?;
+
+    ensure!(
+        buf.remaining() >= payload_len,
+        error::ProtocolSnafu {
+            reason: "audio payload shorter than declared"
+        }
+    );
+
+    let payload = buf.split_to(payload_len);
+
+    Ok(AudioFrame {
+        sequence,
+        timestamp_us,
+        codec,
+        channels,
+        sample_rate,
+        payload,
+    })
+}
+
+fn encode_clock_sync(buf: &mut BytesMut, f: &ClockSync) {
+    buf.put_u8(FrameType::ClockSync as u8);
+    buf.put_u64(f.originate_ts);
+    buf.put_u64(f.receive_ts);
+    buf.put_u64(f.transmit_ts);
+}
+
+fn decode_clock_sync(buf: &mut Bytes) -> Result<ClockSync, error::SyndesisError> {
+    ensure!(
+        buf.remaining() >= 24,
+        error::ProtocolSnafu {
+            reason: "clock sync too short"
+        }
+    );
+    Ok(ClockSync {
+        originate_ts: buf.get_u64(),
+        receive_ts: buf.get_u64(),
+        transmit_ts: buf.get_u64(),
+    })
+}
+
+fn encode_clock_sync_reply(buf: &mut BytesMut, f: &ClockSyncReply) {
+    buf.put_u8(FrameType::ClockSyncReply as u8);
+    buf.put_u64(f.originate_ts);
+    buf.put_u64(f.receive_ts);
+    buf.put_u64(f.transmit_ts);
+    buf.put_u64(f.destination_ts);
+}
+
+fn decode_clock_sync_reply(buf: &mut Bytes) -> Result<ClockSyncReply, error::SyndesisError> {
+    ensure!(
+        buf.remaining() >= 32,
+        error::ProtocolSnafu {
+            reason: "clock sync reply too short"
+        }
+    );
+    Ok(ClockSyncReply {
+        originate_ts: buf.get_u64(),
+        receive_ts: buf.get_u64(),
+        transmit_ts: buf.get_u64(),
+        destination_ts: buf.get_u64(),
+    })
+}
+
+fn encode_session_init(buf: &mut BytesMut, f: &SessionInit) {
+    buf.put_u8(FrameType::SessionInit as u8);
+    buf.put_u8(f.protocol_version);
+    buf.put_u8(f.supported_codecs.len() as u8);
+    for codec in &f.supported_codecs {
+        buf.put_u8(*codec as u8);
+    }
+    buf.put_u8(f.sample_rates.len() as u8);
+    for rate in &f.sample_rates {
+        buf.put_u32(*rate);
+    }
+    buf.put_u8(f.channel_configs.len() as u8);
+    for ch in &f.channel_configs {
+        buf.put_u8(*ch);
+    }
+}
+
+fn decode_session_init(buf: &mut Bytes) -> Result<SessionInit, error::SyndesisError> {
+    ensure!(
+        buf.remaining() >= 2,
+        error::ProtocolSnafu {
+            reason: "session init too short"
+        }
+    );
+
+    let protocol_version = buf.get_u8();
+    let codec_count = buf.get_u8() as usize;
+    ensure!(
+        buf.remaining() >= codec_count,
+        error::ProtocolSnafu {
+            reason: "session init codecs truncated"
+        }
+    );
+    let mut supported_codecs = Vec::with_capacity(codec_count);
+    for _ in 0..codec_count {
+        let c = AudioCodec::from_u8(buf.get_u8()).ok_or_else(|| {
+            error::ProtocolSnafu {
+                reason: "unknown codec in session init",
+            }
+            .build()
+        })?;
+        supported_codecs.push(c);
+    }
+
+    ensure!(
+        buf.has_remaining(),
+        error::ProtocolSnafu {
+            reason: "session init sample rates missing"
+        }
+    );
+    let rate_count = buf.get_u8() as usize;
+    ensure!(
+        buf.remaining() >= rate_count * 4,
+        error::ProtocolSnafu {
+            reason: "session init sample rates truncated"
+        }
+    );
+    let mut sample_rates = Vec::with_capacity(rate_count);
+    for _ in 0..rate_count {
+        sample_rates.push(buf.get_u32());
+    }
+
+    ensure!(
+        buf.has_remaining(),
+        error::ProtocolSnafu {
+            reason: "session init channel configs missing"
+        }
+    );
+    let ch_count = buf.get_u8() as usize;
+    ensure!(
+        buf.remaining() >= ch_count,
+        error::ProtocolSnafu {
+            reason: "session init channel configs truncated"
+        }
+    );
+    let mut channel_configs = Vec::with_capacity(ch_count);
+    for _ in 0..ch_count {
+        channel_configs.push(buf.get_u8());
+    }
+
+    Ok(SessionInit {
+        protocol_version,
+        supported_codecs,
+        sample_rates,
+        channel_configs,
+    })
+}
+
+fn encode_session_accept(buf: &mut BytesMut, f: &SessionAccept) {
+    buf.put_u8(FrameType::SessionAccept as u8);
+    buf.put_u8(f.codec as u8);
+    buf.put_u32(f.sample_rate);
+    buf.put_u8(f.channels);
+    buf.put_u64(f.session_id);
+}
+
+fn decode_session_accept(buf: &mut Bytes) -> Result<SessionAccept, error::SyndesisError> {
+    ensure!(
+        buf.remaining() >= 14,
+        error::ProtocolSnafu {
+            reason: "session accept too short"
+        }
+    );
+    let codec_byte = buf.get_u8();
+    let codec = AudioCodec::from_u8(codec_byte).ok_or_else(|| {
+        error::ProtocolSnafu {
+            reason: "unknown codec in session accept",
+        }
+        .build()
+    })?;
+    let sample_rate = buf.get_u32();
+    let channels = buf.get_u8();
+    let session_id = buf.get_u64();
+    Ok(SessionAccept {
+        codec,
+        sample_rate,
+        channels,
+        session_id,
+    })
+}
+
+fn encode_status_report(buf: &mut BytesMut, f: &StatusReport) {
+    buf.put_u8(FrameType::StatusReport as u8);
+    buf.put_u16(f.buffer_depth_ms);
+    buf.put_u16(f.latency_ms);
+    buf.put_u8(f.device_state as u8);
+    buf.put_u16(f.renderer_id.len() as u16);
+    buf.put_slice(&f.renderer_id);
+}
+
+fn decode_status_report(buf: &mut Bytes) -> Result<StatusReport, error::SyndesisError> {
+    ensure!(
+        buf.remaining() >= 7,
+        error::ProtocolSnafu {
+            reason: "status report too short"
+        }
+    );
+    let buffer_depth_ms = buf.get_u16();
+    let latency_ms = buf.get_u16();
+    let state_byte = buf.get_u8();
+    let device_state = DeviceState::from_u8(state_byte).ok_or_else(|| {
+        error::ProtocolSnafu {
+            reason: "unknown device state",
+        }
+        .build()
+    })?;
+    let id_len = buf.get_u16() as usize;
+    ensure!(
+        buf.remaining() >= id_len,
+        error::ProtocolSnafu {
+            reason: "status report renderer_id truncated"
+        }
+    );
+    let renderer_id = buf.split_to(id_len).to_vec();
+    Ok(StatusReport {
+        buffer_depth_ms,
+        latency_ms,
+        device_state,
+        renderer_id,
+    })
+}
+
+fn encode_command(buf: &mut BytesMut, f: &Command) {
+    buf.put_u8(FrameType::Command as u8);
+    buf.put_u8(f.kind as u8);
+    buf.put_i64(f.value);
+}
+
+fn decode_command(buf: &mut Bytes) -> Result<Command, error::SyndesisError> {
+    ensure!(
+        buf.remaining() >= 9,
+        error::ProtocolSnafu {
+            reason: "command too short"
+        }
+    );
+    let kind_byte = buf.get_u8();
+    let kind = CommandKind::from_u8(kind_byte).ok_or_else(|| {
+        error::ProtocolSnafu {
+            reason: "unknown command kind",
+        }
+        .build()
+    })?;
+    let value = buf.get_i64();
+    Ok(Command { kind, value })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{AudioCodec, CommandKind, DeviceState, PROTOCOL_VERSION};
+
+    #[test]
+    fn audio_frame_round_trip() {
+        let original = Frame::Audio(AudioFrame {
+            sequence: 42,
+            timestamp_us: 1_000_000,
+            codec: AudioCodec::Flac,
+            channels: 2,
+            sample_rate: 44100,
+            payload: Bytes::from_static(b"fake-flac-data"),
+        });
+        let encoded = encode_frame(&original);
+        let mut buf = encoded;
+        let decoded = decode_frame(&mut buf).expect("decode should succeed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn clock_sync_round_trip() {
+        let original = Frame::ClockSync(ClockSync {
+            originate_ts: 100,
+            receive_ts: 200,
+            transmit_ts: 300,
+        });
+        let encoded = encode_datagram(&original);
+        let mut buf = encoded;
+        let decoded = decode_datagram(&mut buf).expect("decode should succeed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn clock_sync_reply_round_trip() {
+        let original = Frame::ClockSyncReply(ClockSyncReply {
+            originate_ts: 100,
+            receive_ts: 200,
+            transmit_ts: 300,
+            destination_ts: 400,
+        });
+        let encoded = encode_datagram(&original);
+        let mut buf = encoded;
+        let decoded = decode_datagram(&mut buf).expect("decode should succeed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn session_init_round_trip() {
+        let original = Frame::SessionInit(SessionInit {
+            protocol_version: PROTOCOL_VERSION,
+            supported_codecs: vec![AudioCodec::Flac, AudioCodec::Pcm],
+            sample_rates: vec![44100, 48000, 96000],
+            channel_configs: vec![2, 6],
+        });
+        let encoded = encode_frame(&original);
+        let mut buf = encoded;
+        let decoded = decode_frame(&mut buf).expect("decode should succeed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn session_accept_round_trip() {
+        let original = Frame::SessionAccept(SessionAccept {
+            codec: AudioCodec::Flac,
+            sample_rate: 48000,
+            channels: 2,
+            session_id: 0xDEAD_BEEF,
+        });
+        let encoded = encode_frame(&original);
+        let mut buf = encoded;
+        let decoded = decode_frame(&mut buf).expect("decode should succeed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn status_report_round_trip() {
+        let original = Frame::StatusReport(StatusReport {
+            buffer_depth_ms: 100,
+            latency_ms: 15,
+            device_state: DeviceState::Active,
+            renderer_id: b"renderer-01".to_vec(),
+        });
+        let encoded = encode_datagram(&original);
+        let mut buf = encoded;
+        let decoded = decode_datagram(&mut buf).expect("decode should succeed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn command_round_trip() {
+        let original = Frame::Command(Command {
+            kind: CommandKind::VolumeAdjust,
+            value: -5,
+        });
+        let encoded = encode_frame(&original);
+        let mut buf = encoded;
+        let decoded = decode_frame(&mut buf).expect("decode should succeed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn empty_payload_audio_frame() {
+        let original = Frame::Audio(AudioFrame {
+            sequence: 0,
+            timestamp_us: 0,
+            codec: AudioCodec::Pcm,
+            channels: 1,
+            sample_rate: 16000,
+            payload: Bytes::new(),
+        });
+        let encoded = encode_frame(&original);
+        let mut buf = encoded;
+        let decoded = decode_frame(&mut buf).expect("decode should succeed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn truncated_frame_returns_error() {
+        let mut buf = Bytes::from_static(&[0x00, 0x00, 0x00, 0x10, 0x01]);
+        assert!(decode_frame(&mut buf).is_err());
+    }
+
+    #[test]
+    fn unknown_frame_type_returns_error() {
+        let mut buf = Bytes::from_static(&[0xFF]);
+        assert!(decode_datagram(&mut buf).is_err());
+    }
+
+    #[test]
+    fn all_command_kinds_round_trip() {
+        for (kind, val) in [
+            (CommandKind::Pause, 0),
+            (CommandKind::Resume, 0),
+            (CommandKind::VolumeAdjust, 75),
+            (CommandKind::Seek, 120_000_000),
+        ] {
+            let original = Frame::Command(Command { kind, value: val });
+            let encoded = encode_frame(&original);
+            let mut buf = encoded;
+            let decoded = decode_frame(&mut buf).expect("decode should succeed");
+            assert_eq!(original, decoded);
+        }
+    }
+}

--- a/crates/syndesis/src/protocol/frame.rs
+++ b/crates/syndesis/src/protocol/frame.rs
@@ -1,0 +1,70 @@
+/// Wire frame types for the syndesis streaming protocol.
+use bytes::Bytes;
+
+use super::{AudioCodec, CommandKind, DeviceState};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AudioFrame {
+    pub sequence: u64,
+    pub timestamp_us: u64,
+    pub codec: AudioCodec,
+    pub channels: u8,
+    pub sample_rate: u32,
+    pub payload: Bytes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClockSync {
+    pub originate_ts: u64,
+    pub receive_ts: u64,
+    pub transmit_ts: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClockSyncReply {
+    pub originate_ts: u64,
+    pub receive_ts: u64,
+    pub transmit_ts: u64,
+    pub destination_ts: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionInit {
+    pub protocol_version: u8,
+    pub supported_codecs: Vec<AudioCodec>,
+    pub sample_rates: Vec<u32>,
+    pub channel_configs: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SessionAccept {
+    pub codec: AudioCodec,
+    pub sample_rate: u32,
+    pub channels: u8,
+    pub session_id: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusReport {
+    pub buffer_depth_ms: u16,
+    pub latency_ms: u16,
+    pub device_state: DeviceState,
+    pub renderer_id: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Command {
+    pub kind: CommandKind,
+    pub value: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Frame {
+    Audio(AudioFrame),
+    ClockSync(ClockSync),
+    ClockSyncReply(ClockSyncReply),
+    SessionInit(SessionInit),
+    SessionAccept(SessionAccept),
+    StatusReport(StatusReport),
+    Command(Command),
+}

--- a/crates/syndesis/src/protocol/mod.rs
+++ b/crates/syndesis/src/protocol/mod.rs
@@ -1,0 +1,91 @@
+/// QUIC streaming wire protocol definitions.
+pub mod codec;
+pub mod frame;
+
+pub const PROTOCOL_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FrameType {
+    AudioFrame = 0x01,
+    ClockSync = 0x02,
+    ClockSyncReply = 0x03,
+    SessionInit = 0x04,
+    SessionAccept = 0x05,
+    StatusReport = 0x06,
+    Command = 0x07,
+}
+
+impl FrameType {
+    pub(crate) fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0x01 => Some(Self::AudioFrame),
+            0x02 => Some(Self::ClockSync),
+            0x03 => Some(Self::ClockSyncReply),
+            0x04 => Some(Self::SessionInit),
+            0x05 => Some(Self::SessionAccept),
+            0x06 => Some(Self::StatusReport),
+            0x07 => Some(Self::Command),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[repr(u8)]
+pub enum AudioCodec {
+    Flac = 0x01,
+    Pcm = 0x02,
+}
+
+impl AudioCodec {
+    pub(crate) fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0x01 => Some(Self::Flac),
+            0x02 => Some(Self::Pcm),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[repr(u8)]
+pub enum DeviceState {
+    Active = 0x01,
+    Idle = 0x02,
+    Error = 0x03,
+    Buffering = 0x04,
+}
+
+impl DeviceState {
+    pub(crate) fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0x01 => Some(Self::Active),
+            0x02 => Some(Self::Idle),
+            0x03 => Some(Self::Error),
+            0x04 => Some(Self::Buffering),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CommandKind {
+    Pause = 0x01,
+    Resume = 0x02,
+    VolumeAdjust = 0x03,
+    Seek = 0x04,
+}
+
+impl CommandKind {
+    pub(crate) fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0x01 => Some(Self::Pause),
+            0x02 => Some(Self::Resume),
+            0x03 => Some(Self::VolumeAdjust),
+            0x04 => Some(Self::Seek),
+            _ => None,
+        }
+    }
+}

--- a/crates/syndesis/src/server/mod.rs
+++ b/crates/syndesis/src/server/mod.rs
@@ -1,0 +1,112 @@
+/// QUIC streaming server: accepts renderer connections and streams audio.
+pub mod session;
+pub mod source;
+
+use snafu::ResultExt;
+use std::net::SocketAddr;
+use tokio::task::JoinSet;
+use tracing::{info, instrument, warn};
+
+use crate::error::{self, SyndesisError};
+use crate::tls;
+
+pub use session::StreamSession;
+pub use source::AudioSource;
+
+pub struct StreamServer {
+    endpoint: quinn::Endpoint,
+    sessions: JoinSet<()>,
+}
+
+impl StreamServer {
+    /// Bind a QUIC streaming server to the given address.
+    #[instrument(skip_all, fields(%bind_addr))]
+    pub fn bind(bind_addr: SocketAddr) -> Result<Self, SyndesisError> {
+        let (certs, key) = tls::generate_self_signed(&["localhost".into()])?;
+        let server_config = tls::build_server_config(certs, key)?;
+
+        let endpoint =
+            quinn::Endpoint::server(server_config, bind_addr).context(error::BindSnafu)?;
+
+        info!("syndesis server listening");
+        Ok(Self {
+            endpoint,
+            sessions: JoinSet::new(),
+        })
+    }
+
+    /// Bind with a pre-built server config (for testing or custom certs).
+    pub fn bind_with_config(
+        bind_addr: SocketAddr,
+        server_config: quinn::ServerConfig,
+    ) -> Result<Self, SyndesisError> {
+        let endpoint =
+            quinn::Endpoint::server(server_config, bind_addr).context(error::BindSnafu)?;
+        Ok(Self {
+            endpoint,
+            sessions: JoinSet::new(),
+        })
+    }
+
+    /// Accept incoming connections and spawn session handlers.
+    /// Runs until the endpoint is closed or the provided cancellation token fires.
+    #[instrument(skip_all)]
+    pub async fn run<S: AudioSource + Clone + Send + 'static>(
+        &mut self,
+        source: S,
+        cancel: tokio::sync::watch::Receiver<bool>,
+    ) {
+        loop {
+            tokio::select! {
+                biased;
+                _ = wait_for_cancel(&cancel) => {
+                    info!("server shutting down");
+                    break;
+                }
+                incoming = self.endpoint.accept() => {
+                    let Some(incoming) = incoming else {
+                        info!("endpoint closed");
+                        break;
+                    };
+                    let source = source.clone();
+                    let cancel = cancel.clone();
+                    self.sessions.spawn(async move {
+                        match incoming.await {
+                            Ok(conn) => {
+                                let addr = conn.remote_address();
+                                info!(%addr, "renderer connected");
+                                let mut session = StreamSession::new(conn);
+                                if let Err(e) = session.run(source, cancel).await {
+                                    warn!(%addr, error = %e, "session ended with error");
+                                }
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "failed to accept connection");
+                            }
+                        }
+                    });
+                }
+            }
+        }
+        self.sessions.shutdown().await;
+        self.endpoint.close(0u32.into(), b"shutdown");
+    }
+
+    /// The local address the server is bound to.
+    #[must_use]
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.endpoint.local_addr().ok()
+    }
+}
+
+async fn wait_for_cancel(cancel: &tokio::sync::watch::Receiver<bool>) {
+    let mut cancel = cancel.clone();
+    loop {
+        if *cancel.borrow() {
+            return;
+        }
+        if cancel.changed().await.is_err() {
+            return;
+        }
+    }
+}

--- a/crates/syndesis/src/server/session.rs
+++ b/crates/syndesis/src/server/session.rs
@@ -1,0 +1,285 @@
+/// Per-renderer server session: negotiation, audio streaming, clock sync, flow control.
+use bytes::Bytes;
+use snafu::ResultExt;
+use tracing::{debug, instrument, trace};
+
+use crate::clock::{ClockEstimator, SyncScheduler};
+use crate::error::{self, SyndesisError};
+use crate::protocol::codec::{decode_datagram, decode_frame, encode_datagram, encode_frame};
+use crate::protocol::frame::{
+    ClockSync, ClockSyncReply, Frame, SessionAccept, SessionInit, StatusReport,
+};
+use crate::protocol::{AudioCodec, PROTOCOL_VERSION};
+use crate::server::source::AudioSource;
+
+const BUFFER_HIGH_WATERMARK_MS: u16 = 200;
+const BUFFER_LOW_WATERMARK_MS: u16 = 80;
+
+pub struct StreamSession {
+    conn: quinn::Connection,
+    session_id: u64,
+    clock: ClockEstimator,
+    scheduler: SyncScheduler,
+    is_paused: bool,
+}
+
+impl StreamSession {
+    pub(crate) fn new(conn: quinn::Connection) -> Self {
+        Self {
+            conn,
+            session_id: 0,
+            clock: ClockEstimator::new(),
+            scheduler: SyncScheduler::new(),
+            is_paused: false,
+        }
+    }
+
+    /// Run the session: negotiate, then stream audio while handling clock sync and status.
+    #[instrument(skip_all, fields(session_id))]
+    pub async fn run<S: AudioSource>(
+        &mut self,
+        mut source: S,
+        cancel: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<(), SyndesisError> {
+        self.negotiate().await?;
+        tracing::Span::current().record("session_id", self.session_id);
+
+        let mut send_stream = self.conn.open_uni().await.context(error::ConnectionSnafu)?;
+
+        let mut sync_interval = tokio::time::interval(self.scheduler.interval());
+        sync_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        let mut source_exhausted = false;
+
+        loop {
+            tokio::select! {
+                biased;
+
+                _ = wait_for_cancel(&cancel) => {
+                    debug!("session cancelled");
+                    break;
+                }
+
+                datagram = self.conn.read_datagram() => {
+                    match datagram {
+                        Ok(data) => {
+                            self.handle_datagram(data)?;
+                        }
+                        Err(e) => {
+                            return Err(e).context(error::ConnectionSnafu);
+                        }
+                    }
+                }
+
+                _ = sync_interval.tick() => {
+                    self.send_clock_probe()?;
+                    let new_interval = self.scheduler.update(&self.clock);
+                    sync_interval = tokio::time::interval(new_interval);
+                    sync_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                }
+
+                frame = source.next_frame(), if !self.is_paused && !source_exhausted => {
+                    match frame {
+                        Some(audio_frame) => {
+                            let encoded = encode_frame(&Frame::Audio(audio_frame));
+                            send_stream.write_all(&encoded).await
+                                .context(error::WriteStreamSnafu)?;
+                        }
+                        None => {
+                            debug!("audio source exhausted");
+                            let _ = send_stream.finish();
+                            source_exhausted = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if !source_exhausted {
+            let _ = send_stream.finish();
+        }
+        Ok(())
+    }
+
+    async fn negotiate(&mut self) -> Result<(), SyndesisError> {
+        let (mut send, mut recv) = self
+            .conn
+            .accept_bi()
+            .await
+            .context(error::ConnectionSnafu)?;
+
+        let init_data = recv
+            .read_to_end(4096)
+            .await
+            .context(error::ReadToEndSnafu)?;
+        let mut init_bytes = Bytes::from(init_data);
+        let frame = decode_frame(&mut init_bytes)?;
+
+        let Frame::SessionInit(init) = frame else {
+            return Err(error::NegotiationSnafu {
+                reason: "expected SessionInit frame",
+            }
+            .build());
+        };
+
+        let (codec, sample_rate, channels) = negotiate_params(&init)?;
+
+        self.session_id = rand::random();
+
+        let accept = Frame::SessionAccept(SessionAccept {
+            codec,
+            sample_rate,
+            channels,
+            session_id: self.session_id,
+        });
+
+        let encoded = encode_frame(&accept);
+        send.write_all(&encoded)
+            .await
+            .context(error::WriteStreamSnafu)?;
+        let _ = send.finish();
+
+        debug!(
+            session_id = self.session_id,
+            ?codec,
+            sample_rate,
+            channels,
+            "session negotiated"
+        );
+
+        Ok(())
+    }
+
+    fn send_clock_probe(&self) -> Result<(), SyndesisError> {
+        let now = current_time_us();
+        let probe = Frame::ClockSync(ClockSync {
+            originate_ts: now,
+            receive_ts: 0,
+            transmit_ts: 0,
+        });
+        let data = encode_datagram(&probe);
+        self.conn.send_datagram(data).map_err(|e| {
+            error::DatagramSnafu {
+                reason: e.to_string(),
+            }
+            .build()
+        })?;
+        trace!("sent clock probe");
+        Ok(())
+    }
+
+    fn handle_datagram(&mut self, data: Bytes) -> Result<(), SyndesisError> {
+        let mut buf = data;
+        let frame = decode_datagram(&mut buf)?;
+
+        match frame {
+            Frame::ClockSyncReply(reply) => self.handle_clock_reply(&reply),
+            Frame::StatusReport(report) => self.handle_status_report(&report),
+            other => {
+                debug!(?other, "unexpected datagram frame type");
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_clock_reply(&mut self, reply: &ClockSyncReply) {
+        self.clock.record_exchange(
+            reply.originate_ts,
+            reply.receive_ts,
+            reply.transmit_ts,
+            reply.destination_ts,
+        );
+        trace!(
+            offset_us = self.clock.offset_us(),
+            stable = self.clock.is_stable(),
+            "clock sync updated"
+        );
+    }
+
+    fn handle_status_report(&mut self, report: &StatusReport) {
+        if report.buffer_depth_ms > BUFFER_HIGH_WATERMARK_MS && !self.is_paused {
+            debug!(
+                buffer_ms = report.buffer_depth_ms,
+                "pausing stream: buffer above high watermark"
+            );
+            self.is_paused = true;
+        } else if report.buffer_depth_ms < BUFFER_LOW_WATERMARK_MS && self.is_paused {
+            debug!(
+                buffer_ms = report.buffer_depth_ms,
+                "resuming stream: buffer below low watermark"
+            );
+            self.is_paused = false;
+        }
+        trace!(
+            buffer_ms = report.buffer_depth_ms,
+            latency_ms = report.latency_ms,
+            ?report.device_state,
+            "status report received"
+        );
+    }
+}
+
+fn negotiate_params(init: &SessionInit) -> Result<(AudioCodec, u32, u8), SyndesisError> {
+    if init.protocol_version != PROTOCOL_VERSION {
+        return Err(error::NegotiationSnafu {
+            reason: "unsupported protocol version",
+        }
+        .build());
+    }
+
+    // WHY: Server preference order: FLAC first (lossless), then PCM as fallback.
+    let codec = if init.supported_codecs.contains(&AudioCodec::Flac) {
+        AudioCodec::Flac
+    } else if init.supported_codecs.contains(&AudioCodec::Pcm) {
+        AudioCodec::Pcm
+    } else {
+        return Err(error::NegotiationSnafu {
+            reason: "no supported codec",
+        }
+        .build());
+    };
+
+    let preferred_rates = [48000, 44100, 96000, 192000];
+    let sample_rate = preferred_rates
+        .iter()
+        .find(|r| init.sample_rates.contains(r))
+        .copied()
+        .ok_or_else(|| {
+            error::NegotiationSnafu {
+                reason: "no supported sample rate",
+            }
+            .build()
+        })?;
+
+    let channels = if init.channel_configs.contains(&2) {
+        2
+    } else {
+        *init.channel_configs.first().ok_or_else(|| {
+            error::NegotiationSnafu {
+                reason: "no channel config",
+            }
+            .build()
+        })?
+    };
+
+    Ok((codec, sample_rate, channels))
+}
+
+pub(crate) fn current_time_us() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_micros() as u64
+}
+
+async fn wait_for_cancel(cancel: &tokio::sync::watch::Receiver<bool>) {
+    let mut cancel = cancel.clone();
+    loop {
+        if *cancel.borrow() {
+            return;
+        }
+        if cancel.changed().await.is_err() {
+            return;
+        }
+    }
+}

--- a/crates/syndesis/src/server/source.rs
+++ b/crates/syndesis/src/server/source.rs
@@ -1,0 +1,33 @@
+/// Audio source trait: abstraction for feeding audio data into the stream.
+use crate::protocol::frame::AudioFrame;
+
+pub trait AudioSource: Send + Sync + 'static {
+    /// Fetch the next audio frame. Returns None when the source is exhausted.
+    fn next_frame(&mut self) -> impl std::future::Future<Output = Option<AudioFrame>> + Send;
+}
+
+/// Test audio source backed by a pre-loaded Vec of frames.
+#[derive(Debug, Clone)]
+pub struct VecAudioSource {
+    frames: Vec<AudioFrame>,
+    index: usize,
+}
+
+impl VecAudioSource {
+    #[must_use]
+    pub fn new(frames: Vec<AudioFrame>) -> Self {
+        Self { frames, index: 0 }
+    }
+}
+
+impl AudioSource for VecAudioSource {
+    async fn next_frame(&mut self) -> Option<AudioFrame> {
+        if self.index < self.frames.len() {
+            let frame = self.frames[self.index].clone();
+            self.index += 1;
+            Some(frame)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/syndesis/src/tls/mod.rs
+++ b/crates/syndesis/src/tls/mod.rs
@@ -1,0 +1,230 @@
+/// TLS certificate management for QUIC transport.
+use std::path::Path;
+use std::sync::Arc;
+
+use quinn::crypto::rustls::QuicServerConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+use snafu::ResultExt;
+
+use crate::error::{self, SyndesisError};
+
+/// Generate a self-signed certificate and private key for QUIC transport.
+pub fn generate_self_signed(
+    subject_alt_names: &[String],
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), SyndesisError> {
+    let mut params = rcgen::CertificateParams::new(subject_alt_names.to_vec()).map_err(|e| {
+        error::TlsSnafu {
+            reason: e.to_string(),
+        }
+        .build()
+    })?;
+    params.distinguished_name = rcgen::DistinguishedName::new();
+    params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "syndesis");
+
+    let key_pair = rcgen::KeyPair::generate().map_err(|e| {
+        error::TlsSnafu {
+            reason: e.to_string(),
+        }
+        .build()
+    })?;
+    let cert = params.self_signed(&key_pair).map_err(|e| {
+        error::TlsSnafu {
+            reason: e.to_string(),
+        }
+        .build()
+    })?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
+
+    Ok((vec![cert_der], key_der))
+}
+
+/// Save certificate and key to disk in DER format.
+pub fn save_identity(
+    cert_path: &Path,
+    key_path: &Path,
+    certs: &[CertificateDer<'_>],
+    key: &PrivateKeyDer<'_>,
+) -> Result<(), SyndesisError> {
+    use std::fs;
+
+    if let Some(parent) = cert_path.parent() {
+        fs::create_dir_all(parent).context(error::IoSnafu)?;
+    }
+    if let Some(parent) = key_path.parent() {
+        fs::create_dir_all(parent).context(error::IoSnafu)?;
+    }
+
+    let mut cert_bytes = Vec::new();
+    for cert in certs {
+        cert_bytes.extend_from_slice(cert.as_ref());
+    }
+    fs::write(cert_path, &cert_bytes).context(error::IoSnafu)?;
+    fs::write(key_path, key.secret_der()).context(error::IoSnafu)?;
+
+    Ok(())
+}
+
+/// Load certificate and key from disk.
+pub fn load_identity(
+    cert_path: &Path,
+    key_path: &Path,
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), SyndesisError> {
+    use std::fs;
+
+    let cert_bytes = fs::read(cert_path).context(error::IoSnafu)?;
+    let key_bytes = fs::read(key_path).context(error::IoSnafu)?;
+
+    let cert = CertificateDer::from(cert_bytes);
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
+
+    Ok((vec![cert], key))
+}
+
+/// Build a quinn ServerConfig with self-signed certs.
+pub fn build_server_config(
+    certs: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+) -> Result<quinn::ServerConfig, SyndesisError> {
+    let mut tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| {
+            error::TlsSnafu {
+                reason: e.to_string(),
+            }
+            .build()
+        })?;
+
+    tls_config.alpn_protocols = vec![b"syndesis/1".to_vec()];
+
+    let quic_server_config = QuicServerConfig::try_from(tls_config).map_err(|e| {
+        error::TlsSnafu {
+            reason: e.to_string(),
+        }
+        .build()
+    })?;
+
+    let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_server_config));
+
+    let mut transport = quinn::TransportConfig::default();
+    transport.datagram_receive_buffer_size(Some(65536));
+    transport.datagram_send_buffer_size(65536);
+    server_config.transport_config(Arc::new(transport));
+
+    Ok(server_config)
+}
+
+/// TOFU certificate verifier that accepts any certificate on first contact.
+#[derive(Debug)]
+struct TofuVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for TofuVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+/// Build a quinn ClientConfig that trusts any server certificate (TOFU model).
+pub fn build_client_config() -> Result<quinn::ClientConfig, SyndesisError> {
+    let mut tls_config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(TofuVerifier))
+        .with_no_client_auth();
+
+    tls_config.alpn_protocols = vec![b"syndesis/1".to_vec()];
+
+    let mut client_config = quinn::ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(tls_config).map_err(|e| {
+            error::TlsSnafu {
+                reason: e.to_string(),
+            }
+            .build()
+        })?,
+    ));
+
+    let mut transport = quinn::TransportConfig::default();
+    transport.datagram_receive_buffer_size(Some(65536));
+    transport.datagram_send_buffer_size(65536);
+    client_config.transport_config(Arc::new(transport));
+
+    Ok(client_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generates_self_signed_cert() {
+        let (certs, _key) = generate_self_signed(&["localhost".to_string()])
+            .expect("cert generation should succeed");
+        assert_eq!(certs.len(), 1);
+        assert!(!certs[0].as_ref().is_empty());
+    }
+
+    #[test]
+    fn builds_server_config_from_generated_cert() {
+        let (certs, key) =
+            generate_self_signed(&["localhost".to_string()]).expect("cert gen should succeed");
+        let config = build_server_config(certs, key);
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn builds_client_config() {
+        let config = build_client_config();
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn save_and_load_identity_round_trip() {
+        let dir = std::env::temp_dir().join("syndesis_tls_test");
+        let cert_path = dir.join("cert.der");
+        let key_path = dir.join("key.der");
+
+        let (certs, key) =
+            generate_self_signed(&["localhost".to_string()]).expect("cert gen should succeed");
+        save_identity(&cert_path, &key_path, &certs, &key).expect("save should succeed");
+        let (loaded_certs, _loaded_key) =
+            load_identity(&cert_path, &key_path).expect("load should succeed");
+
+        assert_eq!(certs[0].as_ref(), loaded_certs[0].as_ref());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/syndesis/tests/integration.rs
+++ b/crates/syndesis/tests/integration.rs
@@ -1,0 +1,150 @@
+/// Integration tests for syndesis QUIC streaming protocol.
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use bytes::Bytes;
+use syndesis::client::StreamClient;
+use syndesis::protocol::AudioCodec;
+use syndesis::protocol::frame::AudioFrame;
+use syndesis::server::StreamServer;
+use syndesis::server::source::VecAudioSource;
+
+fn test_frames(count: usize) -> Vec<AudioFrame> {
+    (0..count)
+        .map(|i| AudioFrame {
+            sequence: i as u64,
+            timestamp_us: i as u64 * 10_000,
+            codec: AudioCodec::Flac,
+            channels: 2,
+            sample_rate: 48000,
+            payload: Bytes::from(vec![0xABu8; 128]),
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn loopback_stream_delivers_all_frames() {
+    let frames = test_frames(50);
+    let source = VecAudioSource::new(frames.clone());
+
+    let server_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let mut server = StreamServer::bind(server_addr).expect("server bind should succeed");
+    let bound_addr = server.local_addr().expect("should have local addr");
+
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+
+    let server_handle = tokio::spawn(async move {
+        server.run(source, cancel_rx).await;
+    });
+
+    // Give server a moment to start accepting
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let client = StreamClient::new(client_addr).expect("client should bind");
+    let mut session = client
+        .connect(bound_addr, "localhost")
+        .await
+        .expect("connect should succeed");
+
+    let accept = session
+        .negotiate(
+            vec![AudioCodec::Flac, AudioCodec::Pcm],
+            vec![44100, 48000],
+            vec![2],
+        )
+        .await
+        .expect("negotiate should succeed");
+
+    assert_eq!(accept.codec, AudioCodec::Flac);
+    assert_eq!(accept.sample_rate, 48000);
+    assert_eq!(accept.channels, 2);
+
+    // Run client session with a timeout
+    let client_cancel_rx = cancel_tx.subscribe();
+    let received = tokio::time::timeout(Duration::from_secs(5), session.run(client_cancel_rx))
+        .await
+        .expect("should not timeout")
+        .expect("client run should succeed");
+
+    // All frames should be received
+    assert_eq!(
+        received.len(),
+        frames.len(),
+        "should receive all {} frames, got {}",
+        frames.len(),
+        received.len()
+    );
+
+    // Verify frame contents match
+    for (i, frame) in received.iter().enumerate() {
+        assert_eq!(frame.sequence, i as u64);
+        assert_eq!(frame.codec, AudioCodec::Flac);
+        assert_eq!(frame.channels, 2);
+        assert_eq!(frame.sample_rate, 48000);
+    }
+
+    let _ = cancel_tx.send(true);
+    let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
+}
+
+#[tokio::test]
+async fn session_negotiation_selects_best_codec() {
+    let source = VecAudioSource::new(vec![]);
+
+    let server_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let mut server = StreamServer::bind(server_addr).expect("server bind should succeed");
+    let bound_addr = server.local_addr().expect("should have local addr");
+
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+
+    let server_handle = tokio::spawn(async move {
+        server.run(source, cancel_rx).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let client = StreamClient::new(client_addr).expect("client should bind");
+    let mut session = client
+        .connect(bound_addr, "localhost")
+        .await
+        .expect("connect should succeed");
+
+    // Only offer PCM
+    let accept = session
+        .negotiate(vec![AudioCodec::Pcm], vec![44100], vec![2, 6])
+        .await
+        .expect("negotiate should succeed");
+
+    assert_eq!(accept.codec, AudioCodec::Pcm);
+    assert_eq!(accept.sample_rate, 44100);
+    assert_eq!(accept.channels, 2);
+
+    let _ = cancel_tx.send(true);
+    let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
+}
+
+#[tokio::test]
+async fn clock_sync_converges_on_loopback() {
+    use syndesis::clock::ClockEstimator;
+
+    let mut estimator = ClockEstimator::new();
+
+    // Simulate loopback with near-zero network delay
+    for i in 0..20u64 {
+        let base = i * 50_000;
+        let originate = base;
+        let receive = base + 100;
+        let transmit = base + 150;
+        let destination = base + 250;
+        estimator.record_exchange(originate, receive, transmit, destination);
+    }
+
+    let offset = estimator.offset_us();
+    assert!(
+        offset.unsigned_abs() < 1000,
+        "loopback offset should be <1ms, got {offset}us"
+    );
+    assert!(estimator.is_stable(), "should be stable after 20 samples");
+}

--- a/crates/theatron/core/src/types.rs
+++ b/crates/theatron/core/src/types.rs
@@ -59,4 +59,3 @@ pub enum ConnectionStatus {
     /// Connection failed.
     Failed(String),
 }
-


### PR DESCRIPTION
## Summary

- New `syndesis` crate implementing QUIC-based streaming protocol for multi-room audio transport
- Binary wire format with zero-copy codec for AudioFrame, ClockSync, SessionInit/Accept, StatusReport, and Command frames
- NTP-style clock synchronization with sliding window estimator, outlier rejection, and adaptive probe scheduling (5s initial, backs off to 30s when stable)
- Server streams audio over QUIC unidirectional streams with flow control (pause/resume based on renderer buffer depth)
- Client receives into jitter buffer with configurable depth (default 100ms), reordering by sequence number, gap detection
- Self-signed TLS via rcgen with TOFU certificate verification for local network operation
- QUIC DATAGRAMs for clock sync probes and status reports (latency, buffer depth, device state)

## Test plan

- [x] Protocol codec round-trip tests for all 7 frame types
- [x] Clock estimator convergence to <1ms on symmetric loopback
- [x] Clock estimator outlier rejection
- [x] Adaptive scheduler backs off to 30s and re-accelerates on drift
- [x] Jitter buffer ordering, depth enforcement, gap detection, clock offset application
- [x] TLS cert generation, save/load round-trip, server/client config build
- [x] Integration: loopback stream delivers all 50 frames in order
- [x] Integration: session negotiation selects best codec
- [x] Integration: clock sync converges on loopback
- [x] Full workspace: `cargo fmt`, `cargo clippy -D warnings`, `cargo test --workspace` pass

## Observations

- **Debt**: `send_datagram` errors are converted via `to_string()` into a `Datagram` error variant rather than using a typed source. Quinn's `SendDatagramError` doesn't impl the right traits for snafu chaining. Worth revisiting if quinn updates.
- **Missing test**: No integration test for flow control (StatusReport triggering pause/resume). Would need a slow-consumer simulation with a synthetic source that yields faster than the buffer drains.
- **Missing test**: No integration test for clock sync over real QUIC DATAGRAMs. The current clock sync integration test is synthetic (no network). DATAGRAMs require both server and client to be connected, and the timing makes assertions non-deterministic.
- **Idea**: The `AudioSource` trait returns owned `AudioFrame`s. For the real paroche integration (prompt 123), a zero-copy path using `Bytes` slices from a shared ring buffer would avoid cloning payload data per-renderer.
- **Doc gap**: No `docs/lexicon.md` entry for `syndesis` yet. Should be added when the crate stabilizes.