### PR TITLE
feat(syndesis): multi-room zone grouping with <=5ms clock sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3404,6 +3404,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "ulid",
  "uuid",
 ]
 
@@ -5648,6 +5649,17 @@ name = "typewit"
 version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "serde",
+ "web-time",
+]
 
 [[package]]
 name = "uncased"

--- a/crates/harmonia-db/migrations/008_zones.sql
+++ b/crates/harmonia-db/migrations/008_zones.sql
@@ -1,0 +1,23 @@
+-- Zone grouping for multi-room synchronized playback.
+
+CREATE TABLE renderers (
+    id         TEXT NOT NULL PRIMARY KEY,
+    name       TEXT NOT NULL,
+    address    TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE TABLE zones (
+    id         TEXT NOT NULL PRIMARY KEY,
+    name       TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE TABLE zone_members (
+    zone_id     TEXT NOT NULL REFERENCES zones(id) ON DELETE CASCADE,
+    renderer_id TEXT NOT NULL REFERENCES renderers(id) ON DELETE CASCADE,
+    joined_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    PRIMARY KEY (zone_id, renderer_id)
+);
+
+CREATE INDEX idx_zone_members_renderer ON zone_members(renderer_id);

--- a/crates/harmonia-db/src/repo/mod.rs
+++ b/crates/harmonia-db/src/repo/mod.rs
@@ -12,3 +12,4 @@ pub mod renderer;
 pub mod tv;
 pub mod user;
 pub mod want;
+pub mod zone;

--- a/crates/harmonia-db/src/repo/zone.rs
+++ b/crates/harmonia-db/src/repo/zone.rs
@@ -1,0 +1,323 @@
+/// Zone and renderer management for multi-room synchronized playback.
+use snafu::ResultExt;
+use sqlx::SqlitePool;
+
+use crate::error::{DbError, NotFoundSnafu, QuerySnafu};
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Zone {
+    pub id: String,
+    pub name: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ZoneMemberRow {
+    pub zone_id: String,
+    pub renderer_id: String,
+    pub joined_at: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Renderer {
+    pub id: String,
+    pub name: String,
+    pub address: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ZoneWithMembers {
+    pub zone: Zone,
+    pub members: Vec<Renderer>,
+}
+
+pub async fn create_zone(pool: &SqlitePool, id: &str, name: &str) -> Result<Zone, DbError> {
+    sqlx::query("INSERT INTO zones (id, name) VALUES (?, ?)")
+        .bind(id)
+        .bind(name)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "zones" })?;
+
+    get_zone_row(pool, id).await?.ok_or_else(|| {
+        NotFoundSnafu {
+            table: "zones",
+            id: id.to_string(),
+        }
+        .build()
+    })
+}
+
+pub async fn delete_zone(pool: &SqlitePool, id: &str) -> Result<(), DbError> {
+    let result = sqlx::query("DELETE FROM zones WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu { table: "zones" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "zones",
+            id: id.to_string(),
+        }
+        .build());
+    }
+    Ok(())
+}
+
+pub async fn add_member(
+    pool: &SqlitePool,
+    zone_id: &str,
+    renderer_id: &str,
+) -> Result<(), DbError> {
+    sqlx::query("INSERT INTO zone_members (zone_id, renderer_id) VALUES (?, ?)")
+        .bind(zone_id)
+        .bind(renderer_id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "zone_members",
+        })?;
+    Ok(())
+}
+
+pub async fn remove_member(
+    pool: &SqlitePool,
+    zone_id: &str,
+    renderer_id: &str,
+) -> Result<(), DbError> {
+    let result = sqlx::query("DELETE FROM zone_members WHERE zone_id = ? AND renderer_id = ?")
+        .bind(zone_id)
+        .bind(renderer_id)
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "zone_members",
+        })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "zone_members",
+            id: format!("{zone_id}/{renderer_id}"),
+        }
+        .build());
+    }
+    Ok(())
+}
+
+pub async fn list_zones(pool: &SqlitePool) -> Result<Vec<ZoneWithMembers>, DbError> {
+    let zones: Vec<Zone> =
+        sqlx::query_as::<_, Zone>("SELECT id, name, created_at FROM zones ORDER BY name")
+            .fetch_all(pool)
+            .await
+            .context(QuerySnafu { table: "zones" })?;
+
+    let mut result = Vec::with_capacity(zones.len());
+    for zone in zones {
+        let members = members_for_zone(pool, &zone.id).await?;
+        result.push(ZoneWithMembers { zone, members });
+    }
+    Ok(result)
+}
+
+pub async fn get_zone(pool: &SqlitePool, id: &str) -> Result<ZoneWithMembers, DbError> {
+    let zone = get_zone_row(pool, id).await?.ok_or_else(|| {
+        NotFoundSnafu {
+            table: "zones",
+            id: id.to_string(),
+        }
+        .build()
+    })?;
+
+    let members = members_for_zone(pool, id).await?;
+    Ok(ZoneWithMembers { zone, members })
+}
+
+pub async fn get_renderer_zone(
+    pool: &SqlitePool,
+    renderer_id: &str,
+) -> Result<Option<Zone>, DbError> {
+    sqlx::query_as::<_, Zone>(
+        "SELECT z.id, z.name, z.created_at \
+         FROM zones z \
+         JOIN zone_members zm ON zm.zone_id = z.id \
+         WHERE zm.renderer_id = ?",
+    )
+    .bind(renderer_id)
+    .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "zones" })
+}
+
+// -- Renderer CRUD --------------------------------------------------------
+
+pub async fn upsert_renderer(
+    pool: &SqlitePool,
+    id: &str,
+    name: &str,
+    address: &str,
+) -> Result<Renderer, DbError> {
+    sqlx::query(
+        "INSERT INTO renderers (id, name, address) VALUES (?, ?, ?) \
+         ON CONFLICT(id) DO UPDATE SET name = excluded.name, address = excluded.address",
+    )
+    .bind(id)
+    .bind(name)
+    .bind(address)
+    .execute(pool)
+    .await
+    .context(QuerySnafu { table: "renderers" })?;
+
+    sqlx::query_as::<_, Renderer>(
+        "SELECT id, name, address, created_at FROM renderers WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await
+    .context(QuerySnafu { table: "renderers" })
+}
+
+pub async fn list_renderers(pool: &SqlitePool) -> Result<Vec<Renderer>, DbError> {
+    sqlx::query_as::<_, Renderer>(
+        "SELECT id, name, address, created_at FROM renderers ORDER BY name",
+    )
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "renderers" })
+}
+
+// -- helpers --------------------------------------------------------------
+
+async fn get_zone_row(pool: &SqlitePool, id: &str) -> Result<Option<Zone>, DbError> {
+    sqlx::query_as::<_, Zone>("SELECT id, name, created_at FROM zones WHERE id = ?")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+        .context(QuerySnafu { table: "zones" })
+}
+
+async fn members_for_zone(pool: &SqlitePool, zone_id: &str) -> Result<Vec<Renderer>, DbError> {
+    sqlx::query_as::<_, Renderer>(
+        "SELECT r.id, r.name, r.address, r.created_at \
+         FROM renderers r \
+         JOIN zone_members zm ON zm.renderer_id = r.id \
+         WHERE zm.zone_id = ? \
+         ORDER BY r.name",
+    )
+    .bind(zone_id)
+    .fetch_all(pool)
+    .await
+    .context(QuerySnafu { table: "renderers" })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::MIGRATOR;
+
+    async fn setup() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn seed_renderer(pool: &SqlitePool, id: &str, name: &str) {
+        upsert_renderer(pool, id, name, "127.0.0.1:5000")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_and_get_zone() {
+        let pool = setup().await;
+        let zone = create_zone(&pool, "z1", "Living Room").await.unwrap();
+        assert_eq!(zone.name, "Living Room");
+
+        let fetched = get_zone(&pool, "z1").await.unwrap();
+        assert_eq!(fetched.zone.name, "Living Room");
+        assert!(fetched.members.is_empty());
+    }
+
+    #[tokio::test]
+    async fn add_remove_members() {
+        let pool = setup().await;
+        create_zone(&pool, "z1", "Kitchen").await.unwrap();
+        seed_renderer(&pool, "r1", "Speaker A").await;
+        seed_renderer(&pool, "r2", "Speaker B").await;
+
+        add_member(&pool, "z1", "r1").await.unwrap();
+        add_member(&pool, "z1", "r2").await.unwrap();
+
+        let zone = get_zone(&pool, "z1").await.unwrap();
+        assert_eq!(zone.members.len(), 2);
+
+        remove_member(&pool, "z1", "r1").await.unwrap();
+        let zone = get_zone(&pool, "z1").await.unwrap();
+        assert_eq!(zone.members.len(), 1);
+        assert_eq!(zone.members[0].id, "r2");
+    }
+
+    #[tokio::test]
+    async fn delete_zone_cascades_members() {
+        let pool = setup().await;
+        create_zone(&pool, "z1", "Bedroom").await.unwrap();
+        seed_renderer(&pool, "r1", "Speaker").await;
+        add_member(&pool, "z1", "r1").await.unwrap();
+
+        delete_zone(&pool, "z1").await.unwrap();
+
+        let zones = list_zones(&pool).await.unwrap();
+        assert!(zones.is_empty());
+
+        // Renderer still exists after zone deletion
+        let renderers = list_renderers(&pool).await.unwrap();
+        assert_eq!(renderers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn list_zones_with_members() {
+        let pool = setup().await;
+        create_zone(&pool, "z1", "A-Zone").await.unwrap();
+        create_zone(&pool, "z2", "B-Zone").await.unwrap();
+        seed_renderer(&pool, "r1", "Speaker 1").await;
+        add_member(&pool, "z1", "r1").await.unwrap();
+
+        let zones = list_zones(&pool).await.unwrap();
+        assert_eq!(zones.len(), 2);
+        assert_eq!(zones[0].zone.name, "A-Zone");
+        assert_eq!(zones[0].members.len(), 1);
+        assert_eq!(zones[1].zone.name, "B-Zone");
+        assert!(zones[1].members.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_renderer_zone_returns_zone() {
+        let pool = setup().await;
+        create_zone(&pool, "z1", "Office").await.unwrap();
+        seed_renderer(&pool, "r1", "Desk Speaker").await;
+        add_member(&pool, "z1", "r1").await.unwrap();
+
+        let zone = get_renderer_zone(&pool, "r1").await.unwrap();
+        assert!(zone.is_some());
+        assert_eq!(zone.unwrap().name, "Office");
+
+        let none = get_renderer_zone(&pool, "r-unknown").await.unwrap();
+        assert!(none.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_zone_returns_not_found() {
+        let pool = setup().await;
+        let result = delete_zone(&pool, "nope").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn remove_nonexistent_member_returns_not_found() {
+        let pool = setup().await;
+        create_zone(&pool, "z1", "Test").await.unwrap();
+        let result = remove_member(&pool, "z1", "r-nope").await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/harmonia-host/Cargo.toml
+++ b/crates/harmonia-host/Cargo.toml
@@ -24,6 +24,7 @@ ergasia.workspace = true
 syntaxis.workspace = true
 aitesis.workspace = true
 syndesmos.workspace = true
+syndesis.workspace = true
 prostheke.workspace = true
 akouo-core = { workspace = true, features = ["native-output"] }
 clap.workspace = true

--- a/crates/harmonia-host/src/main.rs
+++ b/crates/harmonia-host/src/main.rs
@@ -1,7 +1,7 @@
 mod cli;
 mod error;
 mod play;
-mod render;
+pub mod render;
 mod serve;
 mod shutdown;
 mod startup;

--- a/crates/harmonia-host/src/render/mod.rs
+++ b/crates/harmonia-host/src/render/mod.rs
@@ -5,6 +5,7 @@ pub mod credentials;
 pub mod discovery;
 pub mod error;
 pub mod pipeline;
+pub mod playout;
 pub mod protocol;
 pub mod runner;
 pub mod server;

--- a/crates/harmonia-host/src/render/playout.rs
+++ b/crates/harmonia-host/src/render/playout.rs
@@ -1,0 +1,309 @@
+/// Playout scheduling: receives audio frames with playout timestamps and
+/// schedules output at the correct wall-clock moment for zone-synchronized playback.
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use tracing::{debug, trace, warn};
+
+/// Adaptive buffer target bounds.
+const MIN_BUFFER_DEPTH_MS: u64 = 20;
+const MAX_BUFFER_DEPTH_MS: u64 = 200;
+const INITIAL_BUFFER_DEPTH_MS: u64 = 80;
+
+/// Statistics tracking window for adaptive buffer sizing.
+const STATS_WINDOW: usize = 100;
+
+/// A frame queued for playout at a specific local time.
+#[derive(Debug, Clone)]
+pub struct PlayoutFrame {
+    pub sequence: u64,
+    pub playout_ts: u64,
+    pub timestamp_us: u64,
+    pub payload_len: usize,
+}
+
+/// Outcome of scheduling a frame for playout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlayoutDecision {
+    /// Frame is ready to play now.
+    Play,
+    /// Frame should be held until playout time.
+    Hold { wait_us: u64 },
+    /// Frame arrived too late — playout time already passed.
+    Late { late_by_us: u64 },
+}
+
+/// Renderer-side playout pipeline: converts server playout timestamps to local
+/// scheduled output times using clock offset.
+#[derive(Debug)]
+pub struct PlayoutPipeline {
+    clock_offset_us: i64,
+    buffer_target_us: u64,
+    pending: VecDeque<PlayoutFrame>,
+    underrun_count: u64,
+    early_count: u64,
+    late_history: VecDeque<bool>,
+}
+
+impl PlayoutPipeline {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            clock_offset_us: 0,
+            buffer_target_us: INITIAL_BUFFER_DEPTH_MS * 1000,
+            pending: VecDeque::new(),
+            underrun_count: 0,
+            early_count: 0,
+            late_history: VecDeque::with_capacity(STATS_WINDOW),
+        }
+    }
+
+    /// Update the clock offset (server-to-local difference in microseconds).
+    pub fn set_clock_offset(&mut self, offset_us: i64) {
+        self.clock_offset_us = offset_us;
+    }
+
+    /// Enqueue a frame for playout scheduling.
+    pub fn enqueue(&mut self, frame: PlayoutFrame) {
+        self.pending.push_back(frame);
+    }
+
+    /// Evaluate the next frame against the current local time.
+    ///
+    /// `local_now_us` is the current monotonic time in microseconds.
+    #[must_use]
+    pub fn evaluate(&self, local_now_us: u64) -> Option<PlayoutDecision> {
+        let frame = self.pending.front()?;
+
+        if frame.playout_ts == 0 {
+            return Some(PlayoutDecision::Play);
+        }
+
+        // WHY: Convert server playout timestamp to local time by subtracting the
+        // server's clock offset. If server clock is ahead (positive offset),
+        // local playout time is earlier.
+        let local_playout = (frame.playout_ts as i64 - self.clock_offset_us) as u64;
+
+        if local_now_us >= local_playout {
+            let late_by = local_now_us - local_playout;
+            if late_by > self.buffer_target_us {
+                Some(PlayoutDecision::Late {
+                    late_by_us: late_by,
+                })
+            } else {
+                Some(PlayoutDecision::Play)
+            }
+        } else {
+            let wait = local_playout - local_now_us;
+            Some(PlayoutDecision::Hold { wait_us: wait })
+        }
+    }
+
+    /// Dequeue the next frame after deciding to play or skip it.
+    pub fn dequeue(&mut self) -> Option<PlayoutFrame> {
+        self.pending.pop_front()
+    }
+
+    /// Process frames: play ready ones, skip late ones, wait for early ones.
+    /// Returns frames ready to play and the wait duration before checking again.
+    pub fn process(&mut self, local_now_us: u64) -> (Vec<PlayoutFrame>, Option<Duration>) {
+        let mut ready = Vec::new();
+
+        loop {
+            match self.evaluate(local_now_us) {
+                Some(PlayoutDecision::Play) => {
+                    if let Some(frame) = self.dequeue() {
+                        self.record_timing(false);
+                        ready.push(frame);
+                    }
+                }
+                Some(PlayoutDecision::Late { late_by_us }) => {
+                    if let Some(frame) = self.dequeue() {
+                        warn!(
+                            sequence = frame.sequence,
+                            late_by_us, "frame underrun: skipping late frame"
+                        );
+                        self.underrun_count += 1;
+                        self.record_timing(true);
+                    }
+                }
+                Some(PlayoutDecision::Hold { wait_us }) => {
+                    self.early_count += 1;
+                    let wait = Duration::from_micros(wait_us.min(10_000));
+                    return (ready, Some(wait));
+                }
+                None => {
+                    return (ready, None);
+                }
+            }
+        }
+    }
+
+    fn record_timing(&mut self, was_late: bool) {
+        if self.late_history.len() >= STATS_WINDOW {
+            self.late_history.pop_front();
+        }
+        self.late_history.push_back(was_late);
+        self.adapt_buffer();
+    }
+
+    /// Adaptive buffer depth: increase on consistent lateness, decrease on consistency.
+    fn adapt_buffer(&mut self) {
+        if self.late_history.len() < 20 {
+            return;
+        }
+
+        let late_ratio = self.late_history.iter().filter(|&&l| l).count() as f64
+            / self.late_history.len() as f64;
+
+        if late_ratio > 0.1 {
+            let increase = (self.buffer_target_us / 10).max(5_000);
+            let new_target = (self.buffer_target_us + increase).min(MAX_BUFFER_DEPTH_MS * 1000);
+            if new_target != self.buffer_target_us {
+                debug!(
+                    old_ms = self.buffer_target_us / 1000,
+                    new_ms = new_target / 1000,
+                    late_ratio,
+                    "increasing buffer target due to late frames"
+                );
+                self.buffer_target_us = new_target;
+            }
+        } else if late_ratio < 0.01 && self.buffer_target_us > MIN_BUFFER_DEPTH_MS * 1000 {
+            let decrease = (self.buffer_target_us / 20).max(1_000);
+            let new_target = self
+                .buffer_target_us
+                .saturating_sub(decrease)
+                .max(MIN_BUFFER_DEPTH_MS * 1000);
+            if new_target != self.buffer_target_us {
+                trace!(
+                    old_ms = self.buffer_target_us / 1000,
+                    new_ms = new_target / 1000,
+                    "decreasing buffer target -- running smoothly"
+                );
+                self.buffer_target_us = new_target;
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn underrun_count(&self) -> u64 {
+        self.underrun_count
+    }
+
+    #[must_use]
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+
+    #[must_use]
+    pub fn buffer_target_ms(&self) -> u64 {
+        self.buffer_target_us / 1000
+    }
+}
+
+impl Default for PlayoutPipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(seq: u64, playout: u64) -> PlayoutFrame {
+        PlayoutFrame {
+            sequence: seq,
+            playout_ts: playout,
+            timestamp_us: playout.saturating_sub(10_000),
+            payload_len: 1024,
+        }
+    }
+
+    #[test]
+    fn play_when_on_time() {
+        let mut pipe = PlayoutPipeline::new();
+        pipe.enqueue(frame(0, 1_000_000));
+        let decision = pipe.evaluate(1_000_000);
+        assert_eq!(decision, Some(PlayoutDecision::Play));
+    }
+
+    #[test]
+    fn hold_when_early() {
+        let mut pipe = PlayoutPipeline::new();
+        pipe.enqueue(frame(0, 1_000_000));
+        let decision = pipe.evaluate(900_000);
+        assert!(matches!(decision, Some(PlayoutDecision::Hold { .. })));
+        if let Some(PlayoutDecision::Hold { wait_us }) = decision {
+            assert_eq!(wait_us, 100_000);
+        }
+    }
+
+    #[test]
+    fn late_when_very_late() {
+        let mut pipe = PlayoutPipeline::new();
+        pipe.set_clock_offset(0);
+        pipe.enqueue(frame(0, 100_000));
+        let decision = pipe.evaluate(500_000);
+        assert!(matches!(decision, Some(PlayoutDecision::Late { .. })));
+    }
+
+    #[test]
+    fn zero_playout_ts_plays_immediately() {
+        let mut pipe = PlayoutPipeline::new();
+        pipe.enqueue(PlayoutFrame {
+            sequence: 0,
+            playout_ts: 0,
+            timestamp_us: 0,
+            payload_len: 128,
+        });
+        assert_eq!(pipe.evaluate(0), Some(PlayoutDecision::Play));
+    }
+
+    #[test]
+    fn clock_offset_adjusts_playout() {
+        let mut pipe = PlayoutPipeline::new();
+        pipe.set_clock_offset(1000);
+        pipe.enqueue(frame(0, 1_001_000));
+
+        // Local time 1_000_000: server says play at 1_001_000, but server is 1000us
+        // ahead, so local playout = 1_001_000 - 1000 = 1_000_000
+        assert_eq!(pipe.evaluate(1_000_000), Some(PlayoutDecision::Play));
+    }
+
+    #[test]
+    fn process_returns_ready_frames() {
+        let mut pipe = PlayoutPipeline::new();
+        pipe.enqueue(frame(0, 100));
+        pipe.enqueue(frame(1, 200));
+        pipe.enqueue(frame(2, 1_000_000));
+
+        let (ready, wait) = pipe.process(500);
+        assert_eq!(ready.len(), 2);
+        assert_eq!(ready[0].sequence, 0);
+        assert_eq!(ready[1].sequence, 1);
+        assert!(wait.is_some());
+    }
+
+    #[test]
+    fn empty_pipeline_returns_none() {
+        let pipe = PlayoutPipeline::new();
+        assert_eq!(pipe.evaluate(1_000_000), None);
+    }
+
+    #[test]
+    fn adaptive_buffer_increases_on_late_frames() {
+        let mut pipe = PlayoutPipeline::new();
+        let initial = pipe.buffer_target_ms();
+
+        for i in 0..30 {
+            pipe.enqueue(frame(i, 100));
+        }
+        let _ = pipe.process(500_000);
+
+        assert!(
+            pipe.buffer_target_ms() >= initial,
+            "buffer should increase or stay after late frames"
+        );
+    }
+}

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -29,6 +29,7 @@ md5 = "0.8"
 sqlx.workspace = true
 mdns-sd.workspace = true
 jiff.workspace = true
+ulid.workspace = true
 
 [dev-dependencies]
 sqlx.workspace = true

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -44,6 +44,7 @@ pub fn build_router(state: AppState) -> Router {
         .nest("/api/renderers", routes::renderer::renderer_routes())
         .merge(routes::stream::stream_routes())
         .nest("/rest", subsonic::subsonic_routes())
+        .nest("/api/zones", routes::zone::zone_routes())
         .route("/api/ws", axum::routing::get(ws_handler))
         .layer(RequestIdLayer)
         .layer(TraceLayer::new_for_http())

--- a/crates/paroche/src/routes/mod.rs
+++ b/crates/paroche/src/routes/mod.rs
@@ -17,3 +17,4 @@ pub mod system;
 pub mod tv;
 pub mod user;
 pub mod wanted;
+pub mod zone;

--- a/crates/paroche/src/routes/zone.rs
+++ b/crates/paroche/src/routes/zone.rs
@@ -1,0 +1,334 @@
+/// Zone management API for multi-room synchronized playback.
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::ParocheError,
+    response::{ApiResponse, deleted},
+    state::AppState,
+};
+use harmonia_db::repo::zone;
+
+#[derive(Serialize)]
+pub struct RendererResponse {
+    pub id: String,
+    pub name: String,
+    pub address: String,
+    pub created_at: String,
+}
+
+impl From<zone::Renderer> for RendererResponse {
+    fn from(r: zone::Renderer) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            address: r.address,
+            created_at: r.created_at,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct ZoneResponse {
+    pub id: String,
+    pub name: String,
+    pub created_at: String,
+    pub members: Vec<RendererResponse>,
+}
+
+impl From<zone::ZoneWithMembers> for ZoneResponse {
+    fn from(z: zone::ZoneWithMembers) -> Self {
+        Self {
+            id: z.zone.id,
+            name: z.zone.name,
+            created_at: z.zone.created_at,
+            members: z.members.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateZoneBody {
+    pub name: String,
+}
+
+#[derive(Deserialize)]
+pub struct AddMemberBody {
+    pub renderer_id: String,
+}
+
+pub async fn create_zone(
+    State(state): State<AppState>,
+    Json(body): Json<CreateZoneBody>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.name.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "name is required".to_string(),
+        });
+    }
+
+    let id = ulid::Ulid::new().to_string();
+    let created = zone::create_zone(&state.db.write, &id, body.name.trim()).await?;
+    let with_members = zone::ZoneWithMembers {
+        zone: created,
+        members: vec![],
+    };
+    Ok(ApiResponse::created(ZoneResponse::from(with_members)))
+}
+
+pub async fn delete_zone(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    zone::delete_zone(&state.db.write, &id).await?;
+    Ok(deleted())
+}
+
+pub async fn list_zones(
+    State(state): State<AppState>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let zones = zone::list_zones(&state.db.read).await?;
+    let data: Vec<ZoneResponse> = zones.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::ok(data))
+}
+
+pub async fn get_zone(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let z = zone::get_zone(&state.db.read, &id).await?;
+    Ok(ApiResponse::ok(ZoneResponse::from(z)))
+}
+
+pub async fn add_member(
+    State(state): State<AppState>,
+    Path(zone_id): Path<String>,
+    Json(body): Json<AddMemberBody>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    if body.renderer_id.trim().is_empty() {
+        return Err(ParocheError::Validation {
+            message: "renderer_id is required".to_string(),
+        });
+    }
+
+    zone::add_member(&state.db.write, &zone_id, body.renderer_id.trim()).await?;
+    let z = zone::get_zone(&state.db.read, &zone_id).await?;
+    Ok(ApiResponse::ok(ZoneResponse::from(z)))
+}
+
+pub async fn remove_member(
+    State(state): State<AppState>,
+    Path((zone_id, renderer_id)): Path<(String, String)>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    zone::remove_member(&state.db.write, &zone_id, &renderer_id).await?;
+    Ok(deleted())
+}
+
+pub async fn zone_play(
+    State(_state): State<AppState>,
+    Path(_zone_id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    // WHY: Playback initiation requires the streaming subsystem (syndesis).
+    // Full implementation connects to all zone renderers and starts fan-out streaming.
+    // Wired up once syndesis is integrated into the server runtime.
+    Ok(ApiResponse::ok(serde_json::json!({ "status": "playing" })))
+}
+
+pub async fn zone_pause(
+    State(_state): State<AppState>,
+    Path(_zone_id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    Ok(ApiResponse::ok(serde_json::json!({ "status": "paused" })))
+}
+
+pub async fn zone_resume(
+    State(_state): State<AppState>,
+    Path(_zone_id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    Ok(ApiResponse::ok(serde_json::json!({ "status": "playing" })))
+}
+
+pub fn zone_routes() -> axum::Router<AppState> {
+    use axum::routing::{get, post};
+    axum::Router::new()
+        .route("/", get(list_zones).post(create_zone))
+        .route("/{id}", get(get_zone).delete(delete_zone))
+        .route("/{id}/members", post(add_member))
+        .route(
+            "/{id}/members/{renderer_id}",
+            axum::routing::delete(remove_member),
+        )
+        .route("/{id}/play", post(zone_play))
+        .route("/{id}/pause", post(zone_pause))
+        .route("/{id}/resume", post(zone_resume))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::test_helpers::test_state;
+
+    #[tokio::test]
+    async fn zone_crud_lifecycle() {
+        let (state, _) = test_state().await;
+
+        // Seed a renderer directly
+        harmonia_db::repo::zone::upsert_renderer(
+            &state.db.write,
+            "r1",
+            "Speaker",
+            "127.0.0.1:5000",
+        )
+        .await
+        .unwrap();
+
+        let app = crate::build_router(state);
+
+        // Create zone
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/zones")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"name":"Living Room"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let zone_id = body["data"]["id"].as_str().unwrap().to_string();
+        assert_eq!(body["data"]["name"], "Living Room");
+        assert!(body["data"]["members"].as_array().unwrap().is_empty());
+
+        // List zones
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/zones")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["data"].as_array().unwrap().len(), 1);
+
+        // Add member
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/zones/{zone_id}/members"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"renderer_id":"r1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["data"]["members"].as_array().unwrap().len(), 1);
+
+        // Get zone
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/zones/{zone_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Remove member
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/zones/{zone_id}/members/r1"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        // Delete zone
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/zones/{zone_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn zone_playback_controls() {
+        let (state, _) = test_state().await;
+        harmonia_db::repo::zone::upsert_renderer(
+            &state.db.write,
+            "r1",
+            "Speaker",
+            "127.0.0.1:5000",
+        )
+        .await
+        .unwrap();
+        harmonia_db::repo::zone::create_zone(&state.db.write, "z1", "Test Zone")
+            .await
+            .unwrap();
+        harmonia_db::repo::zone::add_member(&state.db.write, "z1", "r1")
+            .await
+            .unwrap();
+
+        let app = crate::build_router(state);
+
+        for endpoint in [
+            "/api/zones/z1/play",
+            "/api/zones/z1/pause",
+            "/api/zones/z1/resume",
+        ] {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(endpoint)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "failed for {endpoint}");
+        }
+    }
+}

--- a/crates/syndesis/src/client/buffer.rs
+++ b/crates/syndesis/src/client/buffer.rs
@@ -135,6 +135,7 @@ mod tests {
         AudioFrame {
             sequence: seq,
             timestamp_us,
+            playout_ts: 0,
             codec: AudioCodec::Pcm,
             channels: 2,
             sample_rate: 48000,

--- a/crates/syndesis/src/clock/coordinator.rs
+++ b/crates/syndesis/src/clock/coordinator.rs
@@ -1,0 +1,287 @@
+/// Multi-renderer clock coordination for zone-synchronized playback.
+use std::collections::HashMap;
+
+use tracing::{debug, info};
+
+use super::ClockEstimator;
+
+/// Default buffer margin added to playout time to absorb jitter.
+const BUFFER_MARGIN_US: i64 = 10_000;
+
+/// Coordinates clock state across all renderers in a zone, computing a unified
+/// playout timestamp so every renderer outputs the same sample at the same
+/// wall-clock moment.
+#[derive(Debug)]
+pub struct ClockCoordinator {
+    /// Per-renderer clock estimators, keyed by renderer ID.
+    estimators: HashMap<String, ClockEstimator>,
+    /// Additional margin added to the worst-case offset to absorb jitter.
+    buffer_margin_us: i64,
+}
+
+/// Snapshot of a single renderer's clock state within the coordinator.
+#[derive(Debug, Clone)]
+pub struct RendererClockState {
+    pub renderer_id: String,
+    pub offset_us: i64,
+    pub is_stable: bool,
+    pub drift_rate: f64,
+}
+
+impl ClockCoordinator {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            estimators: HashMap::new(),
+            buffer_margin_us: BUFFER_MARGIN_US,
+        }
+    }
+
+    #[must_use]
+    pub fn with_margin(buffer_margin_us: i64) -> Self {
+        Self {
+            estimators: HashMap::new(),
+            buffer_margin_us,
+        }
+    }
+
+    /// Register a renderer in the zone. Creates a fresh estimator.
+    pub fn add_renderer(&mut self, renderer_id: &str) {
+        self.estimators.entry(renderer_id.to_string()).or_default();
+        info!(%renderer_id, "renderer added to clock coordinator");
+    }
+
+    /// Remove a renderer from the zone.
+    pub fn remove_renderer(&mut self, renderer_id: &str) {
+        self.estimators.remove(renderer_id);
+        info!(%renderer_id, "renderer removed from clock coordinator");
+    }
+
+    /// Record a clock sync exchange for a specific renderer.
+    pub fn record_exchange(
+        &mut self,
+        renderer_id: &str,
+        originate: u64,
+        receive: u64,
+        transmit: u64,
+        destination: u64,
+    ) {
+        if let Some(est) = self.estimators.get_mut(renderer_id) {
+            est.record_exchange(originate, receive, transmit, destination);
+            debug!(
+                %renderer_id,
+                offset_us = est.offset_us(),
+                stable = est.is_stable(),
+                "renderer clock updated"
+            );
+        }
+    }
+
+    /// Compute the playout timestamp for a frame with the given server-side timestamp.
+    ///
+    /// The playout time is: `server_time + max(all_renderer_offsets) + buffer_margin`.
+    /// Each renderer then adjusts locally: `playout_ts - renderer_offset` gives
+    /// the local-clock moment to output the frame.
+    ///
+    /// Returns `None` if no renderers are registered.
+    #[must_use]
+    pub fn compute_playout_ts(&self, server_timestamp_us: u64) -> Option<u64> {
+        if self.estimators.is_empty() {
+            return None;
+        }
+
+        // WHY: The renderer whose clock is furthest ahead defines the worst-case
+        // offset. All other renderers must wait at least that long, plus margin.
+        let max_offset = self
+            .estimators
+            .values()
+            .map(|e| e.offset_us())
+            .max()
+            .unwrap_or(0);
+
+        let playout = server_timestamp_us as i64 + max_offset.abs() + self.buffer_margin_us;
+        Some(playout.max(0) as u64)
+    }
+
+    /// Per-renderer adjustment: how much a given renderer should shift its playout
+    /// time relative to the zone-wide playout timestamp.
+    ///
+    /// Returns offset in microseconds. Positive means the renderer should delay.
+    #[must_use]
+    pub fn renderer_adjustment(&self, renderer_id: &str) -> i64 {
+        let max_offset = self
+            .estimators
+            .values()
+            .map(|e| e.offset_us())
+            .max()
+            .unwrap_or(0)
+            .abs();
+
+        let renderer_offset = self
+            .estimators
+            .get(renderer_id)
+            .map_or(0, |e| e.offset_us());
+
+        // WHY: If this renderer's clock is behind the worst-case, it needs extra delay.
+        max_offset - renderer_offset.abs()
+    }
+
+    /// Snapshot of all renderer clock states.
+    #[must_use]
+    pub fn renderer_states(&self) -> Vec<RendererClockState> {
+        self.estimators
+            .iter()
+            .map(|(id, est)| RendererClockState {
+                renderer_id: id.clone(),
+                offset_us: est.offset_us(),
+                is_stable: est.is_stable(),
+                drift_rate: est.drift_rate(),
+            })
+            .collect()
+    }
+
+    /// Whether all renderers in the zone have stable clock estimates.
+    #[must_use]
+    pub fn all_stable(&self) -> bool {
+        !self.estimators.is_empty() && self.estimators.values().all(|e| e.is_stable())
+    }
+
+    /// Number of renderers in the zone.
+    #[must_use]
+    pub fn renderer_count(&self) -> usize {
+        self.estimators.len()
+    }
+
+    /// Get the estimator for a specific renderer.
+    #[must_use]
+    pub fn estimator(&self, renderer_id: &str) -> Option<&ClockEstimator> {
+        self.estimators.get(renderer_id)
+    }
+
+    /// Get a mutable estimator for a specific renderer.
+    pub fn estimator_mut(&mut self, renderer_id: &str) -> Option<&mut ClockEstimator> {
+        self.estimators.get_mut(renderer_id)
+    }
+}
+
+impl Default for ClockCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feed_estimator(est: &mut ClockEstimator, offset: i64, count: usize) {
+        for i in 0..count {
+            let base = (i as u64) * 100_000;
+            let originate = base;
+            let receive = (base as i64 + 500 + offset) as u64;
+            let transmit = (base as i64 + 600 + offset) as u64;
+            let destination = base + 1100;
+            est.record_exchange(originate, receive, transmit, destination);
+        }
+    }
+
+    #[test]
+    fn computes_playout_for_three_renderers() {
+        let mut coord = ClockCoordinator::with_margin(5_000);
+        coord.add_renderer("r1");
+        coord.add_renderer("r2");
+        coord.add_renderer("r3");
+
+        // Feed different offsets: r1=0, r2=+2000, r3=-1000
+        for i in 0..10 {
+            let base = (i as u64) * 100_000;
+            coord.record_exchange("r1", base, base + 500, base + 600, base + 1100);
+            coord.record_exchange("r2", base, base + 2500, base + 2600, base + 1100);
+            coord.record_exchange(
+                "r3",
+                base,
+                (base as i64 + 500 - 1000) as u64,
+                (base as i64 + 600 - 1000) as u64,
+                base + 1100,
+            );
+        }
+
+        let playout = coord.compute_playout_ts(1_000_000);
+        assert!(playout.is_some());
+        let ts = playout.unwrap();
+        // Should be server_time + max(abs offsets) + margin
+        assert!(
+            ts > 1_000_000,
+            "playout {ts} should be after server timestamp"
+        );
+    }
+
+    #[test]
+    fn empty_coordinator_returns_none() {
+        let coord = ClockCoordinator::new();
+        assert!(coord.compute_playout_ts(1_000_000).is_none());
+    }
+
+    #[test]
+    fn add_remove_renderer() {
+        let mut coord = ClockCoordinator::new();
+        coord.add_renderer("r1");
+        coord.add_renderer("r2");
+        assert_eq!(coord.renderer_count(), 2);
+
+        coord.remove_renderer("r1");
+        assert_eq!(coord.renderer_count(), 1);
+    }
+
+    #[test]
+    fn all_stable_requires_convergence() {
+        let mut coord = ClockCoordinator::new();
+        coord.add_renderer("r1");
+        assert!(!coord.all_stable(), "fresh estimator should not be stable");
+
+        if let Some(est) = coord.estimator_mut("r1") {
+            feed_estimator(est, 0, 10);
+        }
+        assert!(coord.all_stable());
+    }
+
+    #[test]
+    fn renderer_states_snapshot() {
+        let mut coord = ClockCoordinator::new();
+        coord.add_renderer("r1");
+        coord.add_renderer("r2");
+
+        if let Some(est) = coord.estimator_mut("r1") {
+            feed_estimator(est, 1000, 10);
+        }
+        if let Some(est) = coord.estimator_mut("r2") {
+            feed_estimator(est, -500, 10);
+        }
+
+        let states = coord.renderer_states();
+        assert_eq!(states.len(), 2);
+    }
+
+    #[test]
+    fn renderer_adjustment_compensates_offset_difference() {
+        let mut coord = ClockCoordinator::with_margin(0);
+        coord.add_renderer("fast");
+        coord.add_renderer("slow");
+
+        if let Some(est) = coord.estimator_mut("fast") {
+            feed_estimator(est, 3000, 10);
+        }
+        if let Some(est) = coord.estimator_mut("slow") {
+            feed_estimator(est, 0, 10);
+        }
+
+        let fast_adj = coord.renderer_adjustment("fast");
+        let slow_adj = coord.renderer_adjustment("slow");
+
+        // The fast renderer needs less additional delay than the slow one
+        assert!(
+            slow_adj > fast_adj,
+            "slow renderer ({slow_adj}) should need more adjustment than fast ({fast_adj})"
+        );
+    }
+}

--- a/crates/syndesis/src/clock/estimator.rs
+++ b/crates/syndesis/src/clock/estimator.rs
@@ -1,14 +1,21 @@
-/// NTP-style round-trip clock offset estimator.
+/// NTP-style round-trip clock offset estimator with weighted median and drift tracking.
 use std::collections::VecDeque;
 
-const WINDOW_SIZE: usize = 20;
+use tracing::{error, warn};
+
+const WINDOW_SIZE: usize = 50;
 const OUTLIER_FACTOR: u64 = 2;
+const WARN_OFFSET_US: i64 = 5_000;
+const ERROR_OFFSET_US: i64 = 20_000;
 
 #[derive(Debug)]
 pub struct ClockEstimator {
     samples: VecDeque<Sample>,
     current_offset: i64,
     is_stable: bool,
+    drift_rate: f64,
+    last_drift_ts: Option<u64>,
+    last_drift_offset: Option<i64>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -24,6 +31,9 @@ impl ClockEstimator {
             samples: VecDeque::with_capacity(WINDOW_SIZE),
             current_offset: 0,
             is_stable: false,
+            drift_rate: 0.0,
+            last_drift_ts: None,
+            last_drift_offset: None,
         }
     }
 
@@ -55,6 +65,8 @@ impl ClockEstimator {
         self.samples.push_back(sample);
 
         self.recompute();
+        self.update_drift(destination);
+        self.check_alarm();
     }
 
     fn recompute(&mut self) {
@@ -65,21 +77,53 @@ impl ClockEstimator {
         let median_rtt = self.median_rtt();
         let threshold = median_rtt.saturating_mul(OUTLIER_FACTOR);
 
-        let mut filtered_offsets: Vec<i64> = self
-            .samples
-            .iter()
-            .filter(|s| s.rtt <= threshold)
-            .map(|s| s.offset)
-            .collect();
+        let filtered: Vec<&Sample> = self.samples.iter().filter(|s| s.rtt <= threshold).collect();
 
-        if filtered_offsets.is_empty() {
-            filtered_offsets = self.samples.iter().map(|s| s.offset).collect();
+        let samples_to_use: Vec<&Sample> = if filtered.is_empty() {
+            self.samples.iter().collect()
+        } else {
+            filtered
+        };
+
+        self.current_offset = weighted_median(&samples_to_use);
+
+        self.is_stable = self.samples.len() >= 5 && self.offset_spread(&samples_to_use) < 1000;
+    }
+
+    fn update_drift(&mut self, now_ts: u64) {
+        match (self.last_drift_ts, self.last_drift_offset) {
+            (Some(prev_ts), Some(prev_offset)) => {
+                let dt = now_ts.saturating_sub(prev_ts);
+                if dt > 0 {
+                    let d_offset = self.current_offset - prev_offset;
+                    // WHY: Drift rate in microseconds-per-microsecond. Exponential smoothing
+                    // prevents single-sample noise from dominating the estimate.
+                    let instantaneous = d_offset as f64 / dt as f64;
+                    self.drift_rate = self.drift_rate * 0.8 + instantaneous * 0.2;
+                }
+                self.last_drift_ts = Some(now_ts);
+                self.last_drift_offset = Some(self.current_offset);
+            }
+            _ => {
+                self.last_drift_ts = Some(now_ts);
+                self.last_drift_offset = Some(self.current_offset);
+            }
         }
+    }
 
-        filtered_offsets.sort_unstable();
-        self.current_offset = median_of_sorted(&filtered_offsets);
-
-        self.is_stable = self.samples.len() >= 5 && self.offset_spread(&filtered_offsets) < 1000;
+    fn check_alarm(&self) {
+        let abs = self.current_offset.unsigned_abs() as i64;
+        if abs > ERROR_OFFSET_US {
+            error!(
+                offset_us = self.current_offset,
+                "clock offset exceeds 20ms threshold"
+            );
+        } else if abs > WARN_OFFSET_US {
+            warn!(
+                offset_us = self.current_offset,
+                "clock offset exceeds 5ms threshold"
+            );
+        }
     }
 
     fn median_rtt(&self) -> u64 {
@@ -88,10 +132,12 @@ impl ClockEstimator {
         median_of_sorted_u64(&rtts)
     }
 
-    fn offset_spread(&self, offsets: &[i64]) -> u64 {
-        if offsets.len() < 2 {
+    fn offset_spread(&self, samples: &[&Sample]) -> u64 {
+        if samples.len() < 2 {
             return 0;
         }
+        let mut offsets: Vec<i64> = samples.iter().map(|s| s.offset).collect();
+        offsets.sort_unstable();
         let min = offsets[0];
         let max = offsets[offsets.len() - 1];
         (max - min).unsigned_abs()
@@ -102,6 +148,24 @@ impl ClockEstimator {
     #[must_use]
     pub fn offset_us(&self) -> i64 {
         self.current_offset
+    }
+
+    /// Extrapolate offset to a future timestamp using the drift rate.
+    #[must_use]
+    pub fn extrapolate_offset(&self, target_ts: u64) -> i64 {
+        match self.last_drift_ts {
+            Some(last_ts) if target_ts > last_ts => {
+                let dt = target_ts - last_ts;
+                self.current_offset + (self.drift_rate * dt as f64) as i64
+            }
+            _ => self.current_offset,
+        }
+    }
+
+    /// Current drift rate in microseconds per microsecond (ppm-scale).
+    #[must_use]
+    pub fn drift_rate(&self) -> f64 {
+        self.drift_rate
     }
 
     /// Whether the estimator has converged to a stable offset.
@@ -123,16 +187,38 @@ impl Default for ClockEstimator {
     }
 }
 
-fn median_of_sorted(values: &[i64]) -> i64 {
-    let len = values.len();
-    if len == 0 {
+/// Compute weighted median where weights are inverse RTT.
+/// Lower-RTT samples are more trustworthy because asymmetric delays are smaller.
+fn weighted_median(samples: &[&Sample]) -> i64 {
+    if samples.is_empty() {
         return 0;
     }
-    if len % 2 == 1 {
-        values[len / 2]
-    } else {
-        (values[len / 2 - 1] + values[len / 2]) / 2
+    if samples.len() == 1 {
+        return samples[0].offset;
     }
+
+    let mut entries: Vec<(i64, f64)> = samples
+        .iter()
+        .map(|s| {
+            let weight = if s.rtt == 0 { 1.0 } else { 1.0 / s.rtt as f64 };
+            (s.offset, weight)
+        })
+        .collect();
+
+    entries.sort_unstable_by_key(|(offset, _)| *offset);
+
+    let total_weight: f64 = entries.iter().map(|(_, w)| w).sum();
+    let half = total_weight / 2.0;
+    let mut cumulative = 0.0;
+
+    for (offset, weight) in &entries {
+        cumulative += weight;
+        if cumulative >= half {
+            return *offset;
+        }
+    }
+
+    entries.last().map_or(0, |(offset, _)| *offset)
 }
 
 fn median_of_sorted_u64(values: &[u64]) -> u64 {
@@ -221,10 +307,81 @@ mod tests {
     #[test]
     fn sliding_window_evicts_old_samples() {
         let mut est = ClockEstimator::new();
-        for i in 0..30 {
+        for i in 0..60 {
             let base = i * 100_000;
             est.record_exchange(base, base + 500, base + 600, base + 1100);
         }
         assert_eq!(est.sample_count(), WINDOW_SIZE);
+    }
+
+    #[test]
+    fn weighted_median_favors_low_rtt() {
+        let samples = [
+            Sample {
+                offset: 100,
+                rtt: 1000,
+            },
+            Sample {
+                offset: 100,
+                rtt: 1000,
+            },
+            Sample {
+                offset: 100,
+                rtt: 1000,
+            },
+            // High-RTT sample with different offset should be outweighed
+            Sample {
+                offset: 9000,
+                rtt: 50_000,
+            },
+        ];
+        let refs: Vec<&Sample> = samples.iter().collect();
+        let result = weighted_median(&refs);
+        assert!(
+            (result - 100).unsigned_abs() < 200,
+            "weighted median should favor low-RTT samples, got {result}"
+        );
+    }
+
+    #[test]
+    fn drift_rate_tracks_linear_drift() {
+        let mut est = ClockEstimator::new();
+        // Simulate 10ppm drift: offset grows by 1us per 100_000us interval
+        for i in 0..30u64 {
+            let base = i * 100_000;
+            let drift = i as i64;
+            let originate = base;
+            let receive = (base as i64 + 500 + drift) as u64;
+            let transmit = (base as i64 + 600 + drift) as u64;
+            let destination = base + 1100;
+            est.record_exchange(originate, receive, transmit, destination);
+        }
+        // Drift rate should be positive (offset increasing over time)
+        assert!(
+            est.drift_rate() > 0.0,
+            "drift rate should be positive, got {}",
+            est.drift_rate()
+        );
+    }
+
+    #[test]
+    fn extrapolate_offset_projects_forward() {
+        let mut est = ClockEstimator::new();
+        for i in 0..20u64 {
+            let base = i * 100_000;
+            let drift = i as i64 * 10;
+            let originate = base;
+            let receive = (base as i64 + 500 + drift) as u64;
+            let transmit = (base as i64 + 600 + drift) as u64;
+            let destination = base + 1100;
+            est.record_exchange(originate, receive, transmit, destination);
+        }
+        let current = est.offset_us();
+        let future = est.extrapolate_offset(20 * 100_000 + 1_000_000);
+        // With positive drift, future extrapolation should be >= current
+        assert!(
+            future >= current,
+            "extrapolated {future} should be >= current {current}"
+        );
     }
 }

--- a/crates/syndesis/src/clock/mod.rs
+++ b/crates/syndesis/src/clock/mod.rs
@@ -1,6 +1,8 @@
 /// Clock synchronization for multi-room streaming.
+pub mod coordinator;
 pub mod estimator;
 pub mod scheduler;
 
+pub use coordinator::ClockCoordinator;
 pub use estimator::ClockEstimator;
 pub use scheduler::SyncScheduler;

--- a/crates/syndesis/src/protocol/codec.rs
+++ b/crates/syndesis/src/protocol/codec.rs
@@ -108,6 +108,7 @@ fn encode_audio_frame(buf: &mut BytesMut, f: &AudioFrame) {
     buf.put_u8(FrameType::AudioFrame as u8);
     buf.put_u64(f.sequence);
     buf.put_u64(f.timestamp_us);
+    buf.put_u64(f.playout_ts);
     buf.put_u8(f.codec as u8);
     buf.put_u8(f.channels);
     buf.put_u32(f.sample_rate);
@@ -117,7 +118,7 @@ fn encode_audio_frame(buf: &mut BytesMut, f: &AudioFrame) {
 
 fn decode_audio_frame(buf: &mut Bytes) -> Result<AudioFrame, error::SyndesisError> {
     ensure!(
-        buf.remaining() >= 8 + 8 + 1 + 1 + 4 + 4,
+        buf.remaining() >= 8 + 8 + 8 + 1 + 1 + 4 + 4,
         error::ProtocolSnafu {
             reason: "audio frame header too short"
         }
@@ -125,6 +126,7 @@ fn decode_audio_frame(buf: &mut Bytes) -> Result<AudioFrame, error::SyndesisErro
 
     let sequence = buf.get_u64();
     let timestamp_us = buf.get_u64();
+    let playout_ts = buf.get_u64();
     let codec_byte = buf.get_u8();
     let channels = buf.get_u8();
     let sample_rate = buf.get_u32();
@@ -149,6 +151,7 @@ fn decode_audio_frame(buf: &mut Bytes) -> Result<AudioFrame, error::SyndesisErro
     Ok(AudioFrame {
         sequence,
         timestamp_us,
+        playout_ts,
         codec,
         channels,
         sample_rate,
@@ -396,6 +399,7 @@ mod tests {
         let original = Frame::Audio(AudioFrame {
             sequence: 42,
             timestamp_us: 1_000_000,
+            playout_ts: 1_010_000,
             codec: AudioCodec::Flac,
             channels: 2,
             sample_rate: 44100,
@@ -493,6 +497,7 @@ mod tests {
         let original = Frame::Audio(AudioFrame {
             sequence: 0,
             timestamp_us: 0,
+            playout_ts: 0,
             codec: AudioCodec::Pcm,
             channels: 1,
             sample_rate: 16000,

--- a/crates/syndesis/src/protocol/frame.rs
+++ b/crates/syndesis/src/protocol/frame.rs
@@ -7,6 +7,8 @@ use super::{AudioCodec, CommandKind, DeviceState};
 pub struct AudioFrame {
     pub sequence: u64,
     pub timestamp_us: u64,
+    /// Target playout time for zone-synchronized playback. Zero if not zone-synced.
+    pub playout_ts: u64,
     pub codec: AudioCodec,
     pub channels: u8,
     pub sample_rate: u32,

--- a/crates/syndesis/src/server/mod.rs
+++ b/crates/syndesis/src/server/mod.rs
@@ -2,6 +2,7 @@
 pub mod auth;
 pub mod session;
 pub mod source;
+pub mod zone;
 
 use snafu::ResultExt;
 use std::net::SocketAddr;
@@ -16,6 +17,7 @@ pub use auth::{
 };
 pub use session::StreamSession;
 pub use source::AudioSource;
+pub use zone::ZoneStream;
 
 pub struct StreamServer {
     endpoint: quinn::Endpoint,

--- a/crates/syndesis/src/server/zone.rs
+++ b/crates/syndesis/src/server/zone.rs
@@ -1,0 +1,372 @@
+/// Zone-coordinated streaming: single decode, fan-out to multiple renderers.
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use tokio::sync::{mpsc, watch};
+use tracing::{debug, info, warn};
+
+use crate::clock::ClockCoordinator;
+use crate::protocol::DeviceState;
+use crate::protocol::codec::encode_frame;
+use crate::protocol::frame::{AudioFrame, Frame};
+use crate::server::session::current_time_us;
+use crate::server::source::AudioSource;
+
+const FRAME_CHANNEL_CAPACITY: usize = 256;
+const LOW_WATERMARK_MS: u16 = 50;
+const DEGRADED_LAG_COUNT: u32 = 10;
+
+/// Per-renderer state within a zone.
+struct ZoneMember {
+    frame_tx: mpsc::Sender<Bytes>,
+    buffer_depth_ms: u16,
+    device_state: DeviceState,
+    consecutive_lags: u32,
+    is_degraded: bool,
+}
+
+/// Streaming state for a zone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZonePlayState {
+    Playing,
+    Paused,
+}
+
+/// Coordinates streaming to multiple renderers in a zone with synchronized playout.
+pub struct ZoneStream {
+    coordinator: ClockCoordinator,
+    members: HashMap<String, ZoneMember>,
+    play_state: ZonePlayState,
+    current_sequence: u64,
+}
+
+/// Sync point sent to a renderer joining mid-stream.
+#[derive(Debug, Clone)]
+pub struct SyncPoint {
+    pub sequence: u64,
+    pub playout_ts: u64,
+    pub server_time: u64,
+}
+
+impl ZoneStream {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            coordinator: ClockCoordinator::new(),
+            members: HashMap::new(),
+            play_state: ZonePlayState::Paused,
+            current_sequence: 0,
+        }
+    }
+
+    /// Add a renderer to the zone. Returns a receiver for encoded frames.
+    pub fn add_renderer(&mut self, renderer_id: &str) -> mpsc::Receiver<Bytes> {
+        let (tx, rx) = mpsc::channel(FRAME_CHANNEL_CAPACITY);
+        self.coordinator.add_renderer(renderer_id);
+        self.members.insert(
+            renderer_id.to_string(),
+            ZoneMember {
+                frame_tx: tx,
+                buffer_depth_ms: 0,
+                device_state: DeviceState::Idle,
+                consecutive_lags: 0,
+                is_degraded: false,
+            },
+        );
+        info!(%renderer_id, "renderer joined zone stream");
+        rx
+    }
+
+    /// Remove a renderer from the zone.
+    pub fn remove_renderer(&mut self, renderer_id: &str) {
+        self.members.remove(renderer_id);
+        self.coordinator.remove_renderer(renderer_id);
+        info!(%renderer_id, "renderer left zone stream");
+    }
+
+    /// Get a sync point for a renderer joining mid-stream.
+    #[must_use]
+    pub fn sync_point(&self) -> SyncPoint {
+        let now = current_time_us();
+        SyncPoint {
+            sequence: self.current_sequence,
+            playout_ts: self.coordinator.compute_playout_ts(now).unwrap_or(now),
+            server_time: now,
+        }
+    }
+
+    /// Fan-out an audio frame to all zone members with computed playout timestamp.
+    /// Uses `Bytes` reference counting — no per-renderer payload clone.
+    pub async fn fan_out_frame(&mut self, mut frame: AudioFrame) {
+        let now = current_time_us();
+        frame.playout_ts = self
+            .coordinator
+            .compute_playout_ts(now)
+            .unwrap_or(frame.timestamp_us);
+
+        self.current_sequence = frame.sequence;
+
+        let encoded = encode_frame(&Frame::Audio(frame));
+
+        let mut to_remove = Vec::new();
+        for (id, member) in &self.members {
+            if member.is_degraded {
+                continue;
+            }
+            // WHY: Bytes is reference-counted — all receivers share one allocation.
+            if member.frame_tx.try_send(encoded.clone()).is_err() {
+                warn!(%id, "renderer frame channel full, marking degraded");
+                to_remove.push(id.clone());
+            }
+        }
+        for id in &to_remove {
+            if let Some(m) = self.members.get_mut(id) {
+                m.is_degraded = true;
+                m.consecutive_lags = 0;
+            }
+        }
+    }
+
+    /// Record a clock sync exchange from a renderer.
+    pub fn record_clock_exchange(
+        &mut self,
+        renderer_id: &str,
+        originate: u64,
+        receive: u64,
+        transmit: u64,
+        destination: u64,
+    ) {
+        self.coordinator
+            .record_exchange(renderer_id, originate, receive, transmit, destination);
+    }
+
+    /// Update buffer status from a renderer's status report.
+    pub fn update_renderer_status(
+        &mut self,
+        renderer_id: &str,
+        buffer_depth_ms: u16,
+        device_state: DeviceState,
+    ) {
+        if let Some(member) = self.members.get_mut(renderer_id) {
+            member.buffer_depth_ms = buffer_depth_ms;
+            member.device_state = device_state;
+
+            if buffer_depth_ms < LOW_WATERMARK_MS {
+                member.consecutive_lags += 1;
+                if member.consecutive_lags >= DEGRADED_LAG_COUNT && !member.is_degraded {
+                    warn!(
+                        %renderer_id,
+                        buffer_depth_ms,
+                        "renderer consistently lagging, marking degraded"
+                    );
+                    member.is_degraded = true;
+                }
+            } else {
+                member.consecutive_lags = 0;
+                if member.is_degraded {
+                    debug!(%renderer_id, "renderer recovered from degraded state");
+                    member.is_degraded = false;
+                }
+            }
+        }
+    }
+
+    /// Whether any active (non-degraded) renderer has a low buffer.
+    #[must_use]
+    pub fn needs_backpressure(&self) -> bool {
+        self.members
+            .values()
+            .any(|m| !m.is_degraded && m.buffer_depth_ms < LOW_WATERMARK_MS)
+    }
+
+    pub fn pause(&mut self) {
+        self.play_state = ZonePlayState::Paused;
+        info!("zone paused");
+    }
+
+    pub fn resume(&mut self) {
+        self.play_state = ZonePlayState::Playing;
+        info!("zone resumed");
+    }
+
+    #[must_use]
+    pub fn play_state(&self) -> ZonePlayState {
+        self.play_state
+    }
+
+    #[must_use]
+    pub fn coordinator(&self) -> &ClockCoordinator {
+        &self.coordinator
+    }
+
+    pub fn coordinator_mut(&mut self) -> &mut ClockCoordinator {
+        &mut self.coordinator
+    }
+
+    #[must_use]
+    pub fn member_count(&self) -> usize {
+        self.members.len()
+    }
+
+    #[must_use]
+    pub fn degraded_renderers(&self) -> Vec<String> {
+        self.members
+            .iter()
+            .filter(|(_, m)| m.is_degraded)
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    /// Run the zone stream: decode from source, fan-out to all members.
+    pub async fn run<S: AudioSource>(&mut self, mut source: S, cancel: watch::Receiver<bool>) {
+        self.play_state = ZonePlayState::Playing;
+
+        loop {
+            if *cancel.borrow() {
+                break;
+            }
+
+            if self.play_state == ZonePlayState::Paused {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                continue;
+            }
+
+            if self.needs_backpressure() {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                continue;
+            }
+
+            match source.next_frame().await {
+                Some(frame) => {
+                    self.fan_out_frame(frame).await;
+                }
+                None => {
+                    debug!("zone audio source exhausted");
+                    break;
+                }
+            }
+        }
+
+        self.play_state = ZonePlayState::Paused;
+    }
+}
+
+impl Default for ZoneStream {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::protocol::AudioCodec;
+
+    fn test_frame(seq: u64, ts: u64) -> AudioFrame {
+        AudioFrame {
+            sequence: seq,
+            timestamp_us: ts,
+            playout_ts: 0,
+            codec: AudioCodec::Pcm,
+            channels: 2,
+            sample_rate: 48000,
+            payload: Bytes::from_static(b"zone-test"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fan_out_delivers_to_all_renderers() {
+        let mut zone = ZoneStream::new();
+        let mut rx1 = zone.add_renderer("r1");
+        let mut rx2 = zone.add_renderer("r2");
+
+        zone.fan_out_frame(test_frame(0, 1000)).await;
+
+        assert!(rx1.try_recv().is_ok(), "r1 should receive frame");
+        assert!(rx2.try_recv().is_ok(), "r2 should receive frame");
+    }
+
+    #[tokio::test]
+    async fn fan_out_sets_playout_ts() {
+        let mut zone = ZoneStream::new();
+        let _rx = zone.add_renderer("r1");
+
+        let frame = test_frame(0, 1_000_000);
+        zone.fan_out_frame(frame).await;
+
+        // The encoded frame should have a non-zero playout_ts set by coordinator
+        // (coordinator returns the server timestamp as fallback with no sync data)
+    }
+
+    #[test]
+    fn sync_point_returns_current_state() {
+        let mut zone = ZoneStream::new();
+        let _rx = zone.add_renderer("r1");
+        let sp = zone.sync_point();
+        assert_eq!(sp.sequence, 0);
+        assert!(sp.server_time > 0);
+    }
+
+    #[test]
+    fn degraded_renderer_detection() {
+        let mut zone = ZoneStream::new();
+        let _rx = zone.add_renderer("r1");
+
+        for _ in 0..DEGRADED_LAG_COUNT {
+            zone.update_renderer_status("r1", 10, DeviceState::Active);
+        }
+
+        let degraded = zone.degraded_renderers();
+        assert!(degraded.contains(&"r1".to_string()));
+    }
+
+    #[test]
+    fn degraded_renderer_recovers() {
+        let mut zone = ZoneStream::new();
+        let _rx = zone.add_renderer("r1");
+
+        for _ in 0..DEGRADED_LAG_COUNT {
+            zone.update_renderer_status("r1", 10, DeviceState::Active);
+        }
+        assert!(!zone.degraded_renderers().is_empty());
+
+        zone.update_renderer_status("r1", 100, DeviceState::Active);
+        assert!(zone.degraded_renderers().is_empty());
+    }
+
+    #[test]
+    fn pause_resume() {
+        let mut zone = ZoneStream::new();
+        assert_eq!(zone.play_state(), ZonePlayState::Paused);
+
+        zone.resume();
+        assert_eq!(zone.play_state(), ZonePlayState::Playing);
+
+        zone.pause();
+        assert_eq!(zone.play_state(), ZonePlayState::Paused);
+    }
+
+    #[test]
+    fn add_remove_member() {
+        let mut zone = ZoneStream::new();
+        let _rx = zone.add_renderer("r1");
+        assert_eq!(zone.member_count(), 1);
+
+        zone.remove_renderer("r1");
+        assert_eq!(zone.member_count(), 0);
+    }
+
+    #[test]
+    fn needs_backpressure_when_buffer_low() {
+        let mut zone = ZoneStream::new();
+        let _rx = zone.add_renderer("r1");
+
+        zone.update_renderer_status("r1", 100, DeviceState::Active);
+        assert!(!zone.needs_backpressure());
+
+        zone.update_renderer_status("r1", 10, DeviceState::Active);
+        assert!(zone.needs_backpressure());
+    }
+}

--- a/crates/syndesis/tests/integration.rs
+++ b/crates/syndesis/tests/integration.rs
@@ -14,6 +14,7 @@ fn test_frames(count: usize) -> Vec<AudioFrame> {
         .map(|i| AudioFrame {
             sequence: i as u64,
             timestamp_us: i as u64 * 10_000,
+            playout_ts: 0,
             codec: AudioCodec::Flac,
             channels: 2,
             sample_rate: 48000,
@@ -147,4 +148,152 @@ async fn clock_sync_converges_on_loopback() {
         "loopback offset should be <1ms, got {offset}us"
     );
     assert!(estimator.is_stable(), "should be stable after 20 samples");
+}
+
+#[tokio::test]
+async fn clock_sync_loopback_within_5ms() {
+    use syndesis::clock::ClockEstimator;
+
+    let mut estimator = ClockEstimator::new();
+
+    // Simulate loopback: 50 samples with small jitter (< 100us RTT)
+    for i in 0..50u64 {
+        let base = i * 30_000;
+        let jitter = (i % 7) * 5;
+        let originate = base;
+        let receive = base + 80 + jitter;
+        let transmit = base + 90 + jitter;
+        let destination = base + 170 + jitter * 2;
+        estimator.record_exchange(originate, receive, transmit, destination);
+    }
+
+    let offset = estimator.offset_us();
+    assert!(
+        offset.unsigned_abs() < 5000,
+        "loopback offset should be <5ms, got {offset}us"
+    );
+    assert!(estimator.is_stable(), "should be stable after 50 samples");
+    assert_eq!(estimator.sample_count(), 50);
+}
+
+#[tokio::test]
+async fn zone_stream_fan_out_two_renderers() {
+    use syndesis::protocol::AudioCodec;
+    use syndesis::server::ZoneStream;
+
+    let mut zone = ZoneStream::new();
+    let mut rx1 = zone.add_renderer("renderer-1");
+    let mut rx2 = zone.add_renderer("renderer-2");
+
+    // Feed clock sync data so coordinator has estimates
+    for i in 0..10u64 {
+        let base = i * 100_000;
+        zone.record_clock_exchange("renderer-1", base, base + 200, base + 300, base + 500);
+        zone.record_clock_exchange("renderer-2", base, base + 300, base + 400, base + 700);
+    }
+
+    // Fan out a frame
+    let frame = AudioFrame {
+        sequence: 42,
+        timestamp_us: 5_000_000,
+        playout_ts: 0,
+        codec: AudioCodec::Pcm,
+        channels: 2,
+        sample_rate: 48000,
+        payload: Bytes::from_static(b"sync-test-data"),
+    };
+    zone.fan_out_frame(frame).await;
+
+    // Both renderers should receive the encoded frame
+    let data1 = rx1.try_recv();
+    let data2 = rx2.try_recv();
+    assert!(data1.is_ok(), "renderer-1 should receive frame");
+    assert!(data2.is_ok(), "renderer-2 should receive frame");
+
+    // Decode and verify playout_ts was set
+    use syndesis::protocol::codec::decode_frame;
+    use syndesis::protocol::frame::Frame;
+
+    let mut buf1 = data1.unwrap();
+    let decoded = decode_frame(&mut buf1).expect("should decode");
+    if let Frame::Audio(af) = decoded {
+        assert!(af.playout_ts > 0, "playout_ts should be set by coordinator");
+        assert_eq!(af.sequence, 42);
+    } else {
+        panic!("expected audio frame");
+    }
+}
+
+#[tokio::test]
+async fn zone_stream_sync_point_mid_stream() {
+    use syndesis::protocol::AudioCodec;
+    use syndesis::server::ZoneStream;
+
+    let mut zone = ZoneStream::new();
+    let _rx1 = zone.add_renderer("r1");
+
+    // Simulate some streaming
+    for i in 0..5 {
+        let frame = AudioFrame {
+            sequence: i,
+            timestamp_us: i * 10_000,
+            playout_ts: 0,
+            codec: AudioCodec::Pcm,
+            channels: 2,
+            sample_rate: 48000,
+            payload: Bytes::from_static(b"data"),
+        };
+        zone.fan_out_frame(frame).await;
+    }
+
+    // New renderer joins mid-stream
+    let mut rx2 = zone.add_renderer("r2");
+    let sync = zone.sync_point();
+    assert_eq!(
+        sync.sequence, 4,
+        "sync point should reflect current position"
+    );
+    assert!(sync.server_time > 0);
+
+    // Fan out next frame — both renderers should get it
+    let next = AudioFrame {
+        sequence: 5,
+        timestamp_us: 50_000,
+        playout_ts: 0,
+        codec: AudioCodec::Pcm,
+        channels: 2,
+        sample_rate: 48000,
+        payload: Bytes::from_static(b"new-data"),
+    };
+    zone.fan_out_frame(next).await;
+    assert!(
+        rx2.try_recv().is_ok(),
+        "new renderer should receive frames after join"
+    );
+}
+
+#[tokio::test]
+async fn coordinator_playout_timestamps_within_5ms() {
+    use syndesis::clock::ClockCoordinator;
+
+    let mut coord = ClockCoordinator::with_margin(0);
+    coord.add_renderer("r1");
+    coord.add_renderer("r2");
+
+    // Feed identical loopback-like exchanges to both renderers
+    for i in 0..20u64 {
+        let base = i * 50_000;
+        coord.record_exchange("r1", base, base + 100, base + 150, base + 250);
+        coord.record_exchange("r2", base, base + 120, base + 170, base + 290);
+    }
+
+    let server_ts = 10_000_000u64;
+    let playout = coord.compute_playout_ts(server_ts).expect("should compute");
+
+    // With near-zero offsets on loopback, playout should be close to server_ts
+    let delta = playout.abs_diff(server_ts);
+    assert!(
+        delta < 5000,
+        "playout should be within 5ms of server time on loopback, delta={delta}us"
+    );
 }


### PR DESCRIPTION
## Summary

- Zone model (SQLite migration + ZoneRepo) for multi-room renderer grouping with cascade delete
- REST API for zone CRUD, member management, and playback controls (play/pause/resume)
- Clock sync refinement: 50-sample sliding window, weighted median (inverse RTT), drift rate estimation, alarm thresholds at 5ms/20ms
- ClockCoordinator: per-renderer offset tracking, zone-wide playout timestamp computation (`server_time + max(offsets) + margin`)
- ZoneStream: single-decode fan-out via `Bytes` reference counting, playout timestamps on AudioFrame wire format, sync point for mid-stream join, degraded renderer detection
- Renderer playout pipeline: frame scheduling by playout timestamp, adaptive buffer depth (20-200ms), play/hold/late decision engine

## Test plan

- [x] ZoneRepo CRUD (create, add/remove members, delete cascades, not-found errors)
- [x] Zone API integration tests (create, list, get, add member, remove member, delete, play/pause/resume)
- [x] ClockEstimator weighted median favors low-RTT samples
- [x] Drift rate tracks linear drift and extrapolates forward
- [x] ClockCoordinator computes playout for 3 renderers with different offsets
- [x] Clock sync achieves <=5ms offset on loopback (50 samples with jitter)
- [x] ZoneStream fan-out delivers frames to all renderers
- [x] Playout timestamps set by coordinator on fan-out
- [x] Sync point reflects current stream position for mid-stream join
- [x] Degraded renderer detection and recovery
- [x] Playout pipeline: play on-time, hold when early, skip when late
- [x] Adaptive buffer increases on late frames
- [x] Zero playout_ts plays immediately (non-zone mode)
- [x] AudioFrame codec round-trip with playout_ts field
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 800+ tests)

## Observations

- `current_time_us()` in `server/session.rs:268` uses `SystemTime` (wall clock) rather than monotonic `Instant`. The pitfalls section warns about epoch mixing. This works for loopback and LAN but should be converted to `Instant`-relative microseconds before hardware testing. **Debt.**
- Zone playback controls (`play`/`pause`/`resume`) return stub responses. Full implementation requires wiring syndesis `ZoneStream` into the server runtime event loop. **Idea: a `ZoneManager` service in AppState that owns running `ZoneStream` instances.**
- The `render` module in `harmonia-host` is marked `pub` on the binary crate — acceptable for now but should move to a library crate if the renderer becomes a separate binary. **Debt.**
- No authentication guards on zone API endpoints. Other routes use `AuthenticatedUser` / `RequireAdmin` extractors. Zone endpoints should follow the same pattern before release. **Missing test: auth guards on zone routes.**
- `ZoneStream::run()` uses busy-poll with 5-10ms sleeps for pause/backpressure. A `tokio::sync::Notify` would be more efficient. **Debt.**