### PR TITLE
chore(deps): bump mdns-sd from 0.18 to 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,9 +2940,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "mdns-sd"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d797ab3274a16f4940f9650a29838e940223aeff31773df5c2827ad82150182f"
+checksum = "451927183d65d600e52b4e877a1251e051576f84fa01e5b4a50b450dfaaa537c"
 dependencies = [
  "fastrand",
  "flume",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ rustls          = { version = "0.23", default-features = false, features = ["rin
 rcgen           = { version = "0.14", features = ["pem"] }
 
 # ── mDNS discovery ────────────────────────────────────────────────────────────
-mdns-sd         = "0.18"
+mdns-sd         = "0.19"
 
 # ── Crypto utilities ──────────────────────────────────────────────────────────
 sha2            = "0.11"


### PR DESCRIPTION
## Summary
- Bumps mdns-sd from 0.18.2 to 0.19.0
- Non-breaking API update, compiles clean on current main
- Supersedes dependabot PR #155 (based on stale main)

## Test plan
- [x] `cargo check --workspace` passes
- [ ] mDNS discovery smoke test: `harmonia serve` + device pairing

🤖 Generated with [Claude Code](https://claude.com/claude-code)