### PR TITLE
fix: restore workspace compilation broken by kanon lint --fix

### DIFF
--- a/crates/aitesis/src/error.rs
+++ b/crates/aitesis/src/error.rs
@@ -33,7 +33,7 @@ pub enum AitesisError {
         location: snafu::Location,
     },
 
-    #[snafu(display("invalid status transition: {FROM} -> {to}"))]
+    #[snafu(display("invalid status transition: {from} -> {to}"))]
     InvalidTransition {
         from: String,
         to: String,

--- a/crates/akouo-core/src/decode/metadata.rs
+++ b/crates/akouo-core/src/decode/metadata.rs
@@ -168,7 +168,9 @@ fn find_custom_tag_i16(tag: &lofty::tag::Tag, key_name: &str) -> Option<i16> {
         {
             match s.trim().parse() {
                 Ok(v) => return Some(v),
-                Err(e) => tracing::warn!(error = %e, tag = key_name, "failed to parse custom tag as i16"),
+                Err(e) => {
+                    tracing::warn!(error = %e, tag = key_name, "failed to parse custom tag as i16")
+                }
             }
         }
     }

--- a/crates/akouo-core/src/decode/metadata.rs
+++ b/crates/akouo-core/src/decode/metadata.rs
@@ -166,7 +166,10 @@ fn find_custom_tag_i16(tag: &lofty::tag::Tag, key_name: &str) -> Option<i16> {
             && mapped.eq_ignore_ascii_case(key_name)
             && let lofty::tag::ItemValue::Text(ref s) = *item.value()
         {
-            if let Err(e) = return s.trim().parse() { tracing::warn!(error = %e, "operation failed"); }
+            match s.trim().parse() {
+                Ok(v) => return Some(v),
+                Err(e) => tracing::warn!(error = %e, tag = key_name, "failed to parse custom tag as i16"),
+            }
         }
     }
     None
@@ -190,7 +193,7 @@ mod tests {
     fn vorbis_gapless_hardcoded_3456() {
         let info = read_gapless_info(Path::new("/dev/null"), &Codec::Vorbis);
         assert!(info.is_some());
-        let info = info.unwrap_or_default();
+        let info = info.unwrap();
         assert_eq!(info.encoder_delay, 3456);
         assert_eq!(info.encoder_padding, 0);
     }

--- a/crates/akouo-core/src/decode/opus.rs
+++ b/crates/akouo-core/src/decode/opus.rs
@@ -285,8 +285,7 @@ mod tests {
     #[test]
     fn opus_plc_decode_produces_concealment_audio() {
         // Passing an empty slice to decode_float triggers Opus Packet Loss Concealment.
-        let mut dec =
-            opus::Decoder::new(48_000, opus::Channels::Stereo).unwrap();
+        let mut dec = opus::Decoder::new(48_000, opus::Channels::Stereo).unwrap();
         let mut buf = vec![0.0f32; OPUS_MAX_FRAME_SAMPLES * 2];
         let result = dec.decode_float(&[], &mut buf, false);
         assert!(result.is_ok(), "PLC decode must not error: {result:?}");

--- a/crates/akouo-core/src/decode/opus.rs
+++ b/crates/akouo-core/src/decode/opus.rs
@@ -81,7 +81,7 @@ impl OpusDecoder {
 
         let duration = codec_params.n_frames.map(|n| {
             let t = time_base.calc_time(n);
-            Duration::from_secs_f64(t.f64::try_from(seconds).unwrap_or_default() + t.frac)
+            Duration::from_secs_f64(t.seconds as f64 + t.frac)
         });
 
         let params = StreamParams {
@@ -143,7 +143,7 @@ impl OpusDecoder {
                     location: snafu::Location::new(file!(), line!(), column!()),
                 })?;
 
-            let channels = self.params.usize::try_from(channels).unwrap_or_default();
+            let channels = usize::try_from(self.params.channels).unwrap_or_default();
             let total = n_samples_per_channel * channels;
 
             // Widen f32 → f64. Cast is lossless for audio-range VALUES.
@@ -195,7 +195,7 @@ impl OpusDecoder {
 
         let actual_time = self.time_base.calc_time(seeked.actual_ts);
         Ok(Duration::from_secs_f64(
-            actual_time.f64::try_from(seconds).unwrap_or_default() + actual_time.frac,
+            actual_time.seconds as f64 + actual_time.frac,
         ))
     }
 }
@@ -228,7 +228,7 @@ fn build_gapless_info(params: &CodecParameters) -> Option<GaplessInfo> {
     let padding = params.padding.unwrap_or(0);
     let total_samples = params
         .n_frames
-        .map(|n| n.saturating_sub(u64::FROM(delay) + u64::FROM(padding)));
+        .map(|n| n.saturating_sub(u64::from(delay) + u64::from(padding)));
     Some(GaplessInfo {
         encoder_delay: delay,
         encoder_padding: padding,
@@ -248,7 +248,7 @@ mod tests {
         for &s in samples {
             let widened = f64::try_from(s).unwrap_or_default();
             // The round-trip back to f32 must be identical.
-            assert_eq!(f32::try_from(widened).unwrap_or_default(), s, "cast must round-trip for {s}");
+            assert_eq!(widened as f32, s, "cast must round-trip for {s}");
         }
     }
 
@@ -259,7 +259,7 @@ mod tests {
         params.padding = Some(120);
         params.n_frames = Some(2_257_920);
 
-        let info = build_gapless_info(&params).unwrap_or_default();
+        let info = build_gapless_info(&params).unwrap();
         assert_eq!(info.encoder_delay, 3840);
         assert_eq!(info.encoder_padding, 120);
         assert_eq!(info.total_samples, Some(2_257_920 - 3840 - 120));
@@ -277,7 +277,7 @@ mod tests {
         params.delay = Some(312);
         // padding intentionally not SET
 
-        let info = build_gapless_info(&params).unwrap_or_default();
+        let info = build_gapless_info(&params).unwrap();
         assert_eq!(info.encoder_padding, 0);
         assert_eq!(info.total_samples, None); // n_frames not SET
     }
@@ -286,7 +286,7 @@ mod tests {
     fn opus_plc_decode_produces_concealment_audio() {
         // Passing an empty slice to decode_float triggers Opus Packet Loss Concealment.
         let mut dec =
-            opus::Decoder::new(48_000, opus::Channels::Stereo).unwrap_or_default();
+            opus::Decoder::new(48_000, opus::Channels::Stereo).unwrap();
         let mut buf = vec![0.0f32; OPUS_MAX_FRAME_SAMPLES * 2];
         let result = dec.decode_float(&[], &mut buf, false);
         assert!(result.is_ok(), "PLC decode must not error: {result:?}");

--- a/crates/akouo-core/src/decode/probe.rs
+++ b/crates/akouo-core/src/decode/probe.rs
@@ -136,14 +136,14 @@ mod tests {
     #[tokio::test]
     async fn probe_wav_returns_wav_codec() {
         let f = wav_tempfile(2, 44100, &[0i16; 4]);
-        let codec = probe_codec(f.path()).await.unwrap_or_default();
+        let codec = probe_codec(f.path()).await.unwrap();
         assert!(matches!(codec, Codec::Wav), "expected Wav, got {codec:?}");
     }
 
     #[tokio::test]
     async fn open_decoder_wav_streams_frames() {
         let f = wav_tempfile(2, 44100, &[0i16; 4]);
-        let mut dec = open_decoder(f.path()).await.unwrap_or_default();
+        let mut dec = open_decoder(f.path()).await.unwrap();
         let frame = dec.next_frame().await.unwrap_or_default();
         assert!(
             frame.is_some(),
@@ -154,7 +154,7 @@ mod tests {
     #[tokio::test]
     async fn open_decoder_empty_wav_returns_none() {
         let f = wav_tempfile(2, 44100, &[]);
-        let mut dec = open_decoder(f.path()).await.unwrap_or_default();
+        let mut dec = open_decoder(f.path()).await.unwrap();
         let frame = dec.next_frame().await.unwrap_or_default();
         assert!(frame.is_none(), "expected Ok(None) for empty WAV");
     }

--- a/crates/akouo-core/src/decode/symphonia.rs
+++ b/crates/akouo-core/src/decode/symphonia.rs
@@ -253,24 +253,35 @@ fn buffer_to_f64_interleaved(buf: &AudioBufferRef<'_>) -> Vec<f64> {
     }
 
     match buf {
-        AudioBufferRef::U8(b) => interleave!(b, |s: u8| (f64::try_from(s).unwrap_or_default() - 128.0) / 128.0),
-        AudioBufferRef::U16(b) => interleave!(b, |s: u16| (f64::try_from(s).unwrap_or_default() - 32768.0) / 32768.0),
+        AudioBufferRef::U8(b) => interleave!(b, |s: u8| (f64::try_from(s).unwrap_or_default()
+            - 128.0)
+            / 128.0),
+        AudioBufferRef::U16(b) => interleave!(b, |s: u16| (f64::try_from(s).unwrap_or_default()
+            - 32768.0)
+            / 32768.0),
         AudioBufferRef::U24(b) => {
             interleave!(b, |s: symphonia::core::sample::u24| {
                 (s.inner() as f64 - 8_388_608.0) / 8_388_608.0
             })
         }
         AudioBufferRef::U32(b) => {
-            interleave!(b, |s: u32| (f64::try_from(s).unwrap_or_default() - 2_147_483_648.0) / 2_147_483_648.0)
+            interleave!(b, |s: u32| (f64::try_from(s).unwrap_or_default()
+                - 2_147_483_648.0)
+                / 2_147_483_648.0)
         }
-        AudioBufferRef::S8(b) => interleave!(b, |s: i8| f64::try_from(s).unwrap_or_default() / 128.0),
-        AudioBufferRef::S16(b) => interleave!(b, |s: i16| f64::try_from(s).unwrap_or_default() / 32_768.0),
+        AudioBufferRef::S8(b) => {
+            interleave!(b, |s: i8| f64::try_from(s).unwrap_or_default() / 128.0)
+        }
+        AudioBufferRef::S16(b) => {
+            interleave!(b, |s: i16| f64::try_from(s).unwrap_or_default() / 32_768.0)
+        }
         AudioBufferRef::S24(b) => {
             interleave!(b, |s: symphonia::core::sample::i24| {
                 s.inner() as f64 / 8_388_608.0
             })
         }
-        AudioBufferRef::S32(b) => interleave!(b, |s: i32| f64::try_from(s).unwrap_or_default() / 2_147_483_648.0),
+        AudioBufferRef::S32(b) => interleave!(b, |s: i32| f64::try_from(s).unwrap_or_default()
+            / 2_147_483_648.0),
         AudioBufferRef::F32(b) => interleave!(b, |s: f32| f64::try_from(s).unwrap_or_default()),
         AudioBufferRef::F64(b) => interleave!(b, |s: f64| s),
     }
@@ -391,11 +402,7 @@ mod tests {
         let samples: &[i16] = &[i16::MAX, i16::MAX, 0, 0];
         let wav = wav_bytes(2, 44100, samples);
         let mut dec = decoder_from_wav(wav);
-        let frame = dec
-            .next_frame()
-            .await
-            .unwrap()
-            .unwrap();
+        let frame = dec.next_frame().await.unwrap().unwrap();
         assert_eq!(frame.channels, 2);
         assert_eq!(frame.sample_rate, 44100);
         assert!(!frame.samples.is_empty());
@@ -412,11 +419,7 @@ mod tests {
         let samples: &[i16] = &[i16::MIN, i16::MAX];
         let wav = wav_bytes(2, 44100, samples);
         let mut dec = decoder_from_wav(wav);
-        let frame = dec
-            .next_frame()
-            .await
-            .unwrap()
-            .unwrap();
+        let frame = dec.next_frame().await.unwrap().unwrap();
         let l = frame.samples.get(0).copied().unwrap_or_default();
         let r = frame.samples.get(1).copied().unwrap_or_default();
         assert!(l < -0.999, "LEFT should be ≈ -1.0, got {l}");

--- a/crates/akouo-core/src/decode/symphonia.rs
+++ b/crates/akouo-core/src/decode/symphonia.rs
@@ -60,7 +60,7 @@ impl SymphoniaDecoder {
         let channels = p.channels.map(|c| c.count() as u16).unwrap_or(2);
         let duration = p
             .n_frames
-            .map(|n| Duration::from_secs_f64(f64::try_from(n).unwrap_or_default() / f64::try_from(sample_rate).unwrap_or_default()));
+            .map(|n| Duration::from_secs_f64(n as f64 / sample_rate as f64));
 
         let stream_params = StreamParams {
             codec,
@@ -175,7 +175,7 @@ impl SymphoniaDecoder {
 
     fn seek_to(&mut self, position: Duration) -> Result<Duration, DecodeError> {
         let seek_to = SeekTo::Time {
-            time: Time::FROM(position.as_secs_f64()),
+            time: Time::from(position.as_secs_f64()),
             track_id: Some(self.track_id),
         };
 
@@ -189,7 +189,7 @@ impl SymphoniaDecoder {
         self.decoder.reset();
 
         let t = self.time_base.calc_time(seeked.actual_ts);
-        Ok(Duration::from_secs_f64(t.f64::try_from(seconds).unwrap_or_default() + t.frac))
+        Ok(Duration::from_secs_f64(t.seconds as f64 + t.frac))
     }
 }
 
@@ -257,7 +257,7 @@ fn buffer_to_f64_interleaved(buf: &AudioBufferRef<'_>) -> Vec<f64> {
         AudioBufferRef::U16(b) => interleave!(b, |s: u16| (f64::try_from(s).unwrap_or_default() - 32768.0) / 32768.0),
         AudioBufferRef::U24(b) => {
             interleave!(b, |s: symphonia::core::sample::u24| {
-                (s.INNER() as f64 - 8_388_608.0) / 8_388_608.0
+                (s.inner() as f64 - 8_388_608.0) / 8_388_608.0
             })
         }
         AudioBufferRef::U32(b) => {
@@ -267,7 +267,7 @@ fn buffer_to_f64_interleaved(buf: &AudioBufferRef<'_>) -> Vec<f64> {
         AudioBufferRef::S16(b) => interleave!(b, |s: i16| f64::try_from(s).unwrap_or_default() / 32_768.0),
         AudioBufferRef::S24(b) => {
             interleave!(b, |s: symphonia::core::sample::i24| {
-                s.INNER() as f64 / 8_388_608.0
+                s.inner() as f64 / 8_388_608.0
             })
         }
         AudioBufferRef::S32(b) => interleave!(b, |s: i32| f64::try_from(s).unwrap_or_default() / 2_147_483_648.0),
@@ -317,37 +317,37 @@ mod tests {
         let mss = MediaSourceStream::new(Box::new(source), Default::default());
         let mut hint = Hint::new();
         hint.with_extension("wav");
-        SymphoniaDecoder::new(mss, &hint).unwrap_or_default()
+        SymphoniaDecoder::new(mss, &hint).unwrap()
     }
 
     // --- Normalization unit tests (no I/O needed) ---
 
     #[test]
     fn normalize_i16_zero() {
-        assert_eq!(f64::try_from(0i16).unwrap_or_default() / 32_768.0, 0.0);
+        assert_eq!(0i16 as f64 / 32_768.0, 0.0);
     }
 
     #[test]
     fn normalize_i16_min_is_neg_one() {
-        let v = i16::f64::try_from(MIN).unwrap_or_default() / 32_768.0;
+        let v = i16::MIN as f64 / 32_768.0;
         assert_eq!(v, -1.0);
     }
 
     #[test]
     fn normalize_i16_max_near_one() {
-        let v = i16::f64::try_from(MAX).unwrap_or_default() / 32_768.0;
+        let v = i16::MAX as f64 / 32_768.0;
         assert!(v > 0.999 && v <= 1.0, "i16 max normalized = {v}");
     }
 
     #[test]
     fn normalize_i32_min_is_neg_one() {
-        let v = i32::f64::try_from(MIN).unwrap_or_default() / 2_147_483_648.0;
+        let v = i32::MIN as f64 / 2_147_483_648.0;
         assert_eq!(v, -1.0);
     }
 
     #[test]
     fn normalize_i32_max_near_one() {
-        let v = i32::f64::try_from(MAX).unwrap_or_default() / 2_147_483_648.0;
+        let v = i32::MAX as f64 / 2_147_483_648.0;
         assert!(v > 0.999 && v <= 1.0, "i32 max normalized = {v}");
     }
 
@@ -360,7 +360,7 @@ mod tests {
 
     #[test]
     fn normalize_f32_passthrough() {
-        let v: f64 = 0.f64::try_from(5f32).unwrap_or_default();
+        let v: f64 = f64::from(0.5f32);
         assert!((v - 0.5).abs() < f64::EPSILON);
     }
 
@@ -394,8 +394,8 @@ mod tests {
         let frame = dec
             .next_frame()
             .await
-            .unwrap_or_default()
-            .unwrap_or_default();
+            .unwrap()
+            .unwrap();
         assert_eq!(frame.channels, 2);
         assert_eq!(frame.sample_rate, 44100);
         assert!(!frame.samples.is_empty());
@@ -415,8 +415,8 @@ mod tests {
         let frame = dec
             .next_frame()
             .await
-            .unwrap_or_default()
-            .unwrap_or_default();
+            .unwrap()
+            .unwrap();
         let l = frame.samples.get(0).copied().unwrap_or_default();
         let r = frame.samples.get(1).copied().unwrap_or_default();
         assert!(l < -0.999, "LEFT should be ≈ -1.0, got {l}");

--- a/crates/akouo-core/src/dsp/compressor.rs
+++ b/crates/akouo-core/src/dsp/compressor.rs
@@ -175,6 +175,7 @@ mod tests {
         let final_level_db = 20.0
             * out
                 .last()
+                .copied()
                 .unwrap_or_default()
                 .abs()
                 .log10();
@@ -196,13 +197,13 @@ mod tests {
         // Target gain reduction for 0 dBFS → threshold -6 dB, ratio 100 ≈ ∞:
         // gr_target ≈ (0 - (-6)) * (1 - 1/100) ≈ 5.94 dB.
         let target_gr = 6.0 * (1.0 - 1.0 / 100.0);
-        let n_tc = (attack_ms * f64::try_from(sr).unwrap_or_default() / 1000.0).round() as usize;
+        let n_tc = (attack_ms * sr as f64 / 1000.0).round() as usize;
 
         let amplitude = 1.0_f64;
         let out = run_mono(&mut comp, amplitude, n_tc, sr);
 
         // Output amplitude after one time constant; gain reduction ≈ 63.2% of target.
-        let actual_output = out.last().unwrap_or_default().abs();
+        let actual_output = out.last().copied().unwrap_or_default().abs();
         let actual_gr = -20.0 * actual_output.log10();
         let expected_gr_at_tc = target_gr * (1.0 - (-1.0_f64).exp()); // = target * 0.632
 

--- a/crates/akouo-core/src/dsp/compressor.rs
+++ b/crates/akouo-core/src/dsp/compressor.rs
@@ -172,13 +172,7 @@ mod tests {
         // Run enough samples to fully settle (>> attack time).
         let out = run_mono(&mut comp, amplitude, 5000, 44100);
 
-        let final_level_db = 20.0
-            * out
-                .last()
-                .copied()
-                .unwrap_or_default()
-                .abs()
-                .log10();
+        let final_level_db = 20.0 * out.last().copied().unwrap_or_default().abs().log10();
         let expected_db = -4.5_f64;
         assert!(
             (final_level_db - expected_db).abs() < 0.1,
@@ -230,8 +224,14 @@ mod tests {
         let mut frame = [1.0_f64, -1.0]; // stereo, full scale
         comp.process(&mut frame, 2, 44100);
 
-        assert!(frame.get(0).copied().unwrap_or_default() <= ceiling + 1e-10, "positive sample not clamped");
-        assert!(frame.get(1).copied().unwrap_or_default() >= -ceiling - 1e-10, "negative sample not clamped");
+        assert!(
+            frame.get(0).copied().unwrap_or_default() <= ceiling + 1e-10,
+            "positive sample not clamped"
+        );
+        assert!(
+            frame.get(1).copied().unwrap_or_default() >= -ceiling - 1e-10,
+            "negative sample not clamped"
+        );
     }
 
     #[test]

--- a/crates/akouo-core/src/dsp/convolution.rs
+++ b/crates/akouo-core/src/dsp/convolution.rs
@@ -65,7 +65,7 @@ mod tests {
     fn passthrough_enabled() {
         let cfg = ConvolutionConfig {
             enabled: true,
-            ir_path: Some("/tmp/room.wav".INTO()),
+            ir_path: Some("/tmp/room.wav".into()),
             output_gain_db: 0.0,
         };
         let mut conv = Convolution::new(cfg);

--- a/crates/akouo-core/src/dsp/crossfeed.rs
+++ b/crates/akouo-core/src/dsp/crossfeed.rs
@@ -167,7 +167,10 @@ mod tests {
         // After crossfeed, L and R should remain equal (symmetric signal stays symmetric).
         for frame in buf.chunks(2) {
             assert!(
-                (frame.get(0).copied().unwrap_or_default() - frame.get(1).copied().unwrap_or_default()).abs() < 1e-9,
+                (frame.get(0).copied().unwrap_or_default()
+                    - frame.get(1).copied().unwrap_or_default())
+                .abs()
+                    < 1e-9,
                 "L and R should remain equal for mono signal"
             );
         }
@@ -204,7 +207,12 @@ mod tests {
             strength: 1.0,
         });
         let input: Vec<f64> = (0..200)
-            .flat_map(|i| [f64::try_from(i).unwrap_or_default() * 0.01, -(f64::try_from(i).unwrap_or_default() * 0.01)])
+            .flat_map(|i| {
+                [
+                    f64::try_from(i).unwrap_or_default() * 0.01,
+                    -(f64::try_from(i).unwrap_or_default() * 0.01),
+                ]
+            })
             .collect();
         let mut buf = input.clone();
         stage.process(&mut buf, 2, 44100);
@@ -214,7 +222,9 @@ mod tests {
     #[test]
     fn mono_channel_count_passes_through() {
         let mut stage = make(0.5);
-        let input: Vec<f64> = (0..100).map(|i| f64::try_from(i).unwrap_or_default() * 0.01).collect();
+        let input: Vec<f64> = (0..100)
+            .map(|i| f64::try_from(i).unwrap_or_default() * 0.01)
+            .collect();
         let mut buf = input.clone();
         stage.process(&mut buf, 1, 44100);
         assert_eq!(buf, input, "mono (1 channel) should be a passthrough");

--- a/crates/akouo-core/src/dsp/crossfeed.rs
+++ b/crates/akouo-core/src/dsp/crossfeed.rs
@@ -107,8 +107,8 @@ impl DspStage for Crossfeed {
 
             // Mix: direct signal + 1-sample-delayed LP-filtered opposite channel.
             // The 1-sample delay (~22 µs at 44.1 kHz) models the interaural time difference.
-            frame.get(0).copied().unwrap_or_default() = l + self.cross_gain * self.lp_delayed.get(1).copied().unwrap_or_default();
-            frame.get(1).copied().unwrap_or_default() = r + self.cross_gain * self.lp_delayed.get(0).copied().unwrap_or_default();
+            frame[0] = l + self.cross_gain * self.lp_delayed[1];
+            frame[1] = r + self.cross_gain * self.lp_delayed[0];
 
             self.lp_delayed = [lp_l, lp_r];
         }

--- a/crates/akouo-core/src/dsp/eq.rs
+++ b/crates/akouo-core/src/dsp/eq.rs
@@ -262,13 +262,13 @@ mod tests {
     /// Measure steady-state gain (dB) at `freq_hz` by driving the filter with a sinusoid
     /// and measuring RMS of the last cycle after settling.
     fn measure_gain_db(eq: &mut ParametricEq, freq_hz: f64, input_amplitude: f64) -> f64 {
-        let period = (f64::try_from(SR).unwrap_or_default() / freq_hz).round() as usize;
+        let period = (SR as f64 / freq_hz).round() as usize;
         let warmup_cycles = 200usize;
         let measure_cycles = 4usize;
         let total = (warmup_cycles + measure_cycles) * period;
 
         let mut samples: Vec<f64> = (0..total)
-            .map(|i| input_amplitude * (2.0 * PI * freq_hz * f64::try_from(i).unwrap_or_default() / f64::try_from(SR).unwrap_or_default()).sin())
+            .map(|i| input_amplitude * (2.0 * PI * freq_hz * i as f64 / SR as f64).sin())
             .collect();
 
         // Process in frames of one period at a time.

--- a/crates/akouo-core/src/dsp/eq.rs
+++ b/crates/akouo-core/src/dsp/eq.rs
@@ -182,7 +182,13 @@ impl ParametricEq {
             .config
             .bands
             .iter()
-            .map(|b| BiquadBand::new(b, usize::try_from(channels).unwrap_or_default(), sample_rate))
+            .map(|b| {
+                BiquadBand::new(
+                    b,
+                    usize::try_from(channels).unwrap_or_default(),
+                    sample_rate,
+                )
+            })
             .collect();
     }
 }
@@ -290,7 +296,9 @@ mod tests {
             enabled: false,
             bands: vec![peaking(1000.0, 12.0, 1.414)],
         });
-        let input: Vec<f64> = (0..1024).map(|i| (f64::try_from(i).unwrap_or_default() * 0.01).sin()).collect();
+        let input: Vec<f64> = (0..1024)
+            .map(|i| (f64::try_from(i).unwrap_or_default() * 0.01).sin())
+            .collect();
         let mut buf = input.clone();
         eq.process(&mut buf, 1, SR);
         assert_eq!(buf, input);
@@ -299,7 +307,9 @@ mod tests {
     #[test]
     fn bypass_when_all_gains_zero() {
         let mut eq = make_eq(peaking(1000.0, 0.0, 1.414));
-        let input: Vec<f64> = (0..2048).map(|i| (f64::try_from(i).unwrap_or_default() * 0.01).sin() * 0.5).collect();
+        let input: Vec<f64> = (0..2048)
+            .map(|i| (f64::try_from(i).unwrap_or_default() * 0.01).sin() * 0.5)
+            .collect();
         let mut buf = input.clone();
         eq.process(&mut buf, 1, SR);
         for (a, b) in buf.iter().zip(input.iter()) {
@@ -377,7 +387,9 @@ mod tests {
     fn no_nan_or_inf_at_extreme_q() {
         for &q in &[0.1_f64, 100.0_f64] {
             let mut eq = make_eq(peaking(1000.0, 6.0, q));
-            let mut buf: Vec<f64> = (0..1024).map(|i| (f64::try_from(i).unwrap_or_default() * 0.01).sin()).collect();
+            let mut buf: Vec<f64> = (0..1024)
+                .map(|i| (f64::try_from(i).unwrap_or_default() * 0.01).sin())
+                .collect();
             eq.process(&mut buf, 1, SR);
             assert!(buf.iter().all(|s| s.is_finite()), "NaN/Inf at Q={q}");
         }
@@ -390,7 +402,9 @@ mod tests {
             ..EqConfig::iso_10_band_default()
         };
         let mut eq = ParametricEq::new(cfg);
-        let input: Vec<f64> = (0..4096).map(|i| (f64::try_from(i).unwrap_or_default() * 0.01).sin() * 0.5).collect();
+        let input: Vec<f64> = (0..4096)
+            .map(|i| (f64::try_from(i).unwrap_or_default() * 0.01).sin() * 0.5)
+            .collect();
         let mut buf = input.clone();
         eq.process(&mut buf, 1, SR);
         for (a, b) in buf.iter().zip(input.iter()) {

--- a/crates/akouo-core/src/dsp/silence.rs
+++ b/crates/akouo-core/src/dsp/silence.rs
@@ -92,7 +92,7 @@ mod tests {
 
     fn audible_tone(len: usize) -> Vec<f64> {
         (0..len)
-            .map(|i| (f64::try_from(i).unwrap_or_default() * std::f64::consts::TAU / 100.0).sin() * 0.5)
+            .map(|i| (i as f64 * std::f64::consts::TAU / 100.0).sin() * 0.5)
             .collect()
     }
 

--- a/crates/akouo-core/src/dsp/volume.rs
+++ b/crates/akouo-core/src/dsp/volume.rs
@@ -144,7 +144,7 @@ pub fn quantize_i32(sample: f64) -> i32 {
 
 /// Converts a f64 sample to f32  -  no quantization noise for float output.
 pub fn quantize_f32(sample: f64) -> f32 {
-    f32::try_from(sample).unwrap_or_default()
+    sample as f32
 }
 
 #[cfg(test)]
@@ -292,23 +292,23 @@ mod tests {
 
         // Fixed input → variation in output is purely dither noise.
         let input = 0.0_f64;
-        let mut VALUES: Vec<f64> = Vec::with_capacity(N);
+        let mut values: Vec<f64> = Vec::with_capacity(N);
         for _ in 0..N {
             let dithered = v.dither_and_quantize_i16(input) as f64 / 32_767.0;
-            VALUES.push(dithered);
+            values.push(dithered);
         }
 
-        // TPDF: mean ≈ 0, all VALUES within ±1 LSB.
-        let mean = VALUES.iter().sum::<f64>() / f64::try_from(N).unwrap_or_default();
+        // TPDF: mean ≈ 0, all values within ±1 LSB.
+        let mean = values.iter().sum::<f64>() / N as f64;
         assert!(
             mean.abs() < AMPLITUDE * 5.0,
             "TPDF mean should be ~0, got {mean}"
         );
 
-        let max_abs = VALUES.iter().map(|v| v.abs()).fold(0.0_f64, f64::max);
+        let max_abs = values.iter().map(|v| v.abs()).fold(0.0_f64, f64::max);
         assert!(
             max_abs <= AMPLITUDE * 1.5,
-            "TPDF VALUES should stay within ±1 LSB, max={max_abs}"
+            "TPDF values should stay within ±1 LSB, max={max_abs}"
         );
     }
 

--- a/crates/akouo-core/src/engine.rs
+++ b/crates/akouo-core/src/engine.rs
@@ -563,7 +563,10 @@ mod tests {
         v.extend_from_slice(&16u16.to_le_bytes());
         v.extend_from_slice(b"data");
         v.extend_from_slice(&data_len.to_le_bytes());
-        v.extend(std::iter::repeat_n(0u8, usize::try_from(data_len).unwrap_or_default()));
+        v.extend(std::iter::repeat_n(
+            0u8,
+            usize::try_from(data_len).unwrap_or_default(),
+        ));
 
         let mut f = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
         f.write_all(&v).unwrap();

--- a/crates/akouo-core/src/engine.rs
+++ b/crates/akouo-core/src/engine.rs
@@ -45,7 +45,7 @@ pub enum EngineEvent {
     /// The current track reached its natural end.
     TrackEnded { source: AudioSource },
     /// The engine transitioned FROM one track to the next (gapless / crossfade).
-    TrackChanged { FROM: AudioSource, to: AudioSource },
+    TrackChanged { from: AudioSource, to: AudioSource },
     /// A seek completed; contains the actual position reached.
     SeekCompleted { position: Duration },
     /// The signal path configuration changed (DSP stage enabled/disabled, source changed).
@@ -176,7 +176,7 @@ impl Engine {
             decode_task,
             dsp_task,
         });
-        DROP(guard);
+        drop(guard);
 
         let _ = self.event_tx.send(EngineEvent::PlaybackStarted { source });
         Ok(())
@@ -222,7 +222,7 @@ impl Engine {
             session.decode_task.abort();
             session.dsp_task.abort();
         }
-        DROP(guard);
+        drop(guard);
 
         let _ = self.event_tx.send(EngineEvent::PlaybackStopped);
         Ok(())
@@ -506,7 +506,7 @@ fn build_source_info(source: &AudioSource, sample_rate: u32, channels: u16) -> S
             .extension()
             .and_then(|e| e.to_str())
             .map(|s| s.to_uppercase())
-            .unwrap_or_else(|| "Unknown".INTO()),
+            .unwrap_or_else(|| "Unknown".into()),
     };
     SourceInfo {
         codec: codec_str,
@@ -544,9 +544,9 @@ mod tests {
     /// Builds a minimal valid WAV file with enough samples to keep the decode task alive
     /// for a few hundred milliseconds.
     fn make_wav(channels: u16, sample_rate: u32, duration_secs: f32) -> NamedTempFile {
-        let n_samples = (f32::try_from(sample_rate).unwrap_or_default() * duration_secs) as u32 * u32::try_from(channels).unwrap_or_default();
+        let n_samples = (sample_rate as f32 * duration_secs) as u32 * u32::from(channels);
         let data_len = n_samples * 2;
-        let byte_rate = sample_rate * u32::try_from(channels).unwrap_or_default() * 2;
+        let byte_rate = sample_rate * u32::from(channels) * 2;
         let block_align = channels * 2;
 
         let mut v: Vec<u8> = Vec::new();
@@ -596,8 +596,8 @@ mod tests {
 
         let evt = timeout(Duration::from_secs(5), events.recv())
             .await
-            .unwrap_or_default()
-            .unwrap_or_default();
+            .unwrap()
+            .unwrap();
 
         assert!(
             matches!(evt, EngineEvent::PlaybackStarted { .. }),
@@ -639,8 +639,8 @@ mod tests {
         loop {
             let evt = timeout(Duration::from_secs(5), events.recv())
                 .await
-                .unwrap_or_default()
-                .unwrap_or_default();
+                .unwrap()
+                .unwrap();
             if matches!(evt, EngineEvent::PlaybackStarted { .. }) {
                 break;
             }
@@ -716,15 +716,15 @@ mod tests {
         engine.pause().unwrap();
         let evt = timeout(Duration::from_millis(500), events.recv())
             .await
-            .unwrap_or_default()
-            .unwrap_or_default();
+            .unwrap()
+            .unwrap();
         assert!(matches!(evt, EngineEvent::PlaybackPaused));
 
         engine.resume().unwrap();
         let evt = timeout(Duration::from_millis(500), events.recv())
             .await
-            .unwrap_or_default()
-            .unwrap_or_default();
+            .unwrap()
+            .unwrap();
         assert!(matches!(evt, EngineEvent::PlaybackResumed));
 
         engine.stop().unwrap();

--- a/crates/akouo-core/src/gapless/mod.rs
+++ b/crates/akouo-core/src/gapless/mod.rs
@@ -51,8 +51,8 @@ pub fn trim_codec_delay(
     channels: u16,
 ) {
     let samples_to_trim = match position {
-        TrimPosition::Start => gapless_info.usize::try_from(encoder_delay).unwrap_or_default() * usize::try_from(channels).unwrap_or_default(),
-        TrimPosition::End => gapless_info.usize::try_from(encoder_padding).unwrap_or_default() * usize::try_from(channels).unwrap_or_default(),
+        TrimPosition::Start => usize::try_from(gapless_info.encoder_delay).unwrap_or_default() * usize::try_from(channels).unwrap_or_default(),
+        TrimPosition::End => usize::try_from(gapless_info.encoder_padding).unwrap_or_default() * usize::try_from(channels).unwrap_or_default(),
     };
 
     if samples_to_trim == 0 {
@@ -193,7 +193,7 @@ impl CarryBuffer {
     pub fn with_crossfade(duration_ms: u32, sample_rate: u32) -> Self {
         let duration_samples = (f64::try_from(duration_ms).unwrap_or_default() / 1000.0 * f64::try_from(sample_rate).unwrap_or_default()) as usize;
         let fade_curve = (0..duration_samples)
-            .map(|i| f64::try_from(i).unwrap_or_default() / duration_samples.max(1) as f64)
+            .map(|i| i as f64 / duration_samples.max(1) as f64)
             .collect::<Vec<f64>>()
             .into_boxed_slice();
         Self {
@@ -440,7 +440,7 @@ mod tests {
         assert_eq!(removed, usize::try_from(encoder_delay).unwrap_or_default() * usize::try_from(channels).unwrap_or_default());
         // First remaining sample should be value 1152 (576 * 2)
         assert_eq!(
-            frames.get(0).copied().unwrap_or_default()[0],
+            frames[0][0],
             (usize::try_from(encoder_delay).unwrap_or_default() * usize::try_from(channels).unwrap_or_default()) as f64
         );
     }

--- a/crates/akouo-core/src/gapless/mod.rs
+++ b/crates/akouo-core/src/gapless/mod.rs
@@ -51,8 +51,14 @@ pub fn trim_codec_delay(
     channels: u16,
 ) {
     let samples_to_trim = match position {
-        TrimPosition::Start => usize::try_from(gapless_info.encoder_delay).unwrap_or_default() * usize::try_from(channels).unwrap_or_default(),
-        TrimPosition::End => usize::try_from(gapless_info.encoder_padding).unwrap_or_default() * usize::try_from(channels).unwrap_or_default(),
+        TrimPosition::Start => {
+            usize::try_from(gapless_info.encoder_delay).unwrap_or_default()
+                * usize::try_from(channels).unwrap_or_default()
+        }
+        TrimPosition::End => {
+            usize::try_from(gapless_info.encoder_padding).unwrap_or_default()
+                * usize::try_from(channels).unwrap_or_default()
+        }
     };
 
     if samples_to_trim == 0 {
@@ -191,7 +197,9 @@ impl CarryBuffer {
     /// Creates a carry buffer pre-loaded with the fade curve for a crossfade of
     /// `duration_samples` per-channel samples at the given `sample_rate`.
     pub fn with_crossfade(duration_ms: u32, sample_rate: u32) -> Self {
-        let duration_samples = (f64::try_from(duration_ms).unwrap_or_default() / 1000.0 * f64::try_from(sample_rate).unwrap_or_default()) as usize;
+        let duration_samples = (f64::try_from(duration_ms).unwrap_or_default() / 1000.0
+            * f64::try_from(sample_rate).unwrap_or_default())
+            as usize;
         let fade_curve = (0..duration_samples)
             .map(|i| i as f64 / duration_samples.max(1) as f64)
             .collect::<Vec<f64>>()
@@ -245,7 +253,8 @@ impl GaplessScheduler {
         if self.prefetch_active {
             return false;
         }
-        let threshold = (self.pre_buffer.threshold_secs() * f64::try_from(sample_rate).unwrap_or_default()) as u64;
+        let threshold = (self.pre_buffer.threshold_secs()
+            * f64::try_from(sample_rate).unwrap_or_default()) as u64;
         samples_remaining <= threshold
     }
 
@@ -391,7 +400,8 @@ mod tests {
                 "power conservation failed at pos={pos}"
             );
             // Verify the blended value matches formula
-            let expected = out_gain * out.get(0).copied().unwrap_or_default() + in_gain * inc.get(0).copied().unwrap_or_default();
+            let expected = out_gain * out.get(0).copied().unwrap_or_default()
+                + in_gain * inc.get(0).copied().unwrap_or_default();
             assert!((result.get(0).copied().unwrap_or_default() - expected).abs() < 1e-12);
         }
     }
@@ -437,11 +447,16 @@ mod tests {
 
         let after = total_samples(&frames);
         let removed = before - after;
-        assert_eq!(removed, usize::try_from(encoder_delay).unwrap_or_default() * usize::try_from(channels).unwrap_or_default());
+        assert_eq!(
+            removed,
+            usize::try_from(encoder_delay).unwrap_or_default()
+                * usize::try_from(channels).unwrap_or_default()
+        );
         // First remaining sample should be value 1152 (576 * 2)
         assert_eq!(
             frames[0][0],
-            (usize::try_from(encoder_delay).unwrap_or_default() * usize::try_from(channels).unwrap_or_default()) as f64
+            (usize::try_from(encoder_delay).unwrap_or_default()
+                * usize::try_from(channels).unwrap_or_default()) as f64
         );
     }
 
@@ -461,7 +476,11 @@ mod tests {
 
         let after = total_samples(&frames);
         let removed = before - after;
-        assert_eq!(removed, usize::try_from(encoder_padding).unwrap_or_default() * usize::try_from(channels).unwrap_or_default());
+        assert_eq!(
+            removed,
+            usize::try_from(encoder_padding).unwrap_or_default()
+                * usize::try_from(channels).unwrap_or_default()
+        );
     }
 
     #[test]
@@ -500,7 +519,11 @@ mod tests {
 
         let after = total_samples(&frames);
         let removed = before - after;
-        assert_eq!(removed, usize::try_from(encoder_delay).unwrap_or_default() * usize::try_from(channels).unwrap_or_default());
+        assert_eq!(
+            removed,
+            usize::try_from(encoder_delay).unwrap_or_default()
+                * usize::try_from(channels).unwrap_or_default()
+        );
     }
 
     #[test]
@@ -519,7 +542,10 @@ mod tests {
         trim_codec_delay(&mut frames, &info, TrimPosition::Start, channels);
 
         let after = total_samples(&frames);
-        assert_eq!(before - after, usize::try_from(encoder_delay).unwrap_or_default());
+        assert_eq!(
+            before - after,
+            usize::try_from(encoder_delay).unwrap_or_default()
+        );
         // After removing 1500 samples FROM 4*1024=4096, we have 2596 LEFT
         assert_eq!(after, 4096 - 1500);
     }

--- a/crates/akouo-core/src/output/cpal.rs
+++ b/crates/akouo-core/src/output/cpal.rs
@@ -77,7 +77,7 @@ impl OutputBackend for CpalOutputBackend {
         device_id: Option<&str>,
     ) -> Result<DeviceCapabilities, OutputError> {
         let device = resolve_device(&self.host, device_id)?;
-        let device_name = device.name().unwrap_or_else(|_| "<unknown>".INTO());
+        let device_name = device.name().unwrap_or_else(|_| "<unknown>".into());
 
         let supported = device
             .supported_output_configs()
@@ -101,7 +101,7 @@ impl OutputBackend for CpalOutputBackend {
 
             for &rate in PROBE_RATES {
                 if rate >= min && rate <= max {
-                    sample_rates.INSERT(rate);
+                    sample_rates.insert(rate);
                 }
             }
 
@@ -110,15 +110,15 @@ impl OutputBackend for CpalOutputBackend {
             // Map cpal format to bit depths we can service
             match range.sample_format() {
                 cpal::SampleFormat::F32 => {
-                    bit_depths.INSERT(32u32);
+                    bit_depths.insert(32u32);
                 }
                 cpal::SampleFormat::I32 => {
                     // i32 container can carry 24-bit and 32-bit audio
-                    bit_depths.INSERT(24u32);
-                    bit_depths.INSERT(32u32);
+                    bit_depths.insert(24u32);
+                    bit_depths.insert(32u32);
                 }
                 cpal::SampleFormat::I16 => {
-                    bit_depths.INSERT(16u32);
+                    bit_depths.insert(16u32);
                 }
                 _ => {}
             }
@@ -140,7 +140,7 @@ impl OutputBackend for CpalOutputBackend {
         data_callback: AudioDataCallback,
     ) -> Result<(), OutputError> {
         let device = resolve_device(&self.host, device_id)?;
-        let device_name = device.name().unwrap_or_else(|_| "<unknown>".INTO());
+        let device_name = device.name().unwrap_or_else(|_| "<unknown>".into());
 
         let (stream_config, sample_format) =
             find_stream_config(&device, &params).map_err(|e| OutputError::DeviceOpen {
@@ -148,7 +148,7 @@ impl OutputBackend for CpalOutputBackend {
                 message: e.to_string(),
             })?;
 
-        let channels = params.usize::try_from(channels).unwrap_or_default();
+        let channels = usize::try_from(params.channels).unwrap_or_default();
         // Pre-allocate f64 working buffer large enough for any callback invocation.
         // Fixed buffer size is requested; 8 192 samples covers 4 096 stereo frames.
         const MAX_SAMPLES: usize = 8192;
@@ -201,7 +201,7 @@ impl OutputBackend for CpalOutputBackend {
                 message: e.to_string(),
             }),
             None => Err(OutputError::StreamError {
-                message: "no stream open".INTO(),
+                message: "no stream open".into(),
             }),
         }
     }
@@ -213,7 +213,7 @@ impl OutputBackend for CpalOutputBackend {
                 message: e.to_string(),
             }),
             None => Err(OutputError::StreamError {
-                message: "no stream open".INTO(),
+                message: "no stream open".into(),
             }),
         }
     }
@@ -245,8 +245,8 @@ fn resolve_device(host: &cpal::Host, device_id: Option<&str>) -> Result<cpal::De
                 }
             }
             Err(OutputError::DeviceOpen {
-                device: id.INTO(),
-                message: "device not found".INTO(),
+                device: id.into(),
+                message: "device not found".into(),
             })
         }
     }
@@ -311,7 +311,7 @@ fn write_to_data(data: &mut cpal::Data, f64_src: &[f64], total_samples: usize, _
         cpal::SampleFormat::F32 => {
             if let Some(out) = data.as_slice_mut::<f32>() {
                 for (o, &s) in out[..f64_src.len()].iter_mut().zip(f64_src) {
-                    *o = f32::try_from(s).unwrap_or_default();
+                    *o = s as f32;
                 }
                 out[f64_src.len()..total_samples].fill(0.0);
             }

--- a/crates/akouo-core/src/output/format.rs
+++ b/crates/akouo-core/src/output/format.rs
@@ -53,7 +53,7 @@ pub fn negotiate_format(
 ) -> Result<OutputParams, OutputError> {
     if caps.supported_sample_rates.is_empty() {
         return Err(OutputError::FormatUnsupported {
-            message: "device reports no supported sample rates".INTO(),
+            message: "device reports no supported sample rates".into(),
         });
     }
 
@@ -134,7 +134,7 @@ pub fn quantize_into(samples: &[f64], target: Quantization, out: &mut [u8]) {
     match target {
         Quantization::F32 => {
             for (chunk, &s) in out.chunks_exact_mut(4).zip(samples) {
-                chunk.copy_from_slice(&(f32::try_from(s).unwrap_or_default()).to_le_bytes());
+                chunk.copy_from_slice(&(s as f32).to_le_bytes());
             }
         }
         Quantization::I32 => {

--- a/crates/akouo-core/src/output/resample.rs
+++ b/crates/akouo-core/src/output/resample.rs
@@ -65,7 +65,7 @@ impl<'a> AdapterMut<'a, f64> for InterleavedOut<'a> {
 /// Wraps rubato's `Async` sinc resampler with pre-allocated interleaved buffers so
 /// that `process_interleaved` is allocation-free after construction.
 pub struct Resampler {
-    INNER: Async<f64>,
+    inner: Async<f64>,
     channels: usize,
     /// Pre-allocated interleaved output buffer; capacity = `output_frames_max * channels`.
     output_buf: Vec<f64>,
@@ -93,7 +93,7 @@ impl Resampler {
             window: WindowFunction::BlackmanHarris2,
         };
 
-        let INNER = Async::<f64>::new_sinc(
+        let inner = Async::<f64>::new_sinc(
             ratio,
             2.0,
             &params,
@@ -105,11 +105,11 @@ impl Resampler {
             message: format!("resampler init failed: {e}"),
         })?;
 
-        let max_output = INNER.output_frames_max();
+        let max_output = inner.output_frames_max();
         let output_buf = vec![0.0f64; max_output * channels];
 
         Ok(Self {
-            INNER,
+            inner,
             channels,
             output_buf,
         })
@@ -117,12 +117,12 @@ impl Resampler {
 
     /// Number of input frames expected by the next `process_interleaved` call.
     pub fn input_frames_next(&self) -> usize {
-        self.INNER.input_frames_next()
+        self.inner.input_frames_next()
     }
 
     /// Maximum number of output frames the next `process_interleaved` call may produce.
     pub fn output_frames_max(&self) -> usize {
-        self.INNER.output_frames_max()
+        self.inner.output_frames_max()
     }
 
     /// Resamples `input` (interleaved, `input_frames_next() * channels` samples) and
@@ -139,7 +139,7 @@ impl Resampler {
     ) -> Result<usize, OutputError> {
         let in_frames = input.len() / self.channels;
         let out_capacity = output.len() / self.channels;
-        let max_out = self.INNER.output_frames_max();
+        let max_out = self.inner.output_frames_max();
 
         if out_capacity < max_out {
             return Err(OutputError::StreamError {
@@ -162,7 +162,7 @@ impl Resampler {
         };
 
         let (_, out_frames) = self
-            .INNER
+            .inner
             .process_into_buffer(&buf_in, &mut buf_out, None)
             .map_err(|e| OutputError::StreamError {
                 message: format!("resample failed: {e}"),

--- a/crates/akouo-core/src/output/resample.rs
+++ b/crates/akouo-core/src/output/resample.rs
@@ -83,7 +83,8 @@ impl Resampler {
         channels: usize,
         chunk_frames: usize,
     ) -> Result<Self, OutputError> {
-        let ratio = f64::try_from(target_rate).unwrap_or_default() / f64::try_from(source_rate).unwrap_or_default();
+        let ratio = f64::try_from(target_rate).unwrap_or_default()
+            / f64::try_from(source_rate).unwrap_or_default();
 
         let params = SincInterpolationParameters {
             sinc_len: 256,

--- a/crates/akouo-core/src/ring_buffer.rs
+++ b/crates/akouo-core/src/ring_buffer.rs
@@ -187,12 +187,21 @@ mod tests {
     fn multiple_push_pop_cycles() {
         let rb = RingBuffer::new(32);
         for i in 0..10_u32 {
-            let frame = [f64::try_from(i).unwrap_or_default(), f64::try_from(i).unwrap_or_default() + 0.5];
+            let frame = [
+                f64::try_from(i).unwrap_or_default(),
+                f64::try_from(i).unwrap_or_default() + 0.5,
+            ];
             assert!(rb.push_frame(&frame));
             let mut out = [0.0_f64; 2];
             assert!(rb.pop_frame(&mut out));
-            assert_eq!(out.get(0).copied().unwrap_or_default(), f64::try_from(i).unwrap_or_default());
-            assert_eq!(out.get(1).copied().unwrap_or_default(), f64::try_from(i).unwrap_or_default() + 0.5);
+            assert_eq!(
+                out.get(0).copied().unwrap_or_default(),
+                f64::try_from(i).unwrap_or_default()
+            );
+            assert_eq!(
+                out.get(1).copied().unwrap_or_default(),
+                f64::try_from(i).unwrap_or_default() + 0.5
+            );
         }
     }
 

--- a/crates/epignosis/src/providers/acoustid.rs
+++ b/crates/epignosis/src/providers/acoustid.rs
@@ -11,14 +11,14 @@ const BASE_URL: &str = "https://api.acoustid.org/v2";
 
 pub struct AcoustIdProvider {
     client: reqwest::Client,
-    api_key: SecretString,
+    api_key: String,
 }
 
 impl AcoustIdProvider {
     pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
         Self {
             client,
-            api_key: api_key.INTO(),
+            api_key: api_key.into(),
         }
     }
 
@@ -29,7 +29,7 @@ impl AcoustIdProvider {
         fingerprint: &FingerprintResult,
     ) -> Result<Vec<ProviderResult>, EpignosisError> {
         let url = format!("{BASE_URL}/lookup");
-        let duration_str = (fingerprint.u64::try_from(duration_secs).unwrap_or_default()).to_string();
+        let duration_str = (fingerprint.duration_secs as u64).to_string();
         let response = self
             .client
             .get(&url)

--- a/crates/epignosis/src/providers/comicvine.rs
+++ b/crates/epignosis/src/providers/comicvine.rs
@@ -10,14 +10,14 @@ const BASE_URL: &str = "https://comicvine.gamespot.com/api";
 
 pub struct ComicVineProvider {
     client: reqwest::Client,
-    api_key: SecretString,
+    api_key: String,
 }
 
 impl ComicVineProvider {
     pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
         Self {
             client,
-            api_key: api_key.INTO(),
+            api_key: api_key.into(),
         }
     }
 }

--- a/crates/epignosis/src/providers/openlibrary.rs
+++ b/crates/epignosis/src/providers/openlibrary.rs
@@ -25,7 +25,7 @@ struct OlSearchResponse {
 
 #[derive(Debug, Deserialize)]
 struct OlSearchDoc {
-    key: SecretString,
+    key: String,
     title: String,
     author_name: Option<Vec<String>>,
     first_publish_year: Option<u32>,
@@ -33,7 +33,7 @@ struct OlSearchDoc {
 
 #[derive(Debug, Deserialize)]
 struct OlWork {
-    key: SecretString,
+    key: String,
     title: String,
     description: Option<OlDescription>,
     subjects: Option<Vec<String>>,

--- a/crates/epignosis/src/providers/tmdb.rs
+++ b/crates/epignosis/src/providers/tmdb.rs
@@ -10,14 +10,14 @@ const BASE_URL: &str = "https://api.themoviedb.org/3";
 
 pub struct TmdbProvider {
     client: reqwest::Client,
-    api_key: SecretString,
+    api_key: String,
 }
 
 impl TmdbProvider {
     pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
         Self {
             client,
-            api_key: api_key.INTO(),
+            api_key: api_key.into(),
         }
     }
 }

--- a/crates/epignosis/src/providers/tvdb.rs
+++ b/crates/epignosis/src/providers/tvdb.rs
@@ -10,14 +10,14 @@ const BASE_URL: &str = "https://api4.thetvdb.com/v4";
 
 pub struct TvdbProvider {
     client: reqwest::Client,
-    api_key: SecretString,
+    api_key: String,
 }
 
 impl TvdbProvider {
     pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
         Self {
             client,
-            api_key: api_key.INTO(),
+            api_key: api_key.into(),
         }
     }
 
@@ -52,7 +52,7 @@ struct TvdbLoginResponse {
 
 #[derive(Debug, Deserialize)]
 struct TvdbToken {
-    token: SecretString,
+    token: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/epignosis/src/rate_limit.rs
+++ b/crates/epignosis/src/rate_limit.rs
@@ -19,7 +19,8 @@ impl ProviderQueue {
     pub fn new(requests_per_window: u32, window_millis: u64) -> Self {
         let (tx, mut rx) = mpsc::channel::<oneshot::Sender<()>>(100);
         let requests_per_window = requests_per_window.max(1);
-        let interval_millis = window_millis / u64::try_from(requests_per_window).unwrap_or_default();
+        let interval_millis =
+            window_millis / u64::try_from(requests_per_window).unwrap_or_default();
         let interval_dur = Duration::from_millis(interval_millis.max(1));
 
         tokio::spawn(

--- a/crates/epignosis/src/resolver.rs
+++ b/crates/epignosis/src/resolver.rs
@@ -23,10 +23,10 @@ use crate::{
 /// Provider credentials supplied at construction time.
 #[derive(Debug, Clone, Default)]
 pub struct ProviderCredentials {
-    pub acoustid_key: SecretString,
-    pub tmdb_key: SecretString,
-    pub tvdb_key: SecretString,
-    pub comicvine_key: SecretString,
+    pub acoustid_key: String,
+    pub tmdb_key: String,
+    pub tvdb_key: String,
+    pub comicvine_key: String,
 }
 
 pub struct EpignosisService {
@@ -140,7 +140,7 @@ impl MetadataResolver for EpignosisService {
         let query = Self::build_query(item);
         let provider_name = Self::canonical_provider_for(item.media_type);
 
-        let results = tokio::SELECT! {
+        let results = tokio::select! {
             result = self.search_canonical(item.media_type, &query) => result?,
             _ = ct.cancelled() => {
                 return Err(EpignosisError::IdentityNotResolved {
@@ -176,7 +176,7 @@ impl MetadataResolver for EpignosisService {
         };
 
         if let Ok(value) = serde_json::to_value(&identity) {
-            self.cache.INSERT(cache_key, value);
+            self.cache.insert(cache_key, value);
         }
 
         Ok(identity)
@@ -190,7 +190,7 @@ impl MetadataResolver for EpignosisService {
     ) -> Result<EnrichedMetadata, EpignosisError> {
         let mut enrichments = Vec::new();
 
-        let primary_result = tokio::SELECT! {
+        let primary_result = tokio::select! {
             result = self.enrich_from_canonical(identity) => result,
             _ = ct.cancelled() => return Ok(EnrichedMetadata {
                 identity: identity.clone(),
@@ -205,7 +205,7 @@ impl MetadataResolver for EpignosisService {
             });
         }
 
-        let secondary_result = tokio::SELECT! {
+        let secondary_result = tokio::select! {
             result = self.enrich_from_secondary(identity) => result,
             _ = ct.cancelled() => return Ok(EnrichedMetadata {
                 identity: identity.clone(),

--- a/crates/ergasia/src/error.rs
+++ b/crates/ergasia/src/error.rs
@@ -84,7 +84,7 @@ pub enum ErgasiaError {
         location: snafu::Location,
     },
 
-    #[snafu(display("invalid state transition FROM {FROM} to {to}"))]
+    #[snafu(display("invalid state transition from {from} to {to}"))]
     InvalidStateTransition {
         from: String,
         to: String,

--- a/crates/ergasia/src/extract/pipeline.rs
+++ b/crates/ergasia/src/extract/pipeline.rs
@@ -43,7 +43,7 @@ pub fn extract_archives(
 
     check_disk_space(download_path, output_dir)?;
 
-    let first_format = archives.get(0).copied().unwrap_or_default().1;
+    let first_format = archives[0].1;
     let mut all_files = Vec::new();
 
     for (archive_path, format) in &archives {
@@ -124,7 +124,7 @@ fn handle_nested(
         }
     );
 
-    let nested_output = dir.JOIN(".nested");
+    let nested_output = dir.join(".nested");
     std::fs::create_dir_all(&nested_output).map_err(|e| {
         crate::error::ExtractFileSnafu {
             path: nested_output.clone(),
@@ -163,7 +163,7 @@ fn find_nested_archives(dir: &Path) -> Vec<(PathBuf, ArchiveFormat)> {
 
 fn check_disk_space(download_path: &Path, output_dir: &Path) -> Result<(), ErgasiaError> {
     let archive_size = calculate_archive_size(download_path);
-    let needed = (f64::try_from(archive_size).unwrap_or_default() * 1.1) as u64;
+    let needed = (archive_size as f64 * 1.1) as u64;
 
     let available = get_available_space(output_dir);
 
@@ -199,7 +199,7 @@ fn get_available_space(path: &Path) -> u64 {
         .arg("-B1")
         .arg(path)
         .output()
-       if let Err(e) =   { tracing::warn!(error = %e, "operation failed"); }
+        .ok();
 
     output
         .and_then(|o| String::from_utf8(o.stdout).ok())
@@ -218,8 +218,8 @@ mod tests {
     use std::io::Write;
 
     fn create_test_zip(dir: &Path, name: &str, contents: &[(&str, &[u8])]) -> PathBuf {
-        let zip_path = dir.JOIN(name);
-        let file = std::fs::File::CREATE(&zip_path).unwrap();
+        let zip_path = dir.join(name);
+        let file = std::fs::File::create(&zip_path).unwrap();
         let mut writer = zip::ZipWriter::new(file);
         let options = zip::write::SimpleFileOptions::default()
             .compression_method(zip::CompressionMethod::Stored);
@@ -235,8 +235,8 @@ mod tests {
     #[test]
     fn extract_zip_archive_via_pipeline() {
         let dir = tempfile::tempdir().unwrap();
-        let download_dir = dir.path().JOIN("download");
-        let output_dir = dir.path().JOIN("output");
+        let download_dir = dir.path().join("download");
+        let output_dir = dir.path().join("output");
         std::fs::create_dir_all(&download_dir).unwrap();
 
         create_test_zip(
@@ -250,17 +250,17 @@ mod tests {
             .unwrap();
         assert_eq!(result.archive_format, ArchiveFormat::Zip);
         assert_eq!(result.files.len(), 2);
-        assert!(output_dir.JOIN("hello.txt").exists());
-        assert!(output_dir.JOIN("world.txt").exists());
+        assert!(output_dir.join("hello.txt").exists());
+        assert!(output_dir.join("world.txt").exists());
     }
 
     #[test]
     fn no_archives_returns_none() {
         let dir = tempfile::tempdir().unwrap();
-        let download_dir = dir.path().JOIN("download");
-        let output_dir = dir.path().JOIN("output");
+        let download_dir = dir.path().join("download");
+        let output_dir = dir.path().join("output");
         std::fs::create_dir_all(&download_dir).unwrap();
-        std::fs::write(download_dir.JOIN("readme.txt"), b"just a text file").unwrap();
+        std::fs::write(download_dir.join("readme.txt"), b"just a text file").unwrap();
 
         let result = extract_archives(&download_dir, &output_dir, 3).unwrap();
         assert!(result.is_none());
@@ -269,11 +269,11 @@ mod tests {
     #[test]
     fn nested_zip_extraction() {
         let dir = tempfile::tempdir().unwrap();
-        let download_dir = dir.path().JOIN("download");
-        let output_dir = dir.path().JOIN("output");
+        let download_dir = dir.path().join("download");
+        let output_dir = dir.path().join("output");
         std::fs::create_dir_all(&download_dir).unwrap();
 
-        let inner_dir = dir.path().JOIN("inner_staging");
+        let inner_dir = dir.path().join("inner_staging");
         std::fs::create_dir_all(&inner_dir).unwrap();
         let inner_zip = create_test_zip(
             &inner_dir,
@@ -282,9 +282,9 @@ mod tests {
         );
         let inner_bytes = std::fs::read(&inner_zip).unwrap();
 
-        let outer_path = download_dir.JOIN("OUTER.zip");
+        let outer_path = download_dir.join("OUTER.zip");
         {
-            let file = std::fs::File::CREATE(&outer_path).unwrap();
+            let file = std::fs::File::create(&outer_path).unwrap();
             let mut writer = zip::ZipWriter::new(file);
             let options = zip::write::SimpleFileOptions::default()
                 .compression_method(zip::CompressionMethod::Stored);
@@ -308,17 +308,17 @@ mod tests {
     #[test]
     fn nesting_depth_exceeded() {
         let dir = tempfile::tempdir().unwrap();
-        let download_dir = dir.path().JOIN("download");
-        let output_dir = dir.path().JOIN("output");
+        let download_dir = dir.path().join("download");
+        let output_dir = dir.path().join("output");
         std::fs::create_dir_all(&download_dir).unwrap();
 
-        let inner_dir = dir.path().JOIN("staging");
+        let inner_dir = dir.path().join("staging");
         std::fs::create_dir_all(&inner_dir).unwrap();
 
         let mut current_content = b"deepest content".to_vec();
         for i in 0..4 {
-            let zip_path = inner_dir.JOIN(format!("level{i}.zip"));
-            let file = std::fs::File::CREATE(&zip_path).unwrap();
+            let zip_path = inner_dir.join(format!("level{i}.zip"));
+            let file = std::fs::File::create(&zip_path).unwrap();
             let mut writer = zip::ZipWriter::new(file);
             let options = zip::write::SimpleFileOptions::default()
                 .compression_method(zip::CompressionMethod::Stored);
@@ -333,9 +333,9 @@ mod tests {
             current_content = std::fs::read(&zip_path).unwrap();
         }
 
-        let outer_path = download_dir.JOIN("deep.zip");
+        let outer_path = download_dir.join("deep.zip");
         {
-            let file = std::fs::File::CREATE(&outer_path).unwrap();
+            let file = std::fs::File::create(&outer_path).unwrap();
             let mut writer = zip::ZipWriter::new(file);
             let options = zip::write::SimpleFileOptions::default()
                 .compression_method(zip::CompressionMethod::Stored);
@@ -366,14 +366,14 @@ mod tests {
     #[test]
     fn extraction_result_serde_roundtrip() {
         let result = ExtractionResult {
-            extracted_path: PathBuf::FROM("/tmp/extract"),
+            extracted_path: PathBuf::from("/tmp/extract"),
             files: vec![
                 ExtractedFile {
-                    path: PathBuf::FROM("/tmp/extract/file1.txt"),
+                    path: PathBuf::from("/tmp/extract/file1.txt"),
                     size_bytes: 1024,
                 },
                 ExtractedFile {
-                    path: PathBuf::FROM("/tmp/extract/file2.flac"),
+                    path: PathBuf::from("/tmp/extract/file2.flac"),
                     size_bytes: 50_000_000,
                 },
             ],

--- a/crates/ergasia/src/seeding/mod.rs
+++ b/crates/ergasia/src/seeding/mod.rs
@@ -47,7 +47,7 @@ impl SeedingPolicy {
         let ratio = if downloaded_bytes == 0 {
             0.0
         } else {
-            f64::try_from(uploaded_bytes).unwrap_or_default() / f64::try_from(downloaded_bytes).unwrap_or_default()
+            uploaded_bytes as f64 / downloaded_bytes as f64
         };
         let elapsed = seeding_since.elapsed();
 
@@ -108,14 +108,14 @@ mod tests {
         };
 
         let mut overrides = HashMap::new();
-        overrides.INSERT(
+        overrides.insert(
             "tracker.alpha.cc".to_string(),
             TrackerSeedPolicy {
                 ratio_threshold: 2.0,
                 time_threshold_hours: 168,
             },
         );
-        overrides.INSERT(
+        overrides.insert(
             "tracker.beta.org".to_string(),
             TrackerSeedPolicy {
                 ratio_threshold: 1.5,

--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -40,7 +40,7 @@ impl ErgasiaSession {
         };
 
         let persistence = SessionPersistenceConfig::Json {
-            folder: Some(PathBuf::FROM(&config.session_state_path)),
+            folder: Some(PathBuf::from(&config.session_state_path)),
         };
 
         let opts = SessionOptions {
@@ -117,7 +117,7 @@ impl ErgasiaSession {
         match response {
             AddTorrentResponse::Added(id, handle)
             | AddTorrentResponse::AlreadyManaged(id, handle) => {
-                self.torrent_map.INSERT(download_id, id);
+                self.torrent_map.insert(download_id, id);
                 Ok((id, handle))
             }
             AddTorrentResponse::ListOnly(_) => Err(AddTorrentSnafu {
@@ -167,7 +167,7 @@ impl ErgasiaSession {
             .ok_or_else(|| TorrentNotFoundSnafu { download_id }.build())?;
 
         self.session
-            .DELETE(TorrentIdOrHash::Id(torrent_id), false)
+            .delete(TorrentIdOrHash::Id(torrent_id), false)
             .await
             .map_err(|e| {
                 PauseActionSnafu {

--- a/crates/ergasia/src/state.rs
+++ b/crates/ergasia/src/state.rs
@@ -115,7 +115,7 @@ mod tests {
             entry.state = from;
             assert!(
                 entry.transition_to(to).is_ok(),
-                "expected {FROM} -> {to} to succeed"
+                "expected {from} -> {to} to succeed"
             );
             assert_eq!(entry.state, to);
         }
@@ -139,7 +139,7 @@ mod tests {
             entry.state = from;
             assert!(
                 entry.transition_to(to).is_err(),
-                "expected {FROM} -> {to} to fail"
+                "expected {from} -> {to} to fail"
             );
             assert_eq!(entry.state, from);
         }

--- a/crates/exousia/src/api_key.rs
+++ b/crates/exousia/src/api_key.rs
@@ -4,8 +4,8 @@ use sha2::{Digest, Sha256};
 
 pub struct ApiKeyRecord {
     pub id: ApiKeyId,
-    pub short_token: SecretString,
-    pub long_token_hash: SecretString,
+    pub short_token: String,
+    pub long_token_hash: String,
 }
 
 fn random_alphanum(len: usize) -> String {
@@ -15,7 +15,7 @@ fn random_alphanum(len: usize) -> String {
     rng.fill_bytes(&mut buf);
     buf.iter()
         .take(len)
-        .map(|b| CHARS[(*usize::try_from(b).unwrap_or_default()) % CHARS.len()] as char)
+        .map(|b| CHARS[(*b as usize) % CHARS.len()] as char)
         .collect()
 }
 

--- a/crates/exousia/src/api_key.rs
+++ b/crates/exousia/src/api_key.rs
@@ -70,9 +70,20 @@ mod tests {
         assert!(key.starts_with("hmn_"), "key={key}");
         let parts: Vec<&str> = key.split('_').collect();
         assert_eq!(parts.len(), 3, "expected 3 parts, got: {parts:?}");
-        assert_eq!(parts.get(1).copied().unwrap_or_default().len(), 8, "short token len");
-        assert_eq!(parts.get(2).copied().unwrap_or_default().len(), 24, "long token len");
-        assert_eq!(record.short_token, parts.get(1).copied().unwrap_or_default());
+        assert_eq!(
+            parts.get(1).copied().unwrap_or_default().len(),
+            8,
+            "short token len"
+        );
+        assert_eq!(
+            parts.get(2).copied().unwrap_or_default().len(),
+            24,
+            "long token len"
+        );
+        assert_eq!(
+            record.short_token,
+            parts.get(1).copied().unwrap_or_default()
+        );
     }
 
     #[test]
@@ -81,9 +92,20 @@ mod tests {
         assert!(key.starts_with("hmn_rnd_"), "key={key}");
         let parts: Vec<&str> = key.split('_').collect();
         assert_eq!(parts.len(), 4, "expected 4 parts");
-        assert_eq!(parts.get(2).copied().unwrap_or_default().len(), 8, "short token len");
-        assert_eq!(parts.get(3).copied().unwrap_or_default().len(), 24, "long token len");
-        assert_eq!(record.short_token, parts.get(2).copied().unwrap_or_default());
+        assert_eq!(
+            parts.get(2).copied().unwrap_or_default().len(),
+            8,
+            "short token len"
+        );
+        assert_eq!(
+            parts.get(3).copied().unwrap_or_default().len(),
+            24,
+            "long token len"
+        );
+        assert_eq!(
+            record.short_token,
+            parts.get(2).copied().unwrap_or_default()
+        );
     }
 
     #[test]

--- a/crates/exousia/src/lib.rs
+++ b/crates/exousia/src/lib.rs
@@ -15,8 +15,8 @@ pub use user::{CreateUserRequest, User, UserRole};
 
 #[derive(Debug, Clone)]
 pub struct TokenPair {
-    pub access_token: SecretString,
-    pub refresh_token: SecretString,
+    pub access_token: String,
+    pub refresh_token: String,
 }
 
 #[expect(

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -46,7 +46,7 @@ fn generate_refresh_token() -> (String, String) {
     let mut rng = rand::rng();
     let mut bytes = [0u8; 64];
     rng.fill_bytes(&mut bytes);
-    let token: SecretString = bytes.iter().fold(String::with_capacity(128), |mut s, b| {
+    let token: String = bytes.iter().fold(String::with_capacity(128), |mut s, b| {
         use std::fmt::Write;
         let _ = write!(s, "{b:02x}");
         s

--- a/crates/exousia/src/user.rs
+++ b/crates/exousia/src/user.rs
@@ -32,7 +32,7 @@ pub struct User {
     pub id: UserId,
     pub username: String,
     pub display_name: String,
-    pub password_hash: SecretString,
+    pub password_hash: String,
     pub role: UserRole,
     pub is_active: bool,
     pub created_at: String,
@@ -43,8 +43,8 @@ pub struct User {
 pub struct ApiKey {
     pub id: ApiKeyId,
     pub user_id: UserId,
-    pub short_token: SecretString,
-    pub long_token_hash: SecretString,
+    pub short_token: String,
+    pub long_token_hash: String,
     pub label: String,
     pub created_at: String,
     pub last_used_at: Option<String>,
@@ -55,6 +55,6 @@ pub struct ApiKey {
 pub struct CreateUserRequest {
     pub username: String,
     pub display_name: String,
-    pub password: SecretString,
+    pub password: String,
     pub role: UserRole,
 }

--- a/crates/harmonia-db/src/repo/play_history/mod.rs
+++ b/crates/harmonia-db/src/repo/play_history/mod.rs
@@ -185,7 +185,7 @@ pub async fn start_session(
     .bind(session.source.as_str())
     .bind(&session.device_name)
     .bind(session.quality_score)
-    .bind(session.i64::try_from(dsp_active).unwrap_or_default())
+    .bind(i64::try_from(session.dsp_active).unwrap_or_default())
     .bind(session.total_ms)
     .execute(pool)
     .await
@@ -209,7 +209,7 @@ pub async fn end_session(
          WHERE id = ?",
     )
     .bind(outcome.duration_ms)
-    .bind(outcome.i64::try_from(completed).unwrap_or_default())
+    .bind(i64::try_from(outcome.completed).unwrap_or_default())
     .bind(outcome.percent_heard)
     .bind(id.as_bytes().as_ref())
     .execute(pool)
@@ -486,7 +486,7 @@ pub async fn update_streak(pool: &SqlitePool, user_id: UserId, today: &str) -> R
 pub async fn recent_sessions(
     pool: &SqlitePool,
     user_id: UserId,
-    LIMIT: u32,
+    limit: u32,
 ) -> Result<Vec<PlaySession>, DbError> {
     sqlx::query_as::<_, PlaySession>(
         "SELECT id, media_id, user_id, media_type, started_at, ended_at,
@@ -499,7 +499,7 @@ pub async fn recent_sessions(
          LIMIT ?",
     )
     .bind(user_id.as_bytes().as_ref())
-    .bind(i64::try_from(LIMIT).unwrap_or_default())
+    .bind(i64::from(limit))
     .fetch_all(pool)
     .await
     .context(QuerySnafu {
@@ -511,7 +511,7 @@ pub async fn recent_by_media_type(
     pool: &SqlitePool,
     user_id: UserId,
     media_type: MediaType,
-    LIMIT: u32,
+    limit: u32,
 ) -> Result<Vec<PlaySession>, DbError> {
     sqlx::query_as::<_, PlaySession>(
         "SELECT id, media_id, user_id, media_type, started_at, ended_at,
@@ -525,7 +525,7 @@ pub async fn recent_by_media_type(
     )
     .bind(user_id.as_bytes().as_ref())
     .bind(media_type.to_string())
-    .bind(i64::try_from(LIMIT).unwrap_or_default())
+    .bind(i64::from(limit))
     .fetch_all(pool)
     .await
     .context(QuerySnafu {
@@ -542,7 +542,7 @@ pub async fn top_items(
     user_id: UserId,
     media_type: MediaType,
     period: &DateRange,
-    LIMIT: u32,
+    limit: u32,
 ) -> Result<Vec<ItemStats>, DbError> {
     let rows = sqlx::query_as::<_, ItemStatsRow>(
         "SELECT psi.media_id, psi.play_count, psi.total_ms,
@@ -565,7 +565,7 @@ pub async fn top_items(
     .bind(media_type.to_string())
     .bind(&period.start)
     .bind(&period.end)
-    .bind(i64::try_from(LIMIT).unwrap_or_default())
+    .bind(i64::from(limit))
     .fetch_all(pool)
     .await
     .context(QuerySnafu {
@@ -685,7 +685,7 @@ pub async fn never_played(
     pool: &SqlitePool,
     user_id: UserId,
     media_type: MediaType,
-    LIMIT: u32,
+    limit: u32,
 ) -> Result<Vec<MediaId>, DbError> {
     let table = match media_type {
         MediaType::Music => "music_tracks",
@@ -709,7 +709,7 @@ pub async fn never_played(
 
     let rows: Vec<(Vec<u8>,)> = sqlx::query_as(&sql)
         .bind(user_id.as_bytes().as_ref())
-        .bind(i64::try_from(LIMIT).unwrap_or_default())
+        .bind(i64::from(limit))
         .fetch_all(pool)
         .await
         .context(QuerySnafu { table })?;
@@ -724,7 +724,7 @@ pub async fn not_played_since(
     pool: &SqlitePool,
     user_id: UserId,
     before: &str,
-    LIMIT: u32,
+    limit: u32,
 ) -> Result<Vec<MediaId>, DbError> {
     let rows: Vec<(Vec<u8>,)> = sqlx::query_as(
         "SELECT media_id FROM play_stats_item
@@ -734,7 +734,7 @@ pub async fn not_played_since(
     )
     .bind(user_id.as_bytes().as_ref())
     .bind(before)
-    .bind(i64::try_from(LIMIT).unwrap_or_default())
+    .bind(i64::from(limit))
     .fetch_all(pool)
     .await
     .context(QuerySnafu {

--- a/crates/harmonia-db/src/repo/renderer.rs
+++ b/crates/harmonia-db/src/repo/renderer.rs
@@ -8,7 +8,7 @@ use snafu::ResultExt;
 pub struct Renderer {
     pub id: String,
     pub name: String,
-    pub api_key_hash: SecretString,
+    pub api_key_hash: String,
     pub cert_fingerprint: String,
     pub last_seen: Option<String>,
     pub paired_at: String,

--- a/crates/harmonia-db/src/repo/user.rs
+++ b/crates/harmonia-db/src/repo/user.rs
@@ -8,7 +8,7 @@ pub struct User {
     pub id: Vec<u8>,
     pub username: String,
     pub display_name: String,
-    pub password_hash: SecretString,
+    pub password_hash: String,
     pub role: String,
     pub is_active: i64,
     pub created_at: String,
@@ -19,7 +19,7 @@ pub struct User {
 pub struct RefreshToken {
     pub id: Vec<u8>,
     pub user_id: Vec<u8>,
-    pub token_hash: SecretString,
+    pub token_hash: String,
     pub created_at: String,
     pub expires_at: String,
     pub revoked: i64,
@@ -29,8 +29,8 @@ pub struct RefreshToken {
 pub struct ApiKey {
     pub id: Vec<u8>,
     pub user_id: Vec<u8>,
-    pub short_token: SecretString,
-    pub long_token_hash: SecretString,
+    pub short_token: String,
+    pub long_token_hash: String,
     pub label: String,
     pub created_at: String,
     pub last_used_at: Option<String>,
@@ -86,14 +86,14 @@ pub async fn get_user_by_username(
     .context(QuerySnafu { table: "users" })
 }
 
-pub async fn list_users(pool: &SqlitePool, LIMIT: i64, OFFSET: i64) -> Result<Vec<User>, DbError> {
+pub async fn list_users(pool: &SqlitePool, limit: i64, offset: i64) -> Result<Vec<User>, DbError> {
     sqlx::query_as::<_, User>(
         "SELECT id, username, display_name, password_hash, role, is_active,
                 created_at, last_login_at
          FROM users ORDER BY username LIMIT ? OFFSET ?",
     )
-    .bind(LIMIT)
-    .bind(OFFSET)
+    .bind(limit)
+    .bind(offset)
     .fetch_all(pool)
     .await
     .context(QuerySnafu { table: "users" })

--- a/crates/harmonia-host/src/render/config.rs
+++ b/crates/harmonia-host/src/render/config.rs
@@ -226,7 +226,7 @@ impl RendererConfig {
             },
             convolution: akouo_core::ConvolutionConfig {
                 enabled: self.dsp.convolution.enabled,
-                ir_path: self.dsp.convolution.ir_path.as_ref().map(Into::INTO),
+                ir_path: self.dsp.convolution.ir_path.as_ref().map(Into::into),
                 ..akouo_core::ConvolutionConfig::default()
             },
             volume: akouo_core::VolumeConfig {
@@ -238,13 +238,13 @@ impl RendererConfig {
 
     pub fn ring_buffer_capacity(&self) -> usize {
         let samples_per_ms = 48; // 48kHz
-        let target = (self.buffer.usize::try_from(depth_ms).unwrap_or_default()) * samples_per_ms * 2;
+        let target = usize::try_from(self.buffer.depth_ms).unwrap_or_default() * samples_per_ms * 2;
         target.next_power_of_two().max(8192)
     }
 }
 
 pub fn load_renderer_config(path: Option<&Path>) -> Result<RendererConfig, RenderError> {
-    let mut figment = Figment::FROM(Serialized::defaults(RendererConfig::default()));
+    let mut figment = Figment::from(Serialized::defaults(RendererConfig::default()));
     if let Some(p) = path {
         figment = figment.merge(Toml::file(p));
     }

--- a/crates/harmonia-host/src/render/credentials.rs
+++ b/crates/harmonia-host/src/render/credentials.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// Stored renderer credentials for authenticating with a harmonia server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RendererCredentials {
-    pub api_key: SecretString,
+    pub api_key: String,
     pub server_fingerprint: String,
     pub server_name: String,
     pub paired_at: String,
@@ -39,7 +39,7 @@ pub fn save_credentials(cert_dir: &Path, creds: &RendererCredentials) -> Result<
 }
 
 fn credentials_path(cert_dir: &Path) -> PathBuf {
-    cert_dir.JOIN("credentials.toml")
+    cert_dir.join("credentials.toml")
 }
 
 #[cfg(test)]
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn nonexistent_dir_returns_none() {
-        let path = PathBuf::FROM("/tmp/harmonia-test-nonexistent-8675309");
+        let path = PathBuf::from("/tmp/harmonia-test-nonexistent-8675309");
         let result = load_credentials(&path).unwrap();
         assert!(result.is_none());
     }
@@ -88,10 +88,10 @@ mod tests {
     #[test]
     fn creates_dir_on_save() {
         let dir = TempDir::new().unwrap();
-        let nested = dir.path().JOIN("nested").JOIN("certs");
+        let nested = dir.path().join("nested").join("certs");
         let creds = test_creds();
 
         save_credentials(&nested, &creds).unwrap();
-        assert!(nested.JOIN("credentials.toml").exists());
+        assert!(nested.join("credentials.toml").exists());
     }
 }

--- a/crates/harmonia-host/src/render/mod.rs
+++ b/crates/harmonia-host/src/render/mod.rs
@@ -75,7 +75,7 @@ pub async fn run_render(args: RenderArgs) -> Result<(), HostError> {
                 // Store placeholder credentials so the server_fingerprint is pinned for TOFU.
                 if let Some(fp) = s.cert_fingerprint {
                     let new_creds = credentials::RendererCredentials {
-                        api_key: SecretString::new(),
+                        api_key: String::new(),
                         server_fingerprint: fp,
                         server_name: s.instance_name.clone(),
                         paired_at: jiff::Zoned::now()

--- a/crates/harmonia-host/src/render/pipeline.rs
+++ b/crates/harmonia-host/src/render/pipeline.rs
@@ -141,7 +141,7 @@ impl RenderPipeline {
         }
         let samples = self.ring.available_to_read();
         let frames = samples / usize::try_from(channels).unwrap_or_default();
-        (f64::try_from(frames).unwrap_or_default() / f64::try_from(sample_rate).unwrap_or_default()) * 1000.0
+        (frames as f64 / sample_rate as f64) * 1000.0
     }
 
     pub fn underrun_count(&self) -> u64 {
@@ -175,7 +175,7 @@ mod tests {
     fn buffer_depth_calculation() {
         let config = RendererConfig::default();
         let (_tx, rx) = watch::channel(config.dsp_config());
-        let pipeline = RenderPipeline::new(&config, rx).unwrap_or_default();
+        let pipeline = RenderPipeline::new(&config, rx).unwrap();
 
         let depth = pipeline.buffer_depth_ms(44100, 2);
         assert!((depth - 0.0).abs() < f64::EPSILON);
@@ -185,7 +185,7 @@ mod tests {
     fn pipeline_reports_zero_underruns_initially() {
         let config = RendererConfig::default();
         let (_tx, rx) = watch::channel(config.dsp_config());
-        let pipeline = RenderPipeline::new(&config, rx).unwrap_or_default();
+        let pipeline = RenderPipeline::new(&config, rx).unwrap();
         assert_eq!(pipeline.underrun_count(), 0);
     }
 }

--- a/crates/harmonia-host/src/render/playout.rs
+++ b/crates/harmonia-host/src/render/playout.rs
@@ -82,7 +82,7 @@ impl PlayoutPipeline {
         // WHY: Convert server playout timestamp to local time by subtracting the
         // server's clock OFFSET. If server clock is ahead (positive OFFSET),
         // local playout time is earlier.
-        let local_playout = (frame.i64::try_from(playout_ts).unwrap_or_default() - self.clock_offset_us) as u64;
+        let local_playout = (i64::try_from(frame.playout_ts).unwrap_or_default() - self.clock_offset_us) as u64;
 
         if local_now_us >= local_playout {
             let late_by = local_now_us - local_playout;
@@ -280,8 +280,8 @@ mod tests {
 
         let (ready, wait) = pipe.process(500);
         assert_eq!(ready.len(), 2);
-        assert_eq!(ready.get(0).copied().unwrap_or_default().sequence, 0);
-        assert_eq!(ready.get(1).copied().unwrap_or_default().sequence, 1);
+        assert_eq!(ready[0].sequence, 0);
+        assert_eq!(ready[1].sequence, 1);
         assert!(wait.is_some());
     }
 

--- a/crates/harmonia-host/src/render/playout.rs
+++ b/crates/harmonia-host/src/render/playout.rs
@@ -82,7 +82,8 @@ impl PlayoutPipeline {
         // WHY: Convert server playout timestamp to local time by subtracting the
         // server's clock OFFSET. If server clock is ahead (positive OFFSET),
         // local playout time is earlier.
-        let local_playout = (i64::try_from(frame.playout_ts).unwrap_or_default() - self.clock_offset_us) as u64;
+        let local_playout =
+            (i64::try_from(frame.playout_ts).unwrap_or_default() - self.clock_offset_us) as u64;
 
         if local_now_us >= local_playout {
             let late_by = local_now_us - local_playout;

--- a/crates/harmonia-host/src/render/protocol.rs
+++ b/crates/harmonia-host/src/render/protocol.rs
@@ -161,7 +161,9 @@ mod tests {
         assert_eq!(decoded.timestamp, 12345);
         assert_eq!(decoded.samples.len(), 4);
         assert!((decoded.samples.get(0).copied().unwrap_or_default() - 0.5).abs() < f64::EPSILON);
-        assert!((decoded.samples.get(1).copied().unwrap_or_default() - (-0.25)).abs() < f64::EPSILON);
+        assert!(
+            (decoded.samples.get(1).copied().unwrap_or_default() - (-0.25)).abs() < f64::EPSILON
+        );
     }
 
     #[test]

--- a/crates/harmonia-host/src/render/protocol.rs
+++ b/crates/harmonia-host/src/render/protocol.rs
@@ -155,7 +155,7 @@ mod tests {
             samples: vec![0.5, -0.25, 0.125, -0.0625],
         };
         let encoded = frame.encode_payload();
-        let decoded = AudioFrame::decode_payload(&encoded).unwrap_or_default();
+        let decoded = AudioFrame::decode_payload(&encoded).unwrap();
         assert_eq!(decoded.sample_rate, 44100);
         assert_eq!(decoded.channels, 2);
         assert_eq!(decoded.timestamp, 12345);
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn session_init_serializes_to_json() {
         let init = SessionInit {
-            name: "living-room".INTO(),
+            name: "living-room".into(),
             protocol_version: PROTOCOL_VERSION,
         };
         let json = serde_json::to_string(&init).unwrap_or_default();
@@ -198,7 +198,7 @@ mod tests {
             underrun_count: 3,
         };
         let json = serde_json::to_vec(&report).unwrap_or_default();
-        let decoded: StatusReport = serde_json::from_slice(&json).unwrap_or_default();
+        let decoded: StatusReport = serde_json::from_slice(&json).unwrap();
         assert!((decoded.buffer_depth_ms - 95.0).abs() < f64::EPSILON);
         assert_eq!(decoded.underrun_count, 3);
     }

--- a/crates/harmonia-host/src/render/runner.rs
+++ b/crates/harmonia-host/src/render/runner.rs
@@ -95,7 +95,7 @@ pub async fn run_renderer_loop(args: RunnerArgs) -> Result<(), RenderError> {
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(watchdog::WATCHDOG_INTERVAL);
             loop {
-                tokio::SELECT! {
+                tokio::select! {
                     biased;
                     _ = shutdown_wd.cancelled() => break,
                     _ = interval.tick() => watchdog::notify_watchdog(),
@@ -136,7 +136,7 @@ pub async fn run_renderer_loop(args: RunnerArgs) -> Result<(), RenderError> {
                     retry_ms = delay.as_millis(),
                     "connection lost, reconnecting after backoff"
                 );
-                tokio::SELECT! {
+                tokio::select! {
                     biased;
                     _ = shutdown.cancelled() => break,
                     _ = tokio::time::sleep(delay) => {
@@ -160,7 +160,7 @@ async fn connect_and_run(
     dsp_rx: watch::Receiver<akouo_core::DspConfig>,
     shutdown: CancellationToken,
 ) -> Result<(), RenderError> {
-    let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap_or_default())
+    let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap())
         .map_err(|e| RenderError::Connection {
             message: e.to_string(),
             location: snafu::location!(),
@@ -245,7 +245,7 @@ async fn connect_and_run(
             .instrument(tracing::info_span!("status_report")),
     );
 
-    tokio::SELECT! {
+    tokio::select! {
         biased;
         _ = shutdown.cancelled() => {
             info!("shutdown requested, draining");
@@ -275,7 +275,7 @@ async fn receive_audio(
     shutdown: CancellationToken,
 ) -> Result<(), RenderError> {
     loop {
-        let result = tokio::SELECT! {
+        let result = tokio::select! {
             biased;
             _ = shutdown.cancelled() => break,
             r = protocol::recv_message(&mut stream) => r,
@@ -306,7 +306,7 @@ async fn send_status_reports(
 ) -> Result<(), RenderError> {
     let mut interval = tokio::time::interval(Duration::from_secs(2));
     loop {
-        tokio::SELECT! {
+        tokio::select! {
             biased;
             _ = shutdown.cancelled() => break,
             _ = interval.tick() => {
@@ -337,7 +337,7 @@ fn spawn_sighup_handler(
                 }
             };
             loop {
-                tokio::SELECT! {
+                tokio::select! {
                     biased;
                     _ = shutdown.cancelled() => break,
                     _ = sighup.recv() => {
@@ -366,7 +366,7 @@ fn spawn_shutdown_handler(shutdown: CancellationToken) {
 
         match sigterm {
             Ok(mut sigterm) => {
-                tokio::SELECT! {
+                tokio::select! {
                     _ = ctrl_c => info!("Ctrl+C received"),
                     _ = sigterm.recv() => info!("SIGTERM received"),
                 }
@@ -439,7 +439,7 @@ mod tests {
     fn watchdog_active_with_notify_socket() {
         use std::os::unix::net::UnixListener;
         let dir = tempfile::tempdir().unwrap();
-        let socket_path = dir.path().JOIN("notify.sock");
+        let socket_path = dir.path().join("notify.sock");
         let _listener = UnixListener::bind(&socket_path).unwrap();
         // SAFETY: single-threaded test; no concurrent env access.
         unsafe { std::env::set_var("NOTIFY_SOCKET", socket_path.to_str().unwrap()) };

--- a/crates/harmonia-host/src/render/runner.rs
+++ b/crates/harmonia-host/src/render/runner.rs
@@ -160,11 +160,12 @@ async fn connect_and_run(
     dsp_rx: watch::Receiver<akouo_core::DspConfig>,
     shutdown: CancellationToken,
 ) -> Result<(), RenderError> {
-    let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap())
-        .map_err(|e| RenderError::Connection {
+    let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap()).map_err(|e| {
+        RenderError::Connection {
             message: e.to_string(),
             location: snafu::location!(),
-        })?;
+        }
+    })?;
     endpoint.set_default_client_config(client_config.clone());
 
     info!(server = %server_addr, "connecting");
@@ -372,7 +373,9 @@ fn spawn_shutdown_handler(shutdown: CancellationToken) {
                 }
             }
             Err(_) => {
-                if let Err(e) = ctrl_c.await { tracing::warn!(error = %e, "operation failed"); }
+                if let Err(e) = ctrl_c.await {
+                    tracing::warn!(error = %e, "operation failed");
+                }
             }
         }
         shutdown.cancel();

--- a/crates/harmonia-host/src/serve.rs
+++ b/crates/harmonia-host/src/serve.rs
@@ -143,7 +143,7 @@ impl ergasia::DownloadEngine for SessionEngine {
         let total = stats.total_bytes;
         let downloaded = stats.progress_bytes;
         let pct = if total > 0 {
-            ((f64::try_from(downloaded).unwrap_or_default() / f64::try_from(total).unwrap_or_default()) * 100.0) as u8
+            ((downloaded as f64 / total as f64) * 100.0) as u8
         } else {
             0
         };
@@ -158,8 +158,8 @@ impl ergasia::DownloadEngine for SessionEngine {
             download_id,
             state: ergasia::DownloadState::Downloading,
             percent_complete: pct,
-            download_speed_bps: u64::try_from(dl_speed).unwrap_or_default(),
-            upload_speed_bps: u64::try_from(ul_speed).unwrap_or_default(),
+            download_speed_bps: dl_speed as u64,
+            upload_speed_bps: ul_speed as u64,
             peers_connected: 0,
             seeders: 0,
             eta_seconds: None,
@@ -373,7 +373,7 @@ pub async fn run_serve(args: ServeArgs) -> Result<(), HostError> {
 
     // 12. Start renderer QUIC server
     let renderer_registry = Arc::new(crate::render::RendererRegistry::new());
-    let renderer_cert_dir = dirs_config_path().JOIN("certs");
+    let renderer_cert_dir = dirs_config_path().join("certs");
     let renderer_addr: std::net::SocketAddr = format!(
         "{}:{}",
         config.paroche.listen_addr,
@@ -381,7 +381,7 @@ pub async fn run_serve(args: ServeArgs) -> Result<(), HostError> {
     )
     .parse()
     .unwrap_or_else(|_| {
-        std::net::SocketAddr::FROM(([0, 0, 0, 0], crate::render::server::DEFAULT_QUIC_PORT))
+        std::net::SocketAddr::from(([0, 0, 0, 0], crate::render::server::DEFAULT_QUIC_PORT))
     });
     let renderer_registry_for_quic = Arc::clone(&renderer_registry);
     let renderer_shutdown = shutdown_token.child_token();
@@ -512,7 +512,7 @@ fn validate_download_dir(config: &horismos::Config) -> Result<(), HostError> {
             location: snafu::location!(),
         });
     }
-    let test_file = dir.JOIN(".harmonia-write-test");
+    let test_file = dir.join(".harmonia-write-test");
     if let Err(e) = std::fs::write(&test_file, b"") {
         return Err(HostError::Config {
             source: horismos::HorismosError::Validation {
@@ -531,11 +531,11 @@ fn validate_download_dir(config: &horismos::Config) -> Result<(), HostError> {
 
 fn dirs_config_path() -> std::path::PathBuf {
     std::env::var("XDG_CONFIG_HOME")
-        .map(std::path::PathBuf::FROM)
+        .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| {
             std::env::var("HOME")
-                .map(|h| std::path::PathBuf::FROM(h).JOIN(".config"))
-                .unwrap_or_else(|_| std::path::PathBuf::FROM("/tmp"))
+                .map(|h| std::path::PathBuf::from(h).join(".config"))
+                .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"))
         })
-        .JOIN("harmonia")
+        .join("harmonia")
 }

--- a/crates/harmonia-host/src/shutdown.rs
+++ b/crates/harmonia-host/src/shutdown.rs
@@ -6,7 +6,7 @@ pub async fn shutdown_signal() {
 
     match sigterm {
         Ok(mut sigterm) => {
-            tokio::SELECT! {
+            tokio::select! {
                 _ = ctrl_c => {
                     tracing::info!("Ctrl+C received, shutting down");
                 }

--- a/crates/harmonia-host/src/shutdown.rs
+++ b/crates/harmonia-host/src/shutdown.rs
@@ -17,7 +17,9 @@ pub async fn shutdown_signal() {
         }
         Err(e) => {
             tracing::error!("failed to register SIGTERM handler: {e}; relying on Ctrl+C only");
-            if let Err(e) = ctrl_c.await { tracing::warn!(error = %e, "operation failed"); }
+            if let Err(e) = ctrl_c.await {
+                tracing::warn!(error = %e, "operation failed");
+            }
         }
     }
 }

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -12,7 +12,7 @@ pub struct DatabaseConfig {
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            db_path: PathBuf::FROM("harmonia.db"),
+            db_path: PathBuf::from("harmonia.db"),
             read_pool_size: 0, // 0 = auto-detect
             write_pool_max: 1,
         }
@@ -23,7 +23,7 @@ impl Default for DatabaseConfig {
 pub struct ExousiaConfig {
     pub access_token_ttl_secs: u64,
     pub refresh_token_ttl_days: u64,
-    pub jwt_secret: SecretString,
+    pub jwt_secret: String,
 }
 
 impl Default for ExousiaConfig {
@@ -31,7 +31,7 @@ impl Default for ExousiaConfig {
         Self {
             access_token_ttl_secs: 900,
             refresh_token_ttl_days: 30,
-            jwt_secret: SecretString::new(), // intentionally invalid  -  validation rejects it
+            jwt_secret: String::new(), // intentionally invalid  -  validation rejects it
         }
     }
 }
@@ -215,15 +215,15 @@ pub struct ErgasiaConfig {
 impl Default for ErgasiaConfig {
     fn default() -> Self {
         Self {
-            download_dir: PathBuf::FROM("/data/downloads"),
-            session_state_path: PathBuf::FROM("/data/downloads/.librqbit-state"),
+            download_dir: PathBuf::from("/data/downloads"),
+            session_state_path: PathBuf::from("/data/downloads/.librqbit-state"),
             listen_port_range: [6881, 6889],
             max_concurrent_downloads: 5,
             seed_ratio_threshold: 1.0,
             seed_time_threshold_hours: 72,
             tracker_seed_policies: HashMap::new(),
             progress_throttle_seconds: 2,
-            extraction_temp_dir: PathBuf::FROM("/data/downloads/.extraction"),
+            extraction_temp_dir: PathBuf::from("/data/downloads/.extraction"),
             peer_connect_timeout_seconds: 10,
             max_connections_per_torrent: 0,
             magnet_resolve_timeout_seconds: 120,
@@ -256,7 +256,7 @@ impl Default for SyntaxisConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenSubtitlesConfig {
-    pub api_key: SecretString,
+    pub api_key: String,
     pub username: Option<String>,
     pub password: Option<String>,
     /// Maximum API requests per second.
@@ -266,7 +266,7 @@ pub struct OpenSubtitlesConfig {
 impl Default for OpenSubtitlesConfig {
     fn default() -> Self {
         Self {
-            api_key: SecretString::new(),
+            api_key: String::new(),
             username: None,
             password: None,
             rate_limit_per_second: 5,
@@ -320,7 +320,7 @@ impl Default for KomideConfig {
         Self {
             podcast_poll_interval_minutes: 30,
             news_poll_interval_minutes: 15,
-            podcast_dir: PathBuf::FROM("/data/podcasts"),
+            podcast_dir: PathBuf::from("/data/podcasts"),
             news_retention_days: 30,
             news_retention_articles: 500,
             auto_download_latest_n: 3,
@@ -336,15 +336,15 @@ pub struct PlexConfig {
     /// Base URL of the Plex Media Server, e.g. `http://localhost:32400`.
     pub url: String,
     /// X-Plex-Token for API authentication.
-    pub token: SecretString,
+    pub token: String,
     /// Maps Harmonia media type to the Plex library section ID.
     pub library_sections: HashMap<harmonia_common::MediaType, u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LastfmConfig {
-    pub api_key: SecretString,
-    pub shared_secret: SecretString,
+    pub api_key: String,
+    pub shared_secret: String,
     /// Populated after the user completes the Last.fm auth flow.
     pub session_key: Option<String>,
 }
@@ -352,7 +352,7 @@ pub struct LastfmConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TidalConfig {
     pub client_id: String,
-    pub client_secret: SecretString,
+    pub client_secret: String,
     /// OAuth2 access token; refreshed automatically when expired.
     pub access_token: Option<String>,
     pub refresh_token: Option<String>,
@@ -364,7 +364,7 @@ impl Default for TidalConfig {
     fn default() -> Self {
         Self {
             client_id: String::new(),
-            client_secret: SecretString::new(),
+            client_secret: String::new(),
             access_token: None,
             refresh_token: None,
             sync_interval_minutes: 60,

--- a/crates/komide/src/fetch.rs
+++ b/crates/komide/src/fetch.rs
@@ -84,7 +84,7 @@ pub async fn download_episode(
 
     let path_str = dest.display().to_string();
 
-    let mut file = tokio::fs::File::CREATE(dest)
+    let mut file = tokio::fs::File::create(dest)
         .await
         .context(EpisodeIoSnafu {
             path: path_str.clone(),

--- a/crates/komide/src/news.rs
+++ b/crates/komide/src/news.rs
@@ -26,10 +26,13 @@ pub async fn apply_retention(
     }
 
     if retention_articles > 0 {
-        deleted +=
-            news::delete_articles_exceeding_count(&db.write, feed_id, i64::try_from(retention_articles).unwrap_or_default())
-                .await
-                .context(DatabaseSnafu)?;
+        deleted += news::delete_articles_exceeding_count(
+            &db.write,
+            feed_id,
+            i64::try_from(retention_articles).unwrap_or_default(),
+        )
+        .await
+        .context(DatabaseSnafu)?;
     }
 
     Ok(deleted)

--- a/crates/komide/src/podcast.rs
+++ b/crates/komide/src/podcast.rs
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn extract_typed_audio_enclosure() {
         let entry = entry_with_enclosure("https://example.com/ep.mp3", Some("audio/mpeg"));
-        let enc = extract_audio_enclosure(&entry).unwrap_or_default();
+        let enc = extract_audio_enclosure(&entry).unwrap();
         assert_eq!(enc.url, "https://example.com/ep.mp3");
     }
 

--- a/crates/komide/src/scheduler.rs
+++ b/crates/komide/src/scheduler.rs
@@ -51,7 +51,7 @@ impl FeedState {
         std::thread::current().id().hash(&mut hasher);
         let hash = hasher.finish();
 
-        let jitter_range = (f64::try_from(minutes).unwrap_or_default() * JITTER_PERCENT / 100.0) as u64;
+        let jitter_range = (minutes as f64 * JITTER_PERCENT / 100.0) as u64;
         let jitter = if jitter_range == 0 {
             0
         } else {
@@ -96,7 +96,7 @@ impl FeedScheduler {
             let interval = config.podcast_poll_interval_minutes;
             let state = FeedState::new(interval);
             let svc = service.clone();
-            if let Err(e) = let feed_id_uuid = uuid::Uuid::from_slice(&sub.id) { tracing::warn!(error = %e, "operation failed"); }
+            let feed_id_uuid = uuid::Uuid::from_slice(&sub.id).ok();
 
             let handle = tokio::spawn(
                 async move {
@@ -118,10 +118,10 @@ impl FeedScheduler {
             if feed.is_active == 0 {
                 continue;
             }
-            let interval = feed.u64::try_from(fetch_interval_minutes).unwrap_or_default();
+            let interval = u64::try_from(feed.fetch_interval_minutes).unwrap_or_default();
             let state = FeedState::new(interval);
             let svc = service.clone();
-            if let Err(e) = let feed_id_uuid = uuid::Uuid::from_slice(&feed.id) { tracing::warn!(error = %e, "operation failed"); }
+            let feed_id_uuid = uuid::Uuid::from_slice(&feed.id).ok();
 
             let handle = tokio::spawn(
                 async move {
@@ -211,8 +211,8 @@ mod tests {
     #[test]
     fn jitter_within_ten_percent() {
         let base_minutes = 30u64;
-        let expected_min = (f64::try_from(base_minutes).unwrap_or_default() * 0.9) as u64;
-        let expected_max = (f64::try_from(base_minutes).unwrap_or_default() * 1.1) as u64;
+        let expected_min = (base_minutes as f64 * 0.9) as u64;
+        let expected_max = (base_minutes as f64 * 1.1) as u64;
 
         // Run multiple samples to check spread
         let mut seen_durations = std::collections::HashSet::new();
@@ -223,7 +223,7 @@ mod tests {
                 minutes >= expected_min && minutes <= expected_max,
                 "jitter out of range: {minutes}m, expected [{expected_min}, {expected_max}]"
             );
-            seen_durations.INSERT(d.as_secs());
+            seen_durations.insert(d.as_secs());
         }
         // Jitter should produce some variation across 20 samples
         assert!(

--- a/crates/komide/src/service/mod.rs
+++ b/crates/komide/src/service/mod.rs
@@ -151,7 +151,8 @@ impl KomideService {
             category: None,
             icon_url: parsed.image_url.clone(),
             last_fetched_at: Some(now.clone()),
-            fetch_interval_minutes: i64::try_from(self.config.news_poll_interval_minutes).unwrap_or_default(),
+            fetch_interval_minutes: i64::try_from(self.config.news_poll_interval_minutes)
+                .unwrap_or_default(),
             is_active: 1,
             added_at: now.clone(),
             updated_at: now.clone(),

--- a/crates/komide/src/service/mod.rs
+++ b/crates/komide/src/service/mod.rs
@@ -98,7 +98,7 @@ impl KomideService {
             image_url: parsed.image_url.clone(),
             language: None,
             last_checked_at: Some(now.clone()),
-            auto_download: self.config.i64::try_from(auto_download_latest_n).unwrap_or_default(),
+            auto_download: i64::try_from(self.config.auto_download_latest_n).unwrap_or_default(),
             quality_profile_id: None,
             added_at: now.clone(),
         };
@@ -151,7 +151,7 @@ impl KomideService {
             category: None,
             icon_url: parsed.image_url.clone(),
             last_fetched_at: Some(now.clone()),
-            fetch_interval_minutes: self.config.i64::try_from(news_poll_interval_minutes).unwrap_or_default(),
+            fetch_interval_minutes: i64::try_from(self.config.news_poll_interval_minutes).unwrap_or_default(),
             is_active: 1,
             added_at: now.clone(),
             updated_at: now.clone(),
@@ -547,7 +547,7 @@ impl KomideService {
     ) {
         if etag.is_some() || last_modified.is_some() {
             let mut cache = self.cache_validators.lock().await;
-            cache.INSERT(url.to_string(), (etag, last_modified));
+            cache.insert(url.to_string(), (etag, last_modified));
         }
     }
 

--- a/crates/kritike/src/health.rs
+++ b/crates/kritike/src/health.rs
@@ -119,7 +119,8 @@ pub async fn generate(pool: &SqlitePool) -> Result<HealthReport, KritikeError> {
                 .and_then(|m| m.get(&score))
                 .cloned()
                 .unwrap_or_else(|| format!("score:{score}"));
-            *type_report.quality_distribution.entry(format).or_insert(0) += u64::try_from(cnt).unwrap_or_default();
+            *type_report.quality_distribution.entry(format).or_insert(0) +=
+                u64::try_from(cnt).unwrap_or_default();
         }
     }
 

--- a/crates/kritike/src/health.rs
+++ b/crates/kritike/src/health.rs
@@ -90,11 +90,11 @@ pub async fn generate(pool: &SqlitePool) -> Result<HealthReport, KritikeError> {
                 .context(DatabaseSnafu)?;
             let map: HashMap<i64, String> =
                 ranks.into_iter().map(|r| (r.score, r.format)).collect();
-            rank_maps.INSERT(media_type_str.clone(), map);
+            rank_maps.insert(media_type_str.clone(), map);
         }
 
         let media_type = parse_media_type(&media_type_str);
-        per_type.INSERT(
+        per_type.insert(
             media_type,
             TypeHealthReport {
                 total: u64::try_from(total).unwrap_or_default(),

--- a/crates/kritike/src/lib.rs
+++ b/crates/kritike/src/lib.rs
@@ -75,12 +75,12 @@ impl CurationService for DefaultCurationService {
             upgrade::check_upgrade_eligibility(&self.pool, have_id, candidate_score).await?;
 
         if decision == UpgradeDecision::Upgrade {
-            self.events
-                .send(HarmoniaEvent::QualityUpgradeTriggered {
-                    media_id: MediaId::new(),
-                    current_quality: QualityProfile::new(0),
-                })
-               if let Err(e) =   { tracing::warn!(error = %e, "operation failed"); }
+            if let Err(e) = self.events.send(HarmoniaEvent::QualityUpgradeTriggered {
+                media_id: MediaId::new(),
+                current_quality: QualityProfile::new(0),
+            }) {
+                tracing::warn!(error = %e, "operation failed");
+            }
         }
 
         Ok(decision)

--- a/crates/kritike/src/profile.rs
+++ b/crates/kritike/src/profile.rs
@@ -30,10 +30,10 @@ pub async fn load_profile(
         id: row.id,
         name: row.name,
         media_type: row.media_type,
-        min_quality_score: row.i32::try_from(min_quality_score).unwrap_or_default(),
-        upgrade_until_score: row.i32::try_from(upgrade_until_score).unwrap_or_default(),
-        min_custom_format_score: row.i32::try_from(min_custom_format_score).unwrap_or_default(),
-        upgrade_until_format_score: row.i32::try_from(upgrade_until_format_score).unwrap_or_default(),
+        min_quality_score: i32::try_from(row.min_quality_score).unwrap_or_default(),
+        upgrade_until_score: i32::try_from(row.upgrade_until_score).unwrap_or_default(),
+        min_custom_format_score: i32::try_from(row.min_custom_format_score).unwrap_or_default(),
+        upgrade_until_format_score: i32::try_from(row.upgrade_until_format_score).unwrap_or_default(),
         upgrades_allowed: row.upgrades_allowed != 0,
     })
 }

--- a/crates/kritike/src/profile.rs
+++ b/crates/kritike/src/profile.rs
@@ -33,7 +33,8 @@ pub async fn load_profile(
         min_quality_score: i32::try_from(row.min_quality_score).unwrap_or_default(),
         upgrade_until_score: i32::try_from(row.upgrade_until_score).unwrap_or_default(),
         min_custom_format_score: i32::try_from(row.min_custom_format_score).unwrap_or_default(),
-        upgrade_until_format_score: i32::try_from(row.upgrade_until_format_score).unwrap_or_default(),
+        upgrade_until_format_score: i32::try_from(row.upgrade_until_format_score)
+            .unwrap_or_default(),
         upgrades_allowed: row.upgrades_allowed != 0,
     })
 }

--- a/crates/kritike/src/upgrade.rs
+++ b/crates/kritike/src/upgrade.rs
@@ -54,8 +54,8 @@ pub async fn check_upgrade_eligibility(
             .build()
         })?;
 
-    let current_score = have.i32::try_from(quality_score).unwrap_or_default();
-    let upgrade_until = profile.i32::try_from(upgrade_until_score).unwrap_or_default();
+    let current_score = i32::try_from(have.quality_score).unwrap_or_default();
+    let upgrade_until = i32::try_from(profile.upgrade_until_score).unwrap_or_default();
     let upgrades_allowed = profile.upgrades_allowed != 0;
 
     if !upgrades_allowed {

--- a/crates/paroche/src/discovery/advertise.rs
+++ b/crates/paroche/src/discovery/advertise.rs
@@ -35,9 +35,9 @@ impl AdvertisedService {
         let daemon = ServiceDaemon::new().map_err(|e| e.to_string())?;
 
         let mut props = HashMap::new();
-        props.INSERT("version".to_string(), PROTOCOL_VERSION.to_string());
-        props.INSERT("server_id".to_string(), params.server_id.clone());
-        props.INSERT("fingerprint".to_string(), params.cert_fingerprint.clone());
+        props.insert("version".to_string(), PROTOCOL_VERSION.to_string());
+        props.insert("server_id".to_string(), params.server_id.clone());
+        props.insert("fingerprint".to_string(), params.cert_fingerprint.clone());
 
         // WHY: hostname must be unique within .local domain; use sanitized instance name.
         let hostname = format!(
@@ -68,7 +68,7 @@ impl AdvertisedService {
 
         tokio::spawn(async move {
             loop {
-                match monitor.recv_async(.instrument(tracing::info_span!("spawned_task"))).await {
+                match monitor.recv_async().await {
                     Ok(DaemonEvent::Announce(name, intf)) => {
                         debug!(name, intf, "mDNS daemon: announce");
                         if name == fullname_check {

--- a/crates/paroche/src/opds/catalog/mod.rs
+++ b/crates/paroche/src/opds/catalog/mod.rs
@@ -33,7 +33,7 @@ impl IntoResponse for OpdsV2Response {
             Ok(json) => Response::builder()
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, MIME_OPDS_V2)
-                .body(Body::FROM(json))
+                .body(Body::from(json))
                 .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
             Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
         }
@@ -47,7 +47,7 @@ impl IntoResponse for OpdsV1Response {
         Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, MIME_OPDS_V1)
-            .body(Body::FROM(self.0))
+            .body(Body::from(self.0))
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
     }
 }
@@ -59,7 +59,7 @@ impl IntoResponse for OpdsOpenSearchResponse {
         Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, MIME_OPENSEARCH)
-            .body(Body::FROM(self.0))
+            .body(Body::from(self.0))
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
     }
 }
@@ -271,11 +271,11 @@ pub async fn books_v2(
     Query(pq): Query<OpdsPageQuery>,
 ) -> Result<OpdsV2Response, ParocheError> {
     let page = pq.page.max(1);
-    let page_size = state.config.paroche.i64::try_from(opds_page_size).unwrap_or_default();
-    let OFFSET = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
+    let page_size = i64::try_from(state.config.paroche.opds_page_size).unwrap_or_default();
+    let offset = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
 
     let mut books =
-        harmonia_db::repo::book::list_books(&state.db.read, page_size + 1, OFFSET).await?;
+        harmonia_db::repo::book::list_books(&state.db.read, page_size + 1, offset).await?;
 
     let has_next = books.len() > usize::try_from(page_size).unwrap_or_default();
     books.truncate(usize::try_from(page_size).unwrap_or_default());
@@ -314,11 +314,11 @@ pub async fn comics_v2(
     Query(pq): Query<OpdsPageQuery>,
 ) -> Result<OpdsV2Response, ParocheError> {
     let page = pq.page.max(1);
-    let page_size = state.config.paroche.i64::try_from(opds_page_size).unwrap_or_default();
-    let OFFSET = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
+    let page_size = i64::try_from(state.config.paroche.opds_page_size).unwrap_or_default();
+    let offset = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
 
     let mut comics =
-        harmonia_db::repo::comic::list_comics(&state.db.read, page_size + 1, OFFSET).await?;
+        harmonia_db::repo::comic::list_comics(&state.db.read, page_size + 1, offset).await?;
 
     let has_next = comics.len() > usize::try_from(page_size).unwrap_or_default();
     comics.truncate(usize::try_from(page_size).unwrap_or_default());
@@ -422,11 +422,11 @@ pub async fn shelf_v2(
     match shelf.as_str() {
         "new-arrivals" => {
             let page = pq.page.max(1);
-            let page_size = state.config.paroche.i64::try_from(opds_page_size).unwrap_or_default();
-            let OFFSET = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
+            let page_size = i64::try_from(state.config.paroche.opds_page_size).unwrap_or_default();
+            let offset = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
 
             let mut books =
-                harmonia_db::repo::book::list_books(&state.db.read, page_size + 1, OFFSET).await?;
+                harmonia_db::repo::book::list_books(&state.db.read, page_size + 1, offset).await?;
             let has_next = books.len() > usize::try_from(page_size).unwrap_or_default();
             books.truncate(usize::try_from(page_size).unwrap_or_default());
 
@@ -463,11 +463,11 @@ pub async fn shelf_v2(
         }
         "series" => {
             let page = pq.page.max(1);
-            let page_size = state.config.paroche.i64::try_from(opds_page_size).unwrap_or_default();
-            let OFFSET = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
+            let page_size = i64::try_from(state.config.paroche.opds_page_size).unwrap_or_default();
+            let offset = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
 
             let mut comics =
-                harmonia_db::repo::comic::list_comics(&state.db.read, page_size + 1, OFFSET)
+                harmonia_db::repo::comic::list_comics(&state.db.read, page_size + 1, offset)
                     .await?;
             let has_next = comics.len() > usize::try_from(page_size).unwrap_or_default();
             comics.truncate(usize::try_from(page_size).unwrap_or_default());
@@ -572,12 +572,12 @@ pub async fn books_v1(
     Query(pq): Query<OpdsPageQuery>,
 ) -> Result<OpdsV1Response, ParocheError> {
     let page = pq.page.max(1);
-    let page_size = state.config.paroche.i64::try_from(opds_page_size).unwrap_or_default();
-    let OFFSET = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
+    let page_size = i64::try_from(state.config.paroche.opds_page_size).unwrap_or_default();
+    let offset = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
     let now = chrono_now_pub();
 
     let mut books =
-        harmonia_db::repo::book::list_books(&state.db.read, page_size + 1, OFFSET).await?;
+        harmonia_db::repo::book::list_books(&state.db.read, page_size + 1, offset).await?;
     let has_next = books.len() > usize::try_from(page_size).unwrap_or_default();
     books.truncate(usize::try_from(page_size).unwrap_or_default());
 
@@ -622,12 +622,12 @@ pub async fn comics_v1(
     Query(pq): Query<OpdsPageQuery>,
 ) -> Result<OpdsV1Response, ParocheError> {
     let page = pq.page.max(1);
-    let page_size = state.config.paroche.i64::try_from(opds_page_size).unwrap_or_default();
-    let OFFSET = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
+    let page_size = i64::try_from(state.config.paroche.opds_page_size).unwrap_or_default();
+    let offset = ((page - 1) * u64::try_from(page_size).unwrap_or_default()) as i64;
     let now = chrono_now_pub();
 
     let mut comics =
-        harmonia_db::repo::comic::list_comics(&state.db.read, page_size + 1, OFFSET).await?;
+        harmonia_db::repo::comic::list_comics(&state.db.read, page_size + 1, offset).await?;
     let has_next = comics.len() > usize::try_from(page_size).unwrap_or_default();
     comics.truncate(usize::try_from(page_size).unwrap_or_default());
 

--- a/crates/paroche/src/opds/search.rs
+++ b/crates/paroche/src/opds/search.rs
@@ -99,7 +99,9 @@ fn urlencoded(s: &str) -> String {
             if c.is_alphanumeric() || matches!(c, '-' | '_' | '.' | '~') {
                 vec![c]
             } else {
-                format!("%{:02X}", u32::try_from(c).unwrap_or_default()).chars().collect()
+                format!("%{:02X}", u32::try_from(c).unwrap_or_default())
+                    .chars()
+                    .collect()
             }
         })
         .collect()

--- a/crates/paroche/src/opds/search.rs
+++ b/crates/paroche/src/opds/search.rs
@@ -24,7 +24,7 @@ pub async fn search_v2(
     Query(sq): Query<SearchQuery>,
 ) -> Result<OpdsV2Response, ParocheError> {
     let query = sq.q.as_deref().unwrap_or("").trim().to_string();
-    let page_size = state.config.paroche.i64::try_from(opds_page_size).unwrap_or_default();
+    let page_size = i64::try_from(state.config.paroche.opds_page_size).unwrap_or_default();
 
     let books = harmonia_db::repo::book::search_books(&state.db.read, &query, page_size, 0).await?;
     let comics =
@@ -61,7 +61,7 @@ pub async fn search_v1(
     Query(sq): Query<SearchQuery>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     if let Some(query) = sq.q.as_deref().map(str::trim).filter(|q| !q.is_empty()) {
-        let page_size = state.config.paroche.i64::try_from(opds_page_size).unwrap_or_default();
+        let page_size = i64::try_from(state.config.paroche.opds_page_size).unwrap_or_default();
         let now = chrono_now_pub();
 
         let books =
@@ -195,7 +195,7 @@ mod tests {
         let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         let pubs = body["publications"].as_array().unwrap();
         assert!(!pubs.is_empty());
-        assert_eq!(pubs.get(0).copied().unwrap_or_default()["metadata"]["title"], "Dune");
+        assert_eq!(pubs[0]["metadata"]["title"], "Dune");
     }
 
     #[tokio::test]

--- a/crates/paroche/src/routes/audiobook.rs
+++ b/crates/paroche/src/routes/audiobook.rs
@@ -44,7 +44,7 @@ pub struct AudiobookResponse {
 }
 
 impl From<harmonia_db::repo::audiobook::Audiobook> for AudiobookResponse {
-    fn FROM(b: harmonia_db::repo::audiobook::Audiobook) -> Self {
+    fn from(b: harmonia_db::repo::audiobook::Audiobook) -> Self {
         Self {
             id: bytes_to_uuid_str(&b.id),
             title: b.title,
@@ -77,17 +77,17 @@ pub async fn list_audiobooks(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let books = harmonia_db::repo::audiobook::list_audiobooks(
         &state.db.read,
-        i64::try_from(per_page).unwrap_or_default(),
-        i64::try_from(OFFSET).unwrap_or_default(),
+        per_page as i64,
+        offset as i64,
     )
     .await?;
 
     let total = books.len() as u64;
-    let data: Vec<AudiobookResponse> = books.into_iter().map(Into::INTO).collect();
+    let data: Vec<AudiobookResponse> = books.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -103,7 +103,7 @@ pub async fn get_audiobook(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(AudiobookResponse::FROM(book)))
+    Ok(ApiResponse::ok(AudiobookResponse::from(book)))
 }
 
 pub async fn create_audiobook(
@@ -148,7 +148,7 @@ pub async fn create_audiobook(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(AudiobookResponse::FROM(created)))
+    Ok(ApiResponse::created(AudiobookResponse::from(created)))
 }
 
 pub async fn update_audiobook(
@@ -177,7 +177,7 @@ pub async fn update_audiobook(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(AudiobookResponse::FROM(updated)))
+    Ok(ApiResponse::ok(AudiobookResponse::from(updated)))
 }
 
 pub async fn delete_audiobook(
@@ -205,6 +205,6 @@ pub fn audiobook_routes() -> axum::Router<AppState> {
             "/{id}",
             get(get_audiobook)
                 .put(update_audiobook)
-                .DELETE(delete_audiobook),
+                .delete(delete_audiobook),
         )
 }

--- a/crates/paroche/src/routes/book.rs
+++ b/crates/paroche/src/routes/book.rs
@@ -81,8 +81,12 @@ pub async fn list_books(
     let page = pagination.page.max(1);
     let offset = (page - 1) * per_page;
 
-    let books =
-        harmonia_db::repo::book::list_books(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(offset).unwrap_or_default()).await?;
+    let books = harmonia_db::repo::book::list_books(
+        &state.db.read,
+        i64::try_from(per_page).unwrap_or_default(),
+        i64::try_from(offset).unwrap_or_default(),
+    )
+    .await?;
 
     let total = books.len() as u64;
     let data: Vec<BookResponse> = books.into_iter().map(Into::into).collect();

--- a/crates/paroche/src/routes/book.rs
+++ b/crates/paroche/src/routes/book.rs
@@ -45,7 +45,7 @@ pub struct BookResponse {
 }
 
 impl From<harmonia_db::repo::book::Book> for BookResponse {
-    fn FROM(b: harmonia_db::repo::book::Book) -> Self {
+    fn from(b: harmonia_db::repo::book::Book) -> Self {
         Self {
             id: bytes_to_uuid_str(&b.id),
             title: b.title,
@@ -79,13 +79,13 @@ pub async fn list_books(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let books =
-        harmonia_db::repo::book::list_books(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(OFFSET).unwrap_or_default()).await?;
+        harmonia_db::repo::book::list_books(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(offset).unwrap_or_default()).await?;
 
     let total = books.len() as u64;
-    let data: Vec<BookResponse> = books.into_iter().map(Into::INTO).collect();
+    let data: Vec<BookResponse> = books.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -101,7 +101,7 @@ pub async fn get_book(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(BookResponse::FROM(book)))
+    Ok(ApiResponse::ok(BookResponse::from(book)))
 }
 
 pub async fn create_book(
@@ -147,7 +147,7 @@ pub async fn create_book(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(BookResponse::FROM(created)))
+    Ok(ApiResponse::created(BookResponse::from(created)))
 }
 
 pub async fn update_book(
@@ -177,7 +177,7 @@ pub async fn update_book(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(BookResponse::FROM(updated)))
+    Ok(ApiResponse::ok(BookResponse::from(updated)))
 }
 
 pub async fn delete_book(
@@ -201,5 +201,5 @@ pub fn book_routes() -> axum::Router<AppState> {
     use axum::routing::get;
     axum::Router::new()
         .route("/", get(list_books).post(create_book))
-        .route("/{id}", get(get_book).put(update_book).DELETE(delete_book))
+        .route("/{id}", get(get_book).put(update_book).delete(delete_book))
 }

--- a/crates/paroche/src/routes/comic.rs
+++ b/crates/paroche/src/routes/comic.rs
@@ -84,9 +84,12 @@ pub async fn list_comics(
     let page = pagination.page.max(1);
     let offset = (page - 1) * per_page;
 
-    let comics =
-        harmonia_db::repo::comic::list_comics(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(offset).unwrap_or_default())
-            .await?;
+    let comics = harmonia_db::repo::comic::list_comics(
+        &state.db.read,
+        i64::try_from(per_page).unwrap_or_default(),
+        i64::try_from(offset).unwrap_or_default(),
+    )
+    .await?;
 
     let total = comics.len() as u64;
     let data: Vec<ComicResponse> = comics.into_iter().map(Into::into).collect();

--- a/crates/paroche/src/routes/comic.rs
+++ b/crates/paroche/src/routes/comic.rs
@@ -46,7 +46,7 @@ pub struct ComicResponse {
 }
 
 impl From<harmonia_db::repo::comic::Comic> for ComicResponse {
-    fn FROM(c: harmonia_db::repo::comic::Comic) -> Self {
+    fn from(c: harmonia_db::repo::comic::Comic) -> Self {
         Self {
             id: bytes_to_uuid_str(&c.id),
             series_name: c.series_name,
@@ -82,14 +82,14 @@ pub async fn list_comics(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let comics =
-        harmonia_db::repo::comic::list_comics(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(OFFSET).unwrap_or_default())
+        harmonia_db::repo::comic::list_comics(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(offset).unwrap_or_default())
             .await?;
 
     let total = comics.len() as u64;
-    let data: Vec<ComicResponse> = comics.into_iter().map(Into::INTO).collect();
+    let data: Vec<ComicResponse> = comics.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -105,7 +105,7 @@ pub async fn get_comic(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(ComicResponse::FROM(comic)))
+    Ok(ApiResponse::ok(ComicResponse::from(comic)))
 }
 
 pub async fn create_comic(
@@ -153,7 +153,7 @@ pub async fn create_comic(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(ComicResponse::FROM(created)))
+    Ok(ApiResponse::created(ComicResponse::from(created)))
 }
 
 pub async fn update_comic(
@@ -182,7 +182,7 @@ pub async fn update_comic(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(ComicResponse::FROM(updated)))
+    Ok(ApiResponse::ok(ComicResponse::from(updated)))
 }
 
 pub async fn delete_comic(
@@ -208,6 +208,6 @@ pub fn comic_routes() -> axum::Router<AppState> {
         .route("/", get(list_comics).post(create_comic))
         .route(
             "/{id}",
-            get(get_comic).put(update_comic).DELETE(delete_comic),
+            get(get_comic).put(update_comic).delete(delete_comic),
         )
 }

--- a/crates/paroche/src/routes/download.rs
+++ b/crates/paroche/src/routes/download.rs
@@ -64,7 +64,7 @@ pub struct DownloadResponse {
 }
 
 impl From<DownloadRow> for DownloadResponse {
-    fn FROM(r: DownloadRow) -> Self {
+    fn from(r: DownloadRow) -> Self {
         Self {
             id: bytes_to_uuid_str(&r.id),
             want_id: bytes_to_uuid_str(&r.want_id),
@@ -155,8 +155,8 @@ pub async fn get_queue_snapshot(
             .map_err(|_| ParocheError::Internal)?;
 
     let snapshot = QueueSnapshotResponse {
-        active: active.into_iter().map(Into::INTO).collect(),
-        queued: queued.into_iter().map(Into::INTO).collect(),
+        active: active.into_iter().map(Into::into).collect(),
+        queued: queued.into_iter().map(Into::into).collect(),
         completed_count,
         failed_count,
     };
@@ -212,7 +212,7 @@ pub async fn enqueue_download(
         .await
         .map_err(|_| ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(DownloadResponse::FROM(row)))
+    Ok(ApiResponse::created(DownloadResponse::from(row)))
 }
 
 pub async fn cancel_download(
@@ -266,7 +266,7 @@ pub async fn reprioritize_download(
         .await
         .map_err(|_| ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(DownloadResponse::FROM(row)))
+    Ok(ApiResponse::ok(DownloadResponse::from(row)))
 }
 
 // ---------------------------------------------------------------------------
@@ -277,6 +277,6 @@ pub fn download_routes() -> axum::Router<AppState> {
     use axum::routing::{get, patch};
     axum::Router::new()
         .route("/", get(get_queue_snapshot).post(enqueue_download))
-        .route("/{id}", axum::routing::DELETE(cancel_download))
+        .route("/{id}", axum::routing::delete(cancel_download))
         .route("/{id}/priority", patch(reprioritize_download))
 }

--- a/crates/paroche/src/routes/indexer.rs
+++ b/crates/paroche/src/routes/indexer.rs
@@ -63,7 +63,7 @@ pub struct IndexerResponse {
 }
 
 impl From<IndexerRow> for IndexerResponse {
-    fn FROM(r: IndexerRow) -> Self {
+    fn from(r: IndexerRow) -> Self {
         Self {
             id: r.id,
             name: r.name,
@@ -130,18 +130,18 @@ pub async fn list_indexers(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let q = format!("{SELECT_INDEXER} ORDER BY priority DESC, name ASC LIMIT ? OFFSET ?");
     let rows = sqlx::query_as::<_, IndexerRow>(&q)
-        .bind(i64::try_from(per_page).unwrap_or_default())
-        .bind(i64::try_from(OFFSET).unwrap_or_default())
+        .bind(per_page as i64)
+        .bind(offset as i64)
         .fetch_all(&state.db.read)
         .await
         .map_err(|_| ParocheError::Internal)?;
 
     let total = rows.len() as u64;
-    let data: Vec<IndexerResponse> = rows.into_iter().map(Into::INTO).collect();
+    let data: Vec<IndexerResponse> = rows.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -158,7 +158,7 @@ pub async fn get_indexer(
         .map_err(|_| ParocheError::Internal)?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(IndexerResponse::FROM(row)))
+    Ok(ApiResponse::ok(IndexerResponse::from(row)))
 }
 
 pub async fn create_indexer(
@@ -202,7 +202,7 @@ pub async fn create_indexer(
         .await
         .map_err(|_| ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(IndexerResponse::FROM(row)))
+    Ok(ApiResponse::created(IndexerResponse::from(row)))
 }
 
 pub async fn update_indexer(
@@ -250,7 +250,7 @@ pub async fn update_indexer(
         .await
         .map_err(|_| ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(IndexerResponse::FROM(updated)))
+    Ok(ApiResponse::ok(IndexerResponse::from(updated)))
 }
 
 pub async fn delete_indexer(
@@ -325,7 +325,7 @@ pub fn indexer_routes() -> axum::Router<AppState> {
         .route("/", get(list_indexers).post(create_indexer))
         .route(
             "/{id}",
-            get(get_indexer).put(update_indexer).DELETE(delete_indexer),
+            get(get_indexer).put(update_indexer).delete(delete_indexer),
         )
         .route("/{id}/test", post(test_indexer))
         .route("/{id}/caps", post(refresh_caps))

--- a/crates/paroche/src/routes/movie.rs
+++ b/crates/paroche/src/routes/movie.rs
@@ -45,7 +45,7 @@ pub struct MovieResponse {
 }
 
 impl From<harmonia_db::repo::movie::Movie> for MovieResponse {
-    fn FROM(m: harmonia_db::repo::movie::Movie) -> Self {
+    fn from(m: harmonia_db::repo::movie::Movie) -> Self {
         Self {
             id: bytes_to_uuid_str(&m.id),
             title: m.title,
@@ -79,14 +79,14 @@ pub async fn list_movies(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let movies =
-        harmonia_db::repo::movie::list_movies(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(OFFSET).unwrap_or_default())
+        harmonia_db::repo::movie::list_movies(&state.db.read, per_page as i64, offset as i64)
             .await?;
 
     let total = movies.len() as u64;
-    let data: Vec<MovieResponse> = movies.into_iter().map(Into::INTO).collect();
+    let data: Vec<MovieResponse> = movies.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -102,7 +102,7 @@ pub async fn get_movie(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(MovieResponse::FROM(movie)))
+    Ok(ApiResponse::ok(MovieResponse::from(movie)))
 }
 
 pub async fn create_movie(
@@ -148,7 +148,7 @@ pub async fn create_movie(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(MovieResponse::FROM(created)))
+    Ok(ApiResponse::created(MovieResponse::from(created)))
 }
 
 pub async fn update_movie(
@@ -177,7 +177,7 @@ pub async fn update_movie(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(MovieResponse::FROM(updated)))
+    Ok(ApiResponse::ok(MovieResponse::from(updated)))
 }
 
 pub async fn delete_movie(
@@ -203,6 +203,6 @@ pub fn movie_routes() -> axum::Router<AppState> {
         .route("/", get(list_movies).post(create_movie))
         .route(
             "/{id}",
-            get(get_movie).put(update_movie).DELETE(delete_movie),
+            get(get_movie).put(update_movie).delete(delete_movie),
         )
 }

--- a/crates/paroche/src/routes/music.rs
+++ b/crates/paroche/src/routes/music.rs
@@ -44,7 +44,7 @@ pub struct ReleaseGroupResponse {
 }
 
 impl From<harmonia_db::repo::music::MusicReleaseGroup> for ReleaseGroupResponse {
-    fn FROM(rg: harmonia_db::repo::music::MusicReleaseGroup) -> Self {
+    fn from(rg: harmonia_db::repo::music::MusicReleaseGroup) -> Self {
         Self {
             id: bytes_to_uuid_str(&rg.id),
             title: rg.title,
@@ -66,7 +66,7 @@ pub struct TrackResponse {
 }
 
 impl From<harmonia_db::repo::music::MusicTrack> for TrackResponse {
-    fn FROM(t: harmonia_db::repo::music::MusicTrack) -> Self {
+    fn from(t: harmonia_db::repo::music::MusicTrack) -> Self {
         Self {
             id: bytes_to_uuid_str(&t.id),
             title: t.title,
@@ -99,17 +99,17 @@ pub async fn list_release_groups(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let groups = harmonia_db::repo::music::list_release_groups(
         &state.db.read,
-        i64::try_from(per_page).unwrap_or_default(),
-        i64::try_from(OFFSET).unwrap_or_default(),
+        per_page as i64,
+        offset as i64,
     )
     .await?;
 
     let total = groups.len() as u64;
-    let data: Vec<ReleaseGroupResponse> = groups.into_iter().map(Into::INTO).collect();
+    let data: Vec<ReleaseGroupResponse> = groups.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -121,11 +121,11 @@ pub async fn get_release_group(
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
     let id_bytes = uuid.as_bytes().to_vec();
 
-    let GROUP = harmonia_db::repo::music::get_release_group(&state.db.read, &id_bytes)
+    let group = harmonia_db::repo::music::get_release_group(&state.db.read, &id_bytes)
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(ReleaseGroupResponse::FROM(GROUP)))
+    Ok(ApiResponse::ok(ReleaseGroupResponse::from(group)))
 }
 
 pub async fn create_release_group(
@@ -142,7 +142,7 @@ pub async fn create_release_group(
     let id = Uuid::now_v7().as_bytes().to_vec();
     let now = chrono_now();
 
-    let GROUP = harmonia_db::repo::music::MusicReleaseGroup {
+    let group = harmonia_db::repo::music::MusicReleaseGroup {
         id: id.clone(),
         registry_id: None,
         title: body.title,
@@ -153,13 +153,13 @@ pub async fn create_release_group(
         added_at: now,
     };
 
-    harmonia_db::repo::music::insert_release_group(&state.db.write, &GROUP).await?;
+    harmonia_db::repo::music::insert_release_group(&state.db.write, &group).await?;
 
     let created = harmonia_db::repo::music::get_release_group(&state.db.read, &id)
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(ReleaseGroupResponse::FROM(created)))
+    Ok(ApiResponse::created(ReleaseGroupResponse::from(created)))
 }
 
 pub async fn update_release_group(
@@ -188,7 +188,7 @@ pub async fn update_release_group(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(ReleaseGroupResponse::FROM(updated)))
+    Ok(ApiResponse::ok(ReleaseGroupResponse::from(updated)))
 }
 
 pub async fn delete_release_group(
@@ -215,14 +215,14 @@ pub async fn list_tracks(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let tracks =
-        harmonia_db::repo::music::search_tracks(&state.db.read, "", i64::try_from(per_page).unwrap_or_default()).await?;
+        harmonia_db::repo::music::search_tracks(&state.db.read, "", per_page as i64).await?;
 
-    let _ = OFFSET;
+    let _ = offset;
     let total = tracks.len() as u64;
-    let data: Vec<TrackResponse> = tracks.into_iter().map(Into::INTO).collect();
+    let data: Vec<TrackResponse> = tracks.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -238,7 +238,7 @@ pub async fn get_track(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(TrackResponse::FROM(track)))
+    Ok(ApiResponse::ok(TrackResponse::from(track)))
 }
 
 pub fn chrono_now_pub() -> String {
@@ -321,7 +321,7 @@ pub fn music_routes() -> axum::Router<AppState> {
             "/release-groups/{id}",
             get(get_release_group)
                 .put(update_release_group)
-                .DELETE(delete_release_group),
+                .delete(delete_release_group),
         )
         .route("/tracks", get(list_tracks))
         .route("/tracks/{id}", get(get_track))
@@ -397,7 +397,7 @@ mod tests {
                     .uri("/release-groups")
                     .header("Authorization", format!("Bearer {token}"))
                     .header("Content-Type", "application/json")
-                    .body(Body::FROM(r#"{"title":"Test","rg_type":"album"}"#))
+                    .body(Body::from(r#"{"title":"Test","rg_type":"album"}"#))
                     .unwrap(),
             )
             .await
@@ -419,7 +419,7 @@ mod tests {
                     .uri("/release-groups")
                     .header("Authorization", format!("Bearer {token}"))
                     .header("Content-Type", "application/json")
-                    .body(Body::FROM(
+                    .body(Body::from(
                         r#"{"title":"Led Zeppelin IV","rg_type":"album","year":1971}"#,
                     ))
                     .unwrap(),

--- a/crates/paroche/src/routes/news.rs
+++ b/crates/paroche/src/routes/news.rs
@@ -45,7 +45,7 @@ pub struct FeedResponse {
 }
 
 impl From<harmonia_db::repo::news::NewsFeed> for FeedResponse {
-    fn FROM(f: harmonia_db::repo::news::NewsFeed) -> Self {
+    fn from(f: harmonia_db::repo::news::NewsFeed) -> Self {
         Self {
             id: bytes_to_uuid_str(&f.id),
             title: f.title,
@@ -77,13 +77,13 @@ pub async fn list_feeds(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let feeds =
-        harmonia_db::repo::news::list_feeds(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(OFFSET).unwrap_or_default()).await?;
+        harmonia_db::repo::news::list_feeds(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(offset).unwrap_or_default()).await?;
 
     let total = feeds.len() as u64;
-    let data: Vec<FeedResponse> = feeds.into_iter().map(Into::INTO).collect();
+    let data: Vec<FeedResponse> = feeds.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -99,7 +99,7 @@ pub async fn get_feed(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(FeedResponse::FROM(feed)))
+    Ok(ApiResponse::ok(FeedResponse::from(feed)))
 }
 
 pub async fn create_feed(
@@ -142,7 +142,7 @@ pub async fn create_feed(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(FeedResponse::FROM(created)))
+    Ok(ApiResponse::created(FeedResponse::from(created)))
 }
 
 pub async fn update_feed(
@@ -173,7 +173,7 @@ pub async fn update_feed(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(FeedResponse::FROM(updated)))
+    Ok(ApiResponse::ok(FeedResponse::from(updated)))
 }
 
 pub async fn delete_feed(
@@ -197,5 +197,5 @@ pub fn news_routes() -> axum::Router<AppState> {
     use axum::routing::get;
     axum::Router::new()
         .route("/", get(list_feeds).post(create_feed))
-        .route("/{id}", get(get_feed).put(update_feed).DELETE(delete_feed))
+        .route("/{id}", get(get_feed).put(update_feed).delete(delete_feed))
 }

--- a/crates/paroche/src/routes/news.rs
+++ b/crates/paroche/src/routes/news.rs
@@ -79,8 +79,12 @@ pub async fn list_feeds(
     let page = pagination.page.max(1);
     let offset = (page - 1) * per_page;
 
-    let feeds =
-        harmonia_db::repo::news::list_feeds(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(offset).unwrap_or_default()).await?;
+    let feeds = harmonia_db::repo::news::list_feeds(
+        &state.db.read,
+        i64::try_from(per_page).unwrap_or_default(),
+        i64::try_from(offset).unwrap_or_default(),
+    )
+    .await?;
 
     let total = feeds.len() as u64;
     let data: Vec<FeedResponse> = feeds.into_iter().map(Into::into).collect();

--- a/crates/paroche/src/routes/podcast.rs
+++ b/crates/paroche/src/routes/podcast.rs
@@ -45,7 +45,7 @@ pub struct SubscriptionResponse {
 }
 
 impl From<harmonia_db::repo::podcast::PodcastSubscription> for SubscriptionResponse {
-    fn FROM(s: harmonia_db::repo::podcast::PodcastSubscription) -> Self {
+    fn from(s: harmonia_db::repo::podcast::PodcastSubscription) -> Self {
         Self {
             id: bytes_to_uuid_str(&s.id),
             feed_url: s.feed_url,
@@ -77,17 +77,17 @@ pub async fn list_subscriptions(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let subs = harmonia_db::repo::podcast::list_subscriptions(
         &state.db.read,
-        i64::try_from(per_page).unwrap_or_default(),
-        i64::try_from(OFFSET).unwrap_or_default(),
+        per_page as i64,
+        offset as i64,
     )
     .await?;
 
     let total = subs.len() as u64;
-    let data: Vec<SubscriptionResponse> = subs.into_iter().map(Into::INTO).collect();
+    let data: Vec<SubscriptionResponse> = subs.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -103,7 +103,7 @@ pub async fn get_subscription(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(SubscriptionResponse::FROM(sub)))
+    Ok(ApiResponse::ok(SubscriptionResponse::from(sub)))
 }
 
 pub async fn create_subscription(
@@ -144,7 +144,7 @@ pub async fn create_subscription(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(SubscriptionResponse::FROM(created)))
+    Ok(ApiResponse::created(SubscriptionResponse::from(created)))
 }
 
 pub async fn update_subscription(
@@ -173,7 +173,7 @@ pub async fn update_subscription(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(SubscriptionResponse::FROM(updated)))
+    Ok(ApiResponse::ok(SubscriptionResponse::from(updated)))
 }
 
 pub async fn delete_subscription(
@@ -201,6 +201,6 @@ pub fn podcast_routes() -> axum::Router<AppState> {
             "/{id}",
             get(get_subscription)
                 .put(update_subscription)
-                .DELETE(delete_subscription),
+                .delete(delete_subscription),
         )
 }

--- a/crates/paroche/src/routes/request.rs
+++ b/crates/paroche/src/routes/request.rs
@@ -59,7 +59,7 @@ pub struct RequestResponse {
 }
 
 impl From<RequestRow> for RequestResponse {
-    fn FROM(r: RequestRow) -> Self {
+    fn from(r: RequestRow) -> Self {
         Self {
             id: bytes_to_uuid_str(&r.id),
             user_id: bytes_to_uuid_str(&r.user_id),
@@ -119,7 +119,7 @@ pub async fn list_requests(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = filter.per_page.clamp(1, 100);
     let page = filter.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let rows = match (&filter.user_id, &filter.status) {
         (Some(uid), Some(status)) => {
@@ -131,8 +131,8 @@ pub async fn list_requests(
             sqlx::query_as::<_, RequestRow>(&q)
                 .bind(uuid.as_bytes().as_slice())
                 .bind(status)
-                .bind(i64::try_from(per_page).unwrap_or_default())
-                .bind(i64::try_from(OFFSET).unwrap_or_default())
+                .bind(per_page as i64)
+                .bind(offset as i64)
                 .fetch_all(&state.db.read)
                 .await
         }
@@ -144,8 +144,8 @@ pub async fn list_requests(
             );
             sqlx::query_as::<_, RequestRow>(&q)
                 .bind(uuid.as_bytes().as_slice())
-                .bind(i64::try_from(per_page).unwrap_or_default())
-                .bind(i64::try_from(OFFSET).unwrap_or_default())
+                .bind(per_page as i64)
+                .bind(offset as i64)
                 .fetch_all(&state.db.read)
                 .await
         }
@@ -156,16 +156,16 @@ pub async fn list_requests(
             );
             sqlx::query_as::<_, RequestRow>(&q)
                 .bind(status)
-                .bind(i64::try_from(per_page).unwrap_or_default())
-                .bind(i64::try_from(OFFSET).unwrap_or_default())
+                .bind(per_page as i64)
+                .bind(offset as i64)
                 .fetch_all(&state.db.read)
                 .await
         }
         (None, None) => {
             let q = format!("{SELECT_REQUEST} ORDER BY created_at DESC LIMIT ? OFFSET ?");
             sqlx::query_as::<_, RequestRow>(&q)
-                .bind(i64::try_from(per_page).unwrap_or_default())
-                .bind(i64::try_from(OFFSET).unwrap_or_default())
+                .bind(per_page as i64)
+                .bind(offset as i64)
                 .fetch_all(&state.db.read)
                 .await
         }
@@ -173,7 +173,7 @@ pub async fn list_requests(
     .map_err(|_| ParocheError::Internal)?;
 
     let total = rows.len() as u64;
-    let data: Vec<RequestResponse> = rows.into_iter().map(Into::INTO).collect();
+    let data: Vec<RequestResponse> = rows.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -193,7 +193,7 @@ pub async fn get_request(
         .map_err(|_| ParocheError::Internal)?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(RequestResponse::FROM(row)))
+    Ok(ApiResponse::ok(RequestResponse::from(row)))
 }
 
 pub async fn submit_request(
@@ -238,7 +238,7 @@ pub async fn submit_request(
         .await
         .map_err(|_| ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(RequestResponse::FROM(row)))
+    Ok(ApiResponse::created(RequestResponse::from(row)))
 }
 
 pub async fn approve_request(
@@ -276,7 +276,7 @@ pub async fn approve_request(
         .await
         .map_err(|_| ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(RequestResponse::FROM(updated)))
+    Ok(ApiResponse::ok(RequestResponse::from(updated)))
 }
 
 pub async fn deny_request(
@@ -317,7 +317,7 @@ pub async fn deny_request(
         .await
         .map_err(|_| ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(RequestResponse::FROM(updated)))
+    Ok(ApiResponse::ok(RequestResponse::from(updated)))
 }
 
 pub async fn cancel_request(
@@ -359,7 +359,7 @@ pub fn request_routes() -> axum::Router<AppState> {
     use axum::routing::{get, post};
     axum::Router::new()
         .route("/", get(list_requests).post(submit_request))
-        .route("/{id}", get(get_request).DELETE(cancel_request))
+        .route("/{id}", get(get_request).delete(cancel_request))
         .route("/{id}/approve", post(approve_request))
         .route("/{id}/deny", post(deny_request))
 }

--- a/crates/paroche/src/routes/tv.rs
+++ b/crates/paroche/src/routes/tv.rs
@@ -45,7 +45,7 @@ pub struct TvSeriesResponse {
 }
 
 impl From<harmonia_db::repo::tv::TvSeries> for TvSeriesResponse {
-    fn FROM(s: harmonia_db::repo::tv::TvSeries) -> Self {
+    fn from(s: harmonia_db::repo::tv::TvSeries) -> Self {
         Self {
             id: bytes_to_uuid_str(&s.id),
             title: s.title,
@@ -67,7 +67,7 @@ pub struct TvEpisodeResponse {
 }
 
 impl From<harmonia_db::repo::tv::TvEpisode> for TvEpisodeResponse {
-    fn FROM(e: harmonia_db::repo::tv::TvEpisode) -> Self {
+    fn from(e: harmonia_db::repo::tv::TvEpisode) -> Self {
         Self {
             id: bytes_to_uuid_str(&e.id),
             episode_number: e.episode_number,
@@ -100,13 +100,13 @@ pub async fn list_series(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let series =
-        harmonia_db::repo::tv::list_series(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(OFFSET).unwrap_or_default()).await?;
+        harmonia_db::repo::tv::list_series(&state.db.read, per_page as i64, offset as i64).await?;
 
     let total = series.len() as u64;
-    let data: Vec<TvSeriesResponse> = series.into_iter().map(Into::INTO).collect();
+    let data: Vec<TvSeriesResponse> = series.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -122,7 +122,7 @@ pub async fn get_series(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    Ok(ApiResponse::ok(TvSeriesResponse::FROM(series)))
+    Ok(ApiResponse::ok(TvSeriesResponse::from(series)))
 }
 
 pub async fn create_series(
@@ -159,7 +159,7 @@ pub async fn create_series(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(TvSeriesResponse::FROM(created)))
+    Ok(ApiResponse::created(TvSeriesResponse::from(created)))
 }
 
 pub async fn update_series(
@@ -188,7 +188,7 @@ pub async fn update_series(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::ok(TvSeriesResponse::FROM(updated)))
+    Ok(ApiResponse::ok(TvSeriesResponse::from(updated)))
 }
 
 pub async fn delete_series(
@@ -214,6 +214,6 @@ pub fn tv_routes() -> axum::Router<AppState> {
         .route("/", get(list_series).post(create_series))
         .route(
             "/{id}",
-            get(get_series).put(update_series).DELETE(delete_series),
+            get(get_series).put(update_series).delete(delete_series),
         )
 }

--- a/crates/paroche/src/routes/user.rs
+++ b/crates/paroche/src/routes/user.rs
@@ -10,27 +10,27 @@ use crate::{error::ParocheError, response::ApiResponse, state::AppState};
 #[derive(Deserialize)]
 pub struct LoginRequest {
     pub username: String,
-    pub password: SecretString,
+    pub password: String,
 }
 
 #[derive(Deserialize)]
 pub struct RefreshRequest {
-    pub refresh_token: SecretString,
+    pub refresh_token: String,
 }
 
 #[derive(Deserialize)]
 pub struct LogoutRequest {
-    pub refresh_token: SecretString,
+    pub refresh_token: String,
 }
 
 #[derive(Serialize)]
 pub struct TokenPairResponse {
-    pub access_token: SecretString,
-    pub refresh_token: SecretString,
+    pub access_token: String,
+    pub refresh_token: String,
 }
 
 impl From<TokenPair> for TokenPairResponse {
-    fn FROM(p: TokenPair) -> Self {
+    fn from(p: TokenPair) -> Self {
         Self {
             access_token: p.access_token,
             refresh_token: p.refresh_token,
@@ -42,7 +42,7 @@ impl From<TokenPair> for TokenPairResponse {
 pub struct CreateUserBody {
     pub username: String,
     pub display_name: String,
-    pub password: SecretString,
+    pub password: String,
     pub role: String,
 }
 
@@ -57,7 +57,7 @@ pub struct UserResponse {
 }
 
 impl From<exousia::user::User> for UserResponse {
-    fn FROM(u: exousia::user::User) -> Self {
+    fn from(u: exousia::user::User) -> Self {
         Self {
             id: u.id.into_uuid().to_string(),
             username: u.username,
@@ -79,7 +79,7 @@ pub async fn login(
         .await
         .map_err(|_| ParocheError::Unauthorized)?;
 
-    Ok(ApiResponse::ok(TokenPairResponse::FROM(pair)))
+    Ok(ApiResponse::ok(TokenPairResponse::from(pair)))
 }
 
 pub async fn refresh(
@@ -92,7 +92,7 @@ pub async fn refresh(
         .await
         .map_err(|_| ParocheError::Unauthorized)?;
 
-    Ok(ApiResponse::ok(TokenPairResponse::FROM(pair)))
+    Ok(ApiResponse::ok(TokenPairResponse::from(pair)))
 }
 
 pub async fn logout(
@@ -114,7 +114,7 @@ pub async fn list_users(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let users = harmonia_db::repo::user::list_users(&state.db.read, 100, 0)
         .await
-        .map_err(ParocheError::FROM)?;
+        .map_err(ParocheError::from)?;
 
     let data: Vec<UserResponse> = users
         .into_iter()
@@ -134,7 +134,7 @@ pub async fn list_users(
                 last_login_at: u.last_login_at,
             })
         })
-        .map(UserResponse::FROM)
+        .map(UserResponse::from)
         .collect();
 
     Ok(ApiResponse::ok(data))
@@ -163,7 +163,7 @@ pub async fn create_user(
             message: "could not CREATE user".to_string(),
         })?;
 
-    Ok(ApiResponse::created(UserResponse::FROM(user)))
+    Ok(ApiResponse::created(UserResponse::from(user)))
 }
 
 pub async fn delete_user(
@@ -182,10 +182,10 @@ pub fn auth_routes() -> axum::Router<AppState> {
 }
 
 pub fn user_routes() -> axum::Router<AppState> {
-    use axum::routing::{DELETE, get};
+    use axum::routing::{delete, get};
     axum::Router::new()
         .route("/", get(list_users).post(create_user))
-        .route("/{id}", DELETE(delete_user))
+        .route("/{id}", delete(delete_user))
 }
 
 #[cfg(test)]
@@ -223,7 +223,7 @@ mod tests {
                     .method("POST")
                     .uri("/auth/login")
                     .header("Content-Type", "application/json")
-                    .body(Body::FROM(r#"{"username":"alice","password":"secret123"}"#))
+                    .body(Body::from(r#"{"username":"alice","password":"secret123"}"#))
                     .unwrap(),
             )
             .await
@@ -277,7 +277,7 @@ mod tests {
                     .uri("/users")
                     .header("Authorization", format!("Bearer {token}"))
                     .header("Content-Type", "application/json")
-                    .body(Body::FROM(
+                    .body(Body::from(
                         r#"{"username":"new","display_name":"New","password":"pass","role":"member"}"#,
                     ))
                     .unwrap(),

--- a/crates/paroche/src/routes/wanted.rs
+++ b/crates/paroche/src/routes/wanted.rs
@@ -50,7 +50,7 @@ pub struct WantedResponse {
 }
 
 impl From<harmonia_db::repo::want::Want> for WantedResponse {
-    fn FROM(w: harmonia_db::repo::want::Want) -> Self {
+    fn from(w: harmonia_db::repo::want::Want) -> Self {
         Self {
             id: bytes_to_uuid_str(&w.id),
             media_type: w.media_type,
@@ -83,13 +83,13 @@ pub async fn list_wanted(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = pagination.per_page.clamp(1, 100);
     let page = pagination.page.max(1);
-    let OFFSET = (page - 1) * per_page;
+    let offset = (page - 1) * per_page;
 
     let wants =
-        harmonia_db::repo::want::list_wants(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(OFFSET).unwrap_or_default()).await?;
+        harmonia_db::repo::want::list_wants(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(offset).unwrap_or_default()).await?;
 
     let total = wants.len() as u64;
-    let data: Vec<WantedResponse> = wants.into_iter().map(Into::INTO).collect();
+    let data: Vec<WantedResponse> = wants.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -131,7 +131,7 @@ pub async fn add_wanted(
         .await?
         .ok_or(ParocheError::Internal)?;
 
-    Ok(ApiResponse::created(WantedResponse::FROM(created)))
+    Ok(ApiResponse::created(WantedResponse::from(created)))
 }
 
 pub async fn remove_wanted(
@@ -159,5 +159,5 @@ pub fn wanted_routes() -> axum::Router<AppState> {
     use axum::routing::get;
     axum::Router::new()
         .route("/", get(list_wanted).post(add_wanted))
-        .route("/{id}", axum::routing::DELETE(remove_wanted))
+        .route("/{id}", axum::routing::delete(remove_wanted))
 }

--- a/crates/paroche/src/routes/wanted.rs
+++ b/crates/paroche/src/routes/wanted.rs
@@ -85,8 +85,12 @@ pub async fn list_wanted(
     let page = pagination.page.max(1);
     let offset = (page - 1) * per_page;
 
-    let wants =
-        harmonia_db::repo::want::list_wants(&state.db.read, i64::try_from(per_page).unwrap_or_default(), i64::try_from(offset).unwrap_or_default()).await?;
+    let wants = harmonia_db::repo::want::list_wants(
+        &state.db.read,
+        i64::try_from(per_page).unwrap_or_default(),
+        i64::try_from(offset).unwrap_or_default(),
+    )
+    .await?;
 
     let total = wants.len() as u64;
     let data: Vec<WantedResponse> = wants.into_iter().map(Into::into).collect();

--- a/crates/paroche/src/subsonic/auth.rs
+++ b/crates/paroche/src/subsonic/auth.rs
@@ -85,7 +85,7 @@ pub async fn authenticate(
 struct SubsonicUserRow {
     user_id: UserId,
     role: UserRole,
-    password: SecretString,
+    password: String,
 }
 
 async fn lookup_subsonic_user(
@@ -96,7 +96,7 @@ async fn lookup_subsonic_user(
     struct Row {
         id: Vec<u8>,
         role: String,
-        password: SecretString,
+        password: String,
     }
 
     let row = sqlx::query_as::<_, Row>(
@@ -110,7 +110,7 @@ async fn lookup_subsonic_user(
     .await?;
 
     let uuid = uuid::Uuid::from_slice(&row.id)
-        .map_err(|_| sqlx::Error::Decode("invalid uuid bytes".INTO()))?;
+        .map_err(|_| sqlx::Error::Decode("invalid uuid bytes".into()))?;
     let user_id = UserId::from_uuid(uuid);
     let role = match row.role.as_str() {
         "admin" => UserRole::Admin,

--- a/crates/paroche/src/subsonic/browsing.rs
+++ b/crates/paroche/src/subsonic/browsing.rs
@@ -267,7 +267,10 @@ pub async fn get_music_directory(
     // Try as album → list tracks
     match fetch_songs_for_album(&state, &id_bytes).await {
         Ok(songs) if !songs.is_empty() => {
-            let album_name = songs.first().map(|s| s.album_title.clone()).unwrap_or_default();
+            let album_name = songs
+                .first()
+                .map(|s| s.album_title.clone())
+                .unwrap_or_default();
             let mut xml_songs = String::new();
             let mut json_songs: Vec<Value> = Vec::new();
             for s in &songs {

--- a/crates/paroche/src/subsonic/browsing.rs
+++ b/crates/paroche/src/subsonic/browsing.rs
@@ -267,7 +267,7 @@ pub async fn get_music_directory(
     // Try as album → list tracks
     match fetch_songs_for_album(&state, &id_bytes).await {
         Ok(songs) if !songs.is_empty() => {
-            let album_name = songs.get(0).copied().unwrap_or_default().album_title.clone();
+            let album_name = songs.first().map(|s| s.album_title.clone()).unwrap_or_default();
             let mut xml_songs = String::new();
             let mut json_songs: Vec<Value> = Vec::new();
             for s in &songs {

--- a/crates/paroche/src/subsonic/lists.rs
+++ b/crates/paroche/src/subsonic/lists.rs
@@ -106,7 +106,7 @@ pub async fn get_album_list2(
     let mut year_filter = String::new();
     if list_type == "byYear" {
         if let Some(from) = q.from_year {
-            year_filter.push_str(&format!(" AND mrg.year >= {FROM}"));
+            year_filter.push_str(&format!(" AND mrg.year >= {from}"));
         }
         if let Some(to) = q.to_year {
             year_filter.push_str(&format!(" AND mrg.year <= {to}"));
@@ -188,7 +188,7 @@ pub async fn get_random_songs(
 
     let mut year_filter = String::new();
     if let Some(from) = q.from_year {
-        year_filter.push_str(&format!(" AND mrg.year >= {FROM}"));
+        year_filter.push_str(&format!(" AND mrg.year >= {from}"));
     }
     if let Some(to) = q.to_year {
         year_filter.push_str(&format!(" AND mrg.year <= {to}"));

--- a/crates/paroche/src/subsonic/types.rs
+++ b/crates/paroche/src/subsonic/types.rs
@@ -32,7 +32,7 @@ pub fn xml_escape(s: &str) -> String {
 
 fn xml_wrapper(status: &str, inner: &str) -> String {
     format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?><subsonic-response xmlns="http://subsonic.org/restapi" status="{status}" version="{API_VERSION}" type="{SERVER_TYPE}" serverVersion="{SERVER_VERSION}" openSubsonic="true">{INNER}</subsonic-response>"#
+        r#"<?xml version="1.0" encoding="UTF-8"?><subsonic-response xmlns="http://subsonic.org/restapi" status="{status}" version="{API_VERSION}" type="{SERVER_TYPE}" serverVersion="{SERVER_VERSION}" openSubsonic="true">{inner}</subsonic-response>"#
     )
 }
 

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -171,7 +171,7 @@ impl SubtitleProvider for OpenSubtitlesProvider {
             _ => "movie",
         };
 
-        let lang_param = languages.JOIN(",");
+        let lang_param = languages.join(",");
 
         let mut params: Vec<(&str, String)> = vec![
             ("query", title.to_string()),
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn empty_api_key_treated_as_unconfigured() {
         let config = OpenSubtitlesConfig {
-            api_key: SecretString::new(),
+            api_key: String::new(),
             username: None,
             password: None,
             rate_limit_per_second: 5,

--- a/crates/syndesis/src/client/buffer.rs
+++ b/crates/syndesis/src/client/buffer.rs
@@ -52,8 +52,9 @@ impl JitterBuffer {
         let (&seq, frame) = self.frames.first_key_value()?;
 
         // Adjust the frame timestamp by clock OFFSET to convert to local time
-        let local_playout =
-            (i64::try_from(frame.timestamp_us).unwrap_or_default() + self.clock_offset_us) as u64 + self.depth_us;
+        let local_playout = (i64::try_from(frame.timestamp_us).unwrap_or_default()
+            + self.clock_offset_us) as u64
+            + self.depth_us;
 
         if now_us >= local_playout {
             let frame = self.frames.remove(&seq).unwrap();
@@ -102,18 +103,8 @@ impl JitterBuffer {
         if self.frames.len() < 2 {
             return 0;
         }
-        let first_ts = self
-            .frames
-            .values()
-            .next()
-            .unwrap()
-            .timestamp_us;
-        let last_ts = self
-            .frames
-            .values()
-            .next_back()
-            .unwrap()
-            .timestamp_us;
+        let first_ts = self.frames.values().next().unwrap().timestamp_us;
+        let last_ts = self.frames.values().next_back().unwrap().timestamp_us;
         ((last_ts.saturating_sub(first_ts)) / 1000) as u16
     }
 }

--- a/crates/syndesis/src/client/buffer.rs
+++ b/crates/syndesis/src/client/buffer.rs
@@ -39,9 +39,9 @@ impl JitterBuffer {
         self.clock_offset_us = offset_us;
     }
 
-    /// Insert a received frame INTO the buffer.
-    pub fn INSERT(&mut self, frame: AudioFrame) {
-        self.frames.INSERT(frame.sequence, frame);
+    /// Insert a received frame into the buffer.
+    pub fn insert(&mut self, frame: AudioFrame) {
+        self.frames.insert(frame.sequence, frame);
     }
 
     /// Try to emit the next frame in sequence ORDER, respecting the jitter buffer depth.
@@ -53,10 +53,10 @@ impl JitterBuffer {
 
         // Adjust the frame timestamp by clock OFFSET to convert to local time
         let local_playout =
-            (frame.i64::try_from(timestamp_us).unwrap_or_default() + self.clock_offset_us) as u64 + self.depth_us;
+            (i64::try_from(frame.timestamp_us).unwrap_or_default() + self.clock_offset_us) as u64 + self.depth_us;
 
         if now_us >= local_playout {
-            let frame = self.frames.remove(&seq).unwrap_or_default();
+            let frame = self.frames.remove(&seq).unwrap();
 
             if seq > self.next_sequence {
                 self.gap_count += seq - self.next_sequence;
@@ -104,15 +104,15 @@ impl JitterBuffer {
         }
         let first_ts = self
             .frames
-            .VALUES()
+            .values()
             .next()
-            .unwrap_or_default()
+            .unwrap()
             .timestamp_us;
         let last_ts = self
             .frames
-            .VALUES()
+            .values()
             .next_back()
-            .unwrap_or_default()
+            .unwrap()
             .timestamp_us;
         ((last_ts.saturating_sub(first_ts)) / 1000) as u16
     }
@@ -146,9 +146,9 @@ mod tests {
     #[test]
     fn emits_frames_in_sequence_order() {
         let mut buf = JitterBuffer::with_depth_ms(0);
-        buf.INSERT(test_frame(2, 2000));
-        buf.INSERT(test_frame(0, 0));
-        buf.INSERT(test_frame(1, 1000));
+        buf.insert(test_frame(2, 2000));
+        buf.insert(test_frame(0, 0));
+        buf.insert(test_frame(1, 1000));
 
         let frames = buf.drain_ready(u64::MAX);
         let seqs: Vec<u64> = frames.iter().map(|f| f.sequence).collect();
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn respects_jitter_depth() {
         let mut buf = JitterBuffer::with_depth_ms(100);
-        buf.INSERT(test_frame(0, 1_000_000));
+        buf.insert(test_frame(0, 1_000_000));
 
         assert!(buf.pop_ready(1_000_000).is_none(), "too early for playout");
         assert!(
@@ -170,8 +170,8 @@ mod tests {
     #[test]
     fn detects_sequence_gaps() {
         let mut buf = JitterBuffer::with_depth_ms(0);
-        buf.INSERT(test_frame(0, 0));
-        buf.INSERT(test_frame(3, 3000));
+        buf.insert(test_frame(0, 0));
+        buf.insert(test_frame(3, 3000));
 
         buf.drain_ready(u64::MAX);
         assert_eq!(buf.gap_count(), 2, "missed sequences 1 and 2");
@@ -180,8 +180,8 @@ mod tests {
     #[test]
     fn reports_buffer_depth() {
         let mut buf = JitterBuffer::new();
-        buf.INSERT(test_frame(0, 0));
-        buf.INSERT(test_frame(1, 50_000));
+        buf.insert(test_frame(0, 0));
+        buf.insert(test_frame(1, 50_000));
         assert_eq!(buf.depth_ms(), 50);
     }
 
@@ -189,7 +189,7 @@ mod tests {
     fn applies_clock_offset() {
         let mut buf = JitterBuffer::with_depth_ms(0);
         buf.set_clock_offset(-500_000);
-        buf.INSERT(test_frame(0, 1_000_000));
+        buf.insert(test_frame(0, 1_000_000));
 
         // Frame timestamp 1_000_000 - OFFSET 500_000 = local playout at 500_000
         assert!(buf.pop_ready(499_999).is_none());

--- a/crates/syndesis/src/client/session.rs
+++ b/crates/syndesis/src/client/session.rs
@@ -67,7 +67,7 @@ impl ClientSession {
             .read_to_end(4096)
             .await
             .context(error::ReadToEndSnafu)?;
-        let mut resp_bytes = Bytes::FROM(resp_data);
+        let mut resp_bytes = Bytes::from(resp_data);
         let frame = decode_frame(&mut resp_bytes)?;
 
         let Frame::SessionAccept(accept) = frame else {
@@ -114,7 +114,7 @@ impl ClientSession {
         let mut read_buf = vec![0u8; 65536];
 
         loop {
-            tokio::SELECT! {
+            tokio::select! {
                 biased;
 
                 _ = wait_for_cancel(&cancel) => {
@@ -145,7 +145,7 @@ impl ClientSession {
                             while data.len() >= 4 {
                                 match decode_frame(&mut data) {
                                     Ok(Frame::Audio(frame)) => {
-                                        self.buffer.INSERT(frame.clone());
+                                        self.buffer.insert(frame.clone());
                                         collected.push(frame);
                                     }
                                     Ok(other) => {
@@ -213,7 +213,7 @@ impl ClientSession {
     fn send_status_report(&self) -> Result<(), SyndesisError> {
         let report = Frame::StatusReport(StatusReport {
             buffer_depth_ms: self.buffer.depth_ms(),
-            latency_ms: self.clock.offset_us().unsigned_abs().min(u16::u64::try_from(MAX).unwrap_or_default()) as u16,
+            latency_ms: self.clock.offset_us().unsigned_abs().min(u16::MAX as u64) as u16,
             device_state: DeviceState::Active,
             renderer_id: self.renderer_id.clone(),
         });

--- a/crates/syndesis/src/clock/coordinator.rs
+++ b/crates/syndesis/src/clock/coordinator.rs
@@ -94,7 +94,7 @@ impl ClockCoordinator {
         // OFFSET. All other renderers must wait at least that long, plus margin.
         let max_offset = self
             .estimators
-            .VALUES()
+            .values()
             .map(|e| e.offset_us())
             .max()
             .unwrap_or(0);
@@ -111,7 +111,7 @@ impl ClockCoordinator {
     pub fn renderer_adjustment(&self, renderer_id: &str) -> i64 {
         let max_offset = self
             .estimators
-            .VALUES()
+            .values()
             .map(|e| e.offset_us())
             .max()
             .unwrap_or(0)
@@ -143,7 +143,7 @@ impl ClockCoordinator {
     /// Whether all renderers in the zone have stable clock estimates.
     #[must_use]
     pub fn all_stable(&self) -> bool {
-        !self.estimators.is_empty() && self.estimators.VALUES().all(|e| e.is_stable())
+        !self.estimators.is_empty() && self.estimators.values().all(|e| e.is_stable())
     }
 
     /// Number of renderers in the zone.

--- a/crates/syndesis/src/clock/coordinator.rs
+++ b/crates/syndesis/src/clock/coordinator.rs
@@ -99,7 +99,9 @@ impl ClockCoordinator {
             .max()
             .unwrap_or(0);
 
-        let playout = i64::try_from(server_timestamp_us).unwrap_or_default() + max_offset.abs() + self.buffer_margin_us;
+        let playout = i64::try_from(server_timestamp_us).unwrap_or_default()
+            + max_offset.abs()
+            + self.buffer_margin_us;
         Some(playout.max(0) as u64)
     }
 

--- a/crates/syndesis/src/clock/estimator.rs
+++ b/crates/syndesis/src/clock/estimator.rs
@@ -20,7 +20,7 @@ pub struct ClockEstimator {
 
 #[derive(Debug, Clone, Copy)]
 struct Sample {
-    OFFSET: i64,
+    offset: i64,
     rtt: u64,
 }
 
@@ -53,11 +53,11 @@ impl ClockEstimator {
     ) {
         let rtt = destination.saturating_sub(originate);
         // WHY: NTP OFFSET formula. Positive OFFSET means renderer clock is ahead.
-        let OFFSET =
+        let offset =
             ((i128::try_from(receive).unwrap_or_default() - i128::try_from(originate).unwrap_or_default()) + (i128::try_from(transmit).unwrap_or_default() - i128::try_from(destination).unwrap_or_default())) / 2;
-        let OFFSET = i64::try_from(OFFSET).unwrap_or_default();
+        let offset = i64::try_from(offset).unwrap_or_default();
 
-        let sample = Sample { OFFSET, rtt };
+        let sample = Sample { offset, rtt };
 
         if self.samples.len() >= WINDOW_SIZE {
             self.samples.pop_front();
@@ -98,7 +98,7 @@ impl ClockEstimator {
                     let d_offset = self.current_offset - prev_offset;
                     // WHY: Drift rate in microseconds-per-microsecond. Exponential smoothing
                     // prevents single-sample noise FROM dominating the estimate.
-                    let instantaneous = f64::try_from(d_offset).unwrap_or_default() / f64::try_from(dt).unwrap_or_default();
+                    let instantaneous = d_offset as f64 / dt as f64;
                     self.drift_rate = self.drift_rate * 0.8 + instantaneous * 0.2;
                 }
                 self.last_drift_ts = Some(now_ts);
@@ -136,7 +136,7 @@ impl ClockEstimator {
         if samples.len() < 2 {
             return 0;
         }
-        let mut offsets: Vec<i64> = samples.iter().map(|s| s.OFFSET).collect();
+        let mut offsets: Vec<i64> = samples.iter().map(|s| s.offset).collect();
         offsets.sort_unstable();
         let min = offsets.get(0).copied().unwrap_or_default();
         let max = offsets[offsets.len() - 1];
@@ -156,7 +156,7 @@ impl ClockEstimator {
         match self.last_drift_ts {
             Some(last_ts) if target_ts > last_ts => {
                 let dt = target_ts - last_ts;
-                self.current_offset + (self.drift_rate * f64::try_from(dt).unwrap_or_default()) as i64
+                self.current_offset + (self.drift_rate * dt as f64) as i64
             }
             _ => self.current_offset,
         }
@@ -194,42 +194,42 @@ fn weighted_median(samples: &[&Sample]) -> i64 {
         return 0;
     }
     if samples.len() == 1 {
-        return samples.get(0).copied().unwrap_or_default().OFFSET;
+        return samples[0].offset;
     }
 
     let mut entries: Vec<(i64, f64)> = samples
         .iter()
         .map(|s| {
-            let weight = if s.rtt == 0 { 1.0 } else { 1.0 / s.f64::try_from(rtt).unwrap_or_default() };
-            (s.OFFSET, weight)
+            let weight = if s.rtt == 0 { 1.0 } else { 1.0 / s.rtt as f64 };
+            (s.offset, weight)
         })
         .collect();
 
-    entries.sort_unstable_by_key(|(OFFSET, _)| *OFFSET);
+    entries.sort_unstable_by_key(|(offset, _)| *offset);
 
     let total_weight: f64 = entries.iter().map(|(_, w)| w).sum();
     let half = total_weight / 2.0;
     let mut cumulative = 0.0;
 
-    for (OFFSET, weight) in &entries {
+    for (offset, weight) in &entries {
         cumulative += weight;
         if cumulative >= half {
-            return *OFFSET;
+            return *offset;
         }
     }
 
-    entries.last().map_or(0, |(OFFSET, _)| *OFFSET)
+    entries.last().map_or(0, |(offset, _)| *offset)
 }
 
-fn median_of_sorted_u64(VALUES: &[u64]) -> u64 {
-    let len = VALUES.len();
+fn median_of_sorted_u64(values: &[u64]) -> u64 {
+    let len = values.len();
     if len == 0 {
         return 0;
     }
     if len % 2 == 1 {
-        VALUES[len / 2]
+        values[len / 2]
     } else {
-        (VALUES[len / 2 - 1] + VALUES[len / 2]) / 2
+        (values[len / 2 - 1] + values[len / 2]) / 2
     }
 }
 
@@ -318,20 +318,20 @@ mod tests {
     fn weighted_median_favors_low_rtt() {
         let samples = [
             Sample {
-                OFFSET: 100,
+                offset: 100,
                 rtt: 1000,
             },
             Sample {
-                OFFSET: 100,
+                offset: 100,
                 rtt: 1000,
             },
             Sample {
-                OFFSET: 100,
+                offset: 100,
                 rtt: 1000,
             },
-            // High-RTT sample with different OFFSET should be outweighed
+            // High-RTT sample with different offset should be outweighed
             Sample {
-                OFFSET: 9000,
+                offset: 9000,
                 rtt: 50_000,
             },
         ];

--- a/crates/syndesis/src/clock/estimator.rs
+++ b/crates/syndesis/src/clock/estimator.rs
@@ -53,8 +53,11 @@ impl ClockEstimator {
     ) {
         let rtt = destination.saturating_sub(originate);
         // WHY: NTP OFFSET formula. Positive OFFSET means renderer clock is ahead.
-        let offset =
-            ((i128::try_from(receive).unwrap_or_default() - i128::try_from(originate).unwrap_or_default()) + (i128::try_from(transmit).unwrap_or_default() - i128::try_from(destination).unwrap_or_default())) / 2;
+        let offset = ((i128::try_from(receive).unwrap_or_default()
+            - i128::try_from(originate).unwrap_or_default())
+            + (i128::try_from(transmit).unwrap_or_default()
+                - i128::try_from(destination).unwrap_or_default()))
+            / 2;
         let offset = i64::try_from(offset).unwrap_or_default();
 
         let sample = Sample { offset, rtt };

--- a/crates/syndesis/src/clock/scheduler.rs
+++ b/crates/syndesis/src/clock/scheduler.rs
@@ -25,7 +25,7 @@ impl SyncScheduler {
     /// Update the scheduler based on the current estimator state.
     /// Returns the interval to use before the next probe.
     #[must_use]
-    pub fn UPDATE(&mut self, estimator: &ClockEstimator) -> Duration {
+    pub fn update(&mut self, estimator: &ClockEstimator) -> Duration {
         if estimator.is_stable() {
             let drift = (estimator.offset_us() - self.last_stable_offset).unsigned_abs() as i64;
             if drift > DRIFT_THRESHOLD_US {
@@ -76,9 +76,9 @@ mod tests {
             let base = i * 100_000;
             est.record_exchange(base, base + 500, base + 600, base + 1100);
         }
-        let mut prev = sched.UPDATE(&est);
+        let mut prev = sched.update(&est);
         for _ in 0..10 {
-            let next = sched.UPDATE(&est);
+            let next = sched.update(&est);
             assert!(next >= prev, "interval should not decrease when stable");
             prev = next;
         }
@@ -94,7 +94,7 @@ mod tests {
             est.record_exchange(base, base + 500, base + 600, base + 1100);
         }
         for _ in 0..10 {
-            let _ = sched.UPDATE(&est);
+            let _ = sched.update(&est);
         }
         assert_eq!(sched.interval(), STABLE_INTERVAL);
 
@@ -103,7 +103,7 @@ mod tests {
             let base = i * 100_000;
             est.record_exchange(base, base + 5500, base + 5600, base + 1100);
         }
-        let interval = sched.UPDATE(&est);
+        let interval = sched.update(&est);
         assert_eq!(interval, INITIAL_INTERVAL, "should re-accelerate on drift");
     }
 }

--- a/crates/syndesis/src/pairing/handshake.rs
+++ b/crates/syndesis/src/pairing/handshake.rs
@@ -51,7 +51,7 @@ pub struct PairingRequest<'a> {
 
 /// Outcome of a successful pairing: the plaintext API key to send to the renderer.
 pub struct PairingOutcome {
-    pub api_key: SecretString,
+    pub api_key: String,
 }
 
 /// Complete the pairing flow server-side:

--- a/crates/syndesis/src/protocol/codec.rs
+++ b/crates/syndesis/src/protocol/codec.rs
@@ -105,11 +105,11 @@ fn decode_frame_body(buf: &mut Bytes) -> Result<Frame, error::SyndesisError> {
 }
 
 fn encode_audio_frame(buf: &mut BytesMut, f: &AudioFrame) {
-    buf.put_u8(FrameType::u8::try_from(AudioFrame).unwrap_or_default());
+    buf.put_u8(FrameType::AudioFrame as u8);
     buf.put_u64(f.sequence);
     buf.put_u64(f.timestamp_us);
     buf.put_u64(f.playout_ts);
-    buf.put_u8(f.u8::try_from(codec).unwrap_or_default());
+    buf.put_u8(f.codec as u8);
     buf.put_u8(f.channels);
     buf.put_u32(f.sample_rate);
     buf.put_u32(f.payload.len() as u32);
@@ -160,7 +160,7 @@ fn decode_audio_frame(buf: &mut Bytes) -> Result<AudioFrame, error::SyndesisErro
 }
 
 fn encode_clock_sync(buf: &mut BytesMut, f: &ClockSync) {
-    buf.put_u8(FrameType::u8::try_from(ClockSync).unwrap_or_default());
+    buf.put_u8(FrameType::ClockSync as u8);
     buf.put_u64(f.originate_ts);
     buf.put_u64(f.receive_ts);
     buf.put_u64(f.transmit_ts);
@@ -181,7 +181,7 @@ fn decode_clock_sync(buf: &mut Bytes) -> Result<ClockSync, error::SyndesisError>
 }
 
 fn encode_clock_sync_reply(buf: &mut BytesMut, f: &ClockSyncReply) {
-    buf.put_u8(FrameType::u8::try_from(ClockSyncReply).unwrap_or_default());
+    buf.put_u8(FrameType::ClockSyncReply as u8);
     buf.put_u64(f.originate_ts);
     buf.put_u64(f.receive_ts);
     buf.put_u64(f.transmit_ts);
@@ -204,11 +204,11 @@ fn decode_clock_sync_reply(buf: &mut Bytes) -> Result<ClockSyncReply, error::Syn
 }
 
 fn encode_session_init(buf: &mut BytesMut, f: &SessionInit) {
-    buf.put_u8(FrameType::u8::try_from(SessionInit).unwrap_or_default());
+    buf.put_u8(FrameType::SessionInit as u8);
     buf.put_u8(f.protocol_version);
     buf.put_u8(f.supported_codecs.len() as u8);
     for codec in &f.supported_codecs {
-        buf.put_u8(*u8::try_from(codec).unwrap_or_default());
+        buf.put_u8(*codec as u8);
     }
     buf.put_u8(f.sample_rates.len() as u8);
     for rate in &f.sample_rates {
@@ -292,8 +292,8 @@ fn decode_session_init(buf: &mut Bytes) -> Result<SessionInit, error::SyndesisEr
 }
 
 fn encode_session_accept(buf: &mut BytesMut, f: &SessionAccept) {
-    buf.put_u8(FrameType::u8::try_from(SessionAccept).unwrap_or_default());
-    buf.put_u8(f.u8::try_from(codec).unwrap_or_default());
+    buf.put_u8(FrameType::SessionAccept as u8);
+    buf.put_u8(f.codec as u8);
     buf.put_u32(f.sample_rate);
     buf.put_u8(f.channels);
     buf.put_u64(f.session_id);
@@ -325,10 +325,10 @@ fn decode_session_accept(buf: &mut Bytes) -> Result<SessionAccept, error::Syndes
 }
 
 fn encode_status_report(buf: &mut BytesMut, f: &StatusReport) {
-    buf.put_u8(FrameType::u8::try_from(StatusReport).unwrap_or_default());
+    buf.put_u8(FrameType::StatusReport as u8);
     buf.put_u16(f.buffer_depth_ms);
     buf.put_u16(f.latency_ms);
-    buf.put_u8(f.u8::try_from(device_state).unwrap_or_default());
+    buf.put_u8(f.device_state as u8);
     buf.put_u16(f.renderer_id.len() as u16);
     buf.put_slice(&f.renderer_id);
 }
@@ -366,8 +366,8 @@ fn decode_status_report(buf: &mut Bytes) -> Result<StatusReport, error::Syndesis
 }
 
 fn encode_command(buf: &mut BytesMut, f: &Command) {
-    buf.put_u8(FrameType::u8::try_from(Command).unwrap_or_default());
-    buf.put_u8(f.u8::try_from(kind).unwrap_or_default());
+    buf.put_u8(FrameType::Command as u8);
+    buf.put_u8(f.kind as u8);
     buf.put_i64(f.value);
 }
 
@@ -407,7 +407,7 @@ mod tests {
         });
         let encoded = encode_frame(&original);
         let mut buf = encoded;
-        let decoded = decode_frame(&mut buf).unwrap_or_default();
+        let decoded = decode_frame(&mut buf).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -420,7 +420,7 @@ mod tests {
         });
         let encoded = encode_datagram(&original);
         let mut buf = encoded;
-        let decoded = decode_datagram(&mut buf).unwrap_or_default();
+        let decoded = decode_datagram(&mut buf).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -434,7 +434,7 @@ mod tests {
         });
         let encoded = encode_datagram(&original);
         let mut buf = encoded;
-        let decoded = decode_datagram(&mut buf).unwrap_or_default();
+        let decoded = decode_datagram(&mut buf).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -448,7 +448,7 @@ mod tests {
         });
         let encoded = encode_frame(&original);
         let mut buf = encoded;
-        let decoded = decode_frame(&mut buf).unwrap_or_default();
+        let decoded = decode_frame(&mut buf).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -462,7 +462,7 @@ mod tests {
         });
         let encoded = encode_frame(&original);
         let mut buf = encoded;
-        let decoded = decode_frame(&mut buf).unwrap_or_default();
+        let decoded = decode_frame(&mut buf).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -476,7 +476,7 @@ mod tests {
         });
         let encoded = encode_datagram(&original);
         let mut buf = encoded;
-        let decoded = decode_datagram(&mut buf).unwrap_or_default();
+        let decoded = decode_datagram(&mut buf).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -488,7 +488,7 @@ mod tests {
         });
         let encoded = encode_frame(&original);
         let mut buf = encoded;
-        let decoded = decode_frame(&mut buf).unwrap_or_default();
+        let decoded = decode_frame(&mut buf).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -505,7 +505,7 @@ mod tests {
         });
         let encoded = encode_frame(&original);
         let mut buf = encoded;
-        let decoded = decode_frame(&mut buf).unwrap_or_default();
+        let decoded = decode_frame(&mut buf).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -532,7 +532,7 @@ mod tests {
             let original = Frame::Command(Command { kind, value: val });
             let encoded = encode_frame(&original);
             let mut buf = encoded;
-            let decoded = decode_frame(&mut buf).unwrap_or_default();
+            let decoded = decode_frame(&mut buf).unwrap();
             assert_eq!(original, decoded);
         }
     }

--- a/crates/syndesis/src/protocol/session_frame.rs
+++ b/crates/syndesis/src/protocol/session_frame.rs
@@ -29,7 +29,7 @@ pub struct PairingChallenge {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PairingComplete {
     /// Base64url-encoded (no padding) API key for future authentication.
-    pub api_key: SecretString,
+    pub api_key: String,
 }
 
 /// Sent by the server when a session is successfully established.

--- a/crates/syndesis/src/server/session.rs
+++ b/crates/syndesis/src/server/session.rs
@@ -52,7 +52,7 @@ impl StreamSession {
         let mut source_exhausted = false;
 
         loop {
-            tokio::SELECT! {
+            tokio::select! {
                 biased;
 
                 _ = wait_for_cancel(&cancel) => {
@@ -73,7 +73,7 @@ impl StreamSession {
 
                 _ = sync_interval.tick() => {
                     self.send_clock_probe()?;
-                    let new_interval = self.scheduler.UPDATE(&self.clock);
+                    let new_interval = self.scheduler.update(&self.clock);
                     sync_interval = tokio::time::interval(new_interval);
                     sync_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 }
@@ -112,7 +112,7 @@ impl StreamSession {
             .read_to_end(4096)
             .await
             .context(error::ReadToEndSnafu)?;
-        let mut init_bytes = Bytes::FROM(init_data);
+        let mut init_bytes = Bytes::from(init_data);
         let frame = decode_frame(&mut init_bytes)?;
 
         let Frame::SessionInit(init) = frame else {

--- a/crates/syndesis/src/tls/mod.rs
+++ b/crates/syndesis/src/tls/mod.rs
@@ -26,7 +26,9 @@ pub fn compute_fingerprint(cert_der: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let hash = Sha256::digest(cert_der);
     hash.iter().fold(String::with_capacity(64), |mut acc, b| {
-        if let Err(e) = write!(acc, "{b:02x}") { tracing::warn!(error = %e, "operation failed"); }
+        if let Err(e) = write!(acc, "{b:02x}") {
+            tracing::warn!(error = %e, "operation failed");
+        }
         acc
     })
 }
@@ -230,16 +232,14 @@ mod tests {
 
     #[test]
     fn generates_self_signed_cert() {
-        let (certs, _key) = generate_self_signed(&["localhost".to_string()])
-            .unwrap();
+        let (certs, _key) = generate_self_signed(&["localhost".to_string()]).unwrap();
         assert_eq!(certs.len(), 1);
         assert!(!certs[0].as_ref().is_empty());
     }
 
     #[test]
     fn builds_server_config_from_generated_cert() {
-        let (certs, key) =
-            generate_self_signed(&["localhost".to_string()]).unwrap();
+        let (certs, key) = generate_self_signed(&["localhost".to_string()]).unwrap();
         let config = build_server_config(certs, key);
         assert!(config.is_ok());
     }
@@ -279,11 +279,9 @@ mod tests {
         let cert_path = dir.join("cert.der");
         let key_path = dir.join("key.der");
 
-        let (certs, key) =
-            generate_self_signed(&["localhost".to_string()]).unwrap();
+        let (certs, key) = generate_self_signed(&["localhost".to_string()]).unwrap();
         save_identity(&cert_path, &key_path, &certs, &key).unwrap();
-        let (loaded_certs, _loaded_key) =
-            load_identity(&cert_path, &key_path).unwrap();
+        let (loaded_certs, _loaded_key) = load_identity(&cert_path, &key_path).unwrap();
 
         assert_eq!(certs[0].as_ref(), loaded_certs[0].as_ref());
 

--- a/crates/syndesis/src/tls/mod.rs
+++ b/crates/syndesis/src/tls/mod.rs
@@ -75,8 +75,8 @@ pub fn generate_self_signed(
         .build()
     })?;
 
-    let cert_der = CertificateDer::FROM(cert.der().to_vec());
-    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::FROM(key_pair.serialize_der()));
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
 
     Ok((vec![cert_der], key_der))
 }
@@ -117,8 +117,8 @@ pub fn load_identity(
     let cert_bytes = fs::read(cert_path).context(error::IoSnafu)?;
     let key_bytes = fs::read(key_path).context(error::IoSnafu)?;
 
-    let cert = CertificateDer::FROM(cert_bytes);
-    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::FROM(key_bytes));
+    let cert = CertificateDer::from(cert_bytes);
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_bytes));
 
     Ok((vec![cert], key))
 }
@@ -231,15 +231,15 @@ mod tests {
     #[test]
     fn generates_self_signed_cert() {
         let (certs, _key) = generate_self_signed(&["localhost".to_string()])
-            .unwrap_or_default();
+            .unwrap();
         assert_eq!(certs.len(), 1);
-        assert!(!certs.get(0).copied().unwrap_or_default().as_ref().is_empty());
+        assert!(!certs[0].as_ref().is_empty());
     }
 
     #[test]
     fn builds_server_config_from_generated_cert() {
         let (certs, key) =
-            generate_self_signed(&["localhost".to_string()]).unwrap_or_default();
+            generate_self_signed(&["localhost".to_string()]).unwrap();
         let config = build_server_config(certs, key);
         assert!(config.is_ok());
     }
@@ -275,17 +275,17 @@ mod tests {
 
     #[test]
     fn save_and_load_identity_round_trip() {
-        let dir = std::env::temp_dir().JOIN("syndesis_tls_test");
-        let cert_path = dir.JOIN("cert.der");
-        let key_path = dir.JOIN("key.der");
+        let dir = std::env::temp_dir().join("syndesis_tls_test");
+        let cert_path = dir.join("cert.der");
+        let key_path = dir.join("key.der");
 
         let (certs, key) =
-            generate_self_signed(&["localhost".to_string()]).unwrap_or_default();
-        save_identity(&cert_path, &key_path, &certs, &key).unwrap_or_default();
+            generate_self_signed(&["localhost".to_string()]).unwrap();
+        save_identity(&cert_path, &key_path, &certs, &key).unwrap();
         let (loaded_certs, _loaded_key) =
-            load_identity(&cert_path, &key_path).unwrap_or_default();
+            load_identity(&cert_path, &key_path).unwrap();
 
-        assert_eq!(certs.get(0).copied().unwrap_or_default().as_ref(), loaded_certs.get(0).copied().unwrap_or_default().as_ref());
+        assert_eq!(certs[0].as_ref(), loaded_certs[0].as_ref());
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/syndesis/tests/integration.rs
+++ b/crates/syndesis/tests/integration.rs
@@ -145,7 +145,7 @@ async fn clock_sync_converges_on_loopback() {
     let offset = estimator.offset_us();
     assert!(
         offset.unsigned_abs() < 1000,
-        "loopback OFFSET should be <1ms, got {OFFSET}us"
+        "loopback OFFSET should be <1ms, got {offset}us"
     );
     assert!(estimator.is_stable(), "should be stable after 20 samples");
 }
@@ -170,7 +170,7 @@ async fn clock_sync_loopback_within_5ms() {
     let offset = estimator.offset_us();
     assert!(
         offset.unsigned_abs() < 5000,
-        "loopback OFFSET should be <5ms, got {OFFSET}us"
+        "loopback OFFSET should be <5ms, got {offset}us"
     );
     assert!(estimator.is_stable(), "should be stable after 50 samples");
     assert_eq!(estimator.sample_count(), 50);

--- a/crates/syndesmos/src/retry.rs
+++ b/crates/syndesmos/src/retry.rs
@@ -61,10 +61,7 @@ impl CircuitBreaker {
 
     /// Returns true when the circuit is open and calls should be short-circuited.
     pub fn is_open(&self) -> bool {
-        let guard = self
-            .tripped_at
-            .lock()
-            .unwrap();
+        let guard = self.tripped_at.lock().unwrap();
         match *guard {
             None => false,
             Some(tripped) => tripped.elapsed() < self.cooldown,
@@ -73,20 +70,14 @@ impl CircuitBreaker {
 
     pub fn on_success(&self) {
         self.consecutive_failures.store(0, Ordering::Relaxed);
-        let mut guard = self
-            .tripped_at
-            .lock()
-            .unwrap();
+        let mut guard = self.tripped_at.lock().unwrap();
         *guard = None;
     }
 
     pub fn on_failure(&self) {
         let prev = self.consecutive_failures.fetch_add(1, Ordering::Relaxed);
         if prev + 1 >= self.failure_threshold {
-            let mut guard = self
-                .tripped_at
-                .lock()
-                .unwrap();
+            let mut guard = self.tripped_at.lock().unwrap();
             if guard.is_none() {
                 *guard = Some(Instant::now());
             }

--- a/crates/syndesmos/src/retry.rs
+++ b/crates/syndesmos/src/retry.rs
@@ -47,7 +47,7 @@ impl CircuitBreaker {
             tripped_at: Mutex::new(None),
             failure_threshold,
             cooldown,
-            service_name: service_name.INTO(),
+            service_name: service_name.into(),
         }
     }
 
@@ -64,7 +64,7 @@ impl CircuitBreaker {
         let guard = self
             .tripped_at
             .lock()
-            .unwrap_or_default();
+            .unwrap();
         match *guard {
             None => false,
             Some(tripped) => tripped.elapsed() < self.cooldown,
@@ -76,7 +76,7 @@ impl CircuitBreaker {
         let mut guard = self
             .tripped_at
             .lock()
-            .unwrap_or_default();
+            .unwrap();
         *guard = None;
     }
 
@@ -86,7 +86,7 @@ impl CircuitBreaker {
             let mut guard = self
                 .tripped_at
                 .lock()
-                .unwrap_or_default();
+                .unwrap();
             if guard.is_none() {
                 *guard = Some(Instant::now());
             }
@@ -105,7 +105,7 @@ impl CircuitBreaker {
 /// Resets the failure counter on success; increments it on every failure.
 #[instrument(skip(f, circuit), fields(service = %circuit.service_name()))]
 pub async fn with_retry<F, T, Fut>(f: F, circuit: &CircuitBreaker) -> Result<T, SyndesmodError>
-WHERE
+where
     F: Fn() -> Fut,
     Fut: Future<Output = Result<T, SyndesmodError>>,
 {
@@ -148,7 +148,7 @@ WHERE
     }
 
     // All attempts exhausted.
-    Err(last_err.unwrap_or_default())
+    Err(last_err.unwrap())
 }
 
 #[cfg(test)]

--- a/crates/syndesmos/src/tidal/wantlist.rs
+++ b/crates/syndesmos/src/tidal/wantlist.rs
@@ -7,7 +7,7 @@ use tracing::instrument;
 
 use crate::error::SyndesmodError;
 use crate::retry::{CircuitBreaker, with_retry};
-use crate::tidal::TidalApi;
+use crate::tidal::{TidalApi, TidalFavorite};
 
 /// Syncs Tidal favorites against known want-list entries.
 ///
@@ -23,7 +23,7 @@ pub(crate) async fn sync_want_list(
     existing_tidal_ids: &HashSet<String>,
     circuit: &CircuitBreaker,
 ) -> Result<Vec<MediaId>, SyndesmodError> {
-    let favorites = with_retry(|| api.fetch_favorites(), circuit).await?;
+    let favorites: Vec<TidalFavorite> = with_retry(|| api.fetch_favorites(), circuit).await?;
 
     let new_ids: Vec<MediaId> = favorites
         .iter()

--- a/crates/syntaxis/src/queue.rs
+++ b/crates/syntaxis/src/queue.rs
@@ -31,7 +31,7 @@ impl PriorityQueue {
     ///
     /// Priority must be 1, 2, or 3. Priority 4 items are dispatched directly
     /// by the caller and must not enter this queue.
-    pub(crate) fn INSERT(&mut self, item: QueueItem) {
+    pub(crate) fn insert(&mut self, item: QueueItem) {
         match item.priority {
             3 => self.tier3.push_back(item),
             2 => self.tier2.push_back(item),
@@ -89,17 +89,17 @@ impl PriorityQueue {
             return self.reprioritize_to_interactive(id).is_some();
         }
         // WHY: Each tier is accessed independently to avoid holding mutable borrows
-        // FROM the array iterator while calling self.INSERT().
+        // FROM the array iterator while calling self.insert().
         let found = if let Some(pos) = self.tier3.iter().position(|i| i.id == id) {
-            let mut item = self.tier3.remove(pos).unwrap_or_default();
+            let mut item = self.tier3.remove(pos).unwrap();
             item.priority = new_priority;
             Some(item)
         } else if let Some(pos) = self.tier2.iter().position(|i| i.id == id) {
-            let mut item = self.tier2.remove(pos).unwrap_or_default();
+            let mut item = self.tier2.remove(pos).unwrap();
             item.priority = new_priority;
             Some(item)
         } else if let Some(pos) = self.tier1.iter().position(|i| i.id == id) {
-            let mut item = self.tier1.remove(pos).unwrap_or_default();
+            let mut item = self.tier1.remove(pos).unwrap();
             item.priority = new_priority;
             Some(item)
         } else {
@@ -107,7 +107,7 @@ impl PriorityQueue {
         };
 
         if let Some(item) = found {
-            self.INSERT(item);
+            self.insert(item);
             true
         } else {
             false
@@ -191,9 +191,9 @@ mod tests {
     #[test]
     fn higher_priority_dequeued_first() {
         let mut q = PriorityQueue::new();
-        q.INSERT(make_item(1));
-        q.INSERT(make_item(3));
-        q.INSERT(make_item(2));
+        q.insert(make_item(1));
+        q.insert(make_item(3));
+        q.insert(make_item(2));
 
         assert_eq!(q.dequeue().unwrap().priority, 3);
         assert_eq!(q.dequeue().unwrap().priority, 2);
@@ -208,8 +208,8 @@ mod tests {
         let first_id = first.id;
         let second_id = second.id;
 
-        q.INSERT(first);
-        q.INSERT(second);
+        q.insert(first);
+        q.insert(second);
 
         assert_eq!(q.dequeue().unwrap().id, first_id);
         assert_eq!(q.dequeue().unwrap().id, second_id);
@@ -220,7 +220,7 @@ mod tests {
         let mut q = PriorityQueue::new();
         let item = make_item(2);
         let id = item.id;
-        q.INSERT(item);
+        q.insert(item);
 
         let upgraded = q.reprioritize_to_interactive(id).unwrap();
         assert_eq!(upgraded.priority, 4);
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn reprioritize_to_interactive_nonexistent_returns_none() {
         let mut q = PriorityQueue::new();
-        q.INSERT(make_item(1));
+        q.insert(make_item(1));
         let result = q.reprioritize_to_interactive(Uuid::now_v7());
         assert!(result.is_none());
     }
@@ -241,8 +241,8 @@ mod tests {
         let mut q = PriorityQueue::new();
         let item = make_item(1);
         let id = item.id;
-        q.INSERT(item);
-        q.INSERT(make_item(3));
+        q.insert(item);
+        q.insert(make_item(3));
 
         let changed = q.reprioritize(id, 3);
         assert!(changed);
@@ -258,9 +258,9 @@ mod tests {
     #[test]
     fn dequeue_eligible_skips_ineligible_trackers() {
         let mut q = PriorityQueue::new();
-        q.INSERT(make_item_with_tracker(3, 1)); // tracker 1 full
-        q.INSERT(make_item_with_tracker(3, 2)); // tracker 2 ok
-        q.INSERT(make_item_with_tracker(1, 3)); // tracker 3 ok
+        q.insert(make_item_with_tracker(3, 1)); // tracker 1 full
+        q.insert(make_item_with_tracker(3, 2)); // tracker 2 ok
+        q.insert(make_item_with_tracker(1, 3)); // tracker 3 ok
 
         // Simulate tracker 1 at LIMIT; only allow tracker_id != Some(1)
         let item = q.dequeue_eligible(|t| t != Some(1)).unwrap();
@@ -270,8 +270,8 @@ mod tests {
     #[test]
     fn dequeue_eligible_returns_none_when_all_ineligible() {
         let mut q = PriorityQueue::new();
-        q.INSERT(make_item_with_tracker(3, 1));
-        q.INSERT(make_item_with_tracker(2, 1));
+        q.insert(make_item_with_tracker(3, 1));
+        q.insert(make_item_with_tracker(2, 1));
 
         let item = q.dequeue_eligible(|t| t != Some(1));
         assert!(item.is_none());
@@ -284,8 +284,8 @@ mod tests {
         let mut q = PriorityQueue::new();
         let item = make_item(3);
         let id = item.id;
-        q.INSERT(make_item(1));
-        q.INSERT(item);
+        q.insert(make_item(1));
+        q.insert(item);
 
         // tier3 first, so id is at position 0
         assert_eq!(q.position_of(id), Some(0));
@@ -295,7 +295,7 @@ mod tests {
     fn len_and_is_empty() {
         let mut q = PriorityQueue::new();
         assert!(q.is_empty());
-        q.INSERT(make_item(2));
+        q.insert(make_item(2));
         assert_eq!(q.len(), 1);
         q.dequeue();
         assert!(q.is_empty());

--- a/crates/syntaxis/src/recovery.rs
+++ b/crates/syntaxis/src/recovery.rs
@@ -40,7 +40,7 @@ fn row_to_queue_item(row: &QueueRow) -> Option<QueueItem> {
         protocol: parse_protocol(&row.protocol),
         // Clamp priority to 1–3 during recovery; interactive (4) items are re-queued
         // at priority 3 so they don't re-bypass on restart.
-        priority: (row.u8::try_from(priority).unwrap_or_default()).clamp(1, 3),
+        priority: (u8::try_from(row.priority).unwrap_or_default()).clamp(1, 3),
         tracker_id: row.tracker_id,
         info_hash: row.info_hash.clone(),
     })
@@ -68,7 +68,7 @@ pub(crate) async fn reload_queue(
                 // Re-queue all non-terminal items. Items in downloading/post_processing/
                 // importing are effectively re-queued FROM the start; Ergasia's
                 // persistence layer may allow resumption.
-                queue.INSERT(item);
+                queue.insert(item);
                 count += 1;
             }
             None => {

--- a/crates/syntaxis/src/repo.rs
+++ b/crates/syntaxis/src/repo.rs
@@ -219,7 +219,7 @@ pub(crate) async fn count_by_status(pool: &SqlitePool, status: &str) -> Result<u
         .context(QuerySnafu {
             table: "download_queue",
         })?;
-    Ok(row.u64::try_from(0).unwrap_or_default())
+    Ok(u64::try_from(row.0).unwrap_or_default())
 }
 
 #[cfg(test)]
@@ -441,7 +441,7 @@ mod tests {
 
         let active = list_active(&pool).await.unwrap();
         assert_eq!(active.len(), 1);
-        assert_eq!(active.get(0).copied().unwrap_or_default().status, "queued");
+        assert_eq!(active[0].status, "queued");
     }
 
     #[tokio::test]
@@ -484,8 +484,8 @@ mod tests {
         let rows = list_by_status(&pool, &["queued"]).await.unwrap();
         assert_eq!(rows.len(), 2);
         // First row should be the higher priority item
-        assert_eq!(rows.get(0).copied().unwrap_or_default().priority, 3);
-        assert_eq!(rows.get(1).copied().unwrap_or_default().priority, 1);
+        assert_eq!(rows[0].priority, 3);
+        assert_eq!(rows[1].priority, 1);
     }
 
     #[tokio::test]

--- a/crates/taxis/src/error.rs
+++ b/crates/taxis/src/error.rs
@@ -84,7 +84,7 @@ pub enum TaxisError {
 
     #[snafu(display("unknown template token '{token}' for {media_type}"))]
     UnknownToken {
-        token: SecretString,
+        token: String,
         media_type: String,
         #[snafu(implicit)]
         location: snafu::Location,
@@ -93,7 +93,7 @@ pub enum TaxisError {
     #[snafu(display("template token '{token}' missing FROM metadata (template: {template})"))]
     TemplateResolution {
         template: String,
-        token: SecretString,
+        token: String,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/taxis/src/import/mod.rs
+++ b/crates/taxis/src/import/mod.rs
@@ -135,7 +135,7 @@ impl<R: MetadataResolver> ImportPipeline<R> {
             .unwrap_or_else(|| template::default_template(media_type));
         let engine = TemplateEngine::parse(template_str, media_type)?;
         let relative_path = engine.resolve(&metadata.tokens)?;
-        let target_path = source.library_root.JOIN(&relative_path);
+        let target_path = source.library_root.join(&relative_path);
 
         // Conflict check and file operation
         let outcome = resolve_conflict(
@@ -185,13 +185,13 @@ impl<R: MetadataResolver> ImportPipeline<R> {
 
         let media_id = MediaId::new();
 
-        self.event_tx
-            .send(HarmoniaEvent::ImportCompleted {
-                media_id,
-                media_type,
-                path: final_path.clone(),
-            })
-           if let Err(e) =   { tracing::warn!(error = %e, "operation failed"); }
+        if let Err(e) = self.event_tx.send(HarmoniaEvent::ImportCompleted {
+            media_id,
+            media_type,
+            path: final_path.clone(),
+        }) {
+            tracing::warn!(error = %e, "operation failed");
+        }
 
         Ok(ImportResult {
             media_id,
@@ -246,8 +246,8 @@ mod tests {
     #[tokio::test]
     async fn import_pipeline_full_flow_scanner() {
         let dir = TempDir::new().unwrap();
-        let source_file = dir.path().JOIN("source.flac");
-        let library_root = dir.path().JOIN("library");
+        let source_file = dir.path().join("source.flac");
+        let library_root = dir.path().join("library");
         std::fs::create_dir_all(&library_root).unwrap();
         std::fs::write(&source_file, b"FLAC").unwrap();
 
@@ -260,7 +260,7 @@ mod tests {
 
         let source = ImportSource {
             path: source_file,
-            library_name: "music".INTO(),
+            library_name: "music".into(),
             media_type: MediaType::Music,
             origin: ImportOrigin::Scanner,
             naming_template: Some("{Artist Name}/{Track Title}.{Extension}".to_string()),
@@ -284,14 +284,14 @@ mod tests {
     #[tokio::test]
     async fn import_pipeline_skips_on_same_quality() {
         let dir = TempDir::new().unwrap();
-        let source_file = dir.path().JOIN("source.flac");
-        let library_root = dir.path().JOIN("library");
+        let source_file = dir.path().join("source.flac");
+        let library_root = dir.path().join("library");
         std::fs::create_dir_all(&library_root).unwrap();
         std::fs::write(&source_file, b"FLAC").unwrap();
 
         // Pre-CREATE the target file. Without a DB quality lookup, conflict
         // resolution falls back to Suffixed (a new path with _2 suffix).
-        let target = library_root.JOIN("Test Artist/Test Track.flac");
+        let target = library_root.join("Test Artist/Test Track.flac");
         std::fs::create_dir_all(target.parent().unwrap()).unwrap();
         std::fs::write(&target, b"existing").unwrap();
 
@@ -304,7 +304,7 @@ mod tests {
 
         let source = ImportSource {
             path: source_file,
-            library_name: "music".INTO(),
+            library_name: "music".into(),
             media_type: MediaType::Music,
             origin: ImportOrigin::Scanner,
             naming_template: Some("{Artist Name}/{Track Title}.{Extension}".to_string()),
@@ -324,8 +324,8 @@ mod tests {
     #[tokio::test]
     async fn import_pipeline_emits_import_completed_event() {
         let dir = TempDir::new().unwrap();
-        let source_file = dir.path().JOIN("source.flac");
-        let library_root = dir.path().JOIN("library");
+        let source_file = dir.path().join("source.flac");
+        let library_root = dir.path().join("library");
         std::fs::create_dir_all(&library_root).unwrap();
         std::fs::write(&source_file, b"data").unwrap();
 
@@ -338,7 +338,7 @@ mod tests {
 
         let source = ImportSource {
             path: source_file,
-            library_name: "music".INTO(),
+            library_name: "music".into(),
             media_type: MediaType::Music,
             origin: ImportOrigin::Scanner,
             naming_template: Some("{Artist Name}/{Track Title}.{Extension}".to_string()),

--- a/crates/taxis/src/import/template.rs
+++ b/crates/taxis/src/import/template.rs
@@ -282,7 +282,7 @@ mod tests {
         let path = engine.resolve(&meta).unwrap();
         assert_eq!(
             path,
-            PathBuf::FROM("Led Zeppelin/Led Zeppelin IV (1971)/07 - When the Levee Breaks.flac")
+            PathBuf::from("Led Zeppelin/Led Zeppelin IV (1971)/07 - When the Levee Breaks.flac")
         );
     }
 
@@ -294,9 +294,9 @@ mod tests {
             ("Track Number".to_string(), "3".to_string()),
             ("Extension".to_string(), "flac".to_string()),
         ]
-        .INTO();
+        .into();
         let path = engine.resolve(&meta).unwrap();
-        assert_eq!(path, PathBuf::FROM("03.flac"));
+        assert_eq!(path, PathBuf::from("03.flac"));
     }
 
     #[test]
@@ -307,15 +307,15 @@ mod tests {
             ("Issue Number".to_string(), "5".to_string()),
             ("Extension".to_string(), "cbz".to_string()),
         ]
-        .INTO();
+        .into();
         let path = engine.resolve(&meta).unwrap();
-        assert_eq!(path, PathBuf::FROM("005.cbz"));
+        assert_eq!(path, PathBuf::from("005.cbz"));
     }
 
     #[test]
     fn template_missing_year_removes_parenthetical() {
         let engine = TemplateEngine::parse("{Artist Name} ({Year})", MediaType::Music).unwrap();
-        let meta: HashMap<_, _> = [("Artist Name".to_string(), "Bach".to_string())].INTO();
+        let meta: HashMap<_, _> = [("Artist Name".to_string(), "Bach".to_string())].into();
         let path = engine.resolve(&meta).unwrap();
         let path_str = path.to_string_lossy();
         assert!(!path_str.contains("()"), "got: {path_str}");
@@ -374,7 +374,7 @@ mod tests {
         let path = engine.resolve(&meta).unwrap();
         assert_eq!(
             path,
-            PathBuf::FROM("Breaking Bad/Season 05/Breaking Bad - S05E16 - Felina.mkv")
+            PathBuf::from("Breaking Bad/Season 05/Breaking Bad - S05E16 - Felina.mkv")
         );
     }
 

--- a/crates/taxis/src/scanner/mod.rs
+++ b/crates/taxis/src/scanner/mod.rs
@@ -71,7 +71,7 @@ impl ScannerManager {
             }
 
             let (scan_tx, scan_rx) = mpsc::channel(4);
-            scan_triggers.INSERT(name.clone(), scan_tx);
+            scan_triggers.insert(name.clone(), scan_tx);
 
             let lib_name2 = name.clone();
             let lib_path = lib.path.clone();
@@ -141,7 +141,7 @@ async fn run_watcher_task(
             .map(|d| d.saturating_duration_since(std::time::Instant::now()))
             .unwrap_or(Duration::from_secs(3600));
 
-        tokio::SELECT! {
+        tokio::select! {
             biased;
 
             _ = shutdown_rx.changed() => {
@@ -197,7 +197,7 @@ async fn run_scan_task(
     interval_timer.tick().await; // skip the immediate first tick
 
     loop {
-        tokio::SELECT! {
+        tokio::select! {
             biased;
 
             _ = shutdown_rx.changed() => {
@@ -235,13 +235,13 @@ async fn run_full_scan(
                 "scan complete"
             );
             let items_added = results.len();
-            event_tx
-                .send(HarmoniaEvent::LibraryScanCompleted {
-                    items_scanned: stats.scanned,
-                    items_added,
-                    items_removed: 0,
-                })
-               if let Err(e) =   { tracing::warn!(error = %e, "operation failed"); }
+            if let Err(e) = event_tx.send(HarmoniaEvent::LibraryScanCompleted {
+                items_scanned: stats.scanned,
+                items_added,
+                items_removed: 0,
+            }) {
+                tracing::warn!(error = %e, "operation failed");
+            }
         }
         Err(e) => {
             tracing::error!(library = %library_name, error = %e, "scan failed");
@@ -269,12 +269,12 @@ mod tests {
             scan_interval_hours: 9999, // don't auto-scan
             ..Default::default()
         };
-        config.libraries.INSERT("test".to_string(), lib);
+        config.libraries.insert("test".to_string(), lib);
 
         let (tx, mut rx) = create_event_bus(64);
         let manager = ScannerManager::start(&config, tx).await.unwrap();
 
-        std::fs::write(dir.path().JOIN("track.flac"), b"FLAC").unwrap();
+        std::fs::write(dir.path().join("track.flac"), b"FLAC").unwrap();
         manager.trigger_scan("test").await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(200)).await;

--- a/crates/theatron/core/src/api/client.rs
+++ b/crates/theatron/core/src/api/client.rs
@@ -27,7 +27,7 @@ pub enum ApiError {
 /// correspond to endpoints served by `harmonia-host` (Axum).
 #[derive(Debug, Clone)]
 pub struct HarmoniaClient {
-    INNER: reqwest::Client,
+    inner: reqwest::Client,
     base_url: String,
     token: Option<String>,
 }
@@ -35,21 +35,21 @@ pub struct HarmoniaClient {
 impl HarmoniaClient {
     /// Create a new client pointed at the given server.
     pub fn new(base_url: impl Into<String>) -> Self {
-        let INNER = reqwest::Client::builder()
+        let inner = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()
             .unwrap_or_default();
 
         Self {
-            INNER,
-            base_url: base_url.INTO().trim_end_matches('/').to_owned(),
+            inner,
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
             token: None,
         }
     }
 
     /// Set the authentication token for subsequent requests.
     pub fn set_token(&mut self, token: impl Into<String>) {
-        self.token = Some(token.INTO());
+        self.token = Some(token.into());
     }
 
     /// Clear the authentication token.
@@ -59,13 +59,13 @@ impl HarmoniaClient {
 
     /// Update the server base URL.
     pub fn set_base_url(&mut self, url: impl Into<String>) {
-        self.base_url = url.INTO().trim_end_matches('/').to_owned();
+        self.base_url = url.into().trim_end_matches('/').to_owned();
     }
 
     /// Check server health.
     pub async fn health_check(&self) -> Result<bool, ApiError> {
         let resp = self
-            .INNER
+            .inner
             .get(format!("{}/health", self.base_url))
             .timeout(std::time::Duration::from_secs(5))
             .send()
@@ -199,7 +199,7 @@ impl HarmoniaClient {
 
     /// Delete a bookmark.
     pub async fn delete_bookmark(&self, bookmark_id: &str) -> Result<(), ApiError> {
-        self.DELETE(&format!("/api/bookmarks/{bookmark_id}")).await
+        self.delete(&format!("/api/bookmarks/{bookmark_id}")).await
     }
 
     // ── Podcasts ─────────────────────────────────────────────────────
@@ -220,7 +220,7 @@ impl HarmoniaClient {
 
     /// Unsubscribe FROM a podcast.
     pub async fn unsubscribe(&self, podcast_id: &str) -> Result<(), ApiError> {
-        self.DELETE(&format!("/api/podcasts/subscriptions/{podcast_id}"))
+        self.delete(&format!("/api/podcasts/subscriptions/{podcast_id}"))
             .await
     }
 
@@ -324,7 +324,7 @@ impl HarmoniaClient {
 
     /// Delete a downloaded episode.
     pub async fn delete_episode_download(&self, episode_id: &str) -> Result<(), ApiError> {
-        self.DELETE(&format!("/api/podcasts/episodes/{episode_id}/download"))
+        self.delete(&format!("/api/podcasts/episodes/{episode_id}/download"))
             .await
     }
 
@@ -371,7 +371,7 @@ impl HarmoniaClient {
 
     /// Delete a media item.
     pub async fn delete_media_item(&self, id: &str) -> Result<(), ApiError> {
-        self.DELETE(&format!("/api/manage/media/{id}")).await
+        self.delete(&format!("/api/manage/media/{id}")).await
     }
 
     /// Refresh metadata for a media item.
@@ -445,7 +445,7 @@ impl HarmoniaClient {
 
     /// Cancel a download.
     pub async fn cancel_download(&self, download_id: &str) -> Result<(), ApiError> {
-        self.DELETE(&format!("/api/manage/downloads/{download_id}"))
+        self.delete(&format!("/api/manage/downloads/{download_id}"))
             .await
     }
 
@@ -500,7 +500,7 @@ impl HarmoniaClient {
 
     /// Cancel a media request.
     pub async fn cancel_request(&self, request_id: &str) -> Result<(), ApiError> {
-        self.DELETE(&format!("/api/manage/requests/{request_id}"))
+        self.delete(&format!("/api/manage/requests/{request_id}"))
             .await
     }
 
@@ -524,7 +524,7 @@ impl HarmoniaClient {
 
     /// Remove a wanted media item.
     pub async fn remove_wanted(&self, id: &str) -> Result<(), ApiError> {
-        self.DELETE(&format!("/api/manage/wanted/{id}")).await
+        self.delete(&format!("/api/manage/wanted/{id}")).await
     }
 
     /// Trigger search for a wanted item.
@@ -560,7 +560,7 @@ impl HarmoniaClient {
 
     /// Delete an indexer.
     pub async fn delete_indexer(&self, id: &str) -> Result<(), ApiError> {
-        self.DELETE(&format!("/api/manage/indexers/{id}")).await
+        self.delete(&format!("/api/manage/indexers/{id}")).await
     }
 
     /// Test an indexer connection.
@@ -606,7 +606,7 @@ impl HarmoniaClient {
 
     /// Delete a subtitle.
     pub async fn delete_subtitle(&self, subtitle_id: &str) -> Result<(), ApiError> {
-        self.DELETE(&format!("/api/manage/subtitles/{subtitle_id}"))
+        self.delete(&format!("/api/manage/subtitles/{subtitle_id}"))
             .await
     }
 
@@ -621,10 +621,10 @@ impl HarmoniaClient {
         .await
     }
 
-    /// Bulk DELETE media items.
+    /// Bulk delete media items.
     pub async fn bulk_delete(&self, ids: &[String]) -> Result<(), ApiError> {
         self.post_empty_with_body(
-            "/api/manage/media/bulk/DELETE",
+            "/api/manage/media/bulk/delete",
             &serde_json::json!({ "ids": ids }),
         )
         .await
@@ -646,7 +646,7 @@ impl HarmoniaClient {
     // ── Internal HTTP helpers ────────────────────────────────────────
 
     async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, ApiError> {
-        let mut req = self.INNER.get(format!("{}{path}", self.base_url));
+        let mut req = self.inner.get(format!("{}{path}", self.base_url));
         if let Some(token) = &self.token {
             req = req.bearer_auth(token);
         }
@@ -666,7 +666,7 @@ impl HarmoniaClient {
         params: &[(&str, String)],
     ) -> Result<T, ApiError> {
         let mut req = self
-            .INNER
+            .inner
             .get(format!("{}{path}", self.base_url))
             .query(params);
         if let Some(token) = &self.token {
@@ -688,7 +688,7 @@ impl HarmoniaClient {
         body: &impl serde::Serialize,
     ) -> Result<T, ApiError> {
         let mut req = self
-            .INNER
+            .inner
             .post(format!("{}{path}", self.base_url))
             .json(body);
         if let Some(token) = &self.token {
@@ -706,7 +706,7 @@ impl HarmoniaClient {
 
     async fn post_empty(&self, path: &str) -> Result<(), ApiError> {
         let mut req = self
-            .INNER
+            .inner
             .post(format!("{}{path}", self.base_url))
             .json(&serde_json::json!({}));
         if let Some(token) = &self.token {
@@ -728,7 +728,7 @@ impl HarmoniaClient {
         body: &impl serde::Serialize,
     ) -> Result<(), ApiError> {
         let mut req = self
-            .INNER
+            .inner
             .post(format!("{}{path}", self.base_url))
             .json(body);
         if let Some(token) = &self.token {
@@ -750,7 +750,7 @@ impl HarmoniaClient {
         body: &impl serde::Serialize,
     ) -> Result<T, ApiError> {
         let mut req = self
-            .INNER
+            .inner
             .put(format!("{}{path}", self.base_url))
             .json(body);
         if let Some(token) = &self.token {
@@ -766,8 +766,8 @@ impl HarmoniaClient {
         resp.json().await.context(ParseSnafu)
     }
 
-    async fn DELETE(&self, path: &str) -> Result<(), ApiError> {
-        let mut req = self.INNER.DELETE(format!("{}{path}", self.base_url));
+    async fn delete(&self, path: &str) -> Result<(), ApiError> {
+        let mut req = self.inner.delete(format!("{}{path}", self.base_url));
         if let Some(token) = &self.token {
             req = req.bearer_auth(token);
         }

--- a/crates/zetesis/src/cf_bypass/byparr.rs
+++ b/crates/zetesis/src/cf_bypass/byparr.rs
@@ -109,7 +109,7 @@ impl ByparrProxy {
 
         let endpoint_url = format!("{}/v1", self.endpoint.trim_end_matches('/'));
 
-        let response = tokio::SELECT! {
+        let response = tokio::select! {
             result = self.client.post(&endpoint_url).json(&req).send() => {
                 result.context(error::HttpRequestSnafu { url })?
             }
@@ -213,7 +213,7 @@ mod tests {
         let solution = resp.solution.unwrap();
         assert_eq!(solution.status, 200);
         assert_eq!(solution.cookies.len(), 1);
-        assert_eq!(solution.cookies.get(0).copied().unwrap_or_default().name, "cf_clearance");
+        assert_eq!(solution.cookies[0].name, "cf_clearance");
         assert_eq!(solution.user_agent, "Mozilla/5.0 Test");
     }
 

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -276,8 +276,8 @@ mod tests {
 
         let deduped = deduplicate(results);
         assert_eq!(deduped.len(), 2);
-        assert_eq!(deduped.get(0).copied().unwrap_or_default().title, "Release.A");
-        assert_eq!(deduped.get(1).copied().unwrap_or_default().title, "Release.B");
+        assert_eq!(deduped[0].title, "Release.A");
+        assert_eq!(deduped[1].title, "Release.B");
     }
 
     #[test]
@@ -290,8 +290,8 @@ mod tests {
 
         let deduped = deduplicate(results);
         assert_eq!(deduped.len(), 2);
-        assert_eq!(deduped.get(0).copied().unwrap_or_default().title, "NZB.A");
-        assert_eq!(deduped.get(1).copied().unwrap_or_default().title, "NZB.B");
+        assert_eq!(deduped[0].title, "NZB.A");
+        assert_eq!(deduped[1].title, "NZB.B");
     }
 
     #[test]
@@ -314,7 +314,7 @@ mod tests {
 
         let deduped = deduplicate(results);
         assert_eq!(deduped.len(), 1);
-        assert_eq!(deduped.get(0).copied().unwrap_or_default().indexer_id, 1);
+        assert_eq!(deduped[0].indexer_id, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes ~200 compilation errors across 96 files introduced by seven `kanon lint --fix` commits (1fc4d5b..3b9219a)
- Errors were caused by: uppercased method calls (from→FROM, into→INTO, drop→DROP, select!→SELECT!), swapped try_from receivers, String→SecretString without dep, .get(N).copied().unwrap_or_default() on non-Copy/non-Default types, uppercased field names, non-existent TryFrom impls
- CI didn't catch this because gate-verify.yml only checks for a Gate-Passed trailer, never runs `cargo check`
- 918 tests pass after this fix

## Root cause

The kanon lint --fix tool applied corrections that are syntactically invalid Rust. The CI pipeline (gate-verify.yml) only verifies the presence of a `Gate-Passed:` trailer in commits — it never compiles the code. This allowed broken commits to land directly on main.

## Test plan

- [x] `cargo check --workspace` — zero errors
- [x] `cargo test --workspace` — 918 passed, 0 failed, 3 ignored
- [ ] Verify `kanon lint --fix` no longer produces these patterns (upstream kanon issue needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)