### PR TITLE
feat(harmonia-host): add render subcommand with local DSP and status reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
 ]
@@ -1053,9 +1053,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deflate64"
-version = "0.1.12"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
 
 [[package]]
 name = "der"
@@ -1737,6 +1737,7 @@ dependencies = [
  "epignosis",
  "ergasia",
  "exousia",
+ "figment",
  "harmonia-common",
  "harmonia-db",
  "horismos",
@@ -1744,15 +1745,20 @@ dependencies = [
  "kritike",
  "paroche",
  "prostheke",
+ "quinn",
  "rand 0.10.0",
+ "rcgen",
  "reqwest",
  "rstest",
+ "rustls",
+ "serde",
  "serde_json",
  "snafu",
  "sqlx",
  "syndesmos",
  "syntaxis",
  "taxis",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tower",
@@ -2217,9 +2223,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -2242,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
@@ -3498,9 +3504,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
@@ -3569,7 +3575,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -4175,9 +4181,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5226,9 +5232,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5360,9 +5366,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
@@ -5378,28 +5384,28 @@ dependencies = [
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
@@ -6415,15 +6421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winnow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6566,18 +6563,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6670,9 +6667,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.4.0"
+version = "8.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7756d0206d058333667493c4014f545f4b9603c4330ccd6d9b3f86dcab59f7d9"
+checksum = "5c546feb4481b0fbafb4ef0d79b6204fc41c6f9884b1b73b1d73f82442fc0845"
 dependencies = [
  "aes",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,8 @@ fast_image_resize   = "6.0"
 
 # ── QUIC transport ─────────────────────────────────────────────────────────────
 quinn           = "0.11"
+rustls          = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rcgen           = "0.13"
 
 # ── mDNS discovery ────────────────────────────────────────────────────────────
 mdns-sd         = "0.18"

--- a/crates/akouo-core/src/lib.rs
+++ b/crates/akouo-core/src/lib.rs
@@ -8,7 +8,7 @@ pub mod error;
 pub mod gapless;
 pub mod output;
 pub mod queue;
-pub(crate) mod ring_buffer;
+pub mod ring_buffer;
 pub mod signal_path;
 
 // Config
@@ -44,6 +44,9 @@ pub use signal_path::{
 
 // DSP pipeline (for embedding in custom engine implementations)
 pub use dsp::{DspPipeline, DspStage, StageResult};
+
+// Ring buffer (for custom engine/renderer implementations)
+pub use ring_buffer::RingBuffer;
 
 // Gapless
 pub use gapless::prebuffer::PreBuffer;

--- a/crates/akouo-core/src/ring_buffer.rs
+++ b/crates/akouo-core/src/ring_buffer.rs
@@ -29,7 +29,6 @@ pub struct RingBuffer {
 unsafe impl Send for RingBuffer {}
 unsafe impl Sync for RingBuffer {}
 
-#[expect(dead_code)]
 impl RingBuffer {
     /// Allocates a ring buffer with at least `min_capacity` slots, rounded up to the next
     /// power of two. No allocation occurs after this call.

--- a/crates/harmonia-host/Cargo.toml
+++ b/crates/harmonia-host/Cargo.toml
@@ -29,6 +29,11 @@ akouo-core = { workspace = true, features = ["native-output"] }
 clap.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+quinn.workspace = true
+rustls.workspace = true
+rcgen.workspace = true
+figment.workspace = true
+serde.workspace = true
 axum.workspace = true
 reqwest.workspace = true
 sqlx.workspace = true
@@ -42,3 +47,4 @@ rand.workspace = true
 rstest.workspace = true
 tower.workspace = true
 uuid.workspace = true
+tempfile = "3"

--- a/crates/harmonia-host/src/cli.rs
+++ b/crates/harmonia-host/src/cli.rs
@@ -17,6 +17,8 @@ pub enum Command {
     Db(DbArgs),
     /// Play a local audio file
     Play(PlayArgs),
+    /// Start a headless audio renderer
+    Render(RenderArgs),
 }
 
 #[derive(Args)]
@@ -49,6 +51,25 @@ pub struct PlayArgs {
     /// Audio output device name (uses default if omitted)
     #[arg(long)]
     pub device: Option<String>,
+}
+
+#[derive(Args)]
+pub struct RenderArgs {
+    /// Server QUIC address (host:port)
+    #[arg(long)]
+    pub server: String,
+
+    /// Renderer display name (default: hostname)
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// Path to renderer config TOML (DSP settings, output device)
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Directory for TLS certificates
+    #[arg(long, default_value = "~/.config/harmonia/certs/")]
+    pub cert_dir: PathBuf,
 }
 
 #[derive(Subcommand)]
@@ -90,6 +111,29 @@ mod tests {
         assert_eq!(args.config, PathBuf::from("/etc/harmonia.toml"));
         assert_eq!(args.listen.as_deref(), Some("127.0.0.1"));
         assert_eq!(args.port, Some(9000));
+    }
+
+    #[test]
+    fn render_with_server_parses() {
+        let cli = Cli::parse_from([
+            "harmonia",
+            "render",
+            "--server",
+            "127.0.0.1:4433",
+            "--name",
+            "living-room",
+        ]);
+        let Command::Render(args) = cli.command else {
+            panic!("expected Render command");
+        };
+        assert_eq!(args.server, "127.0.0.1:4433");
+        assert_eq!(args.name.as_deref(), Some("living-room"));
+    }
+
+    #[test]
+    fn render_requires_server_arg() {
+        let result = Cli::try_parse_from(["harmonia", "render"]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/harmonia-host/src/error.rs
+++ b/crates/harmonia-host/src/error.rs
@@ -111,4 +111,11 @@ pub enum HostError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    #[snafu(display("renderer error: {source}"))]
+    Render {
+        source: Box<crate::render::RenderError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }

--- a/crates/harmonia-host/src/main.rs
+++ b/crates/harmonia-host/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod error;
 mod play;
+mod render;
 mod serve;
 mod shutdown;
 mod startup;
@@ -21,6 +22,14 @@ async fn main() {
             }
         },
         Command::Play(args) => play::run_play(args).await,
+        Command::Render(args) => {
+            render::run_render(args)
+                .await
+                .map_err(|e| error::HostError::Render {
+                    source: Box::new(e),
+                    location: snafu::location!(),
+                })
+        }
     };
 
     if let Err(e) = result {

--- a/crates/harmonia-host/src/render/config.rs
+++ b/crates/harmonia-host/src/render/config.rs
@@ -1,0 +1,320 @@
+// Renderer configuration loaded from TOML via figment.
+
+use std::path::Path;
+
+use figment::Figment;
+use figment::providers::{Env, Format, Serialized, Toml};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use super::error::{ConfigSnafu, RenderError};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RendererConfig {
+    pub output: OutputSettings,
+    pub dsp: DspSettings,
+    pub buffer: BufferSettings,
+    pub reconnect: ReconnectSettings,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct OutputSettings {
+    pub device: String,
+    pub exclusive_mode: bool,
+    pub bit_depth: u32,
+}
+
+impl Default for OutputSettings {
+    fn default() -> Self {
+        Self {
+            device: "default".to_string(),
+            exclusive_mode: false,
+            bit_depth: 24,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DspSettings {
+    pub volume: VolumeSettings,
+    pub eq: EqSettings,
+    pub crossfeed: CrossfeedSettings,
+    pub replaygain: ReplayGainSettings,
+    pub compressor: CompressorSettings,
+    pub convolution: ConvolutionSettings,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct VolumeSettings {
+    pub level_db: f64,
+    pub dither: bool,
+}
+
+impl Default for VolumeSettings {
+    fn default() -> Self {
+        Self {
+            level_db: 0.0,
+            dither: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EqSettings {
+    pub enabled: bool,
+    pub bands: Vec<EqBandSettings>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EqBandSettings {
+    pub frequency: f64,
+    pub gain_db: f64,
+    #[serde(default = "default_q")]
+    pub q: f64,
+}
+
+fn default_q() -> f64 {
+    1.414
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CrossfeedSettings {
+    pub enabled: bool,
+    pub strength: f64,
+}
+
+impl Default for CrossfeedSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            strength: 0.3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ReplayGainSettings {
+    pub enabled: bool,
+    pub mode: ReplayGainModeConfig,
+    pub preamp_db: f64,
+}
+
+impl Default for ReplayGainSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mode: ReplayGainModeConfig::Track,
+            preamp_db: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayGainModeConfig {
+    Track,
+    Album,
+    R128,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompressorSettings {
+    pub enabled: bool,
+    pub threshold_db: f64,
+    pub ratio: f64,
+    pub attack_ms: f64,
+    pub release_ms: f64,
+}
+
+impl Default for CompressorSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            threshold_db: -6.0,
+            ratio: 4.0,
+            attack_ms: 5.0,
+            release_ms: 100.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ConvolutionSettings {
+    pub enabled: bool,
+    pub ir_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BufferSettings {
+    pub depth_ms: u64,
+}
+
+impl Default for BufferSettings {
+    fn default() -> Self {
+        Self { depth_ms: 100 }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ReconnectSettings {
+    pub enabled: bool,
+    pub initial_backoff_ms: u64,
+    pub max_backoff_ms: u64,
+}
+
+impl Default for ReconnectSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            initial_backoff_ms: 1000,
+            max_backoff_ms: 30_000,
+        }
+    }
+}
+
+impl RendererConfig {
+    pub fn dsp_config(&self) -> akouo_core::DspConfig {
+        akouo_core::DspConfig {
+            skip_silence: akouo_core::SkipSilenceConfig::default(),
+            eq: akouo_core::EqConfig {
+                enabled: self.dsp.eq.enabled,
+                bands: self
+                    .dsp
+                    .eq
+                    .bands
+                    .iter()
+                    .map(|b| akouo_core::EqBand {
+                        frequency: b.frequency,
+                        gain_db: b.gain_db,
+                        q: b.q,
+                        filter_type: akouo_core::config::FilterType::Peaking,
+                    })
+                    .collect(),
+            },
+            crossfeed: akouo_core::CrossfeedConfig {
+                enabled: self.dsp.crossfeed.enabled,
+                strength: self.dsp.crossfeed.strength,
+            },
+            replaygain: akouo_core::ReplayGainConfig {
+                enabled: self.dsp.replaygain.enabled,
+                mode: match self.dsp.replaygain.mode {
+                    ReplayGainModeConfig::Track => akouo_core::ReplayGainMode::Track,
+                    ReplayGainModeConfig::Album => akouo_core::ReplayGainMode::Album,
+                    ReplayGainModeConfig::R128 => akouo_core::ReplayGainMode::R128,
+                },
+                preamp_db: self.dsp.replaygain.preamp_db,
+                ..akouo_core::ReplayGainConfig::default()
+            },
+            compressor: akouo_core::CompressorConfig {
+                enabled: self.dsp.compressor.enabled,
+                threshold_db: self.dsp.compressor.threshold_db,
+                ratio: self.dsp.compressor.ratio,
+                attack_ms: self.dsp.compressor.attack_ms,
+                release_ms: self.dsp.compressor.release_ms,
+                ..akouo_core::CompressorConfig::default()
+            },
+            convolution: akouo_core::ConvolutionConfig {
+                enabled: self.dsp.convolution.enabled,
+                ir_path: self.dsp.convolution.ir_path.as_ref().map(Into::into),
+                ..akouo_core::ConvolutionConfig::default()
+            },
+            volume: akouo_core::VolumeConfig {
+                level_db: self.dsp.volume.level_db,
+                dither: self.dsp.volume.dither,
+            },
+        }
+    }
+
+    pub fn ring_buffer_capacity(&self) -> usize {
+        let samples_per_ms = 48; // 48kHz
+        let target = (self.buffer.depth_ms as usize) * samples_per_ms * 2;
+        target.next_power_of_two().max(8192)
+    }
+}
+
+pub fn load_renderer_config(path: Option<&Path>) -> Result<RendererConfig, RenderError> {
+    let mut figment = Figment::from(Serialized::defaults(RendererConfig::default()));
+    if let Some(p) = path {
+        figment = figment.merge(Toml::file(p));
+    }
+    figment = figment.merge(Env::prefixed("HARMONIA_RENDER_").split("__"));
+    figment.extract().map_err(Box::new).context(ConfigSnafu)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_loads_without_file() {
+        let config = load_renderer_config(None).expect("should load defaults");
+        assert_eq!(config.output.device, "default");
+        assert_eq!(config.output.bit_depth, 24);
+        assert!(!config.dsp.eq.enabled);
+        assert!(config.reconnect.enabled);
+    }
+
+    #[test]
+    fn dsp_config_conversion_preserves_values() {
+        let mut config = RendererConfig::default();
+        config.dsp.volume.level_db = -6.0;
+        config.dsp.crossfeed.enabled = true;
+        config.dsp.crossfeed.strength = 0.5;
+
+        let dsp = config.dsp_config();
+        assert_eq!(dsp.volume.level_db, -6.0);
+        assert!(dsp.crossfeed.enabled);
+        assert_eq!(dsp.crossfeed.strength, 0.5);
+    }
+
+    #[test]
+    fn ring_buffer_capacity_is_power_of_two() {
+        let config = RendererConfig::default();
+        let cap = config.ring_buffer_capacity();
+        assert!(cap.is_power_of_two());
+        assert!(cap >= 8192);
+    }
+
+    #[test]
+    fn config_loads_from_toml_string() {
+        let toml = r#"
+[output]
+device = "hw:1"
+bit_depth = 32
+
+[dsp.volume]
+level_db = -3.0
+
+[dsp.crossfeed]
+enabled = true
+strength = 0.6
+
+[buffer]
+depth_ms = 200
+
+[reconnect]
+max_backoff_ms = 60000
+"#;
+        let tmp = tempfile::NamedTempFile::with_suffix(".toml").unwrap();
+        std::fs::write(tmp.path(), toml).unwrap();
+
+        let config = load_renderer_config(Some(tmp.path())).expect("should parse");
+        assert_eq!(config.output.device, "hw:1");
+        assert_eq!(config.output.bit_depth, 32);
+        assert_eq!(config.dsp.volume.level_db, -3.0);
+        assert!(config.dsp.crossfeed.enabled);
+        assert_eq!(config.buffer.depth_ms, 200);
+        assert_eq!(config.reconnect.max_backoff_ms, 60000);
+    }
+}

--- a/crates/harmonia-host/src/render/error.rs
+++ b/crates/harmonia-host/src/render/error.rs
@@ -1,0 +1,83 @@
+// Error types for the renderer subsystem.
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum RenderError {
+    #[snafu(display("renderer config error: {source}"))]
+    Config {
+        source: Box<figment::Error>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("protocol error: {message}"))]
+    Protocol {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("QUIC connection error: {message}"))]
+    Connection {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("audio output error: {message}"))]
+    AudioOutput {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("TLS error: {message}"))]
+    Tls {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("I/O error: {source}"))]
+    Io {
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("address parse error: {source}"))]
+    AddrParse {
+        source: std::net::AddrParseError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+impl From<quinn::ConnectionError> for RenderError {
+    fn from(e: quinn::ConnectionError) -> Self {
+        RenderError::Connection {
+            message: e.to_string(),
+            location: snafu::location!(),
+        }
+    }
+}
+
+impl From<quinn::WriteError> for RenderError {
+    fn from(e: quinn::WriteError) -> Self {
+        RenderError::Connection {
+            message: e.to_string(),
+            location: snafu::location!(),
+        }
+    }
+}
+
+impl From<quinn::ReadExactError> for RenderError {
+    fn from(e: quinn::ReadExactError) -> Self {
+        RenderError::Connection {
+            message: e.to_string(),
+            location: snafu::location!(),
+        }
+    }
+}

--- a/crates/harmonia-host/src/render/mod.rs
+++ b/crates/harmonia-host/src/render/mod.rs
@@ -1,0 +1,14 @@
+// Renderer mode: headless audio endpoint receiving streams via QUIC.
+
+pub mod config;
+pub mod error;
+pub mod pipeline;
+pub mod protocol;
+pub mod runner;
+pub mod server;
+pub mod status;
+pub mod tls;
+
+pub use error::RenderError;
+pub use runner::run_render;
+pub use server::RendererRegistry;

--- a/crates/harmonia-host/src/render/pipeline.rs
+++ b/crates/harmonia-host/src/render/pipeline.rs
@@ -1,0 +1,191 @@
+// Render pipeline: receives audio frames, applies local DSP, outputs via cpal.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::watch;
+use tracing::{info, warn};
+
+use akouo_core::output::{AudioDataCallback, OutputBackend, OutputParams};
+use akouo_core::signal_path::QualityTier;
+use akouo_core::{DspConfig, DspPipeline, RingBuffer};
+
+use super::config::RendererConfig;
+use super::error::RenderError;
+use super::protocol::AudioFrame;
+
+pub struct RenderPipeline {
+    dsp: DspPipeline,
+    ring: Arc<RingBuffer>,
+    backend: akouo_core::output::cpal::CpalOutputBackend,
+    output_opened: bool,
+    underrun_count: Arc<AtomicU64>,
+    device_name: Option<String>,
+    output_config: PipelineOutputConfig,
+}
+
+struct PipelineOutputConfig {
+    exclusive_mode: bool,
+    bit_depth: u32,
+}
+
+impl RenderPipeline {
+    pub fn new(
+        config: &RendererConfig,
+        dsp_rx: watch::Receiver<DspConfig>,
+    ) -> Result<Self, RenderError> {
+        let dsp = DspPipeline::new(config.dsp_config(), dsp_rx);
+        let ring = Arc::new(RingBuffer::new(config.ring_buffer_capacity()));
+        let backend = akouo_core::output::cpal::CpalOutputBackend::new();
+        let device_name = if config.output.device == "default" {
+            None
+        } else {
+            Some(config.output.device.clone())
+        };
+        Ok(Self {
+            dsp,
+            ring,
+            backend,
+            output_opened: false,
+            underrun_count: Arc::new(AtomicU64::new(0)),
+            device_name,
+            output_config: PipelineOutputConfig {
+                exclusive_mode: config.output.exclusive_mode,
+                bit_depth: config.output.bit_depth,
+            },
+        })
+    }
+
+    pub async fn process_frame(&mut self, frame: AudioFrame) -> Result<(), RenderError> {
+        if !self.output_opened {
+            self.open_output(frame.sample_rate, frame.channels).await?;
+            self.output_opened = true;
+        }
+
+        let mut samples = frame.samples;
+        let _stage_metas = self
+            .dsp
+            .process_frame(&mut samples, frame.channels, frame.sample_rate);
+
+        // Push to ring buffer with yield-based backpressure.
+        loop {
+            if self.ring.push_frame(&samples) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        Ok(())
+    }
+
+    async fn open_output(&mut self, sample_rate: u32, channels: u16) -> Result<(), RenderError> {
+        let ring_cb = Arc::clone(&self.ring);
+        let underrun_cb = Arc::clone(&self.underrun_count);
+        let callback: AudioDataCallback = Box::new(move |buf: &mut [f64]| {
+            if !ring_cb.pop_frame(buf) {
+                buf.fill(0.0);
+                underrun_cb.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        let params = OutputParams {
+            sample_rate,
+            channels,
+            bit_depth: self.output_config.bit_depth,
+            exclusive_mode: self.output_config.exclusive_mode,
+            needs_resample: false,
+            source_sample_rate: sample_rate,
+            quality_tier: QualityTier::Lossless,
+        };
+
+        if let Ok(devices) = self.backend.available_devices() {
+            info!(
+                available_devices = devices.len(),
+                requested = ?self.device_name,
+                "enumerating audio output devices"
+            );
+            for d in &devices {
+                info!(name = %d.name, is_default = d.is_default, "  device");
+            }
+        }
+
+        self.backend
+            .open(self.device_name.as_deref(), params, callback)
+            .await
+            .map_err(|e| RenderError::AudioOutput {
+                message: e.to_string(),
+                location: snafu::location!(),
+            })?;
+
+        self.backend
+            .start()
+            .await
+            .map_err(|e| RenderError::AudioOutput {
+                message: e.to_string(),
+                location: snafu::location!(),
+            })?;
+
+        info!(
+            sample_rate,
+            channels,
+            device = ?self.device_name,
+            "audio output opened"
+        );
+        Ok(())
+    }
+
+    /// Returns the approximate buffer depth in milliseconds.
+    pub fn buffer_depth_ms(&self, sample_rate: u32, channels: u16) -> f64 {
+        if sample_rate == 0 || channels == 0 {
+            return 0.0;
+        }
+        let samples = self.ring.available_to_read();
+        let frames = samples / channels as usize;
+        (frames as f64 / sample_rate as f64) * 1000.0
+    }
+
+    pub fn underrun_count(&self) -> u64 {
+        self.underrun_count.load(Ordering::Relaxed)
+    }
+
+    /// Drains remaining audio from the ring buffer before shutdown.
+    pub async fn drain(&self) {
+        let remaining = self.ring.available_to_read();
+        if remaining > 0 {
+            info!(remaining_samples = remaining, "draining audio buffer");
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+    }
+
+    pub async fn close(&mut self) {
+        if self.output_opened {
+            if let Err(e) = self.backend.close().await {
+                warn!(error = %e, "error closing audio output");
+            }
+            self.output_opened = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_depth_calculation() {
+        let config = RendererConfig::default();
+        let (_tx, rx) = watch::channel(config.dsp_config());
+        let pipeline = RenderPipeline::new(&config, rx).expect("should create pipeline");
+
+        let depth = pipeline.buffer_depth_ms(44100, 2);
+        assert!((depth - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn pipeline_reports_zero_underruns_initially() {
+        let config = RendererConfig::default();
+        let (_tx, rx) = watch::channel(config.dsp_config());
+        let pipeline = RenderPipeline::new(&config, rx).expect("should create pipeline");
+        assert_eq!(pipeline.underrun_count(), 0);
+    }
+}

--- a/crates/harmonia-host/src/render/protocol.rs
+++ b/crates/harmonia-host/src/render/protocol.rs
@@ -1,0 +1,209 @@
+// Wire protocol for renderer ↔ server QUIC communication.
+
+use serde::{Deserialize, Serialize};
+
+use super::error::{ProtocolSnafu, RenderError};
+
+pub const MSG_SESSION_INIT: u8 = 0x01;
+pub const MSG_SESSION_ACCEPT: u8 = 0x02;
+pub const MSG_AUDIO_FRAME: u8 = 0x03;
+pub const MSG_STATUS_REPORT: u8 = 0x04;
+
+pub const PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionInit {
+    pub name: String,
+    pub protocol_version: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionAccept {
+    pub session_id: String,
+    pub sample_rate: u32,
+    pub channels: u16,
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioFrame {
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub timestamp: u64,
+    pub samples: Vec<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusReport {
+    pub buffer_depth_ms: f64,
+    pub latency_ms: f64,
+    pub device_state: DeviceState,
+    pub underrun_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DeviceState {
+    Opening,
+    Playing,
+    Stopped,
+    Error(String),
+}
+
+impl std::fmt::Display for DeviceState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Opening => write!(f, "opening"),
+            Self::Playing => write!(f, "playing"),
+            Self::Stopped => write!(f, "stopped"),
+            Self::Error(msg) => write!(f, "error: {msg}"),
+        }
+    }
+}
+
+const AUDIO_FRAME_HEADER_LEN: usize = 4 + 2 + 8; // sample_rate + channels + timestamp
+
+impl AudioFrame {
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by server-side frame sending")
+    )]
+    pub fn encode_payload(&self) -> Vec<u8> {
+        let sample_bytes = self.samples.len() * 8;
+        let mut buf = Vec::with_capacity(AUDIO_FRAME_HEADER_LEN + sample_bytes);
+        buf.extend_from_slice(&self.sample_rate.to_le_bytes());
+        buf.extend_from_slice(&self.channels.to_le_bytes());
+        buf.extend_from_slice(&self.timestamp.to_le_bytes());
+        for &s in &self.samples {
+            buf.extend_from_slice(&s.to_le_bytes());
+        }
+        buf
+    }
+
+    pub fn decode_payload(payload: &[u8]) -> Result<Self, RenderError> {
+        if payload.len() < AUDIO_FRAME_HEADER_LEN {
+            return ProtocolSnafu {
+                message: format!(
+                    "audio frame too short: {} bytes, need at least {AUDIO_FRAME_HEADER_LEN}",
+                    payload.len()
+                ),
+            }
+            .fail();
+        }
+        let sample_rate = u32::from_le_bytes(payload[0..4].try_into().expect("4 bytes"));
+        let channels = u16::from_le_bytes(payload[4..6].try_into().expect("2 bytes"));
+        let timestamp = u64::from_le_bytes(payload[6..14].try_into().expect("8 bytes"));
+        let sample_data = &payload[14..];
+        if !sample_data.len().is_multiple_of(8) {
+            return ProtocolSnafu {
+                message: format!(
+                    "sample data length {} not a multiple of 8",
+                    sample_data.len()
+                ),
+            }
+            .fail();
+        }
+        let samples: Vec<f64> = sample_data
+            .chunks_exact(8)
+            .map(|c| f64::from_le_bytes(c.try_into().expect("8 bytes")))
+            .collect();
+        Ok(Self {
+            sample_rate,
+            channels,
+            timestamp,
+            samples,
+        })
+    }
+}
+
+pub async fn send_message(
+    stream: &mut quinn::SendStream,
+    msg_type: u8,
+    payload: &[u8],
+) -> Result<(), RenderError> {
+    let header = [msg_type];
+    let len = (payload.len() as u32).to_le_bytes();
+    stream.write_all(&header).await?;
+    stream.write_all(&len).await?;
+    stream.write_all(payload).await?;
+    Ok(())
+}
+
+pub async fn recv_message(stream: &mut quinn::RecvStream) -> Result<(u8, Vec<u8>), RenderError> {
+    let mut header = [0u8];
+    stream.read_exact(&mut header).await?;
+    let mut len_bytes = [0u8; 4];
+    stream.read_exact(&mut len_bytes).await?;
+    let len = u32::from_le_bytes(len_bytes) as usize;
+    // NOTE: cap at 16 MB to prevent allocation bombs from malformed frames
+    if len > 16 * 1024 * 1024 {
+        return ProtocolSnafu {
+            message: format!("message payload too large: {len} bytes"),
+        }
+        .fail();
+    }
+    let mut payload = vec![0u8; len];
+    stream.read_exact(&mut payload).await?;
+    Ok((header[0], payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audio_frame_roundtrip() {
+        let frame = AudioFrame {
+            sample_rate: 44100,
+            channels: 2,
+            timestamp: 12345,
+            samples: vec![0.5, -0.25, 0.125, -0.0625],
+        };
+        let encoded = frame.encode_payload();
+        let decoded = AudioFrame::decode_payload(&encoded).expect("should decode");
+        assert_eq!(decoded.sample_rate, 44100);
+        assert_eq!(decoded.channels, 2);
+        assert_eq!(decoded.timestamp, 12345);
+        assert_eq!(decoded.samples.len(), 4);
+        assert!((decoded.samples[0] - 0.5).abs() < f64::EPSILON);
+        assert!((decoded.samples[1] - (-0.25)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn audio_frame_decode_rejects_truncated_payload() {
+        let result = AudioFrame::decode_payload(&[0u8; 10]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn audio_frame_decode_rejects_misaligned_samples() {
+        let mut buf = vec![0u8; AUDIO_FRAME_HEADER_LEN + 5];
+        buf[0..4].copy_from_slice(&44100u32.to_le_bytes());
+        buf[4..6].copy_from_slice(&2u16.to_le_bytes());
+        let result = AudioFrame::decode_payload(&buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn session_init_serializes_to_json() {
+        let init = SessionInit {
+            name: "living-room".into(),
+            protocol_version: PROTOCOL_VERSION,
+        };
+        let json = serde_json::to_string(&init).expect("should serialize");
+        assert!(json.contains("living-room"));
+    }
+
+    #[test]
+    fn status_report_roundtrip() {
+        let report = StatusReport {
+            buffer_depth_ms: 95.0,
+            latency_ms: 42.5,
+            device_state: DeviceState::Playing,
+            underrun_count: 3,
+        };
+        let json = serde_json::to_vec(&report).expect("should serialize");
+        let decoded: StatusReport = serde_json::from_slice(&json).expect("should deserialize");
+        assert!((decoded.buffer_depth_ms - 95.0).abs() < f64::EPSILON);
+        assert_eq!(decoded.underrun_count, 3);
+    }
+}

--- a/crates/harmonia-host/src/render/runner.rs
+++ b/crates/harmonia-host/src/render/runner.rs
@@ -1,0 +1,381 @@
+// Renderer runner: main connection loop with auto-reconnect and signal handling.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use snafu::ResultExt;
+use tokio::signal::unix::SignalKind;
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, info, warn};
+
+use super::config::{RendererConfig, load_renderer_config};
+use super::error::{AddrParseSnafu, ProtocolSnafu, RenderError};
+use super::pipeline::RenderPipeline;
+use super::protocol::{
+    self, AudioFrame, DeviceState, MSG_AUDIO_FRAME, MSG_SESSION_ACCEPT, MSG_SESSION_INIT,
+    MSG_STATUS_REPORT, PROTOCOL_VERSION, SessionAccept, SessionInit,
+};
+use super::status::StatusReporter;
+use super::tls;
+use crate::cli::RenderArgs;
+
+pub async fn run_render(args: RenderArgs) -> Result<(), RenderError> {
+    let config = load_renderer_config(args.config.as_deref())?;
+
+    let client_config = tls::build_client_config()?;
+
+    let dsp_config = config.dsp_config();
+    let (dsp_tx, _) = watch::channel(dsp_config);
+
+    let shutdown = CancellationToken::new();
+
+    spawn_sighup_handler(args.config.clone(), dsp_tx.clone(), shutdown.child_token());
+    spawn_shutdown_handler(shutdown.clone());
+
+    let name = args.name.unwrap_or_else(default_renderer_name);
+
+    let server_addr: SocketAddr = args.server.parse().context(AddrParseSnafu)?;
+
+    info!(
+        name = %name,
+        server = %server_addr,
+        "starting renderer"
+    );
+
+    let mut backoff = ExponentialBackoff::new(
+        config.reconnect.initial_backoff_ms,
+        config.reconnect.max_backoff_ms,
+    );
+
+    loop {
+        if shutdown.is_cancelled() {
+            break;
+        }
+
+        match connect_and_run(
+            &server_addr,
+            &name,
+            &client_config,
+            &config,
+            dsp_tx.subscribe(),
+            shutdown.child_token(),
+        )
+        .await
+        {
+            Ok(()) => break,
+            Err(e) => {
+                if !config.reconnect.enabled || shutdown.is_cancelled() {
+                    return Err(e);
+                }
+                let delay = backoff.next_delay();
+                warn!(
+                    error = %e,
+                    retry_ms = delay.as_millis(),
+                    "connection lost, reconnecting after backoff"
+                );
+                tokio::select! {
+                    biased;
+                    _ = shutdown.cancelled() => break,
+                    _ = tokio::time::sleep(delay) => {
+                        // retry
+                    }
+                }
+            }
+        }
+    }
+
+    info!("renderer stopped");
+    Ok(())
+}
+
+async fn connect_and_run(
+    server_addr: &SocketAddr,
+    name: &str,
+    client_config: &quinn::ClientConfig,
+    config: &RendererConfig,
+    dsp_rx: watch::Receiver<akouo_core::DspConfig>,
+    shutdown: CancellationToken,
+) -> Result<(), RenderError> {
+    let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().expect("valid bind addr"))
+        .map_err(|e| RenderError::Connection {
+            message: e.to_string(),
+            location: snafu::location!(),
+        })?;
+    endpoint.set_default_client_config(client_config.clone());
+
+    info!(server = %server_addr, "connecting");
+    let connection = endpoint
+        .connect(*server_addr, "harmonia")
+        .map_err(|e| RenderError::Connection {
+            message: e.to_string(),
+            location: snafu::location!(),
+        })?
+        .await?;
+    info!("QUIC connection established");
+
+    // Session establishment on bidirectional stream.
+    let (mut ctrl_send, mut ctrl_recv) = connection.open_bi().await?;
+
+    let init = SessionInit {
+        name: name.to_string(),
+        protocol_version: PROTOCOL_VERSION,
+    };
+    let init_payload = serde_json::to_vec(&init).map_err(|e| RenderError::Protocol {
+        message: e.to_string(),
+        location: snafu::location!(),
+    })?;
+    protocol::send_message(&mut ctrl_send, MSG_SESSION_INIT, &init_payload).await?;
+
+    let (msg_type, payload) = protocol::recv_message(&mut ctrl_recv).await?;
+    if msg_type != MSG_SESSION_ACCEPT {
+        return ProtocolSnafu {
+            message: format!("expected SessionAccept (0x02), got 0x{msg_type:02x}"),
+        }
+        .fail();
+    }
+    let accept: SessionAccept =
+        serde_json::from_slice(&payload).map_err(|e| RenderError::Protocol {
+            message: e.to_string(),
+            location: snafu::location!(),
+        })?;
+    info!(
+        session_id = %accept.session_id,
+        sample_rate = accept.sample_rate,
+        channels = accept.channels,
+        "session established"
+    );
+
+    let mut pipeline = RenderPipeline::new(config, dsp_rx)?;
+    let status = Arc::new(StatusReporter::new());
+    status.set_device_state(DeviceState::Opening);
+
+    // Accept unidirectional audio stream from server.
+    let audio_recv = connection.accept_uni().await?;
+    status.set_device_state(DeviceState::Playing);
+
+    let status_audio = Arc::clone(&status);
+    let shutdown_audio = shutdown.child_token();
+    let stream_sample_rate = accept.sample_rate;
+    let stream_channels = accept.channels;
+
+    let audio_task = tokio::spawn(
+        async move {
+            receive_audio(
+                audio_recv,
+                &mut pipeline,
+                &status_audio,
+                stream_sample_rate,
+                stream_channels,
+                shutdown_audio,
+            )
+            .await
+        }
+        .instrument(tracing::info_span!("audio_receive")),
+    );
+
+    let status_report = Arc::clone(&status);
+    let shutdown_status = shutdown.child_token();
+
+    let status_task = tokio::spawn(
+        async move { send_status_reports(ctrl_send, &status_report, shutdown_status).await }
+            .instrument(tracing::info_span!("status_report")),
+    );
+
+    tokio::select! {
+        biased;
+        _ = shutdown.cancelled() => {
+            info!("shutdown requested, draining");
+        }
+        result = audio_task => {
+            if let Err(e) = result {
+                warn!(error = %e, "audio task panicked");
+            }
+        }
+        result = status_task => {
+            if let Err(e) = result {
+                warn!(error = %e, "status task panicked");
+            }
+        }
+    }
+
+    status.set_device_state(DeviceState::Stopped);
+    Ok(())
+}
+
+async fn receive_audio(
+    mut stream: quinn::RecvStream,
+    pipeline: &mut RenderPipeline,
+    status: &StatusReporter,
+    sample_rate: u32,
+    channels: u16,
+    shutdown: CancellationToken,
+) -> Result<(), RenderError> {
+    loop {
+        let result = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            r = protocol::recv_message(&mut stream) => r,
+        };
+
+        let (msg_type, payload) = result?;
+        if msg_type != MSG_AUDIO_FRAME {
+            continue;
+        }
+
+        let frame = AudioFrame::decode_payload(&payload)?;
+        pipeline.process_frame(frame).await?;
+
+        let depth = pipeline.buffer_depth_ms(sample_rate, channels);
+        status.update_buffer_depth(depth);
+        status.update_underrun_count(pipeline.underrun_count());
+    }
+
+    pipeline.drain().await;
+    pipeline.close().await;
+    Ok(())
+}
+
+async fn send_status_reports(
+    mut stream: quinn::SendStream,
+    status: &StatusReporter,
+    shutdown: CancellationToken,
+) -> Result<(), RenderError> {
+    let mut interval = tokio::time::interval(Duration::from_secs(2));
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            _ = interval.tick() => {
+                let report = status.report();
+                let payload = serde_json::to_vec(&report).map_err(|e| RenderError::Protocol {
+                    message: e.to_string(),
+                    location: snafu::location!(),
+                })?;
+                protocol::send_message(&mut stream, MSG_STATUS_REPORT, &payload).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn spawn_sighup_handler(
+    config_path: Option<PathBuf>,
+    dsp_tx: watch::Sender<akouo_core::DspConfig>,
+    shutdown: CancellationToken,
+) {
+    tokio::spawn(
+        async move {
+            let mut sighup = match tokio::signal::unix::signal(SignalKind::hangup()) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to register SIGHUP handler");
+                    return;
+                }
+            };
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = shutdown.cancelled() => break,
+                    _ = sighup.recv() => {
+                        info!("SIGHUP received, reloading DSP config");
+                        match load_renderer_config(config_path.as_deref()) {
+                            Ok(config) => {
+                                let _ = dsp_tx.send(config.dsp_config());
+                                info!("DSP config reloaded");
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "config reload failed, keeping current config");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .instrument(tracing::info_span!("sighup_handler")),
+    );
+}
+
+fn spawn_shutdown_handler(shutdown: CancellationToken) {
+    tokio::spawn(async move {
+        let ctrl_c = tokio::signal::ctrl_c();
+        let sigterm = tokio::signal::unix::signal(SignalKind::terminate());
+
+        match sigterm {
+            Ok(mut sigterm) => {
+                tokio::select! {
+                    _ = ctrl_c => info!("Ctrl+C received"),
+                    _ = sigterm.recv() => info!("SIGTERM received"),
+                }
+            }
+            Err(_) => {
+                ctrl_c.await.ok();
+            }
+        }
+        shutdown.cancel();
+    });
+}
+
+fn default_renderer_name() -> String {
+    std::process::Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "harmonia-renderer".to_string())
+}
+
+struct ExponentialBackoff {
+    current_ms: u64,
+    max_ms: u64,
+    initial_ms: u64,
+}
+
+impl ExponentialBackoff {
+    fn new(initial_ms: u64, max_ms: u64) -> Self {
+        Self {
+            current_ms: initial_ms,
+            max_ms,
+            initial_ms,
+        }
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        let delay = Duration::from_millis(self.current_ms);
+        self.current_ms = (self.current_ms * 2).min(self.max_ms);
+        delay
+    }
+
+    #[cfg_attr(not(test), expect(dead_code))]
+    fn reset(&mut self) {
+        self.current_ms = self.initial_ms;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exponential_backoff_increases() {
+        let mut backoff = ExponentialBackoff::new(1000, 30000);
+        assert_eq!(backoff.next_delay(), Duration::from_millis(1000));
+        assert_eq!(backoff.next_delay(), Duration::from_millis(2000));
+        assert_eq!(backoff.next_delay(), Duration::from_millis(4000));
+        assert_eq!(backoff.next_delay(), Duration::from_millis(8000));
+        assert_eq!(backoff.next_delay(), Duration::from_millis(16000));
+        assert_eq!(backoff.next_delay(), Duration::from_millis(30000));
+        assert_eq!(backoff.next_delay(), Duration::from_millis(30000));
+    }
+
+    #[test]
+    fn exponential_backoff_reset() {
+        let mut backoff = ExponentialBackoff::new(500, 10000);
+        backoff.next_delay();
+        backoff.next_delay();
+        backoff.reset();
+        assert_eq!(backoff.next_delay(), Duration::from_millis(500));
+    }
+}

--- a/crates/harmonia-host/src/render/server.rs
+++ b/crates/harmonia-host/src/render/server.rs
@@ -1,0 +1,357 @@
+// Server-side QUIC listener for renderer connections.
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, info, warn};
+
+use super::error::RenderError;
+use super::protocol::{
+    self, MSG_SESSION_ACCEPT, MSG_SESSION_INIT, MSG_STATUS_REPORT, SessionAccept, SessionInit,
+    StatusReport,
+};
+use super::tls;
+
+pub const DEFAULT_QUIC_PORT: u16 = 4433;
+
+#[derive(Debug, Clone)]
+pub struct ConnectedRenderer {
+    pub name: String,
+    pub session_id: String,
+    pub connected_at: Instant,
+    pub last_status: Option<StatusReport>,
+}
+
+pub struct RendererRegistry {
+    entries: RwLock<Vec<ConnectedRenderer>>,
+}
+
+impl RendererRegistry {
+    pub fn new() -> Self {
+        Self {
+            entries: RwLock::new(Vec::new()),
+        }
+    }
+
+    pub async fn add(&self, renderer: ConnectedRenderer) {
+        let mut entries = self.entries.write().await;
+        entries.push(renderer);
+    }
+
+    pub async fn remove(&self, session_id: &str) {
+        let mut entries = self.entries.write().await;
+        entries.retain(|e| e.session_id != session_id);
+    }
+
+    pub async fn update_status(&self, session_id: &str, status: StatusReport) {
+        let mut entries = self.entries.write().await;
+        if let Some(entry) = entries.iter_mut().find(|e| e.session_id == session_id) {
+            entry.last_status = Some(status);
+        }
+    }
+
+    pub async fn list(&self) -> Vec<RendererInfo> {
+        let entries = self.entries.read().await;
+        entries
+            .iter()
+            .map(|e| {
+                let (buffer_depth_ms, latency_ms, state, underrun_count) = match &e.last_status {
+                    Some(s) => (
+                        s.buffer_depth_ms,
+                        s.latency_ms,
+                        s.device_state.to_string(),
+                        s.underrun_count,
+                    ),
+                    None => (0.0, 0.0, "connecting".to_string(), 0),
+                };
+                RendererInfo {
+                    name: e.name.clone(),
+                    session_id: e.session_id.clone(),
+                    connected_secs: e.connected_at.elapsed().as_secs(),
+                    buffer_depth_ms,
+                    latency_ms,
+                    state,
+                    underrun_count,
+                }
+            })
+            .collect()
+    }
+}
+
+/// Serializable renderer status for REST API responses.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RendererInfo {
+    pub name: String,
+    pub session_id: String,
+    pub connected_secs: u64,
+    pub buffer_depth_ms: f64,
+    pub latency_ms: f64,
+    pub state: String,
+    pub underrun_count: u64,
+}
+
+/// Implements `DynRendererRegistry` so the registry can be injected into paroche's AppState.
+impl paroche::state::DynRendererRegistry for RendererRegistry {
+    fn list_renderers(
+        &self,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Vec<paroche::state::RendererInfo>> + Send + '_>,
+    > {
+        Box::pin(async move {
+            self.list()
+                .await
+                .into_iter()
+                .map(|r| paroche::state::RendererInfo {
+                    name: r.name,
+                    session_id: r.session_id,
+                    connected_secs: r.connected_secs,
+                    buffer_depth_ms: r.buffer_depth_ms,
+                    latency_ms: r.latency_ms,
+                    state: r.state,
+                    underrun_count: r.underrun_count,
+                })
+                .collect()
+        })
+    }
+}
+
+pub async fn start_renderer_server(
+    listen_addr: SocketAddr,
+    cert_dir: &Path,
+    registry: Arc<RendererRegistry>,
+    shutdown: CancellationToken,
+) -> Result<(), RenderError> {
+    let server_config = tls::load_or_generate_server_config(cert_dir)?;
+    let endpoint = quinn::Endpoint::server(server_config, listen_addr).map_err(|e| {
+        RenderError::Connection {
+            message: e.to_string(),
+            location: snafu::location!(),
+        }
+    })?;
+
+    info!(addr = %listen_addr, "renderer QUIC server listening");
+
+    loop {
+        let incoming = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            incoming = endpoint.accept() => match incoming {
+                Some(i) => i,
+                None => break,
+            },
+        };
+
+        let registry = Arc::clone(&registry);
+        let ct = shutdown.child_token();
+
+        tokio::spawn(
+            async move {
+                if let Err(e) = handle_renderer_connection(incoming, registry, ct).await {
+                    warn!(error = %e, "renderer connection handler failed");
+                }
+            }
+            .instrument(tracing::info_span!("renderer_conn")),
+        );
+    }
+
+    endpoint.close(0u32.into(), b"server shutting down");
+    info!("renderer QUIC server stopped");
+    Ok(())
+}
+
+async fn handle_renderer_connection(
+    incoming: quinn::Incoming,
+    registry: Arc<RendererRegistry>,
+    shutdown: CancellationToken,
+) -> Result<(), RenderError> {
+    let connection = incoming.await?;
+    let remote = connection.remote_address();
+    info!(remote = %remote, "renderer connected");
+
+    // Accept bidirectional control stream.
+    let (mut ctrl_send, mut ctrl_recv) = connection.accept_bi().await?;
+
+    // Read SessionInit.
+    let (msg_type, payload) = protocol::recv_message(&mut ctrl_recv).await?;
+    if msg_type != MSG_SESSION_INIT {
+        return Err(RenderError::Protocol {
+            message: format!("expected SessionInit (0x01), got 0x{msg_type:02x}"),
+            location: snafu::location!(),
+        });
+    }
+    let init: SessionInit =
+        serde_json::from_slice(&payload).map_err(|e| RenderError::Protocol {
+            message: e.to_string(),
+            location: snafu::location!(),
+        })?;
+    info!(name = %init.name, version = init.protocol_version, "session init received");
+
+    let session_id = generate_session_id();
+
+    // Send SessionAccept.
+    let accept = SessionAccept {
+        session_id: session_id.clone(),
+        sample_rate: 44100,
+        channels: 2,
+    };
+    let accept_payload = serde_json::to_vec(&accept).map_err(|e| RenderError::Protocol {
+        message: e.to_string(),
+        location: snafu::location!(),
+    })?;
+    protocol::send_message(&mut ctrl_send, MSG_SESSION_ACCEPT, &accept_payload).await?;
+
+    info!(
+        session_id = %session_id,
+        name = %init.name,
+        "session established"
+    );
+
+    registry
+        .add(ConnectedRenderer {
+            name: init.name.clone(),
+            session_id: session_id.clone(),
+            connected_at: Instant::now(),
+            last_status: None,
+        })
+        .await;
+
+    // Open unidirectional stream for audio frames.
+    let _audio_send = connection.open_uni().await?;
+
+    // Read status reports from the control stream until disconnection.
+    let result = read_status_loop(&mut ctrl_recv, &registry, &session_id, shutdown).await;
+
+    registry.remove(&session_id).await;
+    info!(
+        session_id = %session_id,
+        name = %init.name,
+        "renderer disconnected"
+    );
+
+    result
+}
+
+async fn read_status_loop(
+    ctrl_recv: &mut quinn::RecvStream,
+    registry: &RendererRegistry,
+    session_id: &str,
+    shutdown: CancellationToken,
+) -> Result<(), RenderError> {
+    loop {
+        let result = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            r = protocol::recv_message(ctrl_recv) => r,
+        };
+
+        match result {
+            Ok((msg_type, payload)) => {
+                if msg_type == MSG_STATUS_REPORT
+                    && let Ok(status) = serde_json::from_slice::<StatusReport>(&payload)
+                {
+                    registry.update_status(session_id, status).await;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    Ok(())
+}
+
+fn generate_session_id() -> String {
+    use rand::Rng;
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 16];
+    rng.fill_bytes(&mut bytes);
+    bytes.iter().fold(String::with_capacity(32), |mut s, b| {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::protocol::DeviceState;
+
+    #[tokio::test]
+    async fn registry_add_and_list() {
+        let registry = RendererRegistry::new();
+        registry
+            .add(ConnectedRenderer {
+                name: "test-renderer".into(),
+                session_id: "abc123".into(),
+                connected_at: Instant::now(),
+                last_status: None,
+            })
+            .await;
+
+        let list = registry.list().await;
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "test-renderer");
+        assert_eq!(list[0].session_id, "abc123");
+    }
+
+    #[tokio::test]
+    async fn registry_remove() {
+        let registry = RendererRegistry::new();
+        registry
+            .add(ConnectedRenderer {
+                name: "a".into(),
+                session_id: "s1".into(),
+                connected_at: Instant::now(),
+                last_status: None,
+            })
+            .await;
+        registry
+            .add(ConnectedRenderer {
+                name: "b".into(),
+                session_id: "s2".into(),
+                connected_at: Instant::now(),
+                last_status: None,
+            })
+            .await;
+
+        registry.remove("s1").await;
+        let list = registry.list().await;
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "b");
+    }
+
+    #[tokio::test]
+    async fn registry_update_status() {
+        let registry = RendererRegistry::new();
+        registry
+            .add(ConnectedRenderer {
+                name: "test".into(),
+                session_id: "s1".into(),
+                connected_at: Instant::now(),
+                last_status: None,
+            })
+            .await;
+
+        let status = StatusReport {
+            buffer_depth_ms: 95.0,
+            latency_ms: 42.0,
+            device_state: DeviceState::Playing,
+            underrun_count: 1,
+        };
+        registry.update_status("s1", status).await;
+
+        let list = registry.list().await;
+        assert!((list[0].buffer_depth_ms - 95.0).abs() < f64::EPSILON);
+        assert_eq!(list[0].underrun_count, 1);
+    }
+
+    #[test]
+    fn session_id_is_32_hex_chars() {
+        let id = generate_session_id();
+        assert_eq!(id.len(), 32);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/harmonia-host/src/render/status.rs
+++ b/crates/harmonia-host/src/render/status.rs
@@ -1,0 +1,122 @@
+// Status reporter: collects renderer metrics and produces status reports.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::protocol::{DeviceState, StatusReport};
+
+pub struct StatusReporter {
+    buffer_depth_ms: AtomicU64,
+    latency_ms: AtomicU64,
+    device_state: Mutex<DeviceState>,
+    underrun_count: AtomicU64,
+}
+
+impl StatusReporter {
+    pub fn new() -> Self {
+        Self {
+            buffer_depth_ms: AtomicU64::new(0.0f64.to_bits()),
+            latency_ms: AtomicU64::new(0.0f64.to_bits()),
+            device_state: Mutex::new(DeviceState::Opening),
+            underrun_count: AtomicU64::new(0),
+        }
+    }
+
+    pub fn update_buffer_depth(&self, depth_ms: f64) {
+        self.buffer_depth_ms
+            .store(depth_ms.to_bits(), Ordering::Release);
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "used when clock sync is implemented in prompt 124"
+        )
+    )]
+    pub fn update_latency(&self, latency_ms: f64) {
+        self.latency_ms
+            .store(latency_ms.to_bits(), Ordering::Release);
+    }
+
+    pub fn set_device_state(&self, state: DeviceState) {
+        let mut guard = self.device_state.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = state;
+    }
+
+    pub fn update_underrun_count(&self, count: u64) {
+        self.underrun_count.store(count, Ordering::Release);
+    }
+
+    pub fn report(&self) -> StatusReport {
+        let buffer_depth_ms = f64::from_bits(self.buffer_depth_ms.load(Ordering::Acquire));
+        let latency_ms = f64::from_bits(self.latency_ms.load(Ordering::Acquire));
+        let device_state = self
+            .device_state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let underrun_count = self.underrun_count.load(Ordering::Acquire);
+
+        if latency_ms > 200.0 {
+            tracing::warn!(latency_ms, "high renderer latency");
+        }
+        if underrun_count > 0 && underrun_count != self.underrun_count.load(Ordering::Relaxed) {
+            tracing::warn!(underrun_count, "audio underruns detected");
+        }
+
+        StatusReport {
+            buffer_depth_ms,
+            latency_ms,
+            device_state,
+            underrun_count,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_report_has_zero_values() {
+        let reporter = StatusReporter::new();
+        let report = reporter.report();
+        assert!((report.buffer_depth_ms - 0.0).abs() < f64::EPSILON);
+        assert!((report.latency_ms - 0.0).abs() < f64::EPSILON);
+        assert_eq!(report.device_state, DeviceState::Opening);
+        assert_eq!(report.underrun_count, 0);
+    }
+
+    #[test]
+    fn updates_are_reflected_in_report() {
+        let reporter = StatusReporter::new();
+        reporter.update_buffer_depth(95.0);
+        reporter.update_latency(42.5);
+        reporter.set_device_state(DeviceState::Playing);
+        reporter.update_underrun_count(3);
+
+        let report = reporter.report();
+        assert!((report.buffer_depth_ms - 95.0).abs() < f64::EPSILON);
+        assert!((report.latency_ms - 42.5).abs() < f64::EPSILON);
+        assert_eq!(report.device_state, DeviceState::Playing);
+        assert_eq!(report.underrun_count, 3);
+    }
+
+    #[test]
+    fn device_state_transitions() {
+        let reporter = StatusReporter::new();
+
+        reporter.set_device_state(DeviceState::Playing);
+        assert_eq!(reporter.report().device_state, DeviceState::Playing);
+
+        reporter.set_device_state(DeviceState::Stopped);
+        assert_eq!(reporter.report().device_state, DeviceState::Stopped);
+
+        reporter.set_device_state(DeviceState::Error("test".into()));
+        assert_eq!(
+            reporter.report().device_state,
+            DeviceState::Error("test".into())
+        );
+    }
+}

--- a/crates/harmonia-host/src/render/tls.rs
+++ b/crates/harmonia-host/src/render/tls.rs
@@ -1,0 +1,108 @@
+// TLS certificate management for QUIC transport.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
+use snafu::ResultExt;
+
+use super::error::{IoSnafu, RenderError};
+
+pub fn load_or_generate_server_config(cert_dir: &Path) -> Result<quinn::ServerConfig, RenderError> {
+    let cert_path = cert_dir.join("server.der");
+    let key_path = cert_dir.join("server.key.der");
+
+    let (cert_der, key_der) = if cert_path.exists() && key_path.exists() {
+        let cert = std::fs::read(&cert_path).context(IoSnafu)?;
+        let key = std::fs::read(&key_path).context(IoSnafu)?;
+        (CertificateDer::from(cert), PrivatePkcs8KeyDer::from(key))
+    } else {
+        std::fs::create_dir_all(cert_dir).context(IoSnafu)?;
+        let certified =
+            rcgen::generate_simple_self_signed(vec!["harmonia".into()]).map_err(|e| {
+                RenderError::Tls {
+                    message: e.to_string(),
+                    location: snafu::location!(),
+                }
+            })?;
+        let cert_der = certified.cert.der().clone();
+        let key_der = PrivatePkcs8KeyDer::from(certified.key_pair.serialize_der());
+        std::fs::write(&cert_path, cert_der.as_ref()).context(IoSnafu)?;
+        std::fs::write(&key_path, key_der.secret_pkcs8_der()).context(IoSnafu)?;
+        tracing::info!(cert_dir = %cert_dir.display(), "generated self-signed TLS certificate");
+        (cert_der, key_der)
+    };
+
+    quinn::ServerConfig::with_single_cert(vec![cert_der], PrivateKeyDer::Pkcs8(key_der)).map_err(
+        |e| RenderError::Tls {
+            message: e.to_string(),
+            location: snafu::location!(),
+        },
+    )
+}
+
+pub fn build_client_config() -> Result<quinn::ClientConfig, RenderError> {
+    // WHY: For development and LAN use, skip server certificate verification.
+    // Prompt 124 implements proper mDNS-based pairing with certificate pinning.
+    let crypto = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(InsecureVerifier))
+        .with_no_client_auth();
+
+    let quic_config = quinn::crypto::rustls::QuicClientConfig::try_from(crypto).map_err(|e| {
+        RenderError::Tls {
+            message: e.to_string(),
+            location: snafu::location!(),
+        }
+    })?;
+
+    Ok(quinn::ClientConfig::new(Arc::new(quic_config)))
+}
+
+// WARNING: Accepts any server certificate. Replaced by certificate pinning in prompt 124.
+#[derive(Debug)]
+struct InsecureVerifier;
+
+impl ServerCertVerifier for InsecureVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::ED25519,
+        ]
+    }
+}

--- a/crates/harmonia-host/src/serve.rs
+++ b/crates/harmonia-host/src/serve.rs
@@ -371,7 +371,37 @@ pub async fn run_serve(args: ServeArgs) -> Result<(), HostError> {
 
     // ── End acquisition startup ─────────────────────────────────────────────
 
-    // 12. Build import service adapter for paroche
+    // 12. Start renderer QUIC server
+    let renderer_registry = Arc::new(crate::render::RendererRegistry::new());
+    let renderer_cert_dir = dirs_config_path().join("certs");
+    let renderer_addr: std::net::SocketAddr = format!(
+        "{}:{}",
+        config.paroche.listen_addr,
+        crate::render::server::DEFAULT_QUIC_PORT
+    )
+    .parse()
+    .unwrap_or_else(|_| {
+        std::net::SocketAddr::from(([0, 0, 0, 0], crate::render::server::DEFAULT_QUIC_PORT))
+    });
+    let renderer_registry_for_quic = Arc::clone(&renderer_registry);
+    let renderer_shutdown = shutdown_token.child_token();
+    tokio::spawn(
+        async move {
+            if let Err(e) = crate::render::server::start_renderer_server(
+                renderer_addr,
+                &renderer_cert_dir,
+                renderer_registry_for_quic,
+                renderer_shutdown,
+            )
+            .await
+            {
+                tracing::error!(error = %e, "renderer QUIC server failed");
+            }
+        }
+        .instrument(tracing::info_span!("renderer_server")),
+    );
+
+    // 13. Build import service adapter for paroche
     let import = paroche::state::make_import_service(|| async { Ok(vec![]) });
 
     // 13. Build HTTP router
@@ -389,6 +419,7 @@ pub async fn run_serve(args: ServeArgs) -> Result<(), HostError> {
         requests: Arc::new(RequestAdapter),
         external: Arc::new(ExternalAdapter(syndesmos_svc)),
         subtitles: Arc::new(SubtitleAdapter),
+        renderers: renderer_registry,
     };
     let router = paroche::build_router(state);
 
@@ -496,4 +527,15 @@ fn validate_download_dir(config: &horismos::Config) -> Result<(), HostError> {
     }
     let _ = std::fs::remove_file(&test_file);
     Ok(())
+}
+
+fn dirs_config_path() -> std::path::PathBuf {
+    std::env::var("XDG_CONFIG_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::env::var("HOME")
+                .map(|h| std::path::PathBuf::from(h).join(".config"))
+                .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"))
+        })
+        .join("harmonia")
 }

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -39,6 +39,7 @@ pub fn build_router(state: AppState) -> Router {
         .nest("/api/v1/wanted", routes::wanted::wanted_routes())
         .nest("/api/v1", routes::subtitle::subtitle_routes())
         .nest("/opds", opds::opds_routes())
+        .nest("/api/renderers", routes::renderer::renderer_routes())
         .merge(routes::stream::stream_routes())
         .nest("/rest", subsonic::subsonic_routes())
         .route("/api/ws", axum::routing::get(ws_handler))

--- a/crates/paroche/src/routes/mod.rs
+++ b/crates/paroche/src/routes/mod.rs
@@ -8,6 +8,7 @@ pub mod movie;
 pub mod music;
 pub mod news;
 pub mod podcast;
+pub mod renderer;
 pub mod request;
 pub mod search;
 pub mod stream;

--- a/crates/paroche/src/routes/renderer.rs
+++ b/crates/paroche/src/routes/renderer.rs
@@ -1,0 +1,14 @@
+// GET /api/renderers — list connected renderers with status.
+
+use axum::{Json, extract::State};
+
+use crate::state::AppState;
+
+pub fn renderer_routes() -> axum::Router<AppState> {
+    axum::Router::new().route("/", axum::routing::get(list_renderers))
+}
+
+async fn list_renderers(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let renderers = state.renderers.list_renderers().await;
+    Json(serde_json::to_value(renderers).unwrap_or_default())
+}

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -54,6 +54,25 @@ pub trait DynSubtitleService: Send + Sync {
     fn search_for_media(&self, media_id: Vec<u8>) -> ServiceFut<()>;
 }
 
+/// Serializable renderer status for the REST API.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RendererInfo {
+    pub name: String,
+    pub session_id: String,
+    pub connected_secs: u64,
+    pub buffer_depth_ms: f64,
+    pub latency_ms: f64,
+    pub state: String,
+    pub underrun_count: u64,
+}
+
+/// Connected renderer listing via the renderer QUIC server.
+pub trait DynRendererRegistry: Send + Sync {
+    fn list_renderers(
+        &self,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<RendererInfo>> + Send + '_>>;
+}
+
 /// Adapter around a closure for import queue retrieval.
 pub struct ImportQueueFn(pub Arc<dyn Fn() -> ImportQueueFut + Send + Sync>);
 
@@ -112,6 +131,15 @@ impl DynSubtitleService for NullSubtitleService {
     }
 }
 
+struct NullRendererRegistry;
+impl DynRendererRegistry for NullRendererRegistry {
+    fn list_renderers(
+        &self,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<RendererInfo>> + Send + '_>> {
+        Box::pin(async { Vec::new() })
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<DbPools>,
@@ -127,6 +155,7 @@ pub struct AppState {
     pub requests: Arc<dyn DynRequestService>,
     pub external: Arc<dyn DynExternalIntegration>,
     pub subtitles: Arc<dyn DynSubtitleService>,
+    pub renderers: Arc<dyn DynRendererRegistry>,
 }
 
 impl AppState {
@@ -158,6 +187,7 @@ impl AppState {
             requests: Arc::new(NullRequestService),
             external: Arc::new(NullExternalIntegration),
             subtitles: Arc::new(NullSubtitleService),
+            renderers: Arc::new(NullRendererRegistry),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `harmonia render --server <addr>` CLI subcommand that connects to a harmonia server via QUIC transport, receives PCM audio frames, and plays them through local cpal output devices with a full akouo-core DSP chain (EQ, crossfeed, ReplayGain, compressor, convolution, volume)
- Implements server-side `RendererRegistry` tracking connected renderers with real-time status (buffer depth, latency, device state, underrun count), exposed via `GET /api/renderers` REST endpoint
- Features exponential backoff auto-reconnect (1s–30s), SIGHUP config hot-reload for DSP settings, self-signed TLS cert generation via rcgen, and a lock-free SPSC ring buffer bridging the DSP pipeline to the real-time cpal audio callback

## Key design decisions

- QUIC transport via quinn 0.11 with custom binary wire protocol (1B type + 4B length + payload) — JSON for control messages, raw f64 for audio frames
- Ring buffer from akouo-core made public (was `pub(crate)`) rather than reimplemented — architecturally correct for the custom audio engine
- paroche integration uses existing `DynRendererRegistry` trait injection pattern (matches `DynSearchService` etc.) — no changes to paroche/Cargo.toml
- InsecureVerifier for TLS during development; proper certificate pinning deferred to prompt 124
- `#[cfg_attr(not(test), expect(dead_code))]` pattern for methods used only by tests currently but needed by future server-side frame construction

## Observations

- `akouo_core::RingBuffer` was `pub(crate)` but needed externally — made it `pub` since the engine is designed for custom pipeline integration
- The `DeviceState` enum is `#[non_exhaustive]` to allow adding states (e.g., `Paused`, `Buffering`) without breaking the wire protocol

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (20 new render tests + all existing)
- [ ] Manual: `harmonia render --server 127.0.0.1:4433 --name test` connects and establishes session
- [ ] Manual: verify `GET /api/renderers` returns connected renderer list with status