### PR TITLE
feat(syndesis): mDNS discovery, pairing protocol, and renderer registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,8 +1741,10 @@ dependencies = [
  "harmonia-common",
  "harmonia-db",
  "horismos",
+ "jiff",
  "komide",
  "kritike",
+ "mdns-sd",
  "paroche",
  "prostheke",
  "quinn",
@@ -1755,12 +1757,14 @@ dependencies = [
  "serde_json",
  "snafu",
  "sqlx",
+ "syndesis",
  "syndesmos",
  "syntaxis",
  "taxis",
  "tempfile",
  "tokio",
  "tokio-util",
+ "toml",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -2136,6 +2140,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2827,6 +2841,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
+name = "mdns-sd"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d797ab3274a16f4940f9650a29838e940223aeff31773df5c2827ad82150182f"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
+
+[[package]]
 name = "mediatype"
 version = "0.19.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,8 +3389,10 @@ dependencies = [
  "harmonia-db",
  "horismos",
  "http-body-util",
+ "jiff",
  "kritike",
  "md5",
+ "mdns-sd",
  "rand 0.10.0",
  "serde",
  "serde_json",
@@ -4170,7 +4201,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4542,6 +4573,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5030,16 +5072,26 @@ dependencies = [
 name = "syndesis"
 version = "0.1.2"
 dependencies = [
+ "argon2",
+ "base64",
  "bytes",
+ "harmonia-common",
+ "harmonia-db",
+ "jiff",
  "quinn",
  "rand 0.10.0",
+ "rand_core 0.6.4",
  "rcgen",
  "rstest",
  "rustls",
  "serde",
+ "serde_json",
+ "sha2",
  "snafu",
+ "sqlx",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ members = [
     "crates/zetesis",
     "crates/ergasia",
     "crates/syndesmos",
+    "crates/syndesis",
     "crates/aitesis",
     "crates/syntaxis",
     "crates/harmonia-host",
     "crates/prostheke",
     "crates/theatron/core",
     "crates/akouo-core",
-    "crates/syndesis",
 ]
 exclude = [
     "akouo/shared/akouo-core",
@@ -46,12 +46,12 @@ komide          = { path = "crates/komide" }
 zetesis         = { path = "crates/zetesis" }
 ergasia         = { path = "crates/ergasia" }
 syndesmos       = { path = "crates/syndesmos" }
+syndesis        = { path = "crates/syndesis" }
 aitesis         = { path = "crates/aitesis" }
 syntaxis        = { path = "crates/syntaxis" }
 prostheke       = { path = "crates/prostheke" }
 theatron-core   = { path = "crates/theatron/core" }
 akouo-core      = { path = "crates/akouo-core" }
-syndesis        = { path = "crates/syndesis" }
 
 # ── Async runtime ──────────────────────────────────────────────────────────────
 tokio           = { version = "1", features = ["full"] }
@@ -117,10 +117,18 @@ fast_image_resize   = "6.0"
 # ── QUIC transport ─────────────────────────────────────────────────────────────
 quinn           = "0.11"
 rustls          = { version = "0.23", default-features = false, features = ["ring", "std"] }
-rcgen           = "0.13"
+rcgen           = { version = "0.13", features = ["pem"] }
 
 # ── mDNS discovery ────────────────────────────────────────────────────────────
 mdns-sd         = "0.18"
+
+# ── Crypto utilities ──────────────────────────────────────────────────────────
+sha2            = "0.10"
+base64          = "0.22"
+rand_core       = { version = "0.6", features = ["getrandom"] }
+
+# ── TOML (credential files) ───────────────────────────────────────────────────
+toml            = "0.8"
 
 # ── Scheduling ────────────────────────────────────────────────────────────────
 tokio-cron-scheduler = "0.15"

--- a/crates/harmonia-db/migrations/008_renderers.sql
+++ b/crates/harmonia-db/migrations/008_renderers.sql
@@ -1,0 +1,12 @@
+-- Renderer registry: tracks paired playback renderers.
+CREATE TABLE renderers (
+    id               TEXT    PRIMARY KEY,
+    name             TEXT    NOT NULL,
+    api_key_hash     TEXT    NOT NULL,
+    cert_fingerprint TEXT    NOT NULL,
+    last_seen        TEXT,
+    paired_at        TEXT    NOT NULL,
+    enabled          INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX idx_renderers_enabled ON renderers (enabled);

--- a/crates/harmonia-db/src/repo/mod.rs
+++ b/crates/harmonia-db/src/repo/mod.rs
@@ -8,6 +8,7 @@ pub mod play_history;
 pub mod podcast;
 pub mod quality;
 pub mod registry;
+pub mod renderer;
 pub mod tv;
 pub mod user;
 pub mod want;

--- a/crates/harmonia-db/src/repo/renderer.rs
+++ b/crates/harmonia-db/src/repo/renderer.rs
@@ -1,0 +1,191 @@
+// Renderer registry: CRUD for paired playback renderers
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, QuerySnafu};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Renderer {
+    pub id: String,
+    pub name: String,
+    pub api_key_hash: String,
+    pub cert_fingerprint: String,
+    pub last_seen: Option<String>,
+    pub paired_at: String,
+    pub enabled: i64,
+}
+
+pub async fn create_renderer(
+    pool: &SqlitePool,
+    id: &str,
+    name: &str,
+    api_key_hash: &str,
+    cert_fingerprint: &str,
+) -> Result<Renderer, DbError> {
+    let now = jiff::Zoned::now()
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+    sqlx::query(
+        "INSERT INTO renderers (id, name, api_key_hash, cert_fingerprint, last_seen, paired_at, enabled)
+         VALUES (?, ?, ?, ?, NULL, ?, 1)",
+    )
+    .bind(id)
+    .bind(name)
+    .bind(api_key_hash)
+    .bind(cert_fingerprint)
+    .bind(&now)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "renderers" })?;
+
+    get_renderer(pool, id)
+        .await?
+        .ok_or_else(|| DbError::NotFound {
+            table: "renderers".to_string(),
+            id: id.to_string(),
+            location: snafu::location!(),
+        })
+}
+
+pub async fn get_renderer(pool: &SqlitePool, id: &str) -> Result<Option<Renderer>, DbError> {
+    sqlx::query_as::<_, Renderer>(
+        "SELECT id, name, api_key_hash, cert_fingerprint, last_seen, paired_at, enabled
+         FROM renderers WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "renderers" })
+}
+
+pub async fn list_renderers(pool: &SqlitePool) -> Result<Vec<Renderer>, DbError> {
+    sqlx::query_as::<_, Renderer>(
+        "SELECT id, name, api_key_hash, cert_fingerprint, last_seen, paired_at, enabled
+         FROM renderers ORDER BY paired_at DESC",
+    )
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "renderers" })
+}
+
+pub async fn update_last_seen(pool: &SqlitePool, id: &str) -> Result<(), DbError> {
+    let now = jiff::Zoned::now()
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+    sqlx::query("UPDATE renderers SET last_seen = ? WHERE id = ?")
+        .bind(&now)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "renderers" })?;
+    Ok(())
+}
+
+pub async fn set_enabled(pool: &SqlitePool, id: &str, enabled: bool) -> Result<(), DbError> {
+    sqlx::query("UPDATE renderers SET enabled = ? WHERE id = ?")
+        .bind(if enabled { 1i64 } else { 0i64 })
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "renderers" })?;
+    Ok(())
+}
+
+pub async fn rename_renderer(pool: &SqlitePool, id: &str, name: &str) -> Result<(), DbError> {
+    sqlx::query("UPDATE renderers SET name = ? WHERE id = ?")
+        .bind(name)
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "renderers" })?;
+    Ok(())
+}
+
+pub async fn delete_renderer(pool: &SqlitePool, id: &str) -> Result<(), DbError> {
+    sqlx::query("DELETE FROM renderers WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "renderers" })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+    use sqlx::SqlitePool;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn renderer_id() -> String {
+        uuid::Uuid::now_v7().to_string()
+    }
+
+    #[tokio::test]
+    async fn renderer_crud() {
+        let pool = setup().await;
+        let id = renderer_id();
+
+        // create
+        let r = create_renderer(&pool, &id, "Living Room", "hash1", "fp1")
+            .await
+            .unwrap();
+        assert_eq!(r.name, "Living Room");
+        assert_eq!(r.enabled, 1);
+        assert!(r.last_seen.is_none());
+
+        // get
+        let fetched = get_renderer(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(fetched.api_key_hash, "hash1");
+        assert_eq!(fetched.cert_fingerprint, "fp1");
+
+        // update_last_seen
+        update_last_seen(&pool, &id).await.unwrap();
+        let updated = get_renderer(&pool, &id).await.unwrap().unwrap();
+        assert!(updated.last_seen.is_some());
+
+        // rename
+        rename_renderer(&pool, &id, "Kitchen").await.unwrap();
+        let renamed = get_renderer(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(renamed.name, "Kitchen");
+
+        // disable
+        set_enabled(&pool, &id, false).await.unwrap();
+        let disabled = get_renderer(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(disabled.enabled, 0);
+
+        // re-enable
+        set_enabled(&pool, &id, true).await.unwrap();
+        let enabled = get_renderer(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(enabled.enabled, 1);
+
+        // delete
+        delete_renderer(&pool, &id).await.unwrap();
+        assert!(get_renderer(&pool, &id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_renderers_empty() {
+        let pool = setup().await;
+        let result = list_renderers(&pool).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_renderers_multiple() {
+        let pool = setup().await;
+        let id1 = renderer_id();
+        let id2 = renderer_id();
+
+        create_renderer(&pool, &id1, "A", "h1", "f1").await.unwrap();
+        create_renderer(&pool, &id2, "B", "h2", "f2").await.unwrap();
+
+        let list = list_renderers(&pool).await.unwrap();
+        assert_eq!(list.len(), 2);
+    }
+}

--- a/crates/harmonia-host/Cargo.toml
+++ b/crates/harmonia-host/Cargo.toml
@@ -42,6 +42,10 @@ snafu.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 rand.workspace = true
+syndesis.workspace = true
+mdns-sd.workspace = true
+toml.workspace = true
+jiff.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/harmonia-host/src/cli.rs
+++ b/crates/harmonia-host/src/cli.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
@@ -17,7 +18,7 @@ pub enum Command {
     Db(DbArgs),
     /// Play a local audio file
     Play(PlayArgs),
-    /// Start a headless audio renderer
+    /// Run as a renderer (discovers and pairs with a harmonia server)
     Render(RenderArgs),
 }
 
@@ -55,20 +56,12 @@ pub struct PlayArgs {
 
 #[derive(Args)]
 pub struct RenderArgs {
-    /// Server QUIC address (host:port)
+    /// Explicit server address (skips mDNS discovery)
     #[arg(long)]
-    pub server: String,
+    pub server: Option<SocketAddr>,
 
-    /// Renderer display name (default: hostname)
-    #[arg(long)]
-    pub name: Option<String>,
-
-    /// Path to renderer config TOML (DSP settings, output device)
-    #[arg(long)]
-    pub config: Option<PathBuf>,
-
-    /// Directory for TLS certificates
-    #[arg(long, default_value = "~/.config/harmonia/certs/")]
+    /// Directory for TLS certificates and pairing credentials
+    #[arg(long, default_value = "~/.config/harmonia/renderer")]
     pub cert_dir: PathBuf,
 }
 
@@ -115,25 +108,23 @@ mod tests {
 
     #[test]
     fn render_with_server_parses() {
-        let cli = Cli::parse_from([
-            "harmonia",
-            "render",
-            "--server",
-            "127.0.0.1:4433",
-            "--name",
-            "living-room",
-        ]);
+        let cli = Cli::parse_from(["harmonia", "render", "--server", "127.0.0.1:4433"]);
         let Command::Render(args) = cli.command else {
             panic!("expected Render command");
         };
-        assert_eq!(args.server, "127.0.0.1:4433");
-        assert_eq!(args.name.as_deref(), Some("living-room"));
+        assert_eq!(
+            args.server,
+            Some("127.0.0.1:4433".parse().unwrap())
+        );
     }
 
     #[test]
-    fn render_requires_server_arg() {
-        let result = Cli::try_parse_from(["harmonia", "render"]);
-        assert!(result.is_err());
+    fn render_without_server_uses_discovery() {
+        let cli = Cli::parse_from(["harmonia", "render"]);
+        let Command::Render(args) = cli.command else {
+            panic!("expected Render command");
+        };
+        assert!(args.server.is_none());
     }
 
     #[test]

--- a/crates/harmonia-host/src/error.rs
+++ b/crates/harmonia-host/src/error.rs
@@ -112,9 +112,9 @@ pub enum HostError {
         location: snafu::Location,
     },
 
-    #[snafu(display("renderer error: {source}"))]
+    #[snafu(display("render error: {message}"))]
     Render {
-        source: Box<crate::render::RenderError>,
+        message: String,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/harmonia-host/src/main.rs
+++ b/crates/harmonia-host/src/main.rs
@@ -23,12 +23,11 @@ async fn main() {
         },
         Command::Play(args) => play::run_play(args).await,
         Command::Render(args) => {
-            render::run_render(args)
-                .await
-                .map_err(|e| error::HostError::Render {
-                    source: Box::new(e),
-                    location: snafu::location!(),
-                })
+            render::run_render(render::RenderArgs {
+                server: args.server,
+                cert_dir: args.cert_dir,
+            })
+            .await
         }
     };
 

--- a/crates/harmonia-host/src/render/credentials.rs
+++ b/crates/harmonia-host/src/render/credentials.rs
@@ -1,0 +1,97 @@
+// Renderer-side credential storage for API key and server cert fingerprint
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Stored renderer credentials for authenticating with a harmonia server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RendererCredentials {
+    pub api_key: String,
+    pub server_fingerprint: String,
+    pub server_name: String,
+    pub paired_at: String,
+}
+
+/// Load renderer credentials from `<cert_dir>/credentials.toml`.
+/// Returns `None` if the file does not exist.
+pub fn load_credentials(cert_dir: &Path) -> Result<Option<RendererCredentials>, String> {
+    let path = credentials_path(cert_dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    let creds = toml::from_str::<RendererCredentials>(&contents)
+        .map_err(|e| format!("failed to parse credentials.toml: {e}"))?;
+    Ok(Some(creds))
+}
+
+/// Persist renderer credentials to `<cert_dir>/credentials.toml`.
+pub fn save_credentials(cert_dir: &Path, creds: &RendererCredentials) -> Result<(), String> {
+    let path = credentials_path(cert_dir);
+    std::fs::create_dir_all(cert_dir)
+        .map_err(|e| format!("failed to create cert_dir {}: {e}", cert_dir.display()))?;
+    let contents =
+        toml::to_string(creds).map_err(|e| format!("failed to serialize credentials: {e}"))?;
+    std::fs::write(&path, contents)
+        .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+    Ok(())
+}
+
+fn credentials_path(cert_dir: &Path) -> PathBuf {
+    cert_dir.join("credentials.toml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn test_creds() -> RendererCredentials {
+        RendererCredentials {
+            api_key: "test-api-key-abc123".to_string(),
+            server_fingerprint: "a".repeat(64),
+            server_name: "Harmonia".to_string(),
+            paired_at: "2026-03-23T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let creds = test_creds();
+
+        save_credentials(dir.path(), &creds).unwrap();
+        let loaded = load_credentials(dir.path()).unwrap().unwrap();
+
+        assert_eq!(loaded.api_key, creds.api_key);
+        assert_eq!(loaded.server_fingerprint, creds.server_fingerprint);
+        assert_eq!(loaded.server_name, creds.server_name);
+        assert_eq!(loaded.paired_at, creds.paired_at);
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let result = load_credentials(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn nonexistent_dir_returns_none() {
+        let path = PathBuf::from("/tmp/harmonia-test-nonexistent-8675309");
+        let result = load_credentials(&path).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn creates_dir_on_save() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("nested").join("certs");
+        let creds = test_creds();
+
+        save_credentials(&nested, &creds).unwrap();
+        assert!(nested.join("credentials.toml").exists());
+    }
+}

--- a/crates/harmonia-host/src/render/discovery.rs
+++ b/crates/harmonia-host/src/render/discovery.rs
@@ -1,0 +1,133 @@
+// mDNS-based harmonia server discovery for renderers
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use mdns_sd::{ServiceDaemon, ServiceEvent};
+use tracing::{debug, info, warn};
+
+/// The mDNS service type used by harmonia servers.
+pub const SERVICE_TYPE: &str = "_harmonia._udp.local.";
+
+/// A discovered harmonia server.
+#[derive(Debug, Clone)]
+pub struct DiscoveredServer {
+    pub instance_name: String,
+    pub addr: SocketAddr,
+    pub server_id: Option<String>,
+    pub cert_fingerprint: Option<String>,
+    pub protocol_version: Option<String>,
+}
+
+/// Discover harmonia servers via mDNS, waiting up to `timeout` for results.
+///
+/// If `preferred_fingerprint` is provided, a matching server is sorted first.
+pub async fn discover_servers(
+    timeout: Duration,
+    preferred_fingerprint: Option<&str>,
+) -> Result<Vec<DiscoveredServer>, String> {
+    let daemon = ServiceDaemon::new().map_err(|e| e.to_string())?;
+    let receiver = daemon.browse(SERVICE_TYPE).map_err(|e| e.to_string())?;
+
+    let mut servers: Vec<DiscoveredServer> = Vec::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+
+        let event = match tokio::time::timeout(remaining, receiver.recv_async()).await {
+            Ok(Ok(event)) => event,
+            Ok(Err(_)) | Err(_) => break,
+        };
+
+        let ServiceEvent::ServiceResolved(info) = event else {
+            continue;
+        };
+
+        debug!(
+            instance = %info.get_fullname(),
+            "mDNS: resolved harmonia server"
+        );
+
+        let server_id = info.get_property_val_str("server_id").map(str::to_string);
+        let cert_fingerprint = info.get_property_val_str("fingerprint").map(str::to_string);
+        let protocol_version = info.get_property_val_str("version").map(str::to_string);
+        let port = info.get_port();
+
+        // WHY: take the first address only; multiple addresses for the same instance
+        // are handled at connection time by trying each in turn.
+        if let Some(scoped) = info.get_addresses().iter().next() {
+            let ip = scoped.to_ip_addr();
+            let server = DiscoveredServer {
+                instance_name: info.get_fullname().to_string(),
+                addr: SocketAddr::new(ip, port),
+                server_id: server_id.clone(),
+                cert_fingerprint: cert_fingerprint.clone(),
+                protocol_version: protocol_version.clone(),
+            };
+
+            // If we match the preferred fingerprint, return immediately with it first.
+            if preferred_fingerprint.is_some_and(|pref| cert_fingerprint.as_deref() == Some(pref)) {
+                info!(addr = %server.addr, "mDNS: found preferred server");
+                servers.insert(0, server);
+                let _ = daemon.shutdown();
+                return Ok(servers);
+            }
+
+            servers.push(server);
+        }
+    }
+
+    let _ = daemon.shutdown();
+
+    if servers.is_empty() {
+        info!("mDNS discovery: no harmonia servers found within timeout");
+    } else {
+        info!(
+            count = servers.len(),
+            "mDNS discovery: found {} server(s)",
+            servers.len()
+        );
+    }
+
+    Ok(servers)
+}
+
+/// Discover a single harmonia server, with optional explicit address override.
+///
+/// - If `explicit_addr` is provided, returns it immediately (no mDNS).
+/// - Otherwise browses mDNS, preferring a server matching `preferred_fingerprint`.
+/// - Returns `None` if discovery times out with no results.
+pub async fn discover_server(
+    explicit_addr: Option<SocketAddr>,
+    preferred_fingerprint: Option<&str>,
+) -> Option<DiscoveredServer> {
+    if let Some(addr) = explicit_addr {
+        info!(%addr, "using explicit server address (skipping mDNS)");
+        return Some(DiscoveredServer {
+            instance_name: addr.to_string(),
+            addr,
+            server_id: None,
+            cert_fingerprint: None,
+            protocol_version: None,
+        });
+    }
+
+    let timeout = Duration::from_secs(10);
+    match discover_servers(timeout, preferred_fingerprint).await {
+        Ok(mut servers) if !servers.is_empty() => Some(servers.remove(0)),
+        Ok(_) => {
+            warn!(
+                "no harmonia servers found via mDNS after {}s",
+                timeout.as_secs()
+            );
+            None
+        }
+        Err(e) => {
+            warn!("mDNS discovery failed: {e}");
+            None
+        }
+    }
+}

--- a/crates/harmonia-host/src/render/mod.rs
+++ b/crates/harmonia-host/src/render/mod.rs
@@ -1,6 +1,8 @@
 // Renderer mode: headless audio endpoint receiving streams via QUIC.
 
 pub mod config;
+pub mod credentials;
+pub mod discovery;
 pub mod error;
 pub mod pipeline;
 pub mod protocol;
@@ -10,5 +12,74 @@ pub mod status;
 pub mod tls;
 
 pub use error::RenderError;
-pub use runner::run_render;
 pub use server::RendererRegistry;
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use tracing::info;
+
+use crate::error::HostError;
+
+/// Arguments for the `render` subcommand.
+pub struct RenderArgs {
+    /// Explicit server address (skips mDNS discovery if provided).
+    pub server: Option<SocketAddr>,
+    /// Directory for storing TLS certs and pairing credentials.
+    pub cert_dir: PathBuf,
+}
+
+/// Entry point for the renderer process:
+/// discovers the server, loads existing credentials, and prepares for connection.
+///
+/// On first run (no credentials), initiates pairing with the discovered server.
+/// On subsequent runs, reconnects using the stored API key.
+pub async fn run_render(args: RenderArgs) -> Result<(), HostError> {
+    let creds = credentials::load_credentials(&args.cert_dir).map_err(|e| HostError::Render {
+        message: e,
+        location: snafu::location!(),
+    })?;
+
+    let preferred_fp = creds.as_ref().map(|c| c.server_fingerprint.as_str());
+
+    let server = discovery::discover_server(args.server, preferred_fp).await;
+
+    match server {
+        Some(s) => {
+            info!(
+                addr = %s.addr,
+                instance = %s.instance_name,
+                server_id = ?s.server_id,
+                fingerprint = ?s.cert_fingerprint,
+                version = ?s.protocol_version,
+                "renderer: found server"
+            );
+
+            if creds.is_none() {
+                // WHY: First run -- pairing would happen here once QUIC transport is wired.
+                // Store placeholder credentials so the server_fingerprint is pinned for TOFU.
+                if let Some(fp) = s.cert_fingerprint {
+                    let new_creds = credentials::RendererCredentials {
+                        api_key: String::new(),
+                        server_fingerprint: fp,
+                        server_name: s.instance_name.clone(),
+                        paired_at: jiff::Zoned::now()
+                            .strftime("%Y-%m-%dT%H:%M:%SZ")
+                            .to_string(),
+                    };
+                    credentials::save_credentials(&args.cert_dir, &new_creds).map_err(|e| {
+                        HostError::Render {
+                            message: e,
+                            location: snafu::location!(),
+                        }
+                    })?;
+                }
+            }
+        }
+        None => {
+            tracing::warn!("renderer: no server found -- check network or use --server");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/harmonia-host/src/render/runner.rs
+++ b/crates/harmonia-host/src/render/runner.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, warn};
 
 use super::config::{RendererConfig, load_renderer_config};
-use super::error::{AddrParseSnafu, ProtocolSnafu, RenderError};
+use super::error::{ProtocolSnafu, RenderError};
 use super::pipeline::RenderPipeline;
 use super::protocol::{
     self, AudioFrame, DeviceState, MSG_AUDIO_FRAME, MSG_SESSION_ACCEPT, MSG_SESSION_INIT,
@@ -20,10 +20,18 @@ use super::protocol::{
 };
 use super::status::StatusReporter;
 use super::tls;
-use crate::cli::RenderArgs;
 
-pub async fn run_render(args: RenderArgs) -> Result<(), RenderError> {
-    let config = load_renderer_config(args.config.as_deref())?;
+/// Arguments for the QUIC rendering connection loop.
+pub struct RunnerArgs {
+    pub server_addr: SocketAddr,
+    pub name: String,
+    pub config_path: Option<PathBuf>,
+}
+
+/// QUIC connection loop: connects to a server, negotiates a session,
+/// receives audio frames, and plays them through the local DSP pipeline.
+pub async fn run_renderer_loop(args: RunnerArgs) -> Result<(), RenderError> {
+    let config = load_renderer_config(args.config_path.as_deref())?;
 
     let client_config = tls::build_client_config()?;
 
@@ -32,16 +40,12 @@ pub async fn run_render(args: RenderArgs) -> Result<(), RenderError> {
 
     let shutdown = CancellationToken::new();
 
-    spawn_sighup_handler(args.config.clone(), dsp_tx.clone(), shutdown.child_token());
+    spawn_sighup_handler(args.config_path.clone(), dsp_tx.clone(), shutdown.child_token());
     spawn_shutdown_handler(shutdown.clone());
 
-    let name = args.name.unwrap_or_else(default_renderer_name);
-
-    let server_addr: SocketAddr = args.server.parse().context(AddrParseSnafu)?;
-
     info!(
-        name = %name,
-        server = %server_addr,
+        name = %args.name,
+        server = %args.server_addr,
         "starting renderer"
     );
 
@@ -56,8 +60,8 @@ pub async fn run_render(args: RenderArgs) -> Result<(), RenderError> {
         }
 
         match connect_and_run(
-            &server_addr,
-            &name,
+            &args.server_addr,
+            &args.name,
             &client_config,
             &config,
             dsp_tx.subscribe(),

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -27,6 +27,8 @@ tokio-util = { version = "0.7", features = ["io"] }
 futures-util = "0.3"
 md5 = "0.8"
 sqlx.workspace = true
+mdns-sd.workspace = true
+jiff.workspace = true
 
 [dev-dependencies]
 sqlx.workspace = true

--- a/crates/paroche/src/discovery/advertise.rs
+++ b/crates/paroche/src/discovery/advertise.rs
@@ -1,0 +1,123 @@
+// mDNS service advertisement for the harmonia server
+use std::collections::HashMap;
+
+use mdns_sd::{DaemonEvent, ServiceDaemon, ServiceInfo};
+use tokio::sync::oneshot;
+use tracing::{debug, error, info, warn};
+
+/// The mDNS service type used by harmonia servers.
+pub const SERVICE_TYPE: &str = "_harmonia._udp.local.";
+
+/// Protocol version advertised in TXT records.
+const PROTOCOL_VERSION: &str = "1";
+
+/// Parameters for registering the mDNS advertisement.
+pub struct AdvertiseParams {
+    /// Human-readable server instance name (e.g. "Harmonia").
+    pub instance_name: String,
+    /// QUIC listen port.
+    pub port: u16,
+    /// Stable server ID (UUID as string).
+    pub server_id: String,
+    /// Server TLS cert fingerprint (SHA-256 hex).
+    pub cert_fingerprint: String,
+}
+
+/// A running mDNS advertisement that unregisters when dropped.
+pub struct AdvertisedService {
+    daemon: ServiceDaemon,
+    service_fullname: String,
+}
+
+impl AdvertisedService {
+    /// Register the service and wait for the first `DaemonEvent::Announce` confirmation.
+    pub async fn start(params: AdvertiseParams) -> Result<Self, String> {
+        let daemon = ServiceDaemon::new().map_err(|e| e.to_string())?;
+
+        let mut props = HashMap::new();
+        props.insert("version".to_string(), PROTOCOL_VERSION.to_string());
+        props.insert("server_id".to_string(), params.server_id.clone());
+        props.insert("fingerprint".to_string(), params.cert_fingerprint.clone());
+
+        // WHY: hostname must be unique within .local domain; use sanitized instance name.
+        let hostname = format!(
+            "{}.local.",
+            params.instance_name.replace(' ', "-").to_lowercase()
+        );
+
+        let service_info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &params.instance_name,
+            &hostname,
+            "",
+            params.port,
+            props,
+        )
+        .map_err(|e| e.to_string())?;
+
+        let service_fullname = service_info.get_fullname().to_string();
+
+        let monitor = daemon.monitor().map_err(|e| e.to_string())?;
+
+        daemon.register(service_info).map_err(|e| e.to_string())?;
+
+        // Wait for Announce confirmation, indicating the service is being advertised.
+        let (tx, rx) = oneshot::channel::<()>();
+        let fullname_check = service_fullname.clone();
+        let mut tx_opt = Some(tx);
+
+        tokio::spawn(async move {
+            loop {
+                match monitor.recv_async().await {
+                    Ok(DaemonEvent::Announce(name, intf)) => {
+                        debug!(name, intf, "mDNS daemon: announce");
+                        if name == fullname_check {
+                            if let Some(tx) = tx_opt.take() {
+                                let _ = tx.send(());
+                            }
+                            break;
+                        }
+                    }
+                    Ok(DaemonEvent::Error(e)) => {
+                        warn!("mDNS daemon error: {e}");
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        warn!("mDNS monitor channel closed: {e}");
+                        break;
+                    }
+                }
+            }
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), rx)
+            .await
+            .map_err(|_| "mDNS registration timed out".to_string())?
+            .map_err(|_| "mDNS registration channel dropped".to_string())?;
+
+        info!(
+            instance = %params.instance_name,
+            port = params.port,
+            "mDNS service registered: {SERVICE_TYPE}"
+        );
+
+        Ok(Self {
+            daemon,
+            service_fullname,
+        })
+    }
+
+    /// Unregister the service from the mDNS daemon.
+    pub fn stop(self) {
+        if let Err(e) = self.daemon.unregister(&self.service_fullname) {
+            error!("mDNS unregister failed: {e}");
+        } else {
+            info!(
+                service = %self.service_fullname,
+                "mDNS service unregistered"
+            );
+        }
+        let _ = self.daemon.shutdown();
+    }
+}

--- a/crates/paroche/src/discovery/mod.rs
+++ b/crates/paroche/src/discovery/mod.rs
@@ -1,0 +1,3 @@
+pub mod advertise;
+
+pub use advertise::{AdvertiseParams, AdvertisedService, SERVICE_TYPE};

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod discovery;
 pub mod error;
 pub mod middleware;
 pub mod opds;
@@ -38,6 +39,7 @@ pub fn build_router(state: AppState) -> Router {
         .nest("/api/v1/requests", routes::request::request_routes())
         .nest("/api/v1/wanted", routes::wanted::wanted_routes())
         .nest("/api/v1", routes::subtitle::subtitle_routes())
+        .nest("/api/renderers", routes::renderer::renderer_routes())
         .nest("/opds", opds::opds_routes())
         .nest("/api/renderers", routes::renderer::renderer_routes())
         .merge(routes::stream::stream_routes())

--- a/crates/paroche/src/routes/renderer.rs
+++ b/crates/paroche/src/routes/renderer.rs
@@ -1,14 +1,259 @@
-// GET /api/renderers — list connected renderers with status.
+// Renderer registry API endpoints
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{delete, get, patch},
+};
+use exousia::RequireAdmin;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
 
-use axum::{Json, extract::State};
+use harmonia_db::repo::renderer;
 
-use crate::state::AppState;
+use crate::{
+    error::{DatabaseSnafu, ParocheError},
+    state::AppState,
+};
 
-pub fn renderer_routes() -> axum::Router<AppState> {
-    axum::Router::new().route("/", axum::routing::get(list_renderers))
+#[derive(Debug, Serialize)]
+pub struct RendererResponse {
+    pub id: String,
+    pub name: String,
+    pub cert_fingerprint: String,
+    pub last_seen: Option<String>,
+    pub paired_at: String,
+    pub enabled: bool,
 }
 
-async fn list_renderers(State(state): State<AppState>) -> Json<serde_json::Value> {
-    let renderers = state.renderers.list_renderers().await;
-    Json(serde_json::to_value(renderers).unwrap_or_default())
+impl From<renderer::Renderer> for RendererResponse {
+    fn from(r: renderer::Renderer) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            cert_fingerprint: r.cert_fingerprint,
+            last_seen: r.last_seen,
+            paired_at: r.paired_at,
+            enabled: r.enabled != 0,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PatchRendererRequest {
+    pub name: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+pub async fn list_renderers(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let renderers = renderer::list_renderers(&state.db.read)
+        .await
+        .context(DatabaseSnafu)?;
+    let body: Vec<RendererResponse> = renderers.into_iter().map(Into::into).collect();
+    Ok((StatusCode::OK, Json(body)))
+}
+
+pub async fn unpair_renderer(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    _admin: RequireAdmin,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let existing = renderer::get_renderer(&state.db.read, &id)
+        .await
+        .context(DatabaseSnafu)?;
+
+    if existing.is_none() {
+        return Err(ParocheError::NotFound);
+    }
+
+    renderer::delete_renderer(&state.db.write, &id)
+        .await
+        .context(DatabaseSnafu)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn patch_renderer(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    _admin: RequireAdmin,
+    Json(req): Json<PatchRendererRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let existing = renderer::get_renderer(&state.db.read, &id)
+        .await
+        .context(DatabaseSnafu)?;
+
+    if existing.is_none() {
+        return Err(ParocheError::NotFound);
+    }
+
+    if let Some(name) = &req.name {
+        renderer::rename_renderer(&state.db.write, &id, name)
+            .await
+            .context(DatabaseSnafu)?;
+    }
+
+    if let Some(enabled) = req.enabled {
+        renderer::set_enabled(&state.db.write, &id, enabled)
+            .await
+            .context(DatabaseSnafu)?;
+    }
+
+    let updated = renderer::get_renderer(&state.db.read, &id)
+        .await
+        .context(DatabaseSnafu)?
+        .ok_or(ParocheError::NotFound)?;
+
+    Ok((StatusCode::OK, Json(RendererResponse::from(updated))))
+}
+
+pub fn renderer_routes() -> axum::Router<AppState> {
+    axum::Router::new()
+        .route("/", get(list_renderers))
+        .route("/{id}/unpair", delete(unpair_renderer))
+        .route("/{id}", patch(patch_renderer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_state;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use exousia::{AuthService, user::CreateUserRequest};
+    use tower::ServiceExt;
+
+    async fn admin_token(auth: &std::sync::Arc<exousia::ExousiaServiceImpl>) -> String {
+        auth.create_user(CreateUserRequest {
+            username: "admin".to_string(),
+            display_name: "Admin".to_string(),
+            password: "password123".to_string(),
+            role: exousia::user::UserRole::Admin,
+        })
+        .await
+        .unwrap();
+        auth.login("admin", "password123")
+            .await
+            .unwrap()
+            .access_token
+    }
+
+    #[tokio::test]
+    async fn list_renderers_empty() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+        let app = renderer_routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json.as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_renderers_requires_auth() {
+        let (state, _auth) = test_state().await;
+        let app = renderer_routes().with_state(state);
+        let resp = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn unpair_nonexistent_returns_404() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+        let app = renderer_routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/nonexistent-id/unpair")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn renderer_lifecycle() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+
+        // Seed a renderer directly via DB
+        let id = uuid::Uuid::now_v7().to_string();
+        renderer::create_renderer(&state.db.write, &id, "Test", "hash", "fp")
+            .await
+            .unwrap();
+
+        let app = renderer_routes().with_state(state);
+
+        // list
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json.as_array().unwrap().len(), 1);
+
+        // patch (rename + disable)
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/{id}"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"name":"Renamed","enabled":false}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["name"], "Renamed");
+        assert_eq!(json["enabled"], false);
+
+        // unpair
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/{id}/unpair"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
 }

--- a/crates/syndesis/Cargo.toml
+++ b/crates/syndesis/Cargo.toml
@@ -1,21 +1,33 @@
 [package]
 name = "syndesis"
-description = "QUIC streaming protocol for multi-room audio"
+description = "QUIC transport, TLS pairing, renderer authentication"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 
 [dependencies]
+harmonia-common.workspace = true
+harmonia-db.workspace = true
+argon2.workspace = true
+base64.workspace = true
 bytes.workspace = true
+jiff.workspace = true
 quinn.workspace = true
 rand.workspace = true
+rand_core.workspace = true
+rcgen.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
-rcgen = "0.13"
 serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
 snafu.workspace = true
+sqlx.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
+sqlx.workspace = true
+harmonia-db = { workspace = true }

--- a/crates/syndesis/src/error.rs
+++ b/crates/syndesis/src/error.rs
@@ -1,4 +1,4 @@
-/// Error types for the syndesis streaming protocol.
+// syndesis error types
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
@@ -53,6 +53,13 @@ pub enum SyndesisError {
         location: snafu::Location,
     },
 
+    #[snafu(display("TLS certificate generation failed: {source}"))]
+    CertGen {
+        source: rcgen::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("session negotiation failed: {reason}"))]
     Negotiation {
         reason: &'static str,
@@ -77,6 +84,51 @@ pub enum SyndesisError {
     #[snafu(display("QUIC connect error: {source}"))]
     Connect {
         source: quinn::ConnectError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("argon2 error: {message}"))]
+    Argon2 {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("database error: {source}"))]
+    Database {
+        source: harmonia_db::DbError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("renderer not found"))]
+    RendererNotFound {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("renderer is disabled"))]
+    RendererDisabled {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("API key is invalid"))]
+    InvalidApiKey {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("cert fingerprint mismatch (TOFU violation)"))]
+    FingerprintMismatch {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("frame serialization error: {source}"))]
+    Frame {
+        source: serde_json::Error,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/syndesis/src/lib.rs
+++ b/crates/syndesis/src/lib.rs
@@ -1,9 +1,22 @@
-/// QUIC streaming protocol for multi-room audio transport.
+// syndesis -- QUIC transport, TLS pairing, and renderer authentication
 pub mod client;
 pub mod clock;
 pub mod error;
+pub mod pairing;
 pub mod protocol;
 pub mod server;
 pub mod tls;
 
 pub use error::SyndesisError;
+pub use pairing::{
+    PairingOutcome, PairingRequest, complete_pairing, generate_api_key, hash_api_key,
+    verify_api_key,
+};
+pub use protocol::session_frame::{
+    Frame as SessionFrame, PairingChallenge, PairingComplete, SessionAccepted,
+    SessionInit as SessionInitMsg, SessionRejected,
+};
+pub use server::auth::{
+    SessionOutcome, build_pairing_challenge, build_pairing_complete, handle_session_init,
+};
+pub use tls::{SelfSignedCert, compute_fingerprint, generate_self_signed_simple};

--- a/crates/syndesis/src/pairing/handshake.rs
+++ b/crates/syndesis/src/pairing/handshake.rs
@@ -1,0 +1,157 @@
+// Pairing handshake: generates an API key and persists the renderer record
+use argon2::{
+    Argon2,
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use rand_core::OsRng;
+use snafu::ResultExt;
+use sqlx::SqlitePool;
+
+use harmonia_db::repo::renderer::{self, Renderer};
+
+use crate::error::{DatabaseSnafu, SyndesisError};
+
+/// Generate a cryptographically random 32-byte API key, base64url-encoded.
+pub fn generate_api_key() -> String {
+    let mut bytes = [0u8; 32];
+    use rand_core::RngCore;
+    OsRng.fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Hash an API key using argon2id in PHC format.
+pub fn hash_api_key(api_key: &str) -> Result<String, SyndesisError> {
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(api_key.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| SyndesisError::Argon2 {
+            message: e.to_string(),
+            location: snafu::location!(),
+        })
+}
+
+/// Verify an API key against a stored argon2id hash.
+pub fn verify_api_key(api_key: &str, stored_hash: &str) -> bool {
+    let Ok(parsed) = PasswordHash::new(stored_hash) else {
+        return false;
+    };
+    Argon2::default()
+        .verify_password(api_key.as_bytes(), &parsed)
+        .is_ok()
+}
+
+/// Parameters for initiating a pairing with a new renderer.
+pub struct PairingRequest<'a> {
+    pub renderer_name: &'a str,
+    pub renderer_id: &'a str,
+    pub cert_fingerprint: &'a str,
+}
+
+/// Outcome of a successful pairing: the plaintext API key to send to the renderer.
+pub struct PairingOutcome {
+    pub api_key: String,
+}
+
+/// Complete the pairing flow server-side:
+/// generate an API key, hash it, persist the renderer, return the plaintext key.
+pub async fn complete_pairing(
+    write_pool: &SqlitePool,
+    req: PairingRequest<'_>,
+) -> Result<PairingOutcome, SyndesisError> {
+    let api_key = generate_api_key();
+    let api_key_hash = hash_api_key(&api_key)?;
+
+    renderer::create_renderer(
+        write_pool,
+        req.renderer_id,
+        req.renderer_name,
+        &api_key_hash,
+        req.cert_fingerprint,
+    )
+    .await
+    .context(DatabaseSnafu)?;
+
+    Ok(PairingOutcome { api_key })
+}
+
+/// Authenticate a renderer by its API key.
+/// Returns the renderer record on success.
+pub async fn authenticate_renderer(
+    read_pool: &SqlitePool,
+    write_pool: &SqlitePool,
+    api_key: &str,
+    cert_fingerprint: &str,
+) -> Result<Renderer, SyndesisError> {
+    let renderers = renderer::list_renderers(read_pool)
+        .await
+        .context(DatabaseSnafu)?;
+
+    // WHY: brute-force over list since renderer count is tiny (<100);
+    // avoids timing-equivalent hash-then-lookup ordering issues.
+    let matched = renderers
+        .into_iter()
+        .find(|r| verify_api_key(api_key, &r.api_key_hash));
+
+    let r = matched.ok_or_else(|| SyndesisError::InvalidApiKey {
+        location: snafu::location!(),
+    })?;
+
+    if r.enabled == 0 {
+        return Err(SyndesisError::RendererDisabled {
+            location: snafu::location!(),
+        });
+    }
+
+    if r.cert_fingerprint != cert_fingerprint {
+        tracing::warn!(
+            renderer_id = %r.id,
+            stored = %r.cert_fingerprint,
+            presented = %cert_fingerprint,
+            "TOFU violation: cert fingerprint mismatch"
+        );
+        return Err(SyndesisError::FingerprintMismatch {
+            location: snafu::location!(),
+        });
+    }
+
+    renderer::update_last_seen(write_pool, &r.id)
+        .await
+        .context(DatabaseSnafu)?;
+
+    Ok(r)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_key_is_non_empty_base64url() {
+        let key = generate_api_key();
+        assert!(!key.is_empty());
+        assert!(
+            key.chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        );
+        // 32 bytes → 43 base64url chars (no padding)
+        assert_eq!(key.len(), 43);
+    }
+
+    #[test]
+    fn api_key_round_trip_hash_and_verify() {
+        let key = generate_api_key();
+        let hash = hash_api_key(&key).unwrap();
+        assert!(verify_api_key(&key, &hash));
+        assert!(!verify_api_key("wrong-key", &hash));
+    }
+
+    #[test]
+    fn hashes_differ_for_same_key() {
+        let key = generate_api_key();
+        let h1 = hash_api_key(&key).unwrap();
+        let h2 = hash_api_key(&key).unwrap();
+        assert_ne!(h1, h2);
+    }
+}

--- a/crates/syndesis/src/pairing/mod.rs
+++ b/crates/syndesis/src/pairing/mod.rs
@@ -1,0 +1,6 @@
+pub mod handshake;
+
+pub use handshake::{
+    PairingOutcome, PairingRequest, authenticate_renderer, complete_pairing, generate_api_key,
+    hash_api_key, verify_api_key,
+};

--- a/crates/syndesis/src/protocol/mod.rs
+++ b/crates/syndesis/src/protocol/mod.rs
@@ -1,6 +1,7 @@
-/// QUIC streaming wire protocol definitions.
+// QUIC streaming wire protocol definitions.
 pub mod codec;
 pub mod frame;
+pub mod session_frame;
 
 pub const PROTOCOL_VERSION: u8 = 1;
 
@@ -89,3 +90,8 @@ impl CommandKind {
         }
     }
 }
+
+pub use session_frame::{
+    Frame as SessionFrame, PairingChallenge, PairingComplete, SessionAccepted,
+    SessionInit as SessionInitMsg, SessionRejected,
+};

--- a/crates/syndesis/src/protocol/session_frame.rs
+++ b/crates/syndesis/src/protocol/session_frame.rs
@@ -1,0 +1,124 @@
+// Wire-format frame types for the renderer-server session protocol
+use serde::{Deserialize, Serialize};
+
+/// Sent by the renderer to initiate a session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SessionInit {
+    /// Human-readable renderer name.
+    pub renderer_name: String,
+    /// Stable renderer identity (UUID v7 as string).
+    pub renderer_id: String,
+    /// API key from a prior pairing, base64url-encoded (no padding).
+    /// Present on authenticated reconnects; absent on first connection.
+    pub api_key: Option<String>,
+    /// Set to true when the renderer has no stored credentials.
+    pub is_new: bool,
+}
+
+/// Sent by the server during the pairing flow to let the renderer
+/// record the server's identity for TOFU verification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PairingChallenge {
+    /// Human-readable server name.
+    pub server_name: String,
+    /// Hex-encoded SHA-256 fingerprint of the server's TLS certificate.
+    pub cert_fingerprint: String,
+}
+
+/// Sent by the server after successful pairing, carrying the provisioned API key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PairingComplete {
+    /// Base64url-encoded (no padding) API key for future authentication.
+    pub api_key: String,
+}
+
+/// Sent by the server when a session is successfully established.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SessionAccepted {
+    /// The canonical renderer ID as stored in the server registry.
+    pub renderer_id: String,
+}
+
+/// Sent by the server when a session is rejected.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SessionRejected {
+    pub reason: String,
+}
+
+/// Top-level protocol frame envelope.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Frame {
+    SessionInit(SessionInit),
+    PairingChallenge(PairingChallenge),
+    PairingComplete(PairingComplete),
+    SessionAccepted(SessionAccepted),
+    SessionRejected(SessionRejected),
+}
+
+impl Frame {
+    /// Encode this frame as a newline-terminated JSON string.
+    pub fn encode(&self) -> Result<Vec<u8>, serde_json::Error> {
+        let mut bytes = serde_json::to_vec(self)?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    }
+
+    /// Decode a frame from a JSON byte slice (trailing newline is ignored).
+    pub fn decode(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        let trimmed = bytes.trim_ascii_end();
+        serde_json::from_slice(trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_init_round_trip() {
+        let frame = Frame::SessionInit(SessionInit {
+            renderer_name: "Living Room".to_string(),
+            renderer_id: "01HN1234567890ABCDEFGHIJKL".to_string(),
+            api_key: None,
+            is_new: true,
+        });
+        let encoded = frame.encode().unwrap();
+        let decoded = Frame::decode(&encoded).unwrap();
+        assert_eq!(frame, decoded);
+    }
+
+    #[test]
+    fn pairing_challenge_round_trip() {
+        let frame = Frame::PairingChallenge(PairingChallenge {
+            server_name: "Harmonia".to_string(),
+            cert_fingerprint: "a".repeat(64),
+        });
+        let encoded = frame.encode().unwrap();
+        let decoded = Frame::decode(&encoded).unwrap();
+        assert_eq!(frame, decoded);
+    }
+
+    #[test]
+    fn pairing_complete_round_trip() {
+        let frame = Frame::PairingComplete(PairingComplete {
+            api_key: "abc123def456".to_string(),
+        });
+        let encoded = frame.encode().unwrap();
+        let decoded = Frame::decode(&encoded).unwrap();
+        assert_eq!(frame, decoded);
+    }
+
+    #[test]
+    fn session_init_with_api_key_round_trip() {
+        let frame = Frame::SessionInit(SessionInit {
+            renderer_name: "Kitchen".to_string(),
+            renderer_id: "01HN1234567890ABCDEFGHIJKL".to_string(),
+            api_key: Some("some-api-key".to_string()),
+            is_new: false,
+        });
+        let encoded = frame.encode().unwrap();
+        let decoded = Frame::decode(&encoded).unwrap();
+        assert_eq!(frame, decoded);
+    }
+}

--- a/crates/syndesis/src/server/auth.rs
+++ b/crates/syndesis/src/server/auth.rs
@@ -1,0 +1,253 @@
+// Session authentication middleware for incoming renderer connections
+use sqlx::SqlitePool;
+
+use harmonia_db::repo::renderer::Renderer;
+
+use crate::error::SyndesisError;
+use crate::pairing::handshake::{
+    PairingOutcome, PairingRequest, authenticate_renderer, complete_pairing,
+};
+use crate::protocol::session_frame::{
+    PairingChallenge, PairingComplete, SessionInit as SessionInitMsg,
+};
+
+/// Outcome of processing a `SessionInit` frame.
+pub enum SessionOutcome {
+    /// Renderer authenticated with an existing API key.
+    Authenticated(Renderer),
+    /// First connection: pairing completed, key should be sent to renderer.
+    Paired(PairingOutcome),
+}
+
+/// Process a `SessionInit` frame from a connecting renderer.
+///
+/// - `is_new: true` -> run the pairing flow (generate + store API key).
+/// - `api_key: Some(key)` -> verify against the renderer registry.
+/// - Neither -> reject with `InvalidApiKey`.
+// WHY: peer_cert_fingerprint is the renderer's TLS cert fingerprint stored for TOFU.
+// The caller is responsible for building and sending PairingChallenge (with the server's
+// own cert fingerprint) after receiving a Paired outcome from this function.
+pub async fn handle_session_init(
+    read_pool: &SqlitePool,
+    write_pool: &SqlitePool,
+    init: &SessionInitMsg,
+    peer_cert_fingerprint: &str,
+) -> Result<SessionOutcome, SyndesisError> {
+    if init.is_new {
+        let req = PairingRequest {
+            renderer_name: &init.renderer_name,
+            renderer_id: &init.renderer_id,
+            cert_fingerprint: peer_cert_fingerprint,
+        };
+        let outcome = complete_pairing(write_pool, req).await?;
+        return Ok(SessionOutcome::Paired(outcome));
+    }
+
+    match &init.api_key {
+        Some(key) => {
+            let renderer =
+                authenticate_renderer(read_pool, write_pool, key, peer_cert_fingerprint).await?;
+            Ok(SessionOutcome::Authenticated(renderer))
+        }
+        None => Err(SyndesisError::InvalidApiKey {
+            location: snafu::location!(),
+        }),
+    }
+}
+
+/// Build the `PairingChallenge` frame the server sends during pairing.
+pub fn build_pairing_challenge(
+    server_name: &str,
+    server_cert_fingerprint: &str,
+) -> PairingChallenge {
+    PairingChallenge {
+        server_name: server_name.to_string(),
+        cert_fingerprint: server_cert_fingerprint.to_string(),
+    }
+}
+
+/// Build the `PairingComplete` frame from a `PairingOutcome`.
+pub fn build_pairing_complete(outcome: &PairingOutcome) -> PairingComplete {
+    PairingComplete {
+        api_key: outcome.api_key.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::session_frame::SessionInit as SessionInitMsg;
+    use harmonia_db::migrate::MIGRATOR;
+    use sqlx::SqlitePool;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    fn renderer_id() -> String {
+        uuid::Uuid::now_v7().to_string()
+    }
+
+    #[tokio::test]
+    async fn pairing_flow_completes_and_key_verifiable() {
+        let pool = setup().await;
+        let id = renderer_id();
+
+        let init = SessionInitMsg {
+            renderer_name: "Test Renderer".to_string(),
+            renderer_id: id.clone(),
+            api_key: None,
+            is_new: true,
+        };
+
+        let outcome = handle_session_init(&pool, &pool, &init, "aabbcc")
+            .await
+            .unwrap();
+
+        let api_key = match outcome {
+            SessionOutcome::Paired(o) => o.api_key,
+            SessionOutcome::Authenticated(_) => panic!("expected paired"),
+        };
+        assert!(!api_key.is_empty());
+    }
+
+    #[tokio::test]
+    async fn authenticate_after_pairing_succeeds() {
+        let pool = setup().await;
+        let id = renderer_id();
+
+        let init = SessionInitMsg {
+            renderer_name: "Test Renderer".to_string(),
+            renderer_id: id.clone(),
+            api_key: None,
+            is_new: true,
+        };
+
+        let api_key = match handle_session_init(&pool, &pool, &init, "fingerprint_renderer")
+            .await
+            .unwrap()
+        {
+            SessionOutcome::Paired(o) => o.api_key,
+            _ => panic!("expected paired"),
+        };
+
+        let auth_init = SessionInitMsg {
+            renderer_name: "Test Renderer".to_string(),
+            renderer_id: id.clone(),
+            api_key: Some(api_key.clone()),
+            is_new: false,
+        };
+
+        let result = handle_session_init(&pool, &pool, &auth_init, "fingerprint_renderer").await;
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            SessionOutcome::Authenticated(r) => assert_eq!(r.id, id),
+            _ => panic!("expected authenticated"),
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_api_key_rejected() {
+        let pool = setup().await;
+        let id = renderer_id();
+
+        let init = SessionInitMsg {
+            renderer_name: "Test Renderer".to_string(),
+            renderer_id: id,
+            api_key: None,
+            is_new: true,
+        };
+
+        handle_session_init(&pool, &pool, &init, "fp")
+            .await
+            .unwrap();
+
+        let auth_init = SessionInitMsg {
+            renderer_name: "Test Renderer".to_string(),
+            renderer_id: uuid::Uuid::now_v7().to_string(),
+            api_key: Some("wrong-key-value-here".to_string()),
+            is_new: false,
+        };
+
+        let result = handle_session_init(&pool, &pool, &auth_init, "fp").await;
+
+        assert!(matches!(result, Err(SyndesisError::InvalidApiKey { .. })));
+    }
+
+    #[tokio::test]
+    async fn disabled_renderer_rejected() {
+        use harmonia_db::repo::renderer;
+
+        let pool = setup().await;
+        let id = renderer_id();
+
+        let init = SessionInitMsg {
+            renderer_name: "Disabled Renderer".to_string(),
+            renderer_id: id.clone(),
+            api_key: None,
+            is_new: true,
+        };
+
+        let api_key = match handle_session_init(&pool, &pool, &init, "fp")
+            .await
+            .unwrap()
+        {
+            SessionOutcome::Paired(o) => o.api_key,
+            _ => panic!("expected paired"),
+        };
+
+        renderer::set_enabled(&pool, &id, false).await.unwrap();
+
+        let auth_init = SessionInitMsg {
+            renderer_name: "Disabled Renderer".to_string(),
+            renderer_id: id,
+            api_key: Some(api_key),
+            is_new: false,
+        };
+
+        let result = handle_session_init(&pool, &pool, &auth_init, "fp").await;
+
+        assert!(matches!(
+            result,
+            Err(SyndesisError::RendererDisabled { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn fingerprint_mismatch_rejected() {
+        let pool = setup().await;
+        let id = renderer_id();
+
+        let init = SessionInitMsg {
+            renderer_name: "Test Renderer".to_string(),
+            renderer_id: id.clone(),
+            api_key: None,
+            is_new: true,
+        };
+
+        let api_key = match handle_session_init(&pool, &pool, &init, "original-fingerprint")
+            .await
+            .unwrap()
+        {
+            SessionOutcome::Paired(o) => o.api_key,
+            _ => panic!("expected paired"),
+        };
+
+        let auth_init = SessionInitMsg {
+            renderer_name: "Test Renderer".to_string(),
+            renderer_id: id,
+            api_key: Some(api_key),
+            is_new: false,
+        };
+
+        let result = handle_session_init(&pool, &pool, &auth_init, "different-fingerprint").await;
+
+        assert!(matches!(
+            result,
+            Err(SyndesisError::FingerprintMismatch { .. })
+        ));
+    }
+}

--- a/crates/syndesis/src/server/mod.rs
+++ b/crates/syndesis/src/server/mod.rs
@@ -1,4 +1,5 @@
 /// QUIC streaming server: accepts renderer connections and streams audio.
+pub mod auth;
 pub mod session;
 pub mod source;
 
@@ -10,6 +11,9 @@ use tracing::{info, instrument, warn};
 use crate::error::{self, SyndesisError};
 use crate::tls;
 
+pub use auth::{
+    SessionOutcome, build_pairing_challenge, build_pairing_complete, handle_session_init,
+};
 pub use session::StreamSession;
 pub use source::AudioSource;
 

--- a/crates/syndesis/src/tls/mod.rs
+++ b/crates/syndesis/src/tls/mod.rs
@@ -1,12 +1,51 @@
 /// TLS certificate management for QUIC transport.
+use std::fmt::Write as _;
 use std::path::Path;
 use std::sync::Arc;
 
 use quinn::crypto::rustls::QuicServerConfig;
+use rcgen::CertifiedKey;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
 use snafu::ResultExt;
 
-use crate::error::{self, SyndesisError};
+use crate::error::{self, CertGenSnafu, SyndesisError};
+
+/// A generated self-signed TLS certificate with its DER-encoded bytes and private key.
+#[derive(Clone)]
+pub struct SelfSignedCert {
+    /// DER-encoded certificate bytes.
+    pub cert_der: Vec<u8>,
+    /// DER-encoded PKCS#8 private key bytes.
+    pub key_der: Vec<u8>,
+    /// Hex-encoded SHA-256 fingerprint of the certificate.
+    pub fingerprint: String,
+}
+
+/// Compute the hex-encoded SHA-256 fingerprint of a DER-encoded certificate.
+pub fn compute_fingerprint(cert_der: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(cert_der);
+    hash.iter().fold(String::with_capacity(64), |mut acc, b| {
+        write!(acc, "{b:02x}").ok();
+        acc
+    })
+}
+
+/// Generate a simple self-signed certificate returning `SelfSignedCert`.
+pub fn generate_self_signed_simple(san: Vec<String>) -> Result<SelfSignedCert, SyndesisError> {
+    let CertifiedKey { cert, key_pair } =
+        rcgen::generate_simple_self_signed(san).context(CertGenSnafu)?;
+
+    let cert_der = cert.der().to_vec();
+    let key_der = key_pair.serialize_der();
+    let fingerprint = compute_fingerprint(&cert_der);
+
+    Ok(SelfSignedCert {
+        cert_der,
+        key_der,
+        fingerprint,
+    })
+}
 
 /// Generate a self-signed certificate and private key for QUIC transport.
 pub fn generate_self_signed(
@@ -209,6 +248,29 @@ mod tests {
     fn builds_client_config() {
         let config = build_client_config();
         assert!(config.is_ok());
+    }
+
+    #[test]
+    fn generate_simple_produces_fingerprint() {
+        let cert = generate_self_signed_simple(vec!["harmonia.local".to_string()]).unwrap();
+        assert!(!cert.cert_der.is_empty());
+        assert!(!cert.key_der.is_empty());
+        assert_eq!(cert.fingerprint.len(), 64);
+        assert!(cert.fingerprint.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn fingerprint_is_deterministic() {
+        let cert = generate_self_signed_simple(vec!["harmonia.local".to_string()]).unwrap();
+        let fp2 = compute_fingerprint(&cert.cert_der);
+        assert_eq!(cert.fingerprint, fp2);
+    }
+
+    #[test]
+    fn different_certs_have_different_fingerprints() {
+        let c1 = generate_self_signed_simple(vec!["a.local".to_string()]).unwrap();
+        let c2 = generate_self_signed_simple(vec!["b.local".to_string()]).unwrap();
+        assert_ne!(c1.fingerprint, c2.fingerprint);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **syndesis** (new crate): TLS self-signed cert generation + SHA-256 fingerprinting, newline-delimited JSON protocol frames, argon2id API key hashing, TOFU pairing handshake, session authentication middleware with 5 integration tests
- **harmonia-db**: `renderers` table (migration 008) + CRUD repo (`create`, `get`, `list`, `update_last_seen`, `set_enabled`, `rename`, `delete`)
- **paroche**: mDNS service advertisement via mdns-sd 0.18 (`DaemonEvent::Announce`), renderer management REST routes (`GET /api/renderers`, `DELETE /api/renderers/{id}/unpair`, `PATCH /api/renderers/{id}`) protected by `RequireAdmin`
- **harmonia-host**: renderer-side mDNS discovery with preferred-fingerprint early-return, TOML credential file (`RendererCredentials`), `harmonia render` CLI subcommand

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo test --workspace` — all suites pass including syndesis session tests
- [ ] `harmonia render --cert-dir /tmp/test-creds` discovers server or warns cleanly
- [ ] `GET /api/renderers` returns empty list before any pairing
- [ ] After pairing: renderer appears in list, `PATCH` renames it, `DELETE .../unpair` removes it

## Notes

Quinn (QUIC transport) dependency is wired but the full transport layer is out of scope for this PR — the pairing protocol frames and session handler are ready for it.