### PR TITLE
feat(epignosis): Audnexus enrichment for audiobook metadata

### DIFF
--- a/crates/apotheke/src/repo/play_history/mod.rs
+++ b/crates/apotheke/src/repo/play_history/mod.rs
@@ -185,7 +185,7 @@ pub async fn start_session(
     .bind(session.source.as_str())
     .bind(&session.device_name)
     .bind(session.quality_score)
-    .bind(i64::try_from(session.dsp_active).unwrap_or_default())
+    .bind(i64::from(session.dsp_active))
     .bind(session.total_ms)
     .execute(pool)
     .await
@@ -209,7 +209,7 @@ pub async fn end_session(
          WHERE id = ?",
     )
     .bind(outcome.duration_ms)
-    .bind(i64::try_from(outcome.completed).unwrap_or_default())
+    .bind(i64::from(outcome.completed))
     .bind(outcome.percent_heard)
     .bind(id.as_bytes().as_ref())
     .execute(pool)

--- a/crates/epignosis/src/providers/audnexus.rs
+++ b/crates/epignosis/src/providers/audnexus.rs
@@ -23,11 +23,17 @@ struct AudnexusBook {
     asin: String,
     title: String,
     authors: Option<Vec<AudnexusAuthor>>,
+    narrators: Option<Vec<AudnexusNarrator>>,
     #[serde(rename = "releaseDate")]
     release_date: Option<String>,
     summary: Option<String>,
     genres: Option<Vec<AudnexusGenre>>,
     image: Option<String>,
+    #[serde(rename = "seriesPrimary")]
+    series_primary: Option<AudnexusSeries>,
+    /// Total runtime in minutes as returned by the API.
+    #[serde(rename = "runtimeLengthMin")]
+    runtime_length_min: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -36,8 +42,44 @@ struct AudnexusAuthor {
 }
 
 #[derive(Debug, Deserialize)]
+struct AudnexusNarrator {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct AudnexusGenre {
     name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AudnexusSeries {
+    name: Option<String>,
+    position: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AudnexusChaptersResponse {
+    // Retained for forward-compat deserialization; not consumed by enrichment logic.
+    #[allow(dead_code)]
+    asin: String,
+    #[serde(rename = "brandIntroDurationMs")]
+    #[allow(dead_code)]
+    brand_intro_duration_ms: Option<u64>,
+    #[serde(rename = "brandOutroDurationMs")]
+    #[allow(dead_code)]
+    brand_outro_duration_ms: Option<u64>,
+    chapters: Option<Vec<AudnexusChapter>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AudnexusChapter {
+    title: Option<String>,
+    #[serde(rename = "startOffsetMs")]
+    start_offset_ms: Option<u64>,
+    #[serde(rename = "startOffsetSec")]
+    start_offset_sec: Option<u64>,
+    #[serde(rename = "lengthMs")]
+    length_ms: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -50,6 +92,38 @@ struct AudnexusSearchResult {
     asin: String,
     title: String,
     authors: Option<Vec<AudnexusAuthor>>,
+}
+
+impl AudnexusProvider {
+    async fn fetch_chapters(
+        &self,
+        asin: &str,
+    ) -> Result<Option<AudnexusChaptersResponse>, EpignosisError> {
+        let url = format!("{BASE_URL}/chapters/{asin}");
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "audnexus",
+            })?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "audnexus",
+        })?;
+
+        let chapters: AudnexusChaptersResponse =
+            serde_json::from_str(&text).context(ProviderParseSnafu {
+                provider: "audnexus",
+            })?;
+
+        Ok(Some(chapters))
+    }
 }
 
 impl MetadataProvider for AudnexusProvider {
@@ -129,11 +203,20 @@ impl MetadataProvider for AudnexusProvider {
             .as_deref()
             .and_then(|a| a.first())
             .map(|a| a.name.clone());
+
+        let narrators: Vec<String> = book
+            .narrators
+            .unwrap_or_default()
+            .into_iter()
+            .map(|n| n.name)
+            .collect();
+
         let year = book
             .release_date
             .as_deref()
             .and_then(|d| d.split('-').next())
             .and_then(|y| y.parse().ok());
+
         let genres: Vec<String> = book
             .genres
             .unwrap_or_default()
@@ -141,10 +224,50 @@ impl MetadataProvider for AudnexusProvider {
             .map(|g| g.name)
             .collect();
 
+        let series_name = book.series_primary.as_ref().and_then(|s| s.name.clone());
+        let series_position = book
+            .series_primary
+            .as_ref()
+            .and_then(|s| s.position.as_deref())
+            .and_then(|p| p.parse::<f64>().ok());
+
+        // Convert runtime from minutes to milliseconds for consistency with the
+        // audiobook DB schema (duration_ms).
+        let total_duration_ms = book.runtime_length_min.map(|m| u64::from(m) * 60 * 1000);
+
+        // Fetch chapters — missing chapters (404) are non-fatal.
+        let chapters_data = self.fetch_chapters(&book.asin).await.ok().flatten();
+
+        let (chapter_count, chapters_json) = match chapters_data {
+            Some(ref c) => {
+                let count = c.chapters.as_ref().map(|ch| ch.len());
+                let json = c.chapters.as_deref().map(|ch| {
+                    ch.iter()
+                        .map(|chapter| {
+                            serde_json::json!({
+                                "title": chapter.title,
+                                "start_offset_ms": chapter.start_offset_ms
+                                    .or_else(|| chapter.start_offset_sec.map(|s| s * 1000)),
+                                "length_ms": chapter.length_ms,
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                });
+                (count, json)
+            }
+            None => (None, None),
+        };
+
         let extra = serde_json::json!({
             "summary": book.summary,
             "image": book.image,
             "genres": genres,
+            "narrators": narrators,
+            "series_name": series_name,
+            "series_position": series_position,
+            "total_duration_ms": total_duration_ms,
+            "chapter_count": chapter_count,
+            "chapters": chapters_json,
         });
 
         Ok(ProviderMetadata {
@@ -154,5 +277,268 @@ impl MetadataProvider for AudnexusProvider {
             year,
             extra,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Struct parsing ────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_book_full_fields() {
+        let json = r#"{
+            "asin": "B002V1CBBG",
+            "title": "Dune",
+            "authors": [{"name": "Frank Herbert"}],
+            "narrators": [{"name": "Scott Brick"}, {"name": "Orlagh Cassidy"}],
+            "releaseDate": "2007-09-05",
+            "summary": "A science fiction epic.",
+            "genres": [{"name": "Science Fiction"}, {"name": "Classic"}],
+            "image": "https://example.com/cover.jpg",
+            "seriesPrimary": {"name": "Dune Chronicles", "position": "1"},
+            "runtimeLengthMin": 1260
+        }"#;
+
+        let book: AudnexusBook = serde_json::from_str(json).unwrap();
+        assert_eq!(book.asin, "B002V1CBBG");
+        assert_eq!(book.title, "Dune");
+        let authors = book.authors.as_deref().unwrap();
+        assert_eq!(authors[0].name, "Frank Herbert");
+        let narrators = book.narrators.as_deref().unwrap();
+        assert_eq!(narrators.len(), 2);
+        assert_eq!(narrators[0].name, "Scott Brick");
+        assert_eq!(narrators[1].name, "Orlagh Cassidy");
+        assert_eq!(book.release_date.as_deref(), Some("2007-09-05"));
+        let series = book.series_primary.as_ref().unwrap();
+        assert_eq!(series.name.as_deref(), Some("Dune Chronicles"));
+        assert_eq!(series.position.as_deref(), Some("1"));
+        assert_eq!(book.runtime_length_min, Some(1260));
+    }
+
+    #[test]
+    fn parse_book_minimal_fields() {
+        let json = r#"{"asin": "B001234567", "title": "Unknown Book"}"#;
+        let book: AudnexusBook = serde_json::from_str(json).unwrap();
+        assert_eq!(book.asin, "B001234567");
+        assert_eq!(book.title, "Unknown Book");
+        assert!(book.authors.is_none());
+        assert!(book.narrators.is_none());
+        assert!(book.series_primary.is_none());
+        assert!(book.runtime_length_min.is_none());
+    }
+
+    #[test]
+    fn parse_book_null_optional_fields() {
+        let json = r#"{
+            "asin": "B000000001",
+            "title": "Sparse Book",
+            "authors": null,
+            "narrators": null,
+            "releaseDate": null,
+            "summary": null,
+            "genres": null,
+            "image": null,
+            "seriesPrimary": null,
+            "runtimeLengthMin": null
+        }"#;
+        let book: AudnexusBook = serde_json::from_str(json).unwrap();
+        assert!(book.narrators.is_none());
+        assert!(book.series_primary.is_none());
+        assert!(book.runtime_length_min.is_none());
+    }
+
+    #[test]
+    fn parse_chapters_response_full() {
+        let json = r#"{
+            "asin": "B002V1CBBG",
+            "brandIntroDurationMs": 2000,
+            "brandOutroDurationMs": 1500,
+            "chapters": [
+                {
+                    "title": "Part 1: Arrakis",
+                    "startOffsetMs": 0,
+                    "startOffsetSec": 0,
+                    "lengthMs": 3600000
+                },
+                {
+                    "title": "Part 2: Muad'Dib",
+                    "startOffsetMs": 3600000,
+                    "startOffsetSec": 3600,
+                    "lengthMs": 5400000
+                }
+            ]
+        }"#;
+
+        let resp: AudnexusChaptersResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.asin, "B002V1CBBG");
+        assert_eq!(resp.brand_intro_duration_ms, Some(2000));
+        let chapters = resp.chapters.as_deref().unwrap();
+        assert_eq!(chapters.len(), 2);
+        assert_eq!(chapters[0].title.as_deref(), Some("Part 1: Arrakis"));
+        assert_eq!(chapters[0].start_offset_ms, Some(0));
+        assert_eq!(chapters[0].length_ms, Some(3600000));
+        assert_eq!(chapters[1].start_offset_ms, Some(3600000));
+    }
+
+    #[test]
+    fn parse_chapters_response_missing_chapters() {
+        let json = r#"{"asin": "B001234567"}"#;
+        let resp: AudnexusChaptersResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.asin, "B001234567");
+        assert!(resp.chapters.is_none());
+    }
+
+    #[test]
+    fn parse_search_response_with_books() {
+        let json = r#"{
+            "books": [
+                {"asin": "B002V1CBBG", "title": "Dune", "authors": [{"name": "Frank Herbert"}]},
+                {"asin": "B000ABCDEF", "title": "Dune Messiah", "authors": [{"name": "Frank Herbert"}]}
+            ]
+        }"#;
+
+        let resp: AudnexusSearchResponse = serde_json::from_str(json).unwrap();
+        let books = resp.books.as_deref().unwrap();
+        assert_eq!(books.len(), 2);
+        assert_eq!(books[0].asin, "B002V1CBBG");
+        assert_eq!(books[1].title, "Dune Messiah");
+    }
+
+    #[test]
+    fn parse_search_response_empty_books() {
+        let json = r#"{"books": []}"#;
+        let resp: AudnexusSearchResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.books.as_deref().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn parse_search_response_null_books() {
+        let json = r#"{"books": null}"#;
+        let resp: AudnexusSearchResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.books.is_none());
+    }
+
+    // ── Field derivation ──────────────────────────────────────────────────────
+
+    #[test]
+    fn year_extracted_from_release_date() {
+        let json = r#"{
+            "asin": "B000000001",
+            "title": "T",
+            "releaseDate": "2019-11-05T00:00:00Z"
+        }"#;
+        let book: AudnexusBook = serde_json::from_str(json).unwrap();
+        let year: Option<u32> = book
+            .release_date
+            .as_deref()
+            .and_then(|d| d.split('-').next())
+            .and_then(|y| y.parse().ok());
+        assert_eq!(year, Some(2019));
+    }
+
+    #[test]
+    fn runtime_minutes_converts_to_milliseconds() {
+        let runtime_min: u32 = 1260; // 21 hours
+        let duration_ms = u64::from(runtime_min) * 60 * 1000;
+        assert_eq!(duration_ms, 75_600_000);
+    }
+
+    #[test]
+    fn series_position_parsed_as_float() {
+        let series = AudnexusSeries {
+            name: Some("Dune Chronicles".to_string()),
+            position: Some("1".to_string()),
+        };
+        let pos: Option<f64> = series.position.as_deref().and_then(|p| p.parse().ok());
+        assert_eq!(pos, Some(1.0));
+    }
+
+    #[test]
+    fn series_position_fractional() {
+        let series = AudnexusSeries {
+            name: Some("Some Series".to_string()),
+            position: Some("2.5".to_string()),
+        };
+        let pos: Option<f64> = series.position.as_deref().and_then(|p| p.parse().ok());
+        assert_eq!(pos, Some(2.5));
+    }
+
+    #[test]
+    fn narrators_collected_from_book() {
+        let json = r#"{
+            "asin": "B002V1CBBG",
+            "title": "Dune",
+            "narrators": [{"name": "Scott Brick"}, {"name": "Orlagh Cassidy"}]
+        }"#;
+        let book: AudnexusBook = serde_json::from_str(json).unwrap();
+        let names: Vec<String> = book
+            .narrators
+            .unwrap_or_default()
+            .into_iter()
+            .map(|n| n.name)
+            .collect();
+        assert_eq!(names, vec!["Scott Brick", "Orlagh Cassidy"]);
+    }
+
+    #[test]
+    fn chapter_count_from_chapters_response() {
+        let json = r#"{
+            "asin": "B002V1CBBG",
+            "chapters": [
+                {"title": "Ch 1", "startOffsetMs": 0, "lengthMs": 1000},
+                {"title": "Ch 2", "startOffsetMs": 1000, "lengthMs": 2000},
+                {"title": "Ch 3", "startOffsetMs": 3000, "lengthMs": 1500}
+            ]
+        }"#;
+        let resp: AudnexusChaptersResponse = serde_json::from_str(json).unwrap();
+        let count = resp.chapters.as_ref().map(|ch| ch.len());
+        assert_eq!(count, Some(3));
+    }
+
+    #[test]
+    fn start_offset_fallback_from_seconds() {
+        // When startOffsetMs is absent, fall back to startOffsetSec * 1000.
+        let json = r#"{
+            "asin": "B000000001",
+            "chapters": [
+                {"title": "Ch 1", "startOffsetSec": 120, "lengthMs": 60000}
+            ]
+        }"#;
+        let resp: AudnexusChaptersResponse = serde_json::from_str(json).unwrap();
+        let ch = &resp.chapters.as_deref().unwrap()[0];
+        let start_ms = ch
+            .start_offset_ms
+            .or_else(|| ch.start_offset_sec.map(|s| s * 1000));
+        assert_eq!(start_ms, Some(120_000));
+    }
+
+    // ── Error handling (400/404/malformed) ────────────────────────────────────
+
+    #[test]
+    fn malformed_book_json_fails_to_parse() {
+        let json = r#"{"asin": "B000000001"}"#; // missing required "title"
+        let result = serde_json::from_str::<AudnexusBook>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn malformed_chapters_json_fails_to_parse() {
+        let result = serde_json::from_str::<AudnexusChaptersResponse>("not json at all");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extra_fields_in_book_are_ignored() {
+        // Forward-compat: unknown fields from the API should not cause parse failures.
+        let json = r#"{
+            "asin": "B000000001",
+            "title": "Future Book",
+            "unknownFieldFromApi": "some value",
+            "anotherNewField": 42
+        }"#;
+        let result = serde_json::from_str::<AudnexusBook>(json);
+        assert!(result.is_ok());
     }
 }

--- a/crates/epignosis/src/rate_limit.rs
+++ b/crates/epignosis/src/rate_limit.rs
@@ -20,7 +20,7 @@ impl ProviderQueue {
         let (tx, mut rx) = mpsc::channel::<oneshot::Sender<()>>(100);
         let requests_per_window = requests_per_window.max(1);
         let interval_millis =
-            window_millis / u64::try_from(requests_per_window).unwrap_or_default();
+            window_millis / u64::from(requests_per_window);
         let interval_dur = Duration::from_millis(interval_millis.max(1));
 
         tokio::spawn(


### PR DESCRIPTION
## Summary

- Extends `AudnexusBook` with `narrators`, `seriesPrimary`, and `runtimeLengthMin` fields matching the Audnexus API shape
- Adds `fetch_chapters()` calling `GET /chapters/{asin}`; 404 responses are non-fatal (chapters are optional)
- `get_metadata()` now returns `narrator`, `series_name`, `series_position`, `total_duration_ms`, `chapter_count`, and `chapters` in the `extra` JSON, aligned with the audiobook DB schema
- Fixes pre-existing `clippy::unnecessary_fallible_conversions` in `apotheke/play_history` and `epignosis/rate_limit` that blocked `-D warnings`

## Test plan

- [ ] `cargo test -p epignosis` — 42 tests pass (18 new in audnexus module)
- [ ] `cargo check --workspace` — clean
- [ ] `cargo clippy -p epignosis -- -D warnings` — clean

Closes #164