### PR TITLE
fix: resolve 4 lint violations via kanon lint --fix (tier-0)

### DIFF
--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -33,9 +33,9 @@
 
 | Crate | Greek | Pronunciation | Over | L3 Essential Nature |
 |-------|-------|--------------|------|---------------------|
-| **harmonia-common** | — | — | "shared types" | Domain primitives, IDs, and shared types used across all crates. |
-| **harmonia-db** | — | — | "storage" | SQLite storage layer, migrations, and query interface. |
-| **harmonia-host** | — | — | "server" | Axum HTTP server and binary entry point. The process boundary. |
+| **harmonia-common** |  -  |  -  | "shared types" | Domain primitives, IDs, and shared types used across all crates. |
+| **harmonia-db** |  -  |  -  | "storage" | SQLite storage layer, migrations, and query interface. |
+| **harmonia-host** |  -  |  -  | "server" | Axum HTTP server and binary entry point. The process boundary. |
 | **horismos** | ὁρισμός | hor-is-MOS | "config" | Definition, delimitation: the act of setting boundaries. All system configuration as the single parameterized source of truth. |
 | **exousia** | ἐξουσία | ex-oo-SEE-ah | "auth" | Authority: the power that comes from legitimate standing. Identity, authentication, authorization for household users. |
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -52,7 +52,7 @@ Import the modules in your Pi's `configuration.nix`:
     };
   };
 
-  # DAC HAT overlay (Raspberry Pi 4 only — see Pi 5 note below).
+  # DAC HAT overlay (Raspberry Pi 4 only  -  see Pi 5 note below).
   services.harmonia-render.dac = {
     enable = true;
     model = "hifiberry-dacplus";  # or: hifiberry-dac2hd, iqaudio-dacplus, iqaudio-dacpro
@@ -89,7 +89,7 @@ module works on Pi 5 without change; only `harmonia-dac` needs adjustment.
 2. Start the renderer on the Pi (`systemctl start harmonia-render`).
 3. mDNS discovery finds the server automatically on the same LAN.
 4. On first run, the renderer stores the server's TLS fingerprint in `certDir`
-   (TOFU — Trust On First Use). Subsequent reconnects verify the fingerprint.
+   (TOFU  -  Trust On First Use). Subsequent reconnects verify the fingerprint.
 5. If the server is on a different subnet, set `services.harmonia-render.server`.
 
 ## Troubleshooting


### PR DESCRIPTION
Deterministic fixes by `kanon lint --fix`. No LLM, no GPU.
**Fixed:** 4 | **Before:** 1809 | **After:** 1805
Gate-Passed: kanon 0.1.0