### PR TITLE
fix: migration 004 BOOLEAN to INTEGER for STRICT (closes #194)

### DIFF
--- a/crates/apotheke/migrations/004_indexers.sql
+++ b/crates/apotheke/migrations/004_indexers.sql
@@ -7,8 +7,8 @@ CREATE TABLE IF NOT EXISTS indexers (
     url         TEXT NOT NULL,
     protocol    TEXT NOT NULL CHECK (protocol IN ('torznab', 'newznab')),
     api_key     TEXT,
-    enabled     BOOLEAN NOT NULL DEFAULT TRUE,
-    cf_bypass   BOOLEAN NOT NULL DEFAULT FALSE,
+    enabled     INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+    cf_bypass   INTEGER NOT NULL DEFAULT 0 CHECK (cf_bypass IN (0, 1)),
     status      TEXT NOT NULL DEFAULT 'active'
                     CHECK (status IN ('active', 'degraded', 'failed')),
     last_tested TEXT,

--- a/crates/apotheke/migrations/007_subtitles.sql
+++ b/crates/apotheke/migrations/007_subtitles.sql
@@ -9,8 +9,8 @@ CREATE TABLE IF NOT EXISTS subtitles (
     file_path        TEXT NOT NULL,
     provider         TEXT NOT NULL,
     provider_id      TEXT NOT NULL,
-    hearing_impaired BOOLEAN NOT NULL DEFAULT FALSE,
-    forced           BOOLEAN NOT NULL DEFAULT FALSE,
+    hearing_impaired INTEGER NOT NULL DEFAULT 0 CHECK (hearing_impaired IN (0, 1)),
+    forced           INTEGER NOT NULL DEFAULT 0 CHECK (forced IN (0, 1)),
     score            REAL NOT NULL,
     acquired_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 ) STRICT;


### PR DESCRIPTION
## Summary

- Replace `BOOLEAN` columns with `INTEGER NOT NULL DEFAULT 0/1 CHECK (col IN (0, 1))` in migrations 004 (`indexers.enabled`, `indexers.cf_bypass`) and 007 (`subtitles.hearing_impaired`, `subtitles.forced`).
- SQLite `STRICT` tables only accept `INT`, `INTEGER`, `REAL`, `TEXT`, `BLOB`, `ANY`. `BOOLEAN` is rejected at migration-execution time with `unknown datatype for indexers.enabled: "BOOLEAN"`, which blocked every crate running `apotheke::migrate::MIGRATOR` (aitesis, archon, paroche, syndesis, syntaxis, zetesis, prostheke, ...).
- `sqlx` `bool` bindings already round-trip through INTEGER 0/1, so no Rust code changes are needed. `WHERE enabled = TRUE` style queries remain valid since TRUE/FALSE are SQL keyword aliases for 1/0 independent of STRICT.

## Repro

```
cargo nextest run --workspace
# pre-fix: ExecuteMigration(Database(SqliteError { code: 1, message: "unknown datatype for indexers.enabled: \"BOOLEAN\"" }), 4)
# post-fix: 1059 passed, 0 failed, 3 skipped
```

## Fix choice: edit 004 in place, not a new 005

Migration 004 + STRICT landed together (f51917a) and have never migrated cleanly — no deployed DB can possibly contain the broken schema, so correcting the column type at source is safe and preserves linear migration history. Same logic for 007.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo nextest run --workspace` - 1059 passed, 0 failed (previously RED with ExecuteMigration blocker)
- [x] `kanon lint` clean on 004 and 007 (remaining 2 violations are pre-existing in 009_zones.sql, unrelated)

Closes #194