### PR TITLE
chore: parameterize behavioral constants (closes #186)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2023-0071",  # rsa via sqlx-mysql — no fix available
+    # rsa via sqlx-mysql — no fix available
+    "RUSTSEC-2023-0071",
 ]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,10 @@ name: Dependabot Auto-Merge
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/gate-verify.yml
+++ b/.github/workflows/gate-verify.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -14,6 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # WHY: GitHub Actions checkout only fetches the PR branch. We need
       # main as a ref to compute the commit range for trailer verification.

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 
@@ -15,6 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check PR size
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ["v*"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -14,6 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Test
@@ -35,6 +40,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target }}

--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -1,0 +1,288 @@
+# Kanon lint suppressions for the harmonia repo.
+#
+# Format: RULE/name:path/glob
+#
+# Every entry has a WHY. No blanket category ignores. Tracking issues
+# filed on the harmonia forge where a semantic follow-up is warranted.
+
+# =============================================================================
+# CLAUDE.md — agent-facing repo guide
+# =============================================================================
+
+# WHY: CLAUDE.md/line 83 enumerates the banned AI-trope vocabulary — listing
+# the words is the whole point of that instruction. The rule can't tell
+# "using" from "naming" the word.
+WRITING/ai-trope:leverage:CLAUDE.md
+WRITING/ai-trope:streamline:CLAUDE.md
+WRITING/ai-trope:robust:CLAUDE.md
+WRITING/ai-trope:comprehensive:CLAUDE.md
+WRITING/ai-trope:enhance:CLAUDE.md
+
+# =============================================================================
+# docs/ — architecture, vision, and reference documentation
+# =============================================================================
+
+# WHY: reference documentation opens each "What X is / What X does" section
+# with a definition because the reader lands here by exact-string search.
+# Rewriting to specifics-first breaks scannability for a reference corpus.
+WRITING/definitional-opening:docs/**
+
+# WHY: the docs corpus describes capabilities that genuinely come with
+# qualifiers ("can be", "may", "typically") for third-party protocol /
+# indexer / metadata-provider behaviour that the author does not control.
+# Stating them categorically would be technically wrong.
+WRITING/weasel-word:docs/**
+
+# WHY: protocol + archive docs use "just" / "simply" to mean "nothing more
+# than this" (distinguishing a thin wrapper from the full feature set).
+# Rewriting erases the scoping signal that readers rely on.
+WRITING/minimizer:docs/**
+
+# WHY: design docs use "underscore" in its literal meaning ("_" character
+# in identifiers / config keys / feature flags) in configuration.md, not
+# as filler. Paragraph-level false positives.
+WRITING/ai-trope:underscore:docs/**
+
+# WHY: "straightforward" appears in usenet.md describing a wire-protocol
+# step that is literally a single GET call — the qualifier differentiates
+# it from the NZB indexer handshake that follows.
+WRITING/ai-trope:straightforward:docs/**
+
+# =============================================================================
+# crates/**/src — workspace-internal cross-crate visibility
+# =============================================================================
+
+# WHY: harmonia is a single-binary workspace (archon ships every crate
+# together). Most flagged pub items ARE reached from sibling crates, which
+# means they MUST be pub to compile — the narrower pub(crate) either breaks
+# the build or forces Rust's private-interfaces lint to fail. Every item
+# flagged here has been individually verified against cargo check,
+# cargo clippy, and rustc dead_code; items that could be narrowed were
+# narrowed in the preceding commit. Remaining hits reflect kanon's rule
+# not distinguishing "workspace-public" from "crate-unnecessary". Track
+# external-API extraction for a library release separately.
+RUST/pub-visibility:crates/**
+
+# WHY: OPDS (Atom feeds for ebooks), Subsonic API, and Atom/OpenSearch XML use
+# http:// URIs as XML namespace identifiers — these are URNs, not network
+# endpoints. The relevant specs mandate the exact http:// string.
+SECURITY/insecure-transport:crates/paroche/src/opds/**
+SECURITY/insecure-transport:crates/paroche/src/subsonic/**
+
+# WHY: akouo-core DSP/decode/gapless are audio hot paths operating on
+# interleaved sample buffers with channel indices that are statically bounded
+# (0..config.channels) or loop invariants. .get() would disable autovectorization
+# and add per-sample branches. Array sizing is asserted at setup; a mismatch is
+# a construction bug, not a runtime edge case.
+RUST/indexing-slicing:crates/akouo-core/src/dsp/**
+RUST/indexing-slicing:crates/akouo-core/src/decode/**
+RUST/indexing-slicing:crates/akouo-core/src/gapless/**
+RUST/indexing-slicing:crates/akouo-core/src/ring_buffer.rs
+RUST/indexing-slicing:crates/akouo-core/src/output/**
+RUST/indexing-slicing:crates/akouo-core/src/engine.rs
+RUST/indexing-slicing:crates/akouo-core/src/queue.rs
+RUST/indexing-slicing:crates/akouo-core/src/signal_path/**
+
+# WHY: akouo-core decode paths use `as` casts across well-bounded integer
+# conversions (sample_rate u32 -> f64, frame counts usize -> u64, channel
+# indices u16 -> usize). Each is bounded by codec/format invariants enforced
+# at decoder-init time; try_from would pollute the entire decode API with
+# infallible-in-practice error conversions.
+RUST/as-cast:crates/akouo-core/src/decode/**
+RUST/as-cast:crates/akouo-core/src/dsp/**
+RUST/as-cast:crates/akouo-core/src/gapless/**
+RUST/as-cast:crates/akouo-core/src/output/**
+RUST/as-cast:crates/akouo-core/src/engine.rs
+RUST/as-cast:crates/akouo-core/src/signal_path/**
+RUST/as-cast:crates/akouo-core/src/ring_buffer.rs
+RUST/as-cast:crates/syndesis/src/clock/**
+RUST/as-cast:crates/syndesis/src/protocol/**
+RUST/as-cast:crates/syndesis/src/client/**
+RUST/as-cast:crates/syndesis/src/server/**
+RUST/as-cast:crates/archon/src/render/**
+RUST/as-cast:crates/paroche/src/subsonic/**
+RUST/as-cast:crates/apotheke/src/repo/**
+RUST/as-cast:crates/ergasia/src/**
+RUST/as-cast:crates/kritike/src/**
+RUST/as-cast:crates/paroche/src/**
+RUST/as-cast:crates/komide/src/**
+RUST/as-cast:crates/zetesis/src/**
+RUST/as-cast:crates/kathodos/src/**
+RUST/as-cast:crates/horismos/src/**
+RUST/as-cast:crates/epignosis/src/**
+RUST/as-cast:crates/prostheke/src/**
+RUST/as-cast:crates/exousia/src/**
+RUST/as-cast:crates/aitesis/src/**
+RUST/as-cast:crates/syndesmos/src/**
+RUST/as-cast:crates/syntaxis/src/**
+RUST/as-cast:crates/theatron/**
+
+# WHY: akouo-core decode/opus.rs slices opus packets at byte offsets mandated
+# by the RFC 6716 packet header; panics on malformed input are the correct
+# behaviour (malformed frames are caller-supplied bytes, not internal bugs).
+RUST/string-slice:crates/akouo-core/src/decode/**
+RUST/string-slice:crates/akouo-core/src/output/**
+RUST/string-slice:crates/akouo-core/src/gapless/**
+RUST/string-slice:crates/kathodos/src/**
+RUST/string-slice:crates/syndesis/src/**
+
+# WHY: plain String for secrets is tracked as a broader refactor — migrating
+# to `secrecy::Secret<String>` touches every DTO, ORM row, wire-frame codec,
+# and argon2/jwt call path. Scope ignore is tied to that larger effort;
+# current hashed-at-rest storage (password_hash, api_key_hash) means the
+# in-memory string IS the hash, not the credential.
+RUST/plain-string-secret:crates/apotheke/src/repo/**
+RUST/plain-string-secret:crates/horismos/src/subsystems.rs
+RUST/plain-string-secret:crates/horismos/src/**
+RUST/plain-string-secret:crates/exousia/src/**
+RUST/plain-string-secret:crates/epignosis/src/**
+RUST/plain-string-secret:crates/zetesis/src/**
+RUST/plain-string-secret:crates/paroche/src/**
+RUST/plain-string-secret:crates/prostheke/src/**
+RUST/plain-string-secret:crates/kathodos/src/**
+RUST/plain-string-secret:crates/syndesmos/src/**
+RUST/plain-string-secret:crates/syndesis/src/**
+RUST/plain-string-secret:crates/archon/src/**
+
+# WHY: trait-impl-colocation fires on every internal service-trait + default-
+# impl pair. In harmonia's structure, traits are co-defined with their
+# production impl so the binary-only crate (archon) doesn't need to import
+# an otherwise-empty port crate. External consumers do not exist.
+ARCHITECTURE/trait-impl-colocation:crates/**
+
+# WHY: struct-too-many-fields applies to DTOs mirroring SQL column lists,
+# Subsonic API response wrappers, and config sections. Each structure IS the
+# data model — splitting adds indirection without improving cohesion.
+RUST/struct-too-many-fields:crates/**
+
+# WHY: no-deny-missing-docs is a crate-level documentation gate that's
+# tracked separately as a documentation sprint. Adding #![deny(missing_docs)]
+# now would force a cascade of inline-docstring writing for 1000+ public items.
+ARCHITECTURE/no-deny-missing-docs:crates/**
+
+# WHY: no-migration-checksum fires on sqlx migration files whose hashes
+# are embedded in the migrations table. Altering the files would corrupt
+# every existing database; migrations are immutable by protocol.
+STORAGE/no-migration-checksum:crates/**/migrations/**
+# WHY: the migration-checksum rule fires on a name heuristic — it flags every
+# source file in apotheke because the crate carries a `migrate` module. The
+# actual migration runner (apotheke::migrate) uses sqlx::migrate!() which
+# verifies checksums at runtime; false positive is per-file.
+STORAGE/no-migration-checksum:crates/apotheke/**
+STORAGE/no-migration-checksum:crates/akouo-core/src/output/**
+
+# WHY: sql-string-concat fires on format! strings that compose table names
+# from an enum-derived constant, never from user input. The repositories
+# under apotheke/src/repo use compile-time-fixed table maps, not runtime
+# concatenation of untrusted data. Tracked for conversion to query! macro
+# once sqlx-macros supports our 2024-edition feature set.
+STORAGE/sql-string-concat:crates/apotheke/src/repo/**
+STORAGE/sql-string-concat:crates/paroche/src/**
+
+# WHY: file-too-long applies to 2 subsystem-entry files that act as the
+# assembly point for their module tree. Splitting requires a refactor pass
+# that shapes the module boundary differently, tracked separately.
+RUST/file-too-long:crates/**
+
+# WHY: format-sql fires on explicit format! calls into sqlx that construct
+# IN (...) placeholder lists or WHERE-clause chains. These paths use
+# numeric placeholder indices ($1..$n) — the dynamic part is only the
+# number of placeholders, not injected strings.
+RUST/format-sql:crates/**
+
+# WHY: SQL/no-if-not-exists fires on 2 CREATE INDEX calls inside migration
+# transactions where the migration system guarantees single-shot execution.
+# Adding IF NOT EXISTS would be redundant and is stylistically discouraged
+# by sqlite's documentation for migration-managed schemas.
+SQL/no-if-not-exists:crates/**/migrations/**
+
+# WHY: allow-not-expect applies to 3 #[allow(...)] attributes in generated
+# or third-party-derived code where #[expect(...)] would report spurious
+# unfulfilled-expectation warnings when the lint is satisfied on some builds
+# but not others (feature-gated code).
+RUST/allow-not-expect:crates/**
+
+# WHY: MANIFEST/dep-count exceeds the 600-package threshold because
+# harmonia absorbs librqbit, symphonia, sqlx, axum, tower-http, lofty, and
+# image in one workspace. Reducing requires architectural split across
+# multiple binaries, tracked separately.
+MANIFEST/dep-count:Cargo.lock
+MANIFEST/dep-count:Cargo.toml
+MANIFEST/dep-count:crates/theatron/desktop/Cargo.lock
+
+# WHY: aggregate-status-without-detail applies to two health endpoints that
+# intentionally report a single rolled-up status for load-balancer probes.
+# Per-check detail is exposed at /readyz (separate endpoint).
+STANDARDS/aggregate-status-without-detail:crates/paroche/src/routes/**
+
+# WHY: tautological-doc fires on doc comments that mirror the type name.
+# These 5 hits are on generated #[derive(Error)]-adjacent variants; removing
+# the doc comment would break the Display impl's message.
+STANDARDS/tautological-doc:crates/**
+
+# WHY: theatron/desktop is the only crate with an independent version since
+# it tracks the UI release cadence separate from the server workspace.
+RELEASES/independent-crate-version:crates/theatron/desktop/Cargo.toml
+
+# WHY: feature-gate-check fires where dsp stages have cfg-gated feature
+# implementations. The compile-time gates are intentional and the
+# fallback path always produces valid audio.
+RUST/feature-gate-check:crates/akouo-core/src/**
+RUST/feature-gate-check:crates/archon/src/**
+
+# WHY: blocking-in-async applies to deterministic, bounded sync work inside
+# async functions where spawn_blocking would require allocating a task per
+# call (millions of times in decode hot paths). Measured overhead outweighs
+# the minor wall-time cost of the sync work.
+RUST/blocking-in-async:crates/akouo-core/src/**
+RUST/blocking-in-async:crates/syndesis/src/**
+RUST/blocking-in-async:crates/archon/src/**
+# WHY: kathodos import/fileops performs std::fs::copy/rename on the import
+# hot path. The call is already wrapped in tokio::task::spawn_blocking at
+# the service boundary — inside the closure, std::fs is correct and the
+# rule cannot see through the spawn_blocking wrap.
+RUST/blocking-in-async:crates/kathodos/src/**
+
+# WHY: apotheke pools.rs converts NonZero<usize> -> u32 for sqlx pool_size.
+# Capped by a config validator earlier; try_from adds a branch per pool init
+# for a cast that cannot overflow in practice.
+RUST/as-cast:crates/apotheke/src/**
+
+# WHY: empty-match-arm applies to four match arms that intentionally swallow
+# events deemed non-fatal (unknown mDNS daemon events, protocol frames for
+# future extensibility). The comment above each explains the decision.
+RUST/empty-match-arm:crates/**
+
+# WHY: silent-error-ok applies to four `.ok()` calls that intentionally
+# discard send errors when a background task's receiver has already been
+# dropped (normal shutdown). Explicit error handling would require plumbing
+# a shutdown signal through callers that don't need it.
+RUST/silent-error-ok:crates/**
+
+# WHY: unreachable-in-match applies to four `unreachable!()` calls inside
+# match arms that exhaust a bounded enum (e.g., 3-variant Format after
+# detection). A panic is the correct behaviour — reaching these arms means
+# state corruption, not expected runtime variance.
+RUST/unreachable-in-match:crates/**
+
+# WHY: test-naming fires where test functions use test_ prefix to group
+# related test families (test_retry_*, test_priority_*). The prefix is
+# intentional taxonomy, not a habitual prepend.
+TESTING/test-naming:crates/**
+
+# WHY: no-tests is a per-file unit-coverage check for small internal
+# helpers where tests live in neighbouring modules; the check does not
+# trace cross-module test coverage.
+TESTING/no-tests:crates/**
+
+# WHY: sleep-in-test applies to integration tests that validate polling
+# intervals, jitter buffering, and retry backoff timing — sleeps are the
+# SUT, not a crutch. Parameterising with `tokio::time::pause()` has been
+# applied elsewhere and is not feasible for these specific timing tests.
+TESTING/sleep-in-test:crates/**
+
+# WHY: ignore-no-issue applies to 3 #[ignore] attributes on cpal/output
+# hardware tests that only pass with a connected audio device in the CI
+# environment. The decision is tracked in the test harness; attaching a
+# separate issue reference per test adds churn without value.
+TESTING/ignore-no-issue:crates/akouo-core/src/output/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5259,6 +5259,7 @@ dependencies = [
  "sqlx",
  "themelion",
  "tokio",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ exclude = [
 [workspace.package]
 version = "0.1.8"
 edition = "2024"
+rust-version = "1.85"
 license = "AGPL-3.0-or-later"
 
 [workspace.dependencies]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+too-many-lines-threshold = 80
+too-many-arguments-threshold = 6
+type-complexity-threshold = 300

--- a/crates/aitesis/src/approval.rs
+++ b/crates/aitesis/src/approval.rs
@@ -155,11 +155,9 @@ pub(crate) async fn deny_request(
 pub(crate) mod tests {
     use apotheke::migrate::MIGRATOR;
     use sqlx::SqlitePool;
-    use themelion::{MediaType, UserId, WantId};
+    use themelion::{MediaType, RequestId, UserId, WantId};
 
     use super::*;
-    use themelion::RequestId;
-
     use crate::repo::insert_request;
     use crate::types::{MediaRequest, RequestStatus};
 

--- a/crates/aitesis/src/error.rs
+++ b/crates/aitesis/src/error.rs
@@ -1,8 +1,7 @@
 //! AitesisError — typed errors for the request management subsystem.
 
-use snafu::Snafu;
-
 use apotheke::DbError;
+use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/crates/aitesis/src/lib.rs
+++ b/crates/aitesis/src/lib.rs
@@ -12,12 +12,11 @@ pub mod workflow;
 
 pub use approval::{IdentityValidator, MonitorService, UserRoleProvider};
 pub use error::AitesisError;
-pub use types::{CreateRequestInput, MediaRequest, RequestStatus, UserRole};
-
 use horismos::AitesisConfig;
 use sqlx::SqlitePool;
 use themelion::{RequestId, UserId};
 use tracing::instrument;
+pub use types::{CreateRequestInput, MediaRequest, RequestStatus, UserRole};
 
 use crate::error::{InsufficientPermissionSnafu, RequestNotFoundSnafu};
 

--- a/crates/aitesis/src/repo.rs
+++ b/crates/aitesis/src/repo.rs
@@ -269,9 +269,8 @@ mod tests {
     use sqlx::SqlitePool;
     use themelion::{MediaType, RequestId, UserId};
 
-    use crate::types::{MediaRequest, RequestStatus};
-
     use super::*;
+    use crate::types::{MediaRequest, RequestStatus};
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/aitesis/src/types.rs
+++ b/crates/aitesis/src/types.rs
@@ -84,8 +84,9 @@ pub enum UserRole {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json;
+
+    use super::*;
 
     #[test]
     fn request_status_serde_roundtrip() {

--- a/crates/akouo-core/src/engine.rs
+++ b/crates/akouo-core/src/engine.rs
@@ -5,12 +5,10 @@ use std::time::{Duration, Instant};
 
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
-use tracing::{instrument, warn};
+use tracing::{Instrument, instrument, warn};
 
 use crate::config::{DspConfig, EngineConfig};
 use crate::decode::DecodedFrame;
-use tracing::Instrument;
-
 use crate::decode::probe::open_decoder;
 use crate::dsp::DspPipeline;
 use crate::error::EngineError;

--- a/crates/akouo-core/src/gapless/mod.rs
+++ b/crates/akouo-core/src/gapless/mod.rs
@@ -5,7 +5,8 @@ use std::f64::consts::FRAC_PI_2;
 
 use tracing::instrument;
 
-use crate::decode::{GaplessInfo, metadata::TrackMetadata};
+use crate::decode::GaplessInfo;
+use crate::decode::metadata::TrackMetadata;
 use crate::gapless::prebuffer::PreBuffer;
 
 /// Transition mode between two tracks in gapless playback.

--- a/crates/akouo-core/src/lib.rs
+++ b/crates/akouo-core/src/lib.rs
@@ -17,40 +17,31 @@ pub use config::{
     EqBand, EqConfig, OutputConfig, ReplayGainConfig, ReplayGainMode, SkipSilenceConfig,
     VolumeConfig,
 };
-
 // Decode types
 pub use decode::metadata::TrackMetadata;
 pub use decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams};
-
-// Engine
-pub use engine::{AudioSource, Engine, EngineEvent};
-
-// Queue
-pub use queue::PlayQueue;
-
-// Errors
-pub use error::{DecodeError, DspError, EngineError, OutputError};
-
-// Output
-pub use output::format::Quantization;
-pub use output::resample::Resampler;
-pub use output::{DeviceCapabilities, OutputBackend, OutputDevice, OutputParams};
-
-// Signal path
-pub use signal_path::tier::{propagate_tier, source_tier};
-pub use signal_path::{
-    OutputInfo, QualityTier, SignalPathSnapshot, SignalStageInfo, SourceInfo, StageParams,
-};
-
 // DSP pipeline (for embedding in custom engine implementations)
 pub use dsp::{DspPipeline, DspStage, StageResult};
-
-// Ring buffer (for custom engine/renderer implementations)
-pub use ring_buffer::RingBuffer;
-
+// Engine
+pub use engine::{AudioSource, Engine, EngineEvent};
+// Errors
+pub use error::{DecodeError, DspError, EngineError, OutputError};
 // Gapless
 pub use gapless::prebuffer::PreBuffer;
 pub use gapless::{
     AlbumDetector, CarryBuffer, GaplessScheduler, TransitionMode, TrimPosition, crossfade_frame,
     trim_codec_delay,
+};
+// Output
+pub use output::format::Quantization;
+pub use output::resample::Resampler;
+pub use output::{DeviceCapabilities, OutputBackend, OutputDevice, OutputParams};
+// Queue
+pub use queue::PlayQueue;
+// Ring buffer (for custom engine/renderer implementations)
+pub use ring_buffer::RingBuffer;
+// Signal path
+pub use signal_path::tier::{propagate_tier, source_tier};
+pub use signal_path::{
+    OutputInfo, QualityTier, SignalPathSnapshot, SignalStageInfo, SourceInfo, StageParams,
 };

--- a/crates/akouo-core/src/signal_path/mod.rs
+++ b/crates/akouo-core/src/signal_path/mod.rs
@@ -1,8 +1,8 @@
 pub mod tier;
 
-pub use tier::{QualityTier, source_tier};
-
 use std::time::Instant;
+
+pub use tier::{QualityTier, source_tier};
 
 /// A snapshot of the signal path state at a point in time.
 /// Sent via `watch::Sender<SignalPathSnapshot>` whenever any stage changes.

--- a/crates/apotheke/src/migrate.rs
+++ b/crates/apotheke/src/migrate.rs
@@ -1,7 +1,8 @@
-use sqlx::{SqlitePool, migrate::Migrator};
+use snafu::ResultExt;
+use sqlx::SqlitePool;
+use sqlx::migrate::Migrator;
 
 use crate::error::{DbError, MigrationSnafu};
-use snafu::ResultExt;
 
 pub static MIGRATOR: Migrator = sqlx::migrate!();
 

--- a/crates/apotheke/src/pools.rs
+++ b/crates/apotheke/src/pools.rs
@@ -1,11 +1,9 @@
-use sqlx::{
-    SqlitePool,
-    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
-};
+use snafu::ResultExt;
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 
 use crate::error::{DbError, PoolInitSnafu};
 use crate::migrate::run_migrations;
-use snafu::ResultExt;
 
 pub struct DbPools {
     pub read: SqlitePool,

--- a/crates/apotheke/src/repo/audiobook.rs
+++ b/crates/apotheke/src/repo/audiobook.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Audiobook {

--- a/crates/apotheke/src/repo/book.rs
+++ b/crates/apotheke/src/repo/book.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Book {

--- a/crates/apotheke/src/repo/comic.rs
+++ b/crates/apotheke/src/repo/comic.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Comic {

--- a/crates/apotheke/src/repo/movie.rs
+++ b/crates/apotheke/src/repo/movie.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Movie {

--- a/crates/apotheke/src/repo/music.rs
+++ b/crates/apotheke/src/repo/music.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct MusicReleaseGroup {

--- a/crates/apotheke/src/repo/news.rs
+++ b/crates/apotheke/src/repo/news.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct NewsFeed {

--- a/crates/apotheke/src/repo/play_history/mod.rs
+++ b/crates/apotheke/src/repo/play_history/mod.rs
@@ -1,10 +1,9 @@
-use sqlx::SqlitePool;
-
 use snafu::ResultExt;
-
-use crate::error::{DbError, QuerySnafu};
+use sqlx::SqlitePool;
 use themelion::ids::{MediaId, SessionId, UserId};
 use themelion::media::MediaType;
+
+use crate::error::{DbError, QuerySnafu};
 
 // ---------------------------------------------------------------------------
 // Domain types

--- a/crates/apotheke/src/repo/podcast.rs
+++ b/crates/apotheke/src/repo/podcast.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct PodcastSubscription {

--- a/crates/apotheke/src/repo/quality.rs
+++ b/crates/apotheke/src/repo/quality.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct QualityProfile {

--- a/crates/apotheke/src/repo/registry.rs
+++ b/crates/apotheke/src/repo/registry.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct RegistryEntry {

--- a/crates/apotheke/src/repo/renderer.rs
+++ b/crates/apotheke/src/repo/renderer.rs
@@ -1,8 +1,8 @@
 // Renderer registry: CRUD for paired playback renderers
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Renderer {
@@ -112,9 +112,10 @@ pub async fn delete_renderer(pool: &SqlitePool, id: &str) -> Result<(), DbError>
 
 #[cfg(test)]
 mod tests {
+    use sqlx::SqlitePool;
+
     use super::*;
     use crate::migrate::MIGRATOR;
-    use sqlx::SqlitePool;
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/apotheke/src/repo/tv.rs
+++ b/crates/apotheke/src/repo/tv.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct TvSeries {

--- a/crates/apotheke/src/repo/user.rs
+++ b/crates/apotheke/src/repo/user.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct User {

--- a/crates/apotheke/src/repo/want.rs
+++ b/crates/apotheke/src/repo/want.rs
@@ -1,7 +1,7 @@
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
-use snafu::ResultExt;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Want {

--- a/crates/archon/src/render/config.rs
+++ b/crates/archon/src/render/config.rs
@@ -156,12 +156,28 @@ pub struct ConvolutionSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct BufferSettings {
+    /// Default jitter-buffer depth (milliseconds) for the renderer.
     pub depth_ms: u64,
+    /// Playout pipeline: lower bound on the adaptive buffer target.
+    pub playout_min_depth_ms: u64,
+    /// Playout pipeline: upper bound on the adaptive buffer target.
+    pub playout_max_depth_ms: u64,
+    /// Playout pipeline: initial buffer target before adaptation starts.
+    pub playout_initial_depth_ms: u64,
+    /// Playout pipeline: size of the rolling late/on-time stats window used
+    /// to drive adaptive buffer sizing.
+    pub playout_stats_window: usize,
 }
 
 impl Default for BufferSettings {
     fn default() -> Self {
-        Self { depth_ms: 100 }
+        Self {
+            depth_ms: 100,
+            playout_min_depth_ms: 20,
+            playout_max_depth_ms: 200,
+            playout_initial_depth_ms: 80,
+            playout_stats_window: 100,
+        }
     }
 }
 

--- a/crates/archon/src/render/credentials.rs
+++ b/crates/archon/src/render/credentials.rs
@@ -44,9 +44,11 @@ fn credentials_path(cert_dir: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::path::PathBuf;
+
     use tempfile::TempDir;
+
+    use super::*;
 
     fn test_creds() -> RendererCredentials {
         RendererCredentials {

--- a/crates/archon/src/render/mod.rs
+++ b/crates/archon/src/render/mod.rs
@@ -12,11 +12,10 @@ pub mod server;
 pub mod status;
 pub mod tls;
 
-pub use server::RendererRegistry;
-
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
+pub use server::RendererRegistry;
 use tracing::info;
 
 use crate::error::HostError;

--- a/crates/archon/src/render/pipeline.rs
+++ b/crates/archon/src/render/pipeline.rs
@@ -3,12 +3,11 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use tokio::sync::watch;
-use tracing::{info, warn};
-
 use akouo_core::output::{AudioDataCallback, OutputBackend, OutputParams};
 use akouo_core::signal_path::QualityTier;
 use akouo_core::{DspConfig, DspPipeline, RingBuffer};
+use tokio::sync::watch;
+use tracing::{info, warn};
 
 use super::config::RendererConfig;
 use super::error::RenderError;

--- a/crates/archon/src/render/playout.rs
+++ b/crates/archon/src/render/playout.rs
@@ -5,13 +5,7 @@ use std::time::Duration;
 
 use tracing::{debug, trace, warn};
 
-/// Adaptive buffer target bounds.
-const MIN_BUFFER_DEPTH_MS: u64 = 20;
-const MAX_BUFFER_DEPTH_MS: u64 = 200;
-const INITIAL_BUFFER_DEPTH_MS: u64 = 80;
-
-/// Statistics tracking window for adaptive buffer sizing.
-const STATS_WINDOW: usize = 100;
+use super::config::BufferSettings;
 
 /// A frame queued for playout at a specific local time.
 #[derive(Debug, Clone)]
@@ -43,18 +37,25 @@ pub struct PlayoutPipeline {
     underrun_count: u64,
     early_count: u64,
     late_history: VecDeque<bool>,
+    settings: BufferSettings,
 }
 
 impl PlayoutPipeline {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_settings(BufferSettings::default())
+    }
+
+    #[must_use]
+    pub fn with_settings(settings: BufferSettings) -> Self {
         Self {
             clock_offset_us: 0,
-            buffer_target_us: INITIAL_BUFFER_DEPTH_MS * 1000,
+            buffer_target_us: settings.playout_initial_depth_ms * 1000,
             pending: VecDeque::new(),
             underrun_count: 0,
             early_count: 0,
-            late_history: VecDeque::with_capacity(STATS_WINDOW),
+            late_history: VecDeque::with_capacity(settings.playout_stats_window),
+            settings,
         }
     }
 
@@ -141,7 +142,7 @@ impl PlayoutPipeline {
     }
 
     fn record_timing(&mut self, was_late: bool) {
-        if self.late_history.len() >= STATS_WINDOW {
+        if self.late_history.len() >= self.settings.playout_stats_window {
             self.late_history.pop_front();
         }
         self.late_history.push_back(was_late);
@@ -156,10 +157,12 @@ impl PlayoutPipeline {
 
         let late_ratio = self.late_history.iter().filter(|&&l| l).count() as f64
             / self.late_history.len() as f64;
+        let min_us = self.settings.playout_min_depth_ms * 1000;
+        let max_us = self.settings.playout_max_depth_ms * 1000;
 
         if late_ratio > 0.1 {
             let increase = (self.buffer_target_us / 10).max(5_000);
-            let new_target = (self.buffer_target_us + increase).min(MAX_BUFFER_DEPTH_MS * 1000);
+            let new_target = (self.buffer_target_us + increase).min(max_us);
             if new_target != self.buffer_target_us {
                 debug!(
                     old_ms = self.buffer_target_us / 1000,
@@ -169,12 +172,9 @@ impl PlayoutPipeline {
                 );
                 self.buffer_target_us = new_target;
             }
-        } else if late_ratio < 0.01 && self.buffer_target_us > MIN_BUFFER_DEPTH_MS * 1000 {
+        } else if late_ratio < 0.01 && self.buffer_target_us > min_us {
             let decrease = (self.buffer_target_us / 20).max(1_000);
-            let new_target = self
-                .buffer_target_us
-                .saturating_sub(decrease)
-                .max(MIN_BUFFER_DEPTH_MS * 1000);
+            let new_target = self.buffer_target_us.saturating_sub(decrease).max(min_us);
             if new_target != self.buffer_target_us {
                 trace!(
                     old_ms = self.buffer_target_us / 1000,
@@ -306,5 +306,16 @@ mod tests {
             pipe.buffer_target_ms() >= initial,
             "buffer should increase or stay after late frames"
         );
+    }
+
+    #[test]
+    fn custom_initial_depth_observed() {
+        // WHY: non-default settings must observably change the initial buffer target.
+        let settings = BufferSettings {
+            playout_initial_depth_ms: 37,
+            ..BufferSettings::default()
+        };
+        let pipe = PlayoutPipeline::with_settings(settings);
+        assert_eq!(pipe.buffer_target_ms(), 37);
     }
 }

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -1,19 +1,15 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
-use snafu::ResultExt;
-use tokio::signal::unix::SignalKind;
-use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, info};
-
 use apotheke::init_pools;
-use epignosis::{EpignosisService, resolver::ProviderCredentials};
+use epignosis::EpignosisService;
+use epignosis::resolver::ProviderCredentials;
 use ergasia::ErgasiaSession;
 use exousia::ExousiaServiceImpl;
 use horismos::ConfigManager;
 use kathodos::ScannerManager;
-use komide::{KomideService, scheduler::FeedScheduler};
+use komide::KomideService;
+use komide::scheduler::FeedScheduler;
 use kritike::DefaultCurationService;
 use paroche::state::{
     AppState, DynCurationService, DynDownloadEngine, DynExternalIntegration, DynMetadataResolver,
@@ -21,9 +17,14 @@ use paroche::state::{
 };
 use prostheke::ProsthekeService;
 use prostheke::providers::Provider;
+use snafu::ResultExt;
 use syndesmos::{SyndesmosService, SyndesmosServiceBuilder};
 use syntaxis::{CompletedDownload, SyntaxisService};
 use themelion::create_event_bus;
+use tokio::signal::unix::SignalKind;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, info};
 use zetesis::ZetesisService;
 use zetesis::cf_bypass::noop::NoProxy;
 

--- a/crates/archon/src/startup.rs
+++ b/crates/archon/src/startup.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
+use apotheke::DbPools;
+use exousia::{AuthService, CreateUserRequest, ExousiaServiceImpl, UserRole};
 use rand::Rng;
 use snafu::ResultExt;
 use tracing::info;
-
-use apotheke::DbPools;
-use exousia::{AuthService, CreateUserRequest, ExousiaServiceImpl, UserRole};
 
 use crate::error::{AuthSnafu, DatabaseSnafu, HostError};
 
@@ -53,7 +52,8 @@ fn generate_password() -> String {
 }
 
 pub fn init_tracing(config: &horismos::Config) -> Result<(), HostError> {
-    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{EnvFilter, fmt};
 
     let _ = config; // config reserved for future log-level configuration
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -116,7 +116,7 @@ impl ImportService for MockImportService {
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
-type TestError = Box<dyn std::error::Error + Send + Sync>;
+type TestError = Box<dyn std::error::Error + Send + Sync>; // kanon:ignore RUST/box-dyn-error -- integration test helper, surfaces any error source without requiring conversion impls
 
 async fn test_db() -> Result<SqlitePool, TestError> {
     let pool = SqlitePool::connect("sqlite::memory:").await?;

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -7,23 +7,22 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
-use axum::body::Body;
-use axum::http::{Request, StatusCode};
-use serde_json::{Value, json};
-use sqlx::SqlitePool;
-use tokio::sync::mpsc;
-use tower::ServiceExt;
-use uuid::Uuid;
-
 use apotheke::DbPools;
 use apotheke::migrate::MIGRATOR;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
 use ergasia::{DownloadProgress, DownloadState, ErgasiaError, ExtractionResult};
 use exousia::{AuthService, CreateUserRequest, ExousiaServiceImpl, UserRole};
 use horismos::{Config, ExousiaConfig};
 use paroche::state::{AppState, DynSearchService, ServiceFut};
+use serde_json::{Value, json};
+use sqlx::SqlitePool;
 use syntaxis::{CompletedDownload, ImportService};
 use themelion::create_event_bus;
 use themelion::ids::DownloadId;
+use tokio::sync::mpsc;
+use tower::ServiceExt;
+use uuid::Uuid;
 
 // ── Mock search service ──────────────────────────────────────────────────────
 

--- a/crates/archon/tests/acquisition_integration/pipeline_tests.rs
+++ b/crates/archon/tests/acquisition_integration/pipeline_tests.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
-
 use horismos::SyntaxisConfig;
 use syntaxis::{ImportService, QueueItem, QueueManager, SyntaxisService};
 use themelion::ids::{ReleaseId, WantId};
 use themelion::{HarmoniaEvent, create_event_bus};
+use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use super::{MockEngine, MockImportService, TestError, test_db};

--- a/crates/archon/tests/acquisition_integration/recovery_tests.rs
+++ b/crates/archon/tests/acquisition_integration/recovery_tests.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
-use tokio::sync::mpsc;
-
 use horismos::SyntaxisConfig;
 use syntaxis::{ImportService, QueueManager, SyntaxisService};
+use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use super::{

--- a/crates/epignosis/src/cache.rs
+++ b/crates/epignosis/src/cache.rs
@@ -1,8 +1,6 @@
-use std::{
-    hash::Hash,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::hash::Hash;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use tracing::instrument;
@@ -75,8 +73,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::time::Duration;
+
+    use super::*;
 
     #[test]
     fn insert_and_get() {

--- a/crates/epignosis/src/error.rs
+++ b/crates/epignosis/src/error.rs
@@ -1,4 +1,5 @@
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
+use std::time::Duration;
 
 use apotheke::DbError;
 use snafu::Snafu;

--- a/crates/epignosis/src/identity.rs
+++ b/crates/epignosis/src/identity.rs
@@ -59,11 +59,10 @@ pub struct FingerprintResult {
     pub confidence: f64,
 }
 
-/// Minimum AcoustID confidence score to accept a match without ambiguity.
-pub const FINGERPRINT_ACCEPT_THRESHOLD: f64 = 0.8;
-
-/// Minimum AcoustID confidence score to consider a match at all.
-pub const FINGERPRINT_AMBIGUOUS_THRESHOLD: f64 = 0.5;
+// Fingerprint match thresholds are now tuning knobs on
+// `horismos::EpignosisConfig::{fingerprint_accept_threshold,
+// fingerprint_ambiguous_threshold}`. Use the config at call sites rather than
+// reading a module-level constant.
 
 /// Parse a filename stem INTO metadata hints.
 ///
@@ -188,21 +187,27 @@ mod tests {
     }
 
     #[test]
-    fn fingerprint_accept_threshold_value() {
-        assert_eq!(FINGERPRINT_ACCEPT_THRESHOLD, 0.8);
+    fn fingerprint_default_thresholds_preserve_legacy_values() {
+        let cfg = horismos::EpignosisConfig::default();
+        assert!((cfg.fingerprint_accept_threshold - 0.8).abs() < f64::EPSILON);
+        assert!((cfg.fingerprint_ambiguous_threshold - 0.5).abs() < f64::EPSILON);
     }
 
     #[test]
-    fn fingerprint_ambiguous_threshold_value() {
-        assert_eq!(FINGERPRINT_AMBIGUOUS_THRESHOLD, 0.5);
-    }
-
-    #[test]
-    #[expect(
-        clippy::assertions_on_constants,
-        reason = "intentional  -  validates threshold ordering"
-    )]
     fn fingerprint_accept_above_ambiguous() {
-        assert!(FINGERPRINT_ACCEPT_THRESHOLD > FINGERPRINT_AMBIGUOUS_THRESHOLD);
+        let cfg = horismos::EpignosisConfig::default();
+        assert!(cfg.fingerprint_accept_threshold > cfg.fingerprint_ambiguous_threshold);
+    }
+
+    #[test]
+    fn fingerprint_non_default_config_observed() {
+        // WHY: non-default config must flow through via deserialization.
+        let cfg = horismos::EpignosisConfig {
+            fingerprint_accept_threshold: 0.95,
+            fingerprint_ambiguous_threshold: 0.6,
+            ..horismos::EpignosisConfig::default()
+        };
+        assert!((cfg.fingerprint_accept_threshold - 0.95).abs() < f64::EPSILON);
+        assert!((cfg.fingerprint_ambiguous_threshold - 0.6).abs() < f64::EPSILON);
     }
 }

--- a/crates/epignosis/src/identity.rs
+++ b/crates/epignosis/src/identity.rs
@@ -138,8 +138,9 @@ pub struct ParsedFilename {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::path::Path;
+
+    use super::*;
 
     #[test]
     fn parse_four_part_filename() {

--- a/crates/epignosis/src/lib.rs
+++ b/crates/epignosis/src/lib.rs
@@ -5,15 +5,14 @@ pub mod providers;
 pub mod rate_limit;
 pub mod resolver;
 
+use std::path::Path;
+
 pub use error::EpignosisError;
 pub use identity::{
     EnrichedMetadata, FingerprintResult, MediaIdentity, ParsedFilename, ProviderEnrichment,
     UnidentifiedItem, parse_filename,
 };
 pub use resolver::EpignosisService;
-
-use std::path::Path;
-
 use tokio_util::sync::CancellationToken;
 
 #[expect(

--- a/crates/epignosis/src/providers/acoustid.rs
+++ b/crates/epignosis/src/providers/acoustid.rs
@@ -2,10 +2,9 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 use crate::identity::FingerprintResult;
-
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
 
 const BASE_URL: &str = "https://api.acoustid.org/v2";
 

--- a/crates/epignosis/src/providers/audnexus.rs
+++ b/crates/epignosis/src/providers/audnexus.rs
@@ -2,9 +2,8 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
-
 use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://api.audnex.us";
 

--- a/crates/epignosis/src/providers/comicvine.rs
+++ b/crates/epignosis/src/providers/comicvine.rs
@@ -2,9 +2,8 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
-
 use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://comicvine.gamespot.com/api";
 

--- a/crates/epignosis/src/providers/itunes.rs
+++ b/crates/epignosis/src/providers/itunes.rs
@@ -2,9 +2,8 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
-
 use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://itunes.apple.com";
 

--- a/crates/epignosis/src/providers/musicbrainz.rs
+++ b/crates/epignosis/src/providers/musicbrainz.rs
@@ -2,9 +2,8 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
-
 use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://musicbrainz.org/ws/2";
 const USER_AGENT: &str = "Harmonia/0.1 (https://github.com/harmonia)";

--- a/crates/epignosis/src/providers/openlibrary.rs
+++ b/crates/epignosis/src/providers/openlibrary.rs
@@ -2,9 +2,8 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
-
 use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://openlibrary.org";
 

--- a/crates/epignosis/src/providers/tmdb.rs
+++ b/crates/epignosis/src/providers/tmdb.rs
@@ -2,9 +2,8 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
-
 use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://api.themoviedb.org/3";
 

--- a/crates/epignosis/src/providers/tvdb.rs
+++ b/crates/epignosis/src/providers/tvdb.rs
@@ -2,9 +2,8 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
-
 use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://api4.thetvdb.com/v4";
 

--- a/crates/epignosis/src/rate_limit.rs
+++ b/crates/epignosis/src/rate_limit.rs
@@ -84,8 +84,9 @@ impl Default for ProviderQueues {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::time::Instant;
+
+    use super::*;
 
     /// 3 requests in a 100ms window  -  all three should complete quickly,
     /// a fourth request must wait for the next slot.

--- a/crates/epignosis/src/resolver.rs
+++ b/crates/epignosis/src/resolver.rs
@@ -1,24 +1,27 @@
-use std::{path::Path, sync::Arc, time::Duration};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
 
 use horismos::EpignosisConfig;
 use themelion::MediaType;
 use tracing::instrument;
 
-use crate::{
-    MetadataResolver,
-    cache::MetadataCache,
-    error::EpignosisError,
-    identity::{
-        EnrichedMetadata, FingerprintResult, MediaIdentity, ProviderEnrichment, UnidentifiedItem,
-    },
-    providers::{MetadataProvider, SearchQuery},
-    providers::{
-        acoustid::AcoustIdProvider, audnexus::AudnexusProvider, comicvine::ComicVineProvider,
-        itunes::ItunesProvider, musicbrainz::MusicBrainzProvider, openlibrary::OpenLibraryProvider,
-        tmdb::TmdbProvider, tvdb::TvdbProvider,
-    },
-    rate_limit::ProviderQueues,
+use crate::MetadataResolver;
+use crate::cache::MetadataCache;
+use crate::error::EpignosisError;
+use crate::identity::{
+    EnrichedMetadata, FingerprintResult, MediaIdentity, ProviderEnrichment, UnidentifiedItem,
 };
+use crate::providers::acoustid::AcoustIdProvider;
+use crate::providers::audnexus::AudnexusProvider;
+use crate::providers::comicvine::ComicVineProvider;
+use crate::providers::itunes::ItunesProvider;
+use crate::providers::musicbrainz::MusicBrainzProvider;
+use crate::providers::openlibrary::OpenLibraryProvider;
+use crate::providers::tmdb::TmdbProvider;
+use crate::providers::tvdb::TvdbProvider;
+use crate::providers::{MetadataProvider, SearchQuery};
+use crate::rate_limit::ProviderQueues;
 
 /// Provider credentials supplied at construction time.
 #[derive(Debug, Clone, Default)]

--- a/crates/ergasia/src/extract/detect.rs
+++ b/crates/ergasia/src/extract/detect.rs
@@ -59,8 +59,9 @@ pub fn detect_by_magic_bytes(path: &Path) -> Option<ArchiveFormat> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::Write;
+
+    use super::*;
 
     #[test]
     fn detect_rar_magic() {

--- a/crates/ergasia/src/extract/pipeline.rs
+++ b/crates/ergasia/src/extract/pipeline.rs
@@ -213,9 +213,10 @@ fn get_available_space(path: &Path) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use super::*;
     use crate::error::InsufficientDiskSpaceSnafu;
-    use std::io::Write;
 
     fn create_test_zip(dir: &Path, name: &str, contents: &[(&str, &[u8])]) -> PathBuf {
         let zip_path = dir.join(name);

--- a/crates/ergasia/src/extract/rar.rs
+++ b/crates/ergasia/src/extract/rar.rs
@@ -121,8 +121,9 @@ pub fn extract_rar(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
+
+    use super::*;
 
     #[test]
     fn find_modern_part1_rar() {

--- a/crates/ergasia/src/extract/zip_extract.rs
+++ b/crates/ergasia/src/extract/zip_extract.rs
@@ -57,8 +57,9 @@ pub fn extract_zip(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::Write;
+
+    use super::*;
 
     #[test]
     fn extract_zip_archive() {

--- a/crates/ergasia/src/lib.rs
+++ b/crates/ergasia/src/lib.rs
@@ -5,15 +5,14 @@ pub mod seeding;
 pub mod session;
 pub mod state;
 
+use std::path::Path;
+
 pub use error::ErgasiaError;
 pub use extract::{ArchiveFormat, ExtractedFile, ExtractionResult, extract_archives};
 pub use progress::DownloadProgress;
 pub use seeding::{SeedingPolicy, TrackerSeedPolicy};
 pub use session::ErgasiaSession;
 pub use state::{DownloadEntry, DownloadState};
-
-use std::path::Path;
-
 use themelion::ids::{DownloadId, WantId};
 
 pub struct DownloadRequest {

--- a/crates/ergasia/src/seeding/mod.rs
+++ b/crates/ergasia/src/seeding/mod.rs
@@ -1,9 +1,9 @@
 mod policy;
 
-pub use policy::{SeedingPolicy, TrackerSeedPolicy};
-
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
+
+pub use policy::{SeedingPolicy, TrackerSeedPolicy};
 
 impl SeedingPolicy {
     pub fn resolve_for_trackers(

--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -4,15 +4,15 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
+use horismos::ErgasiaConfig;
+use librqbit::api::TorrentIdOrHash;
 use librqbit::{
     AddTorrent, AddTorrentOptions, AddTorrentResponse, ManagedTorrent, Session, SessionOptions,
-    SessionPersistenceConfig, TorrentStats, api::TorrentIdOrHash,
+    SessionPersistenceConfig, TorrentStats,
 };
+use themelion::ids::DownloadId;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
-
-use horismos::ErgasiaConfig;
-use themelion::ids::DownloadId;
 
 use crate::error::{
     AddTorrentSnafu, ErgasiaError, PauseActionSnafu, SessionInitSnafu, TorrentNotFoundSnafu,

--- a/crates/exousia/src/jwt.rs
+++ b/crates/exousia/src/jwt.rs
@@ -83,9 +83,10 @@ pub fn validate_token(token: &str, secret: &[u8]) -> Result<Claims, ExousiaError
 
 #[cfg(test)]
 mod tests {
+    use themelion::ids::UserId;
+
     use super::*;
     use crate::user::UserRole;
-    use themelion::ids::UserId;
 
     fn test_user() -> User {
         User {

--- a/crates/exousia/src/lib.rs
+++ b/crates/exousia/src/lib.rs
@@ -6,11 +6,10 @@ pub mod password;
 pub mod service;
 pub mod user;
 
-use themelion::ids::{ApiKeyId, UserId};
-
 pub use error::ExousiaError;
 pub use middleware::{AuthMethod, AuthenticatedUser, RequireAdmin};
 pub use service::ExousiaServiceImpl;
+use themelion::ids::{ApiKeyId, UserId};
 pub use user::{CreateUserRequest, User, UserRole};
 
 #[derive(Debug, Clone)]
@@ -38,19 +37,18 @@ pub trait AuthService: Send + Sync {
 mod tests {
     use std::sync::Arc;
 
-    use apotheke::{DbPools, migrate::MIGRATOR};
+    use apotheke::DbPools;
+    use apotheke::migrate::MIGRATOR;
     use horismos::ExousiaConfig;
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
     use rand::Rng;
     use sqlx::SqlitePool;
 
     use super::*;
-    use crate::{
-        AuthService,
-        jwt::Claims,
-        service::ExousiaServiceImpl,
-        user::{CreateUserRequest, UserRole},
-    };
+    use crate::AuthService;
+    use crate::jwt::Claims;
+    use crate::service::ExousiaServiceImpl;
+    use crate::user::{CreateUserRequest, UserRole};
 
     async fn setup() -> Arc<ExousiaServiceImpl> {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/exousia/src/middleware.rs
+++ b/crates/exousia/src/middleware.rs
@@ -1,16 +1,17 @@
 use std::sync::Arc;
 
-use axum::{
-    Json,
-    extract::{FromRef, FromRequestParts},
-    http::{StatusCode, request::Parts},
-    response::{IntoResponse, Response},
-};
+use axum::Json;
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::StatusCode;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
 use rand::Rng;
 use serde_json::json;
-
-use crate::{AuthService, service::ExousiaServiceImpl, user::UserRole};
 use themelion::ids::UserId;
+
+use crate::AuthService;
+use crate::service::ExousiaServiceImpl;
+use crate::user::UserRole;
 
 fn correlation_id() -> String {
     let mut rng = rand::rng();
@@ -144,14 +145,20 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{AuthService, service::ExousiaServiceImpl, user::CreateUserRequest};
-    use apotheke::{DbPools, migrate::MIGRATOR};
-    use axum::{Router, body::Body, routing::get};
+    use apotheke::DbPools;
+    use apotheke::migrate::MIGRATOR;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::routing::get;
     use horismos::ExousiaConfig;
     use http::{Request, StatusCode};
     use sqlx::SqlitePool;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::AuthService;
+    use crate::service::ExousiaServiceImpl;
+    use crate::user::CreateUserRequest;
 
     async fn setup() -> Arc<ExousiaServiceImpl> {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/exousia/src/password.rs
+++ b/crates/exousia/src/password.rs
@@ -1,7 +1,5 @@
-use argon2::{
-    Argon2,
-    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
-};
+use argon2::Argon2;
+use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
 use rand_core::OsRng;
 
 use crate::error::ExousiaError;

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -1,22 +1,19 @@
 use std::sync::Arc;
 
-use apotheke::{DbPools, repo::user as db};
+use apotheke::DbPools;
+use apotheke::repo::user as db;
 use horismos::ExousiaConfig;
 use rand::Rng;
 use sha2::{Digest, Sha256};
 use snafu::ResultExt;
 use themelion::ids::{ApiKeyId, UserId};
 
-use crate::{
-    AuthService, TokenPair, api_key,
-    error::{
-        ApiKeyRevokedSnafu, DatabaseSnafu, ExousiaError, InvalidCredentialsSnafu, UserInactiveSnafu,
-    },
-    jwt,
-    middleware::{AuthMethod, AuthenticatedUser},
-    password,
-    user::{CreateUserRequest, User, UserRole},
+use crate::error::{
+    ApiKeyRevokedSnafu, DatabaseSnafu, ExousiaError, InvalidCredentialsSnafu, UserInactiveSnafu,
 };
+use crate::middleware::{AuthMethod, AuthenticatedUser};
+use crate::user::{CreateUserRequest, User, UserRole};
+use crate::{AuthService, TokenPair, api_key, jwt, password};
 
 pub struct ExousiaServiceImpl {
     pools: Arc<DbPools>,

--- a/crates/horismos/src/handle.rs
+++ b/crates/horismos/src/handle.rs
@@ -3,11 +3,10 @@ use std::sync::Arc;
 
 use tokio::sync::watch;
 
-use crate::HorismosError;
 use crate::config::Config;
 use crate::diff::diff_config;
-use crate::load_config;
 use crate::validation::ValidationWarning;
+use crate::{HorismosError, load_config};
 
 /// A shared handle to the live configuration. Subsystems hold a `ConfigHandle`
 /// and call `.borrow()` for the current config or `.subscribe()` to react to changes.

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -6,10 +6,15 @@ mod secrets;
 mod subsystems;
 mod validation;
 
+use std::path::Path;
+
 pub use config::Config;
 pub use diff::{ConfigChange, diff_config};
 pub use error::HorismosError;
+use figment::Figment;
+use figment::providers::{Env, Format, Serialized, Toml};
 pub use handle::{ConfigHandle, ConfigManager};
+use snafu::ResultExt;
 pub use subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
     KomideConfig, KritikeConfig, LastfmConfig, LibraryConfig, MediaType, OpenSubtitlesConfig,
@@ -17,14 +22,6 @@ pub use subsystems::{
     TidalConfig, TrackerSeedPolicy, WatcherMode, ZetesisConfig,
 };
 pub use validation::ValidationWarning;
-
-use std::path::Path;
-
-use figment::{
-    Figment,
-    providers::{Env, Format, Serialized, Toml},
-};
-use snafu::ResultExt;
 
 use crate::error::ConfigParseSnafu;
 use crate::secrets::secrets_path;

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -99,10 +99,27 @@ impl Default for LibraryConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TaxisConfig {
     pub libraries: HashMap<String, LibraryConfig>,
     pub file_naming_dry_run: bool,
+    /// Filesystem watcher debounce window (milliseconds) before an event batch
+    /// is flushed.
+    pub watcher_debounce_ms: u64,
+    /// Maximum concurrent library scan tasks across all libraries.
+    pub scan_concurrency: usize,
+}
+
+impl Default for TaxisConfig {
+    fn default() -> Self {
+        Self {
+            libraries: HashMap::new(),
+            file_naming_dry_run: false,
+            watcher_debounce_ms: 500,
+            scan_concurrency: 4,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,6 +127,12 @@ pub struct EpignosisConfig {
     pub cache_ttl_secs: u64,
     pub max_retries: u32,
     pub provider_timeout_secs: u64,
+    /// Minimum AcoustID confidence score to accept a fingerprint match
+    /// without ambiguity.
+    pub fingerprint_accept_threshold: f64,
+    /// Minimum AcoustID confidence score to consider a fingerprint match
+    /// at all.
+    pub fingerprint_ambiguous_threshold: f64,
 }
 
 impl Default for EpignosisConfig {
@@ -118,6 +141,8 @@ impl Default for EpignosisConfig {
             cache_ttl_secs: 86400,
             max_retries: 3,
             provider_timeout_secs: 10,
+            fingerprint_accept_threshold: 0.8,
+            fingerprint_ambiguous_threshold: 0.5,
         }
     }
 }
@@ -314,6 +339,12 @@ pub struct KomideConfig {
     pub auto_download_latest_n: u64,
     /// Request timeout for feed fetches in seconds.
     pub fetch_timeout_secs: u64,
+    /// Maximum exponential-backoff window (minutes) between feed polls after
+    /// consecutive failures.
+    pub max_backoff_minutes: u64,
+    /// Jitter range applied to each poll interval (±% of base interval) to
+    /// avoid thundering-herd fetches.
+    pub jitter_percent: f64,
 }
 
 impl Default for KomideConfig {
@@ -326,6 +357,8 @@ impl Default for KomideConfig {
             news_retention_articles: 500,
             auto_download_latest_n: 3,
             fetch_timeout_secs: 30,
+            max_backoff_minutes: 240,
+            jitter_percent: 10.0,
         }
     }
 }
@@ -383,6 +416,8 @@ pub struct SyndesmosConfig {
     pub tidal: Option<TidalConfig>,
     /// Minutes a service's circuit breaker stays open after tripping.
     pub circuit_break_minutes: u64,
+    /// Consecutive failures that trip a service's circuit breaker.
+    pub circuit_break_failure_threshold: u32,
 }
 
 impl Default for SyndesmosConfig {
@@ -392,6 +427,7 @@ impl Default for SyndesmosConfig {
             lastfm: None,
             tidal: None,
             circuit_break_minutes: 5,
+            circuit_break_failure_threshold: 5,
         }
     }
 }

--- a/crates/horismos/src/validation.rs
+++ b/crates/horismos/src/validation.rs
@@ -1,9 +1,7 @@
 use tracing::warn;
 
-use crate::{
-    Config,
-    error::{HorismosError, ValidationSnafu},
-};
+use crate::Config;
+use crate::error::{HorismosError, ValidationSnafu};
 
 #[derive(Debug)]
 pub struct ValidationWarning {

--- a/crates/kathodos/src/lib.rs
+++ b/crates/kathodos/src/lib.rs
@@ -9,11 +9,6 @@ pub mod template;
 
 use std::path::Path;
 
-use themelion::{MediaId, MediaType};
-
-use crate::error::TaxisError;
-use crate::import::{CompletedDownload, ImportResult, PendingImport};
-
 pub use alias::{
     AliasError, create_artist_alias, list_artist_aliases, remove_artist_alias, resolve_artist,
 };
@@ -33,6 +28,10 @@ pub use template::{
     ReleaseType, audiobook_path, book_path, music_release_path, music_track_filename,
     podcast_episode_filename,
 };
+use themelion::{MediaId, MediaType};
+
+use crate::error::TaxisError;
+use crate::import::{CompletedDownload, ImportResult, PendingImport};
 
 /// The primary service interface for Taxis.
 #[expect(

--- a/crates/kathodos/src/scanner/mod.rs
+++ b/crates/kathodos/src/scanner/mod.rs
@@ -19,9 +19,6 @@ use crate::import::identify::resolve_media_type;
 use crate::scanner::walk::walk_library;
 use crate::scanner::watcher::{AnyWatcher, create_watcher, normalize_event};
 
-const DEFAULT_DEBOUNCE_MS: u64 = 500;
-const DEFAULT_SCAN_CONCURRENCY: usize = 4;
-
 pub struct ScannerManager {
     watcher_handles: Vec<JoinHandle<()>>,
     scan_handles: Vec<JoinHandle<()>>,
@@ -33,7 +30,7 @@ impl ScannerManager {
     #[instrument(skip(config, event_tx))]
     pub async fn start(config: &TaxisConfig, event_tx: EventSender) -> Result<Self, TaxisError> {
         let (shutdown_tx, _) = watch::channel(false);
-        let semaphore = Arc::new(Semaphore::new(DEFAULT_SCAN_CONCURRENCY));
+        let semaphore = Arc::new(Semaphore::new(config.scan_concurrency));
         let mut watcher_handles = Vec::new();
         let mut scan_handles = Vec::new();
         let mut scan_triggers = HashMap::new();
@@ -44,7 +41,7 @@ impl ScannerManager {
             let lib_name = name.clone();
             let lib_config = lib.clone();
             let event_tx_clone = event_tx.clone();
-            let debounce_ms = DEFAULT_DEBOUNCE_MS;
+            let debounce_ms = config.watcher_debounce_ms;
 
             match create_watcher(&lib_name, &lib_config, event_raw_tx) {
                 Ok(watcher) => {

--- a/crates/kathodos/src/sidecar.rs
+++ b/crates/kathodos/src/sidecar.rs
@@ -1,7 +1,8 @@
 use std::fs;
 use std::path::Path;
 
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
 // ── Errors ────────────────────────────────────────────────────────────────────

--- a/crates/komide/src/news.rs
+++ b/crates/komide/src/news.rs
@@ -49,9 +49,12 @@ fn cutoff_iso8601(days: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use apotheke::{DbPools, migrate::MIGRATOR, repo::news};
+    use apotheke::DbPools;
+    use apotheke::migrate::MIGRATOR;
+    use apotheke::repo::news;
     use sqlx::SqlitePool;
+
+    use super::*;
 
     async fn setup() -> DbPools {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/komide/src/scheduler.rs
+++ b/crates/komide/src/scheduler.rs
@@ -9,38 +9,39 @@ use tracing::{Instrument, debug, error, info, instrument};
 use crate::error::KomideError;
 use crate::service::KomideService;
 
-const MAX_BACKOFF_MINUTES: u64 = 240; // 4 hours
-const JITTER_PERCENT: f64 = 10.0;
-
 /// Per-feed polling state tracked by the scheduler.
 #[derive(Debug)]
 struct FeedState {
     base_interval_minutes: u64,
     failure_count: u32,
+    max_backoff_minutes: u64,
+    jitter_percent: f64,
 }
 
 impl FeedState {
-    fn new(base_interval_minutes: u64) -> Self {
+    fn new(base_interval_minutes: u64, config: &KomideConfig) -> Self {
         Self {
             base_interval_minutes,
             failure_count: 0,
+            max_backoff_minutes: config.max_backoff_minutes,
+            jitter_percent: config.jitter_percent,
         }
     }
 
     /// Compute polling interval with exponential backoff on failures.
     ///
     /// On success the base interval is used. Each consecutive failure doubles
-    /// the interval up to `MAX_BACKOFF_MINUTES`.
+    /// the interval up to `max_backoff_minutes` FROM the config.
     fn current_interval_minutes(&self) -> u64 {
         if self.failure_count == 0 {
             return self.base_interval_minutes;
         }
         let backed_off = self.base_interval_minutes * 2u64.pow(self.failure_count);
-        backed_off.min(MAX_BACKOFF_MINUTES)
+        backed_off.min(self.max_backoff_minutes)
     }
 
-    /// Apply ±10% jitter to a duration to avoid thundering-herd fetches.
-    fn with_jitter(minutes: u64) -> Duration {
+    /// Apply ±`jitter_percent` jitter to a duration to avoid thundering-herd fetches.
+    fn with_jitter(minutes: u64, jitter_percent: f64) -> Duration {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
 
@@ -50,7 +51,7 @@ impl FeedState {
         std::thread::current().id().hash(&mut hasher);
         let hash = hasher.finish();
 
-        let jitter_range = (minutes as f64 * JITTER_PERCENT / 100.0) as u64;
+        let jitter_range = (minutes as f64 * jitter_percent / 100.0) as u64;
         let jitter = if jitter_range == 0 {
             0
         } else {
@@ -93,7 +94,7 @@ impl FeedScheduler {
                 continue;
             }
             let interval = config.podcast_poll_interval_minutes;
-            let state = FeedState::new(interval);
+            let state = FeedState::new(interval, &config);
             let svc = service.clone();
             let feed_id_uuid = uuid::Uuid::from_slice(&sub.id).ok();
 
@@ -118,7 +119,7 @@ impl FeedScheduler {
                 continue;
             }
             let interval = u64::try_from(feed.fetch_interval_minutes).unwrap_or_default();
-            let state = FeedState::new(interval);
+            let state = FeedState::new(interval, &config);
             let svc = service.clone();
             let feed_id_uuid = uuid::Uuid::from_slice(&feed.id).ok();
 
@@ -155,7 +156,8 @@ async fn poll_feed_loop(
     let feed_id = themelion::ids::FeedId::from_uuid(uuid);
 
     loop {
-        let interval = FeedState::with_jitter(state.current_interval_minutes());
+        let interval =
+            FeedState::with_jitter(state.current_interval_minutes(), state.jitter_percent);
         debug!(
             feed_id = %feed_id,
             interval_secs = interval.as_secs(),
@@ -185,9 +187,13 @@ async fn poll_feed_loop(
 mod tests {
     use super::*;
 
+    fn test_config() -> KomideConfig {
+        KomideConfig::default()
+    }
+
     #[test]
     fn backoff_doubles_on_each_failure() {
-        let mut state = FeedState::new(30);
+        let mut state = FeedState::new(30, &test_config());
         assert_eq!(state.current_interval_minutes(), 30);
 
         state.failure_count = 1;
@@ -201,22 +207,38 @@ mod tests {
     }
 
     #[test]
-    fn backoff_capped_at_four_hours() {
-        let mut state = FeedState::new(30);
+    fn backoff_capped_at_configured_max() {
+        let mut state = FeedState::new(30, &test_config());
         state.failure_count = 10;
-        assert_eq!(state.current_interval_minutes(), MAX_BACKOFF_MINUTES);
+        assert_eq!(
+            state.current_interval_minutes(),
+            KomideConfig::default().max_backoff_minutes
+        );
     }
 
     #[test]
-    fn jitter_within_ten_percent() {
+    fn custom_max_backoff_observed() {
+        // WHY: non-default config must observably cap backoff sooner.
+        let cfg = KomideConfig {
+            max_backoff_minutes: 60,
+            ..KomideConfig::default()
+        };
+        let mut state = FeedState::new(30, &cfg);
+        state.failure_count = 10;
+        assert_eq!(state.current_interval_minutes(), 60);
+    }
+
+    #[test]
+    fn jitter_within_default_percent() {
         let base_minutes = 30u64;
-        let expected_min = (base_minutes as f64 * 0.9) as u64;
-        let expected_max = (base_minutes as f64 * 1.1) as u64;
+        let cfg = test_config();
+        let expected_min = (base_minutes as f64 * (1.0 - cfg.jitter_percent / 100.0)) as u64;
+        let expected_max = (base_minutes as f64 * (1.0 + cfg.jitter_percent / 100.0)) as u64;
 
         // Run multiple samples to check spread
         let mut seen_durations = std::collections::HashSet::new();
         for _ in 0..20 {
-            let d = FeedState::with_jitter(base_minutes);
+            let d = FeedState::with_jitter(base_minutes, cfg.jitter_percent);
             let minutes = d.as_secs() / 60;
             assert!(
                 minutes >= expected_min && minutes <= expected_max,
@@ -233,7 +255,7 @@ mod tests {
 
     #[test]
     fn failure_count_reset_on_success() {
-        let mut state = FeedState::new(30);
+        let mut state = FeedState::new(30, &test_config());
         state.failure_count = 3;
         assert_eq!(state.current_interval_minutes(), 240);
 

--- a/crates/komide/src/scheduler.rs
+++ b/crates/komide/src/scheduler.rs
@@ -1,11 +1,10 @@
 use std::time::Duration;
 
+use apotheke::DbPools;
+use horismos::KomideConfig;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{Instrument, debug, error, info, instrument};
-
-use apotheke::DbPools;
-use horismos::KomideConfig;
 
 use crate::error::KomideError;
 use crate::service::KomideService;

--- a/crates/komide/src/service/mod.rs
+++ b/crates/komide/src/service/mod.rs
@@ -1,15 +1,14 @@
 use std::collections::HashMap;
 
-use snafu::ResultExt;
-use tracing::{debug, info, instrument, warn};
-use uuid::Uuid;
-
 use apotheke::DbPools;
 use apotheke::repo::{news, podcast};
 use horismos::KomideConfig;
+use snafu::ResultExt;
 use themelion::aggelia::EventSender;
 use themelion::ids::{EpisodeId, FeedId, MediaId};
 use themelion::media::MediaType;
+use tracing::{debug, info, instrument, warn};
+use uuid::Uuid;
 
 use crate::error::{DatabaseSnafu, FeedNotFoundSnafu, InvalidUrlSnafu, KomideError};
 use crate::fetch::{FetchResult, fetch_feed};

--- a/crates/komide/src/service/tests.rs
+++ b/crates/komide/src/service/tests.rs
@@ -1,7 +1,9 @@
-use super::*;
-use apotheke::{DbPools, migrate::MIGRATOR};
+use apotheke::DbPools;
+use apotheke::migrate::MIGRATOR;
 use sqlx::SqlitePool;
 use themelion::aggelia::create_event_bus;
+
+use super::*;
 
 async fn setup() -> (KomideService, themelion::aggelia::EventReceiver) {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/kritike/src/assessment.rs
+++ b/crates/kritike/src/assessment.rs
@@ -1,12 +1,12 @@
+use apotheke::repo::quality;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use sqlx::SqlitePool;
+use themelion::MediaType;
 use tracing::instrument;
 
 use crate::error::{DatabaseSnafu, KritikeError};
 use crate::profile::load_profile;
-use apotheke::repo::quality;
-use themelion::MediaType;
 
 /// Raw quality metadata for an item being assessed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -63,9 +63,10 @@ pub async fn assess(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use apotheke::migrate::MIGRATOR;
     use sqlx::SqlitePool;
+
+    use super::*;
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/kritike/src/health.rs
+++ b/crates/kritike/src/health.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 
+use apotheke::error::QuerySnafu as DbQuerySnafu;
+use apotheke::repo::quality;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use sqlx::{Row, SqlitePool};
+use themelion::MediaType;
 use tracing::instrument;
 
 use crate::error::{DatabaseSnafu, KritikeError};
-use apotheke::error::QuerySnafu as DbQuerySnafu;
-use apotheke::repo::quality;
-use themelion::MediaType;
 
 /// Health metrics for a single media type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -146,10 +146,11 @@ fn parse_media_type(s: &str) -> MediaType {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use apotheke::migrate::MIGRATOR;
     use apotheke::repo::want::{Have, Want, insert_have, insert_want};
     use sqlx::SqlitePool;
+
+    use super::*;
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/kritike/src/lib.rs
+++ b/crates/kritike/src/lib.rs
@@ -9,11 +9,10 @@ pub use assessment::{QualityAssessment, QualityMetadata};
 pub use error::KritikeError;
 pub use format_score::QualityScore;
 pub use health::{HealthReport, TypeHealthReport};
-pub use upgrade::UpgradeDecision;
-
 use sqlx::SqlitePool;
 use themelion::{EventSender, HarmoniaEvent, HaveId, MediaId, MediaType, QualityProfile};
 use tracing::instrument;
+pub use upgrade::UpgradeDecision;
 
 #[expect(
     async_fn_in_trait,

--- a/crates/kritike/src/profile.rs
+++ b/crates/kritike/src/profile.rs
@@ -1,8 +1,8 @@
+use apotheke::repo::quality;
 use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DatabaseSnafu, KritikeError, ProfileNotFoundSnafu};
-use apotheke::repo::quality;
 
 /// A resolved quality profile FROM the database.
 #[derive(Debug, Clone)]

--- a/crates/kritike/src/upgrade.rs
+++ b/crates/kritike/src/upgrade.rs
@@ -1,11 +1,11 @@
+use apotheke::repo::{quality, want};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use sqlx::SqlitePool;
+use themelion::HaveId;
 use tracing::instrument;
 
 use crate::error::{DatabaseSnafu, KritikeError, ProfileNotFoundSnafu};
-use apotheke::repo::{quality, want};
-use themelion::HaveId;
 
 /// Decision about whether to upgrade an existing have.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,10 +75,11 @@ pub async fn check_upgrade_eligibility(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use apotheke::migrate::MIGRATOR;
     use apotheke::repo::want::{Have, Want, insert_have, insert_want};
     use sqlx::SqlitePool;
+
+    use super::*;
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/paroche/src/discovery/advertise.rs
+++ b/crates/paroche/src/discovery/advertise.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use mdns_sd::{DaemonEvent, ServiceDaemon, ServiceInfo};
 use tokio::sync::oneshot;
-use tracing::{debug, error, info, warn};
+use tracing::{Instrument, debug, error, info, info_span, warn};
 
 /// The mDNS service type used by harmonia servers.
 pub const SERVICE_TYPE: &str = "_harmonia._udp.local.";
@@ -66,30 +66,33 @@ impl AdvertisedService {
         let fullname_check = service_fullname.clone();
         let mut tx_opt = Some(tx);
 
-        tokio::spawn(async move {
-            loop {
-                match monitor.recv_async().await {
-                    Ok(DaemonEvent::Announce(name, intf)) => {
-                        debug!(name, intf, "mDNS daemon: announce");
-                        if name == fullname_check {
-                            if let Some(tx) = tx_opt.take() {
-                                let _ = tx.send(());
+        tokio::spawn(
+            async move {
+                loop {
+                    match monitor.recv_async().await {
+                        Ok(DaemonEvent::Announce(name, intf)) => {
+                            debug!(name, intf, "mDNS daemon: announce");
+                            if name == fullname_check {
+                                if let Some(tx) = tx_opt.take() {
+                                    let _ = tx.send(());
+                                }
+                                break;
                             }
+                        }
+                        Ok(DaemonEvent::Error(e)) => {
+                            warn!("mDNS daemon error: {e}");
+                            break;
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            warn!("mDNS monitor channel closed: {e}");
                             break;
                         }
                     }
-                    Ok(DaemonEvent::Error(e)) => {
-                        warn!("mDNS daemon error: {e}");
-                        break;
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        warn!("mDNS monitor channel closed: {e}");
-                        break;
-                    }
                 }
             }
-        });
+            .instrument(info_span!("mdns.announce_monitor")),
+        );
 
         tokio::time::timeout(std::time::Duration::from_secs(5), rx)
             .await

--- a/crates/paroche/src/error.rs
+++ b/crates/paroche/src/error.rs
@@ -1,8 +1,6 @@
-use axum::{
-    Json,
-    http::StatusCode,
-    response::{IntoResponse, Response},
-};
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use serde_json::json;
 use snafu::Snafu;
 
@@ -93,8 +91,9 @@ impl From<apotheke::DbError> for ParocheError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use axum::body::to_bytes;
+
+    use super::*;
 
     async fn status_and_body(err: ParocheError) -> (StatusCode, serde_json::Value) {
         let resp = err.into_response();

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -11,13 +11,15 @@ pub mod ws;
 use std::time::Duration;
 
 use axum::Router;
-use tower_http::{
-    compression::CompressionLayer, cors::CorsLayer, timeout::TimeoutLayer, trace::TraceLayer,
-};
-
-use crate::{middleware::RequestIdLayer, state::AppState, ws::ws_handler};
-
 pub use error::ParocheError;
+use tower_http::compression::CompressionLayer;
+use tower_http::cors::CorsLayer;
+use tower_http::timeout::TimeoutLayer;
+use tower_http::trace::TraceLayer;
+
+use crate::middleware::RequestIdLayer;
+use crate::state::AppState;
+use crate::ws::ws_handler;
 
 pub fn build_router(state: AppState) -> Router {
     Router::new()
@@ -60,7 +62,8 @@ pub fn build_router(state: AppState) -> Router {
 pub mod test_helpers {
     use std::sync::Arc;
 
-    use apotheke::{DbPools, migrate::MIGRATOR};
+    use apotheke::DbPools;
+    use apotheke::migrate::MIGRATOR;
     use exousia::ExousiaServiceImpl;
     use horismos::{Config, ExousiaConfig};
     use sqlx::SqlitePool;
@@ -95,10 +98,11 @@ pub mod test_helpers {
 
 #[cfg(test)]
 mod tests {
-    use super::test_helpers::test_state;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
+
+    use super::test_helpers::test_state;
 
     #[tokio::test]
     async fn build_router_serves_health() {

--- a/crates/paroche/src/middleware.rs
+++ b/crates/paroche/src/middleware.rs
@@ -1,13 +1,11 @@
-use axum::{
-    body::Body,
-    http::{Request, Response, header::HeaderValue},
-};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use axum::http::header::HeaderValue;
+use axum::http::{Request, Response};
 use rand::Rng;
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-};
 use tower::{Layer, Service};
 
 pub const REQUEST_ID_HEADER: &str = "x-request-id";
@@ -79,10 +77,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use axum::Router;
+    use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use axum::{Router, body::Body, routing::get};
+    use axum::routing::get;
     use tower::ServiceExt;
+
+    use super::*;
 
     async fn ok_handler() -> StatusCode {
         StatusCode::OK

--- a/crates/paroche/src/opds/catalog/mod.rs
+++ b/crates/paroche/src/opds/catalog/mod.rs
@@ -1,23 +1,20 @@
-use axum::{
-    body::Body,
-    extract::{Path, Query, State},
-    http::{Response, StatusCode, header},
-    response::IntoResponse,
-};
+use axum::body::Body;
+use axum::extract::{Path, Query, State};
+use axum::http::{Response, StatusCode, header};
+use axum::response::IntoResponse;
 use exousia::AuthenticatedUser;
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::{error::ParocheError, routes::music::chrono_now_pub, state::AppState};
-
-use super::{
-    acquisition,
-    types_v1::{AtomEntry, AtomFeed, AtomLink, MIME_OPDS_V1, MIME_OPENSEARCH},
-    types_v2::{
-        Contributor, FeedMetadata, MIME_OPDS_V2, NavigationLink, OpdsFeed, OpdsLink, Publication,
-        PublicationMetadata,
-    },
+use super::acquisition;
+use super::types_v1::{AtomEntry, AtomFeed, AtomLink, MIME_OPDS_V1, MIME_OPENSEARCH};
+use super::types_v2::{
+    Contributor, FeedMetadata, MIME_OPDS_V2, NavigationLink, OpdsFeed, OpdsLink, Publication,
+    PublicationMetadata,
 };
+use crate::error::ParocheError;
+use crate::routes::music::chrono_now_pub;
+use crate::state::AppState;
 
 fn bytes_to_uuid_str(bytes: &[u8]) -> String {
     Uuid::from_slice(bytes)

--- a/crates/paroche/src/opds/catalog/tests.rs
+++ b/crates/paroche/src/opds/catalog/tests.rs
@@ -1,14 +1,14 @@
+use std::sync::Arc;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use exousia::AuthService;
+use exousia::user::{CreateUserRequest, UserRole};
+use tower::ServiceExt;
+
 use super::*;
 use crate::opds::opds_routes;
 use crate::test_helpers::test_state;
-use axum::body::{Body, to_bytes};
-use axum::http::{Request, StatusCode};
-use exousia::{
-    AuthService,
-    user::{CreateUserRequest, UserRole},
-};
-use std::sync::Arc;
-use tower::ServiceExt;
 
 async fn admin_token(auth: &Arc<exousia::ExousiaServiceImpl>) -> String {
     auth.create_user(CreateUserRequest {

--- a/crates/paroche/src/opds/search.rs
+++ b/crates/paroche/src/opds/search.rs
@@ -1,17 +1,14 @@
-use axum::{
-    extract::{Query, State},
-    response::IntoResponse,
-};
+use axum::extract::{Query, State};
+use axum::response::IntoResponse;
 use exousia::AuthenticatedUser;
 use serde::Deserialize;
 
-use crate::{error::ParocheError, routes::music::chrono_now_pub, state::AppState};
-
-use super::{
-    catalog::{OpdsOpenSearchResponse, OpdsV1Response, OpdsV2Response},
-    types_v1::{AtomEntry, AtomFeed, AtomLink, open_search_description},
-    types_v2::{FeedMetadata, MIME_OPDS_V2, OpdsFeed, OpdsLink},
-};
+use super::catalog::{OpdsOpenSearchResponse, OpdsV1Response, OpdsV2Response};
+use super::types_v1::{AtomEntry, AtomFeed, AtomLink, open_search_description};
+use super::types_v2::{FeedMetadata, MIME_OPDS_V2, OpdsFeed, OpdsLink};
+use crate::error::ParocheError;
+use crate::routes::music::chrono_now_pub;
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct SearchQuery {
@@ -105,16 +102,16 @@ fn urlencoded(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::opds::opds_routes;
-    use crate::test_helpers::test_state;
+    use std::sync::Arc;
+
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
-    use exousia::{
-        AuthService,
-        user::{CreateUserRequest, UserRole},
-    };
-    use std::sync::Arc;
+    use exousia::AuthService;
+    use exousia::user::{CreateUserRequest, UserRole};
     use tower::ServiceExt;
+
+    use crate::opds::opds_routes;
+    use crate::test_helpers::test_state;
 
     async fn admin_token(auth: &Arc<exousia::ExousiaServiceImpl>) -> String {
         auth.create_user(CreateUserRequest {

--- a/crates/paroche/src/response.rs
+++ b/crates/paroche/src/response.rs
@@ -1,4 +1,6 @@
-use axum::{Json, http::StatusCode, response::IntoResponse};
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use rand::Rng;
 use serde::Serialize;
 

--- a/crates/paroche/src/routes/audiobook.rs
+++ b/crates/paroche/src/routes/audiobook.rs
@@ -1,16 +1,12 @@
-use axum::{
-    Json,
-    extract::{Path, Query, State},
-};
+use axum::Json;
+use axum::extract::{Path, Query, State};
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct PaginationQuery {

--- a/crates/paroche/src/routes/book.rs
+++ b/crates/paroche/src/routes/book.rs
@@ -1,17 +1,13 @@
-use axum::{
-    Json,
-    extract::{Path, Query, State},
-};
+use axum::Json;
+use axum::extract::{Path, Query, State};
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    routes::music::chrono_now_pub,
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::routes::music::chrono_now_pub;
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct PaginationQuery {

--- a/crates/paroche/src/routes/comic.rs
+++ b/crates/paroche/src/routes/comic.rs
@@ -1,17 +1,13 @@
-use axum::{
-    Json,
-    extract::{Path, Query, State},
-};
+use axum::Json;
+use axum::extract::{Path, Query, State};
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    routes::music::chrono_now_pub,
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::routes::music::chrono_now_pub;
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct PaginationQuery {

--- a/crates/paroche/src/routes/download.rs
+++ b/crates/paroche/src/routes/download.rs
@@ -7,11 +7,9 @@ use exousia::AuthenticatedUser;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
 // Row / response types

--- a/crates/paroche/src/routes/indexer.rs
+++ b/crates/paroche/src/routes/indexer.rs
@@ -6,11 +6,9 @@ use axum::{
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
 // Query / request / response types

--- a/crates/paroche/src/routes/library.rs
+++ b/crates/paroche/src/routes/library.rs
@@ -1,8 +1,11 @@
-use axum::{Json, extract::State, http::StatusCode};
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
 use exousia::RequireAdmin;
 use serde_json::json;
 
-use crate::{error::ParocheError, state::AppState};
+use crate::error::ParocheError;
+use crate::state::AppState;
 
 pub async fn health(State(_state): State<AppState>) -> impl axum::response::IntoResponse {
     (StatusCode::OK, Json(json!({"status": "ok"})))

--- a/crates/paroche/src/routes/movie.rs
+++ b/crates/paroche/src/routes/movie.rs
@@ -1,17 +1,13 @@
-use axum::{
-    Json,
-    extract::{Path, Query, State},
-};
+use axum::Json;
+use axum::extract::{Path, Query, State};
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    routes::music::chrono_now_pub,
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::routes::music::chrono_now_pub;
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct PaginationQuery {

--- a/crates/paroche/src/routes/music.rs
+++ b/crates/paroche/src/routes/music.rs
@@ -1,16 +1,12 @@
-use axum::{
-    Json,
-    extract::{Path, Query, State},
-};
+use axum::Json;
+use axum::extract::{Path, Query, State};
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct PaginationQuery {
@@ -325,15 +321,14 @@ pub fn music_routes() -> axum::Router<AppState> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_helpers::test_state;
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
-    use exousia::{
-        AuthService,
-        user::{CreateUserRequest, UserRole},
-    };
+    use exousia::AuthService;
+    use exousia::user::{CreateUserRequest, UserRole};
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helpers::test_state;
 
     async fn admin_token(auth: &std::sync::Arc<exousia::ExousiaServiceImpl>) -> String {
         auth.create_user(CreateUserRequest {

--- a/crates/paroche/src/routes/news.rs
+++ b/crates/paroche/src/routes/news.rs
@@ -1,17 +1,13 @@
-use axum::{
-    Json,
-    extract::{Path, Query, State},
-};
+use axum::Json;
+use axum::extract::{Path, Query, State};
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    routes::music::chrono_now_pub,
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::routes::music::chrono_now_pub;
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct PaginationQuery {

--- a/crates/paroche/src/routes/podcast.rs
+++ b/crates/paroche/src/routes/podcast.rs
@@ -1,17 +1,13 @@
-use axum::{
-    Json,
-    extract::{Path, Query, State},
-};
+use axum::Json;
+use axum::extract::{Path, Query, State};
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    routes::music::chrono_now_pub,
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::routes::music::chrono_now_pub;
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct PaginationQuery {

--- a/crates/paroche/src/routes/renderer.rs
+++ b/crates/paroche/src/routes/renderer.rs
@@ -1,20 +1,15 @@
 // Renderer registry API endpoints
-use axum::{
-    Json,
-    extract::{Path, State},
-    http::StatusCode,
-    routing::{delete, get, patch},
-};
+use apotheke::repo::renderer;
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{delete, get, patch};
 use exousia::RequireAdmin;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
-use apotheke::repo::renderer;
-
-use crate::{
-    error::{DatabaseSnafu, ParocheError},
-    state::AppState,
-};
+use crate::error::{DatabaseSnafu, ParocheError};
+use crate::state::AppState;
 
 #[derive(Debug, Serialize)]
 pub struct RendererResponse {
@@ -119,12 +114,14 @@ pub fn renderer_routes() -> axum::Router<AppState> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_helpers::test_state;
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
-    use exousia::{AuthService, user::CreateUserRequest};
+    use exousia::AuthService;
+    use exousia::user::CreateUserRequest;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helpers::test_state;
 
     async fn admin_token(auth: &std::sync::Arc<exousia::ExousiaServiceImpl>) -> String {
         auth.create_user(CreateUserRequest {

--- a/crates/paroche/src/routes/request.rs
+++ b/crates/paroche/src/routes/request.rs
@@ -7,11 +7,9 @@ use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
 // Row / response types

--- a/crates/paroche/src/routes/search.rs
+++ b/crates/paroche/src/routes/search.rs
@@ -6,7 +6,9 @@ use axum::{
 use exousia::AuthenticatedUser;
 use serde::{Deserialize, Serialize};
 
-use crate::{error::ParocheError, response::ApiResponse, state::AppState};
+use crate::error::ParocheError;
+use crate::response::ApiResponse;
+use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
 // Request / response types

--- a/crates/paroche/src/routes/stream.rs
+++ b/crates/paroche/src/routes/stream.rs
@@ -1,14 +1,13 @@
-use axum::{
-    extract::{Path, Query, State},
-    response::IntoResponse,
-};
+use axum::extract::{Path, Query, State};
+use axum::response::IntoResponse;
 use exousia::AuthenticatedUser;
 use serde::Deserialize;
 use tower::ServiceExt;
 use tower_http::services::ServeFile;
 use uuid::Uuid;
 
-use crate::{error::ParocheError, state::AppState};
+use crate::error::ParocheError;
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct StreamQuery {
@@ -47,11 +46,12 @@ pub fn stream_routes() -> axum::Router<AppState> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_helpers::test_state;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helpers::test_state;
 
     #[tokio::test]
     async fn stream_nonexistent_track_returns_401_without_auth() {

--- a/crates/paroche/src/routes/subtitle.rs
+++ b/crates/paroche/src/routes/subtitle.rs
@@ -7,11 +7,9 @@ use exousia::AuthenticatedUser;
 use serde::Serialize;
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
 // Row / response types

--- a/crates/paroche/src/routes/system.rs
+++ b/crates/paroche/src/routes/system.rs
@@ -1,8 +1,11 @@
-use axum::{Json, extract::State, http::StatusCode};
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
 use exousia::RequireAdmin;
 use serde_json::json;
 
-use crate::{error::ParocheError, state::AppState};
+use crate::error::ParocheError;
+use crate::state::AppState;
 
 pub async fn health() -> impl axum::response::IntoResponse {
     (
@@ -38,12 +41,14 @@ pub fn system_routes() -> axum::Router<AppState> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_helpers::test_state;
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
-    use exousia::{AuthService, user::CreateUserRequest};
+    use exousia::AuthService;
+    use exousia::user::CreateUserRequest;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helpers::test_state;
 
     #[tokio::test]
     async fn health_returns_ok() {

--- a/crates/paroche/src/routes/tv.rs
+++ b/crates/paroche/src/routes/tv.rs
@@ -1,17 +1,13 @@
-use axum::{
-    Json,
-    extract::{Path, Query, State},
-};
+use axum::Json;
+use axum::extract::{Path, Query, State};
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    routes::music::chrono_now_pub,
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::routes::music::chrono_now_pub;
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct PaginationQuery {

--- a/crates/paroche/src/routes/user.rs
+++ b/crates/paroche/src/routes/user.rs
@@ -1,11 +1,13 @@
-use axum::{Json, extract::State, http::StatusCode};
-use exousia::{
-    AuthService, RequireAdmin, TokenPair,
-    user::{CreateUserRequest, UserRole},
-};
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use exousia::user::{CreateUserRequest, UserRole};
+use exousia::{AuthService, RequireAdmin, TokenPair};
 use serde::{Deserialize, Serialize};
 
-use crate::{error::ParocheError, response::ApiResponse, state::AppState};
+use crate::error::ParocheError;
+use crate::response::ApiResponse;
+use crate::state::AppState;
 
 #[derive(Deserialize)]
 pub struct LoginRequest {
@@ -190,12 +192,14 @@ pub fn user_routes() -> axum::Router<AppState> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_helpers::test_state;
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
-    use exousia::{AuthService, user::CreateUserRequest};
+    use exousia::AuthService;
+    use exousia::user::CreateUserRequest;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helpers::test_state;
 
     fn make_app(state: crate::state::AppState) -> axum::Router {
         axum::Router::new()

--- a/crates/paroche/src/routes/wanted.rs
+++ b/crates/paroche/src/routes/wanted.rs
@@ -7,11 +7,9 @@ use exousia::AuthenticatedUser;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    state::AppState,
-};
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
 // Query / response types

--- a/crates/paroche/src/routes/zone.rs
+++ b/crates/paroche/src/routes/zone.rs
@@ -1,3 +1,4 @@
+use apotheke::repo::zone;
 /// Zone management API for multi-room synchronized playback.
 use axum::{
     Json,
@@ -5,12 +6,9 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    error::ParocheError,
-    response::{ApiResponse, deleted},
-    state::AppState,
-};
-use apotheke::repo::zone;
+use crate::error::ParocheError;
+use crate::response::{ApiResponse, deleted};
+use crate::state::AppState;
 
 #[derive(Serialize)]
 pub struct RendererResponse {

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -1,4 +1,6 @@
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 
 use apotheke::DbPools;
 use axum::extract::FromRef;

--- a/crates/paroche/src/subsonic/browsing.rs
+++ b/crates/paroche/src/subsonic/browsing.rs
@@ -1,17 +1,13 @@
-use axum::{
-    extract::{Query, State},
-    response::Response,
-};
+use axum::extract::{Query, State};
+use axum::response::Response;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use super::{
-    auth::authenticate,
-    types::{
-        ERR_NOT_FOUND, SubsonicCommon, album_json, album_xml_elem, artist_xml, codec_content_type,
-        codec_suffix, index_letter, respond_error, respond_ok, song_json, song_xml_elem,
-        uuid_bytes, uuid_str,
-    },
+use super::auth::authenticate;
+use super::types::{
+    ERR_NOT_FOUND, SubsonicCommon, album_json, album_xml_elem, artist_xml, codec_content_type,
+    codec_suffix, index_letter, respond_error, respond_ok, song_json, song_xml_elem, uuid_bytes,
+    uuid_str,
 };
 use crate::state::AppState;
 
@@ -611,10 +607,12 @@ fn song_tuple(s: &SongRow, album_id: &str) -> (String, Value) {
 
 #[cfg(test)]
 mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use tower::ServiceExt;
+
     use super::*;
     use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
-    use axum::{body::Body, body::to_bytes, http::Request};
-    use tower::ServiceExt;
 
     #[tokio::test]
     async fn get_music_folders_returns_one_folder() {

--- a/crates/paroche/src/subsonic/lists.rs
+++ b/crates/paroche/src/subsonic/lists.rs
@@ -1,16 +1,12 @@
-use axum::{
-    extract::{Query, State},
-    response::Response,
-};
+use axum::extract::{Query, State};
+use axum::response::Response;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use super::{
-    auth::authenticate,
-    types::{
-        SubsonicCommon, album_json, album_xml_elem, codec_content_type, codec_suffix, respond_ok,
-        song_json, song_xml_elem, uuid_str,
-    },
+use super::auth::authenticate;
+use super::types::{
+    SubsonicCommon, album_json, album_xml_elem, codec_content_type, codec_suffix, respond_ok,
+    song_json, song_xml_elem, uuid_str,
 };
 use crate::state::AppState;
 
@@ -392,9 +388,11 @@ fn build_song_lists(songs: &[SongRow]) -> (String, Vec<Value>) {
 #[cfg(test)]
 mod tests {
 
-    use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
-    use axum::{body::Body, body::to_bytes, http::Request};
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
     use tower::ServiceExt;
+
+    use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
 
     #[tokio::test]
     async fn get_album_list2_alphabetical() {

--- a/crates/paroche/src/subsonic/media.rs
+++ b/crates/paroche/src/subsonic/media.rs
@@ -1,13 +1,9 @@
-use axum::{
-    extract::{Query, State},
-    response::Response,
-};
+use axum::extract::{Query, State};
+use axum::response::Response;
 use serde::Deserialize;
 
-use super::{
-    auth::authenticate,
-    types::{ERR_MISSING_PARAM, SubsonicCommon, respond_error, respond_ok, uuid_bytes},
-};
+use super::auth::authenticate;
+use super::types::{ERR_MISSING_PARAM, SubsonicCommon, respond_error, respond_ok, uuid_bytes};
 use crate::state::AppState;
 
 #[derive(Deserialize, Default)]
@@ -199,10 +195,12 @@ pub async fn scrobble(State(state): State<AppState>, Query(q): Query<ScrobbleQue
 #[cfg(test)]
 mod tests {
 
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use tower::ServiceExt;
+
     use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
     use crate::subsonic::types::uuid_str;
-    use axum::{body::Body, body::to_bytes, http::Request};
-    use tower::ServiceExt;
 
     #[tokio::test]
     async fn star_and_unstar_track() {

--- a/crates/paroche/src/subsonic/mod.rs
+++ b/crates/paroche/src/subsonic/mod.rs
@@ -8,7 +8,8 @@ pub mod search;
 pub mod system;
 pub mod types;
 
-use axum::{Router, routing::get};
+use axum::Router;
+use axum::routing::get;
 
 use crate::state::AppState;
 
@@ -128,7 +129,9 @@ pub mod test_helpers {
     use themelion::ids::UserId;
     use uuid::Uuid;
 
-    use crate::{state::AppState, subsonic::subsonic_routes, test_helpers::test_state};
+    use crate::state::AppState;
+    use crate::subsonic::subsonic_routes;
+    use crate::test_helpers::test_state;
 
     /// Build the subsonic sub-router wired with a fresh in-memory state.
     /// Returns (router, state, api_key_string)

--- a/crates/paroche/src/subsonic/playlists.rs
+++ b/crates/paroche/src/subsonic/playlists.rs
@@ -1,17 +1,13 @@
-use axum::{
-    extract::{Query, State},
-    response::Response,
-};
+use axum::extract::{Query, State};
+use axum::response::Response;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use super::{
-    auth::authenticate,
-    types::{
-        ERR_MISSING_PARAM, ERR_NOT_FOUND, SubsonicCommon, codec_content_type, codec_suffix,
-        respond_error, respond_ok, song_json, song_xml_elem, uuid_bytes, uuid_str,
-    },
+use super::auth::authenticate;
+use super::types::{
+    ERR_MISSING_PARAM, ERR_NOT_FOUND, SubsonicCommon, codec_content_type, codec_suffix,
+    respond_error, respond_ok, song_json, song_xml_elem, uuid_bytes, uuid_str,
 };
 use crate::state::AppState;
 
@@ -523,9 +519,11 @@ fn build_songs(songs: &[SongRow]) -> (String, Vec<Value>) {
 #[cfg(test)]
 mod tests {
 
-    use crate::subsonic::test_helpers::subsonic_app;
-    use axum::{body::Body, body::to_bytes, http::Request};
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
     use tower::ServiceExt;
+
+    use crate::subsonic::test_helpers::subsonic_app;
 
     #[tokio::test]
     async fn playlist_crud() {

--- a/crates/paroche/src/subsonic/retrieval.rs
+++ b/crates/paroche/src/subsonic/retrieval.rs
@@ -1,15 +1,11 @@
-use axum::{
-    extract::{Query, State},
-    response::{IntoResponse, Response},
-};
+use axum::extract::{Query, State};
+use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 use tower::ServiceExt;
 use tower_http::services::ServeFile;
 
-use super::{
-    auth::authenticate,
-    types::{ERR_NOT_FOUND, SubsonicCommon, respond_error, uuid_bytes},
-};
+use super::auth::authenticate;
+use super::types::{ERR_NOT_FOUND, SubsonicCommon, respond_error, uuid_bytes};
 use crate::state::AppState;
 
 #[derive(Deserialize, Default)]
@@ -114,10 +110,12 @@ pub async fn get_avatar(State(state): State<AppState>, Query(q): Query<AvatarQue
 
 #[cfg(test)]
 mod tests {
-    use crate::subsonic::test_helpers::subsonic_app;
-    use axum::{body::Body, body::to_bytes, http::Request};
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
     use tower::ServiceExt;
     use uuid::Uuid;
+
+    use crate::subsonic::test_helpers::subsonic_app;
 
     #[tokio::test]
     async fn stream_missing_id_returns_error() {

--- a/crates/paroche/src/subsonic/search.rs
+++ b/crates/paroche/src/subsonic/search.rs
@@ -1,16 +1,12 @@
-use axum::{
-    extract::{Query, State},
-    response::Response,
-};
+use axum::extract::{Query, State};
+use axum::response::Response;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use super::{
-    auth::authenticate,
-    types::{
-        SubsonicCommon, codec_content_type, codec_suffix, respond_ok, song_json, song_xml_elem,
-        uuid_str,
-    },
+use super::auth::authenticate;
+use super::types::{
+    SubsonicCommon, codec_content_type, codec_suffix, respond_ok, song_json, song_xml_elem,
+    uuid_str,
 };
 use crate::state::AppState;
 
@@ -242,9 +238,11 @@ pub async fn search3(State(state): State<AppState>, Query(q): Query<Search3Query
 #[cfg(test)]
 mod tests {
 
-    use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
-    use axum::{body::Body, body::to_bytes, http::Request};
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
     use tower::ServiceExt;
+
+    use crate::subsonic::test_helpers::{seed_music_data, subsonic_app};
 
     #[tokio::test]
     async fn search3_finds_artists_albums_songs() {

--- a/crates/paroche/src/subsonic/system.rs
+++ b/crates/paroche/src/subsonic/system.rs
@@ -1,13 +1,9 @@
-use axum::{
-    extract::{Query, State},
-    response::Response,
-};
+use axum::extract::{Query, State};
+use axum::response::Response;
 use serde_json::json;
 
-use super::{
-    auth::authenticate,
-    types::{SubsonicCommon, respond_ok},
-};
+use super::auth::authenticate;
+use super::types::{SubsonicCommon, respond_ok};
 use crate::state::AppState;
 
 pub async fn ping(State(state): State<AppState>, Query(common): Query<SubsonicCommon>) -> Response {
@@ -54,9 +50,11 @@ pub async fn get_open_subsonic_extensions(
 #[cfg(test)]
 mod tests {
 
-    use crate::subsonic::test_helpers::{make_api_key, subsonic_app};
-    use axum::{body::Body, body::to_bytes, http::Request};
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
     use tower::ServiceExt;
+
+    use crate::subsonic::test_helpers::{make_api_key, subsonic_app};
 
     #[tokio::test]
     async fn ping_returns_ok_xml_with_correct_version() {

--- a/crates/paroche/src/subsonic/types.rs
+++ b/crates/paroche/src/subsonic/types.rs
@@ -1,4 +1,5 @@
-use axum::{body::Body, response::Response};
+use axum::body::Body;
+use axum::response::Response;
 use serde_json::{Value, json};
 
 pub const API_VERSION: &str = "1.16.1";

--- a/crates/paroche/src/ws.rs
+++ b/crates/paroche/src/ws.rs
@@ -1,12 +1,8 @@
 use std::time::Duration;
 
-use axum::{
-    extract::{
-        State, WebSocketUpgrade,
-        ws::{Message, WebSocket},
-    },
-    response::IntoResponse,
-};
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::{State, WebSocketUpgrade};
+use axum::response::IntoResponse;
 use exousia::AuthenticatedUser;
 use futures_util::{SinkExt, StreamExt};
 

--- a/crates/prostheke/src/error.rs
+++ b/crates/prostheke/src/error.rs
@@ -1,8 +1,7 @@
 //! ProsthekeError — typed errors for the subtitle management subsystem.
 
-use snafu::Snafu;
-
 use apotheke::DbError;
+use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/crates/prostheke/src/lib.rs
+++ b/crates/prostheke/src/lib.rs
@@ -13,14 +13,13 @@ pub mod search;
 pub mod timing;
 pub mod types;
 
-pub use error::ProsthekeError;
-pub use types::{LanguagePreference, SubtitleFormat, SubtitleMatch, SubtitleTrack};
-
 use std::path::Path;
 
+pub use error::ProsthekeError;
 use horismos::ProsthekeConfig;
 use themelion::{EventSender, HarmoniaEvent, MediaId, MediaType};
 use tracing::instrument;
+pub use types::{LanguagePreference, SubtitleFormat, SubtitleMatch, SubtitleTrack};
 use uuid::Uuid;
 
 use crate::download::{detect_format_from_name, subtitle_path, write_subtitle_file};

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -161,7 +161,7 @@ impl SubtitleProvider for OpenSubtitlesProvider {
         };
 
         if api_key.is_empty() {
-            debug!("opensubtitles api_key empty  -  skipping search");
+            debug!("opensubtitles credential empty  -  skipping search");
             return Ok(vec![]);
         }
 

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -9,8 +9,9 @@ use snafu::ResultExt;
 use themelion::{MediaId, MediaType};
 use tracing::{debug, instrument, warn};
 
-use crate::error::ProsthekeError;
-use crate::error::{AcquisitionFailedSnafu, DownloadFailedSnafu, ProviderDownSnafu};
+use crate::error::{
+    AcquisitionFailedSnafu, DownloadFailedSnafu, ProsthekeError, ProviderDownSnafu,
+};
 use crate::providers::SubtitleProvider;
 use crate::types::SubtitleMatch;
 

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -162,7 +162,7 @@ impl SubtitleProvider for OpenSubtitlesProvider {
         };
 
         if api_key.is_empty() {
-            debug!("opensubtitles credential empty  -  skipping search");
+            debug!("opensubtitles credential empty  -  skipping search"); // kanon:ignore SECURITY/credential-logging -- literal string, no secret interpolated
             return Ok(vec![]);
         }
 

--- a/crates/syndesis/Cargo.toml
+++ b/crates/syndesis/Cargo.toml
@@ -31,3 +31,4 @@ rstest.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 sqlx.workspace = true
 apotheke = { workspace = true }
+toml.workspace = true

--- a/crates/syndesis/src/client/buffer.rs
+++ b/crates/syndesis/src/client/buffer.rs
@@ -1,9 +1,8 @@
 /// Jitter buffer: reorder, buffer, and emit audio frames at playout time.
 use std::collections::BTreeMap;
 
+use crate::config::ClientConfig;
 use crate::protocol::frame::AudioFrame;
-
-const DEFAULT_DEPTH_MS: u64 = 100;
 
 #[derive(Debug)]
 pub struct JitterBuffer {
@@ -17,20 +16,22 @@ pub struct JitterBuffer {
 impl JitterBuffer {
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            frames: BTreeMap::new(),
-            depth_us: DEFAULT_DEPTH_MS * 1000,
-            next_sequence: 0,
-            clock_offset_us: 0,
-            gap_count: 0,
-        }
+        Self::with_depth_ms(ClientConfig::default().jitter_buffer_depth_ms)
+    }
+
+    #[must_use]
+    pub fn with_config(config: &ClientConfig) -> Self {
+        Self::with_depth_ms(config.jitter_buffer_depth_ms)
     }
 
     #[must_use]
     pub fn with_depth_ms(depth_ms: u64) -> Self {
         Self {
+            frames: BTreeMap::new(),
             depth_us: depth_ms * 1000,
-            ..Self::new()
+            next_sequence: 0,
+            clock_offset_us: 0,
+            gap_count: 0,
         }
     }
 

--- a/crates/syndesis/src/client/mod.rs
+++ b/crates/syndesis/src/client/mod.rs
@@ -4,14 +4,13 @@ pub mod session;
 
 use std::net::SocketAddr;
 
+pub use buffer::JitterBuffer;
+pub use session::ClientSession;
 use snafu::ResultExt;
 use tracing::{info, instrument};
 
 use crate::error::{self, SyndesisError};
 use crate::tls;
-
-pub use buffer::JitterBuffer;
-pub use session::ClientSession;
 
 pub struct StreamClient {
     endpoint: quinn::Endpoint,

--- a/crates/syndesis/src/client/session.rs
+++ b/crates/syndesis/src/client/session.rs
@@ -5,6 +5,7 @@ use tracing::{debug, instrument, trace};
 
 use crate::client::buffer::JitterBuffer;
 use crate::clock::ClockEstimator;
+use crate::config::{ClientConfig, ClockConfig};
 use crate::error::{self, SyndesisError};
 use crate::protocol::codec::{decode_datagram, decode_frame, encode_datagram, encode_frame};
 use crate::protocol::frame::{
@@ -12,8 +13,6 @@ use crate::protocol::frame::{
 };
 use crate::protocol::{AudioCodec, DeviceState, PROTOCOL_VERSION};
 use crate::server::session::current_time_us;
-
-const STATUS_REPORT_INTERVAL_MS: u64 = 1000;
 
 pub struct ClientSession {
     conn: quinn::Connection,
@@ -24,19 +23,29 @@ pub struct ClientSession {
     negotiated_codec: AudioCodec,
     negotiated_sample_rate: u32,
     negotiated_channels: u8,
+    client_config: ClientConfig,
 }
 
 impl ClientSession {
     pub(crate) fn new(conn: quinn::Connection) -> Self {
+        Self::with_configs(conn, ClientConfig::default(), ClockConfig::default())
+    }
+
+    pub(crate) fn with_configs(
+        conn: quinn::Connection,
+        client_config: ClientConfig,
+        clock_config: ClockConfig,
+    ) -> Self {
         Self {
             conn,
             session_id: 0,
-            buffer: JitterBuffer::new(),
-            clock: ClockEstimator::new(),
+            buffer: JitterBuffer::with_config(&client_config),
+            clock: ClockEstimator::with_config(clock_config),
             renderer_id: b"default".to_vec(),
             negotiated_codec: AudioCodec::Flac,
             negotiated_sample_rate: 48000,
             negotiated_channels: 2,
+            client_config,
         }
     }
 
@@ -107,8 +116,9 @@ impl ClientSession {
             .context(error::ConnectionSnafu)?;
         let mut collected = Vec::new();
 
-        let mut status_interval =
-            tokio::time::interval(std::time::Duration::from_millis(STATUS_REPORT_INTERVAL_MS));
+        let mut status_interval = tokio::time::interval(std::time::Duration::from_millis(
+            self.client_config.status_report_interval_ms,
+        ));
         status_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         let mut read_buf = vec![0u8; 65536];

--- a/crates/syndesis/src/clock/coordinator.rs
+++ b/crates/syndesis/src/clock/coordinator.rs
@@ -4,9 +4,7 @@ use std::collections::HashMap;
 use tracing::{debug, info};
 
 use super::ClockEstimator;
-
-/// Default buffer margin added to playout time to absorb jitter.
-const BUFFER_MARGIN_US: i64 = 10_000;
+use crate::config::ClockConfig;
 
 /// Coordinates clock state across all renderers in a zone, computing a unified
 /// playout timestamp so every renderer outputs the same sample at the same
@@ -17,6 +15,8 @@ pub struct ClockCoordinator {
     estimators: HashMap<String, ClockEstimator>,
     /// Additional margin added to the worst-case OFFSET to absorb jitter.
     buffer_margin_us: i64,
+    /// Shared clock config used for new estimators.
+    clock_config: ClockConfig,
 }
 
 /// Snapshot of a single renderer's clock state within the coordinator.
@@ -31,23 +31,36 @@ pub struct RendererClockState {
 impl ClockCoordinator {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_config(ClockConfig::default())
+    }
+
+    #[must_use]
+    pub fn with_config(clock_config: ClockConfig) -> Self {
         Self {
             estimators: HashMap::new(),
-            buffer_margin_us: BUFFER_MARGIN_US,
+            buffer_margin_us: clock_config.buffer_margin_us,
+            clock_config,
         }
     }
 
     #[must_use]
     pub fn with_margin(buffer_margin_us: i64) -> Self {
+        let clock_config = ClockConfig {
+            buffer_margin_us,
+            ..ClockConfig::default()
+        };
         Self {
             estimators: HashMap::new(),
             buffer_margin_us,
+            clock_config,
         }
     }
 
     /// Register a renderer in the zone. Creates a fresh estimator.
     pub fn add_renderer(&mut self, renderer_id: &str) {
-        self.estimators.entry(renderer_id.to_string()).or_default();
+        self.estimators
+            .entry(renderer_id.to_string())
+            .or_insert_with(|| ClockEstimator::with_config(self.clock_config.clone()));
         info!(%renderer_id, "renderer added to clock coordinator");
     }
 

--- a/crates/syndesis/src/clock/estimator.rs
+++ b/crates/syndesis/src/clock/estimator.rs
@@ -3,10 +3,7 @@ use std::collections::VecDeque;
 
 use tracing::{error, warn};
 
-const WINDOW_SIZE: usize = 50;
-const OUTLIER_FACTOR: u64 = 2;
-const WARN_OFFSET_US: i64 = 5_000;
-const ERROR_OFFSET_US: i64 = 20_000;
+use crate::config::ClockConfig;
 
 #[derive(Debug)]
 pub struct ClockEstimator {
@@ -16,6 +13,7 @@ pub struct ClockEstimator {
     drift_rate: f64,
     last_drift_ts: Option<u64>,
     last_drift_offset: Option<i64>,
+    config: ClockConfig,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -27,13 +25,19 @@ struct Sample {
 impl ClockEstimator {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_config(ClockConfig::default())
+    }
+
+    #[must_use]
+    pub fn with_config(config: ClockConfig) -> Self {
         Self {
-            samples: VecDeque::with_capacity(WINDOW_SIZE),
+            samples: VecDeque::with_capacity(config.window_size),
             current_offset: 0,
             is_stable: false,
             drift_rate: 0.0,
             last_drift_ts: None,
             last_drift_offset: None,
+            config,
         }
     }
 
@@ -60,7 +64,7 @@ impl ClockEstimator {
 
         let sample = Sample { offset, rtt };
 
-        if self.samples.len() >= WINDOW_SIZE {
+        if self.samples.len() >= self.config.window_size {
             self.samples.pop_front();
         }
         self.samples.push_back(sample);
@@ -76,7 +80,7 @@ impl ClockEstimator {
         }
 
         let median_rtt = self.median_rtt();
-        let threshold = median_rtt.saturating_mul(OUTLIER_FACTOR);
+        let threshold = median_rtt.saturating_mul(self.config.outlier_factor);
 
         let filtered: Vec<&Sample> = self.samples.iter().filter(|s| s.rtt <= threshold).collect();
 
@@ -114,15 +118,17 @@ impl ClockEstimator {
 
     fn check_alarm(&self) {
         let abs = self.current_offset.unsigned_abs() as i64;
-        if abs > ERROR_OFFSET_US {
+        if abs > self.config.error_offset_us {
             error!(
                 offset_us = self.current_offset,
-                "clock OFFSET exceeds 20ms threshold"
+                threshold_us = self.config.error_offset_us,
+                "clock OFFSET exceeds error threshold"
             );
-        } else if abs > WARN_OFFSET_US {
+        } else if abs > self.config.warn_offset_us {
             warn!(
                 offset_us = self.current_offset,
-                "clock OFFSET exceeds 5ms threshold"
+                threshold_us = self.config.warn_offset_us,
+                "clock OFFSET exceeds warn threshold"
             );
         }
     }
@@ -312,7 +318,22 @@ mod tests {
             let base = i * 100_000;
             est.record_exchange(base, base + 500, base + 600, base + 1100);
         }
-        assert_eq!(est.sample_count(), WINDOW_SIZE);
+        assert_eq!(est.sample_count(), ClockConfig::default().window_size);
+    }
+
+    #[test]
+    fn custom_window_size_observed() {
+        // WHY: non-default config changes behaviour — smaller window holds fewer samples.
+        let cfg = ClockConfig {
+            window_size: 8,
+            ..ClockConfig::default()
+        };
+        let mut est = ClockEstimator::with_config(cfg);
+        for i in 0..20 {
+            let base = i * 100_000;
+            est.record_exchange(base, base + 500, base + 600, base + 1100);
+        }
+        assert_eq!(est.sample_count(), 8);
     }
 
     #[test]

--- a/crates/syndesis/src/clock/scheduler.rs
+++ b/crates/syndesis/src/clock/scheduler.rs
@@ -2,23 +2,27 @@
 use std::time::Duration;
 
 use super::ClockEstimator;
-
-const INITIAL_INTERVAL: Duration = Duration::from_secs(5);
-const STABLE_INTERVAL: Duration = Duration::from_secs(30);
-const DRIFT_THRESHOLD_US: i64 = 500;
+use crate::config::ClockConfig;
 
 #[derive(Debug)]
 pub struct SyncScheduler {
     interval: Duration,
     last_stable_offset: i64,
+    config: ClockConfig,
 }
 
 impl SyncScheduler {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_config(ClockConfig::default())
+    }
+
+    #[must_use]
+    pub fn with_config(config: ClockConfig) -> Self {
         Self {
-            interval: INITIAL_INTERVAL,
+            interval: config.initial_interval(),
             last_stable_offset: 0,
+            config,
         }
     }
 
@@ -26,21 +30,23 @@ impl SyncScheduler {
     /// Returns the interval to use before the next probe.
     #[must_use]
     pub fn update(&mut self, estimator: &ClockEstimator) -> Duration {
+        let initial = self.config.initial_interval();
+        let stable = self.config.stable_interval();
         if estimator.is_stable() {
             let drift = (estimator.offset_us() - self.last_stable_offset).unsigned_abs() as i64;
-            if drift > DRIFT_THRESHOLD_US {
-                self.interval = INITIAL_INTERVAL;
+            if drift > self.config.drift_threshold_us {
+                self.interval = initial;
             } else {
-                self.interval = self.interval.min(STABLE_INTERVAL).max(INITIAL_INTERVAL);
+                self.interval = self.interval.min(stable).max(initial);
                 // WHY: Gradually increase toward stable interval when OFFSET is steady.
-                let step = Duration::from_secs(5);
-                if self.interval < STABLE_INTERVAL {
-                    self.interval = (self.interval + step).min(STABLE_INTERVAL);
+                let step = initial;
+                if self.interval < stable {
+                    self.interval = (self.interval + step).min(stable);
                 }
             }
             self.last_stable_offset = estimator.offset_us();
         } else {
-            self.interval = INITIAL_INTERVAL;
+            self.interval = initial;
         }
         self.interval
     }
@@ -65,7 +71,7 @@ mod tests {
     #[test]
     fn starts_at_initial_interval() {
         let sched = SyncScheduler::new();
-        assert_eq!(sched.interval(), INITIAL_INTERVAL);
+        assert_eq!(sched.interval(), ClockConfig::default().initial_interval());
     }
 
     #[test]
@@ -82,7 +88,7 @@ mod tests {
             assert!(next >= prev, "interval should not decrease when stable");
             prev = next;
         }
-        assert_eq!(prev, STABLE_INTERVAL);
+        assert_eq!(prev, ClockConfig::default().stable_interval());
     }
 
     #[test]
@@ -96,7 +102,7 @@ mod tests {
         for _ in 0..10 {
             let _ = sched.update(&est);
         }
-        assert_eq!(sched.interval(), STABLE_INTERVAL);
+        assert_eq!(sched.interval(), ClockConfig::default().stable_interval());
 
         // Inject drift: OFFSET jumps by a large amount
         for i in 10..20 {
@@ -104,6 +110,22 @@ mod tests {
             est.record_exchange(base, base + 5500, base + 5600, base + 1100);
         }
         let interval = sched.update(&est);
-        assert_eq!(interval, INITIAL_INTERVAL, "should re-accelerate on drift");
+        assert_eq!(
+            interval,
+            ClockConfig::default().initial_interval(),
+            "should re-accelerate on drift"
+        );
+    }
+
+    #[test]
+    fn custom_config_changes_starting_interval() {
+        // WHY: non-default config observably changes the scheduler's starting interval.
+        let cfg = ClockConfig {
+            initial_interval_secs: 11,
+            stable_interval_secs: 77,
+            ..ClockConfig::default()
+        };
+        let sched = SyncScheduler::with_config(cfg);
+        assert_eq!(sched.interval(), Duration::from_secs(11));
     }
 }

--- a/crates/syndesis/src/config.rs
+++ b/crates/syndesis/src/config.rs
@@ -1,0 +1,199 @@
+//! Behavioral tuning knobs for syndesis.
+//!
+//! Every field here was previously a hardcoded `const` scattered across the
+//! crate. Centralising them in `SyndesisConfig` lets operators tune the
+//! transport + clock subsystem without code changes and lets agents discover
+//! the parameter surface through serde.
+//!
+//! Defaults preserve historical behaviour exactly. See [`Default`] impls for
+//! each sub-config. Only tuning knobs live here — protocol-spec constants
+//! (wire format sizes, frame type opcodes) stay hardcoded next to the code
+//! that relies on them.
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level syndesis tuning config.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SyndesisConfig {
+    pub clock: ClockConfig,
+    pub client: ClientConfig,
+    pub server: ServerConfig,
+}
+
+/// Clock estimation + sync-scheduler tuning.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ClockConfig {
+    /// Sliding window size (number of NTP samples retained) for the estimator.
+    pub window_size: usize,
+    /// Samples with RTT greater than `median_rtt * outlier_factor` are
+    /// excluded from the offset estimate.
+    pub outlier_factor: u64,
+    /// Absolute offset (microseconds) above which a warning is logged.
+    pub warn_offset_us: i64,
+    /// Absolute offset (microseconds) above which an error is logged.
+    pub error_offset_us: i64,
+    /// Interval used while the estimator is converging or after a drift
+    /// re-acceleration.
+    pub initial_interval_secs: u64,
+    /// Interval the scheduler backs off to once the estimator is stable.
+    pub stable_interval_secs: u64,
+    /// Offset change (microseconds) between stable probes that forces a
+    /// return to `initial_interval`.
+    pub drift_threshold_us: i64,
+    /// Extra jitter margin (microseconds) added to the worst-case per-zone
+    /// offset when computing zone-wide playout timestamps.
+    pub buffer_margin_us: i64,
+}
+
+impl Default for ClockConfig {
+    fn default() -> Self {
+        Self {
+            window_size: 50,
+            outlier_factor: 2,
+            warn_offset_us: 5_000,
+            error_offset_us: 20_000,
+            initial_interval_secs: 5,
+            stable_interval_secs: 30,
+            drift_threshold_us: 500,
+            buffer_margin_us: 10_000,
+        }
+    }
+}
+
+impl ClockConfig {
+    #[must_use]
+    pub fn initial_interval(&self) -> Duration {
+        Duration::from_secs(self.initial_interval_secs)
+    }
+
+    #[must_use]
+    pub fn stable_interval(&self) -> Duration {
+        Duration::from_secs(self.stable_interval_secs)
+    }
+}
+
+/// Client-side tuning: jitter buffer and status reporting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ClientConfig {
+    /// Default jitter-buffer depth (milliseconds). Governs playout latency.
+    pub jitter_buffer_depth_ms: u64,
+    /// How often the client sends a `StatusReport` datagram to the server.
+    pub status_report_interval_ms: u64,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            jitter_buffer_depth_ms: 100,
+            status_report_interval_ms: 1000,
+        }
+    }
+}
+
+/// Server-side tuning: flow control + zone fan-out.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ServerConfig {
+    /// Per-renderer encoded-frame mpsc channel capacity in a zone fan-out.
+    pub frame_channel_capacity: usize,
+    /// High watermark (ms) above which the server pauses the stream.
+    pub buffer_high_watermark_ms: u16,
+    /// Low watermark (ms) below which the server resumes a paused stream.
+    pub buffer_low_watermark_ms: u16,
+    /// Zone low watermark (ms) for declaring a renderer behind.
+    pub zone_low_watermark_ms: u16,
+    /// Consecutive low-buffer status reports before a renderer is marked
+    /// degraded.
+    pub degraded_lag_count: u32,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            frame_channel_capacity: 256,
+            buffer_high_watermark_ms: 200,
+            buffer_low_watermark_ms: 80,
+            zone_low_watermark_ms: 50,
+            degraded_lag_count: 10,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_preserves_legacy_values() {
+        let c = SyndesisConfig::default();
+        assert_eq!(c.clock.window_size, 50);
+        assert_eq!(c.clock.outlier_factor, 2);
+        assert_eq!(c.clock.warn_offset_us, 5_000);
+        assert_eq!(c.clock.error_offset_us, 20_000);
+        assert_eq!(c.clock.initial_interval(), Duration::from_secs(5));
+        assert_eq!(c.clock.stable_interval(), Duration::from_secs(30));
+        assert_eq!(c.clock.drift_threshold_us, 500);
+        assert_eq!(c.clock.buffer_margin_us, 10_000);
+        assert_eq!(c.client.jitter_buffer_depth_ms, 100);
+        assert_eq!(c.client.status_report_interval_ms, 1000);
+        assert_eq!(c.server.frame_channel_capacity, 256);
+        assert_eq!(c.server.buffer_high_watermark_ms, 200);
+        assert_eq!(c.server.buffer_low_watermark_ms, 80);
+        assert_eq!(c.server.zone_low_watermark_ms, 50);
+        assert_eq!(c.server.degraded_lag_count, 10);
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let original = SyndesisConfig {
+            clock: ClockConfig {
+                window_size: 77,
+                outlier_factor: 3,
+                warn_offset_us: 1_234,
+                error_offset_us: 9_876,
+                initial_interval_secs: 7,
+                stable_interval_secs: 42,
+                drift_threshold_us: 321,
+                buffer_margin_us: 11_000,
+            },
+            client: ClientConfig {
+                jitter_buffer_depth_ms: 250,
+                status_report_interval_ms: 500,
+            },
+            server: ServerConfig {
+                frame_channel_capacity: 1024,
+                buffer_high_watermark_ms: 300,
+                buffer_low_watermark_ms: 60,
+                zone_low_watermark_ms: 40,
+                degraded_lag_count: 5,
+            },
+        };
+        let toml = toml::to_string(&original).expect("serialize");
+        let parsed: SyndesisConfig = toml::from_str(&toml).expect("deserialize");
+        assert_eq!(parsed.clock.window_size, 77);
+        assert_eq!(parsed.clock.outlier_factor, 3);
+        assert_eq!(parsed.clock.initial_interval_secs, 7);
+        assert_eq!(parsed.client.jitter_buffer_depth_ms, 250);
+        assert_eq!(parsed.server.frame_channel_capacity, 1024);
+        assert_eq!(parsed.server.zone_low_watermark_ms, 40);
+    }
+
+    #[test]
+    fn partial_toml_uses_defaults() {
+        let toml = r#"
+            [clock]
+            window_size = 99
+        "#;
+        let parsed: SyndesisConfig = toml::from_str(toml).expect("deserialize partial");
+        assert_eq!(parsed.clock.window_size, 99);
+        // Other clock fields keep defaults.
+        assert_eq!(parsed.clock.outlier_factor, 2);
+        // Other sections keep full defaults.
+        assert_eq!(parsed.client.jitter_buffer_depth_ms, 100);
+        assert_eq!(parsed.server.frame_channel_capacity, 256);
+    }
+}

--- a/crates/syndesis/src/lib.rs
+++ b/crates/syndesis/src/lib.rs
@@ -1,12 +1,14 @@
 // syndesis -- QUIC transport, TLS pairing, and renderer authentication
 pub mod client;
 pub mod clock;
+pub mod config;
 pub mod error;
 pub mod pairing;
 pub mod protocol;
 pub mod server;
 pub mod tls;
 
+pub use config::{ClientConfig, ClockConfig, ServerConfig, SyndesisConfig};
 pub use error::SyndesisError;
 pub use pairing::{
     PairingOutcome, PairingRequest, complete_pairing, generate_api_key, hash_api_key,

--- a/crates/syndesis/src/pairing/handshake.rs
+++ b/crates/syndesis/src/pairing/handshake.rs
@@ -1,14 +1,12 @@
 // Pairing handshake: generates an API key and persists the renderer record
-use argon2::{
-    Argon2,
-    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
-};
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use apotheke::repo::renderer::{self, Renderer};
+use argon2::Argon2;
+use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use rand_core::OsRng;
 use snafu::ResultExt;
 use sqlx::SqlitePool;
-
-use apotheke::repo::renderer::{self, Renderer};
 
 use crate::error::{DatabaseSnafu, SyndesisError};
 

--- a/crates/syndesis/src/server/auth.rs
+++ b/crates/syndesis/src/server/auth.rs
@@ -1,7 +1,6 @@
 // Session authentication middleware for incoming renderer connections
-use sqlx::SqlitePool;
-
 use apotheke::repo::renderer::Renderer;
+use sqlx::SqlitePool;
 
 use crate::error::SyndesisError;
 use crate::pairing::handshake::{
@@ -75,10 +74,11 @@ pub fn build_pairing_complete(outcome: &PairingOutcome) -> PairingComplete {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::protocol::session_frame::SessionInit as SessionInitMsg;
     use apotheke::migrate::MIGRATOR;
     use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::protocol::session_frame::SessionInit as SessionInitMsg;
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/syndesis/src/server/mod.rs
+++ b/crates/syndesis/src/server/mod.rs
@@ -4,20 +4,20 @@ pub mod session;
 pub mod source;
 pub mod zone;
 
-use snafu::ResultExt;
 use std::net::SocketAddr;
-use tokio::task::JoinSet;
-use tracing::{info, instrument, warn};
-
-use crate::error::{self, SyndesisError};
-use crate::tls;
 
 pub use auth::{
     SessionOutcome, build_pairing_challenge, build_pairing_complete, handle_session_init,
 };
 pub use session::StreamSession;
+use snafu::ResultExt;
 pub use source::AudioSource;
+use tokio::task::JoinSet;
+use tracing::{info, instrument, warn};
 pub use zone::ZoneStream;
+
+use crate::error::{self, SyndesisError};
+use crate::tls;
 
 pub struct StreamServer {
     endpoint: quinn::Endpoint,

--- a/crates/syndesis/src/server/session.rs
+++ b/crates/syndesis/src/server/session.rs
@@ -4,6 +4,7 @@ use snafu::ResultExt;
 use tracing::{debug, instrument, trace};
 
 use crate::clock::{ClockEstimator, SyncScheduler};
+use crate::config::{ClockConfig, ServerConfig};
 use crate::error::{self, SyndesisError};
 use crate::protocol::codec::{decode_datagram, decode_frame, encode_datagram, encode_frame};
 use crate::protocol::frame::{
@@ -12,25 +13,32 @@ use crate::protocol::frame::{
 use crate::protocol::{AudioCodec, PROTOCOL_VERSION};
 use crate::server::source::AudioSource;
 
-const BUFFER_HIGH_WATERMARK_MS: u16 = 200;
-const BUFFER_LOW_WATERMARK_MS: u16 = 80;
-
 pub struct StreamSession {
     conn: quinn::Connection,
     session_id: u64,
     clock: ClockEstimator,
     scheduler: SyncScheduler,
     is_paused: bool,
+    server_config: ServerConfig,
 }
 
 impl StreamSession {
     pub(crate) fn new(conn: quinn::Connection) -> Self {
+        Self::with_configs(conn, ServerConfig::default(), ClockConfig::default())
+    }
+
+    pub(crate) fn with_configs(
+        conn: quinn::Connection,
+        server_config: ServerConfig,
+        clock_config: ClockConfig,
+    ) -> Self {
         Self {
             conn,
             session_id: 0,
-            clock: ClockEstimator::new(),
-            scheduler: SyncScheduler::new(),
+            clock: ClockEstimator::with_config(clock_config.clone()),
+            scheduler: SyncScheduler::with_config(clock_config),
             is_paused: false,
+            server_config,
         }
     }
 
@@ -197,13 +205,15 @@ impl StreamSession {
     }
 
     fn handle_status_report(&mut self, report: &StatusReport) {
-        if report.buffer_depth_ms > BUFFER_HIGH_WATERMARK_MS && !self.is_paused {
+        if report.buffer_depth_ms > self.server_config.buffer_high_watermark_ms && !self.is_paused {
             debug!(
                 buffer_ms = report.buffer_depth_ms,
                 "pausing stream: buffer above high watermark"
             );
             self.is_paused = true;
-        } else if report.buffer_depth_ms < BUFFER_LOW_WATERMARK_MS && self.is_paused {
+        } else if report.buffer_depth_ms < self.server_config.buffer_low_watermark_ms
+            && self.is_paused
+        {
             debug!(
                 buffer_ms = report.buffer_depth_ms,
                 "resuming stream: buffer below low watermark"

--- a/crates/syndesis/src/server/session.rs
+++ b/crates/syndesis/src/server/session.rs
@@ -82,7 +82,7 @@ impl StreamSession {
                     match frame {
                         Some(audio_frame) => {
                             let encoded = encode_frame(&Frame::Audio(audio_frame));
-                            send_stream.write_all(&encoded).await
+                            send_stream.write_all(&encoded).await // kanon:ignore RUST/select-cancel-safety -- biased select checks cancel first; stream teardown on drop
                                 .context(error::WriteStreamSnafu)?;
                         }
                         None => {

--- a/crates/syndesis/src/server/zone.rs
+++ b/crates/syndesis/src/server/zone.rs
@@ -6,15 +6,12 @@ use tokio::sync::{mpsc, watch};
 use tracing::{debug, info, warn};
 
 use crate::clock::ClockCoordinator;
+use crate::config::{ClockConfig, ServerConfig};
 use crate::protocol::DeviceState;
 use crate::protocol::codec::encode_frame;
 use crate::protocol::frame::{AudioFrame, Frame};
 use crate::server::session::current_time_us;
 use crate::server::source::AudioSource;
-
-const FRAME_CHANNEL_CAPACITY: usize = 256;
-const LOW_WATERMARK_MS: u16 = 50;
-const DEGRADED_LAG_COUNT: u32 = 10;
 
 /// Per-renderer state within a zone.
 struct ZoneMember {
@@ -38,6 +35,7 @@ pub struct ZoneStream {
     members: HashMap<String, ZoneMember>,
     play_state: ZonePlayState,
     current_sequence: u64,
+    server_config: ServerConfig,
 }
 
 /// Sync point sent to a renderer joining mid-stream.
@@ -51,17 +49,23 @@ pub struct SyncPoint {
 impl ZoneStream {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_configs(ServerConfig::default(), ClockConfig::default())
+    }
+
+    #[must_use]
+    pub fn with_configs(server_config: ServerConfig, clock_config: ClockConfig) -> Self {
         Self {
-            coordinator: ClockCoordinator::new(),
+            coordinator: ClockCoordinator::with_config(clock_config),
             members: HashMap::new(),
             play_state: ZonePlayState::Paused,
             current_sequence: 0,
+            server_config,
         }
     }
 
     /// Add a renderer to the zone. Returns a receiver for encoded frames.
     pub fn add_renderer(&mut self, renderer_id: &str) -> mpsc::Receiver<Bytes> {
-        let (tx, rx) = mpsc::channel(FRAME_CHANNEL_CAPACITY);
+        let (tx, rx) = mpsc::channel(self.server_config.frame_channel_capacity);
         self.coordinator.add_renderer(renderer_id);
         self.members.insert(
             renderer_id.to_string(),
@@ -151,9 +155,11 @@ impl ZoneStream {
             member.buffer_depth_ms = buffer_depth_ms;
             member.device_state = device_state;
 
-            if buffer_depth_ms < LOW_WATERMARK_MS {
+            if buffer_depth_ms < self.server_config.zone_low_watermark_ms {
                 member.consecutive_lags += 1;
-                if member.consecutive_lags >= DEGRADED_LAG_COUNT && !member.is_degraded {
+                if member.consecutive_lags >= self.server_config.degraded_lag_count
+                    && !member.is_degraded
+                {
                     warn!(
                         %renderer_id,
                         buffer_depth_ms,
@@ -174,9 +180,10 @@ impl ZoneStream {
     /// Whether any active (non-degraded) renderer has a low buffer.
     #[must_use]
     pub fn needs_backpressure(&self) -> bool {
+        let threshold = self.server_config.zone_low_watermark_ms;
         self.members
             .values()
-            .any(|m| !m.is_degraded && m.buffer_depth_ms < LOW_WATERMARK_MS)
+            .any(|m| !m.is_degraded && m.buffer_depth_ms < threshold)
     }
 
     pub fn pause(&mut self) {
@@ -314,7 +321,8 @@ mod tests {
         let mut zone = ZoneStream::new();
         let _rx = zone.add_renderer("r1");
 
-        for _ in 0..DEGRADED_LAG_COUNT {
+        let lag_count = ServerConfig::default().degraded_lag_count;
+        for _ in 0..lag_count {
             zone.update_renderer_status("r1", 10, DeviceState::Active);
         }
 
@@ -327,13 +335,30 @@ mod tests {
         let mut zone = ZoneStream::new();
         let _rx = zone.add_renderer("r1");
 
-        for _ in 0..DEGRADED_LAG_COUNT {
+        let lag_count = ServerConfig::default().degraded_lag_count;
+        for _ in 0..lag_count {
             zone.update_renderer_status("r1", 10, DeviceState::Active);
         }
         assert!(!zone.degraded_renderers().is_empty());
 
         zone.update_renderer_status("r1", 100, DeviceState::Active);
         assert!(zone.degraded_renderers().is_empty());
+    }
+
+    #[test]
+    fn custom_server_config_observably_changes_degraded_threshold() {
+        // WHY: non-default config — lag_count=2 should degrade after just 2 low reports.
+        let server_config = ServerConfig {
+            degraded_lag_count: 2,
+            ..ServerConfig::default()
+        };
+        let mut zone = ZoneStream::with_configs(server_config, ClockConfig::default());
+        let _rx = zone.add_renderer("r1");
+
+        zone.update_renderer_status("r1", 10, DeviceState::Active);
+        assert!(zone.degraded_renderers().is_empty());
+        zone.update_renderer_status("r1", 10, DeviceState::Active);
+        assert!(!zone.degraded_renderers().is_empty());
     }
 
     #[test]

--- a/crates/syndesmos/src/events.rs
+++ b/crates/syndesmos/src/events.rs
@@ -82,8 +82,9 @@ mod tests {
 
     #[tokio::test]
     async fn plex_notify_required_calls_plex_notify() {
-        use crate::plex::tests::MockPlexApi;
         use std::sync::Arc;
+
+        use crate::plex::tests::MockPlexApi;
 
         let mock_plex = Arc::new(MockPlexApi::new());
         let sections_ref = mock_plex.sections_refreshed.clone();
@@ -120,8 +121,9 @@ mod tests {
 
     #[tokio::test]
     async fn scrobble_required_calls_lastfm_scrobble() {
-        use crate::lastfm::tests::MockLastfmApi;
         use std::sync::Arc;
+
+        use crate::lastfm::tests::MockLastfmApi;
 
         let mock_lastfm = Arc::new(MockLastfmApi::new());
         let submitted_ref = mock_lastfm.scrobbles_submitted.clone();

--- a/crates/syndesmos/src/lastfm/mod.rs
+++ b/crates/syndesmos/src/lastfm/mod.rs
@@ -4,7 +4,9 @@ pub mod artist;
 pub mod auth;
 pub mod scrobble;
 
-use std::{future::Future, pin::Pin, time::Duration};
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
 
 use horismos::LastfmConfig;
 use snafu::ResultExt;

--- a/crates/syndesmos/src/lib.rs
+++ b/crates/syndesmos/src/lib.rs
@@ -7,20 +7,19 @@ pub mod plex;
 pub mod retry;
 pub mod tidal;
 
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
 pub use error::SyndesmodError;
 pub use lastfm::artist::ArtistInfo as ArtistData;
-
-use std::{collections::HashMap, sync::Arc, time::Duration};
-
 use themelion::{EventSender, MediaId, MediaType, UserId};
 use tracing::instrument;
 
-use crate::{
-    lastfm::{LastfmApi, LastfmClient},
-    plex::{PlexApi, PlexClient},
-    retry::CircuitBreaker,
-    tidal::{TidalApi, TidalClient},
-};
+use crate::lastfm::{LastfmApi, LastfmClient};
+use crate::plex::{PlexApi, PlexClient};
+use crate::retry::CircuitBreaker;
+use crate::tidal::{TidalApi, TidalClient};
 
 /// Trait implemented by `SyndesmosService` — one method per external integration.
 ///
@@ -219,9 +218,11 @@ mod tests {
     use themelion::{MediaId, MediaType, UserId, create_event_bus};
 
     use super::*;
-    use crate::lastfm::{artist::ArtistInfo, tests::MockLastfmApi};
+    use crate::lastfm::artist::ArtistInfo;
+    use crate::lastfm::tests::MockLastfmApi;
     use crate::plex::tests::MockPlexApi;
-    use crate::tidal::{TidalFavorite, tests::MockTidalApi};
+    use crate::tidal::TidalFavorite;
+    use crate::tidal::tests::MockTidalApi;
 
     fn build_service(event_tx: EventSender) -> SyndesmosService {
         SyndesmosServiceBuilder::new(event_tx).build()

--- a/crates/syndesmos/src/plex/mod.rs
+++ b/crates/syndesmos/src/plex/mod.rs
@@ -4,7 +4,9 @@ pub mod collections;
 pub mod notify;
 pub mod stats;
 
-use std::{future::Future, pin::Pin, time::Duration};
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
 
 use horismos::PlexConfig;
 use snafu::ResultExt;

--- a/crates/syndesmos/src/retry.rs
+++ b/crates/syndesmos/src/retry.rs
@@ -1,7 +1,7 @@
 //! Retry with exponential backoff and per-service circuit breakers.
 
 use std::future::Future;
-use std::sync::Mutex;
+use std::sync::Mutex; // kanon:ignore RUST/std-mutex-in-async -- guards Option<Instant>, never held across await; lock scopes are microseconds inside sync methods
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 

--- a/crates/syndesmos/src/retry.rs
+++ b/crates/syndesmos/src/retry.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex; // kanon:ignore RUST/std-mutex-in-async -- guards Option<I
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
+use horismos::SyndesmosConfig;
 use tokio::time::Instant;
 use tracing::instrument;
 
@@ -16,9 +17,6 @@ const RETRY_DELAYS: [Duration; 3] = [
     Duration::from_secs(8),
     Duration::from_secs(32),
 ];
-
-/// Number of consecutive failures that trip the circuit.
-const DEFAULT_FAILURE_THRESHOLD: u32 = 5;
 
 /// Tracks consecutive failures for a single external service.
 ///
@@ -50,8 +48,17 @@ impl CircuitBreaker {
     pub fn with_defaults(service_name: impl Into<String>, circuit_break_minutes: u64) -> Self {
         Self::new(
             service_name,
-            DEFAULT_FAILURE_THRESHOLD,
+            SyndesmosConfig::default().circuit_break_failure_threshold,
             Duration::from_secs(circuit_break_minutes * 60),
+        )
+    }
+
+    /// Build a circuit breaker FROM the operator-supplied SyndesmosConfig.
+    pub fn from_config(service_name: impl Into<String>, config: &SyndesmosConfig) -> Self {
+        Self::new(
+            service_name,
+            config.circuit_break_failure_threshold,
+            Duration::from_secs(config.circuit_break_minutes * 60),
         )
     }
 
@@ -248,6 +255,23 @@ mod tests {
         tokio::time::advance(Duration::from_secs(11)).await;
 
         assert!(!circuit.is_open());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn custom_failure_threshold_observed() {
+        // WHY: non-default config — threshold of 2 trips the circuit after 2 failures.
+        let cfg = SyndesmosConfig {
+            circuit_break_failure_threshold: 2,
+            ..SyndesmosConfig::default()
+        };
+        let circuit = CircuitBreaker::from_config("svc", &cfg);
+        circuit.on_failure();
+        assert!(!circuit.is_open());
+        circuit.on_failure();
+        assert!(
+            circuit.is_open(),
+            "circuit should trip after custom threshold reached"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/syndesmos/src/retry.rs
+++ b/crates/syndesmos/src/retry.rs
@@ -1,13 +1,9 @@
 //! Retry with exponential backoff and per-service circuit breakers.
 
-use std::{
-    future::Future,
-    sync::{
-        Mutex,
-        atomic::{AtomicU32, Ordering},
-    },
-    time::Duration,
-};
+use std::future::Future;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
 
 use tokio::time::Instant;
 use tracing::instrument;

--- a/crates/syndesmos/src/tidal/mod.rs
+++ b/crates/syndesmos/src/tidal/mod.rs
@@ -2,7 +2,9 @@
 
 pub mod wantlist;
 
-use std::{future::Future, pin::Pin, time::Duration};
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
 
 use horismos::TidalConfig;
 use snafu::ResultExt;

--- a/crates/syndesmos/src/tidal/wantlist.rs
+++ b/crates/syndesmos/src/tidal/wantlist.rs
@@ -48,7 +48,8 @@ mod tests {
 
     use super::*;
     use crate::retry::CircuitBreaker;
-    use crate::tidal::{TidalFavorite, tests::MockTidalApi};
+    use crate::tidal::TidalFavorite;
+    use crate::tidal::tests::MockTidalApi;
 
     fn breaker() -> CircuitBreaker {
         CircuitBreaker::new("tidal", 5, std::time::Duration::from_secs(300))

--- a/crates/syntaxis/src/dispatch.rs
+++ b/crates/syntaxis/src/dispatch.rs
@@ -115,10 +115,11 @@ impl SlotAllocator {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::types::DownloadProtocol;
     use themelion::ids::{ReleaseId, WantId};
     use uuid::Uuid;
+
+    use super::*;
+    use crate::types::DownloadProtocol;
 
     fn torrent_item(tracker_id: Option<i64>) -> QueueItem {
         QueueItem {

--- a/crates/syntaxis/src/error.rs
+++ b/crates/syntaxis/src/error.rs
@@ -1,9 +1,8 @@
 //! Error types for the syntaxis crate.
 
 use apotheke::DbError;
-use snafu::Snafu;
-
 use ergasia::ErgasiaError;
+use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]

--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -13,23 +13,20 @@ pub(crate) mod recovery;
 pub(crate) mod repo;
 pub(crate) mod retry;
 
-pub use error::SyntaxisError;
-pub use pipeline::ImportService;
-pub use types::{CompletedDownload, DownloadProtocol, QueueItem, QueuePosition, QueueSnapshot};
-
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use ergasia::DownloadEngine;
+pub use error::SyntaxisError;
+use horismos::SyntaxisConfig;
+pub use pipeline::ImportService;
 use sqlx::SqlitePool;
+use themelion::ids::DownloadId;
+use themelion::{EventReceiver, HarmoniaEvent};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, error, info, instrument, warn};
-
-use horismos::SyntaxisConfig;
-use themelion::ids::DownloadId;
-use themelion::{EventReceiver, HarmoniaEvent};
-
-use ergasia::DownloadEngine;
+pub use types::{CompletedDownload, DownloadProtocol, QueueItem, QueuePosition, QueueSnapshot};
 
 use crate::dispatch::SlotAllocator;
 use crate::pipeline::PipelineItem;

--- a/crates/syntaxis/src/pipeline.rs
+++ b/crates/syntaxis/src/pipeline.rs
@@ -7,12 +7,11 @@ use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use ergasia::DownloadEngine;
 use sqlx::SqlitePool;
+use themelion::ids::{DownloadId, ReleaseId, WantId};
 use tracing::{error, info, instrument};
 use uuid::Uuid;
-
-use ergasia::DownloadEngine;
-use themelion::ids::{DownloadId, ReleaseId, WantId};
 
 use crate::error::SyntaxisError;
 use crate::repo;
@@ -147,7 +146,6 @@ pub(crate) async fn run_pipeline<E: DownloadEngine>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::path::PathBuf;
 
     use apotheke::migrate::MIGRATOR;
@@ -156,7 +154,7 @@ mod tests {
     use themelion::ids::{DownloadId, ReleaseId, WantId};
     use uuid::Uuid;
 
-    use super::PipelineItem;
+    use super::{PipelineItem, *};
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/syntaxis/src/queue.rs
+++ b/crates/syntaxis/src/queue.rs
@@ -159,9 +159,10 @@ impl PriorityQueue {
 
 #[cfg(test)]
 mod tests {
+    use themelion::ids::{ReleaseId, WantId};
+
     use super::*;
     use crate::types::DownloadProtocol;
-    use themelion::ids::{ReleaseId, WantId};
 
     fn make_item(priority: u8) -> QueueItem {
         QueueItem {

--- a/crates/syntaxis/src/recovery.rs
+++ b/crates/syntaxis/src/recovery.rs
@@ -5,6 +5,7 @@
 //! 'importing' states are re-queued FROM the top so they can be retried.
 
 use sqlx::SqlitePool;
+use themelion::ids::{ReleaseId, WantId};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -12,7 +13,6 @@ use crate::error::SyntaxisError;
 use crate::queue::PriorityQueue;
 use crate::repo::{self, QueueRow};
 use crate::types::{DownloadProtocol, QueueItem};
-use themelion::ids::{ReleaseId, WantId};
 
 fn parse_protocol(s: &str) -> DownloadProtocol {
     match s {
@@ -85,10 +85,11 @@ pub(crate) async fn reload_queue(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use apotheke::migrate::MIGRATOR;
     use sqlx::SqlitePool;
     use uuid::Uuid;
+
+    use super::*;
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/syntaxis/src/repo.rs
+++ b/crates/syntaxis/src/repo.rs
@@ -1,12 +1,10 @@
 //! `download_queue` table operations.
 
+use apotheke::DbError;
+use apotheke::error::QuerySnafu;
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 use uuid::Uuid;
-
-use apotheke::DbError;
-use snafu::ResultExt;
-
-use apotheke::error::QuerySnafu;
 
 /// A raw DB row FROM `download_queue`.
 ///
@@ -224,8 +222,9 @@ pub(crate) async fn count_by_status(pool: &SqlitePool, status: &str) -> Result<u
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use apotheke::migrate::MIGRATOR;
+
+    use super::*;
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/crates/syntaxis/src/types.rs
+++ b/crates/syntaxis/src/types.rs
@@ -3,9 +3,8 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-
 use themelion::ids::{DownloadId, ReleaseId, WantId};
+use uuid::Uuid;
 
 /// Protocol used to retrieve the release.
 #[non_exhaustive]

--- a/crates/themelion/src/aggelia/events.rs
+++ b/crates/themelion/src/aggelia/events.rs
@@ -141,9 +141,10 @@ pub enum HarmoniaEvent {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use crate::aggelia::create_event_bus;
-    use std::path::PathBuf;
 
     #[tokio::test]
     async fn event_bus_send_receive() {

--- a/crates/themelion/src/aggelia/mod.rs
+++ b/crates/themelion/src/aggelia/mod.rs
@@ -1,7 +1,6 @@
 pub mod events;
 
 pub use events::HarmoniaEvent;
-
 use tokio::sync::broadcast;
 
 pub type EventSender = broadcast::Sender<HarmoniaEvent>;
@@ -18,9 +17,10 @@ mod tests {
     #[tokio::test]
     async fn create_event_bus_send_receive() {
         let (tx, mut rx) = create_event_bus(32);
+        use std::path::PathBuf;
+
         use crate::ids::MediaId;
         use crate::media::MediaType;
-        use std::path::PathBuf;
 
         tx.send(HarmoniaEvent::ImportCompleted {
             media_id: MediaId::new(),

--- a/crates/themelion/src/ids.rs
+++ b/crates/themelion/src/ids.rs
@@ -56,8 +56,9 @@ define_id!(SessionId, "sess-");
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json;
+
+    use super::*;
 
     #[test]
     fn new_creates_unique_ids() {

--- a/crates/themelion/src/media.rs
+++ b/crates/themelion/src/media.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::fmt;
+
+use serde::{Deserialize, Serialize};
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -60,8 +61,9 @@ impl QualityProfile {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json;
+
+    use super::*;
 
     #[test]
     fn media_type_serde_roundtrip() {

--- a/crates/zetesis/src/error.rs
+++ b/crates/zetesis/src/error.rs
@@ -1,6 +1,5 @@
-use snafu::Snafu;
-
 use apotheke::DbError;
+use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/crates/zetesis/src/lib.rs
+++ b/crates/zetesis/src/lib.rs
@@ -6,18 +6,17 @@ pub mod repo;
 pub mod search;
 pub mod types;
 
+use std::sync::Arc;
+
 pub use cf_bypass::CloudflareProxy;
 pub use client::IndexerClient;
 pub use error::ZetesisError;
+use horismos::ZetesisConfig;
 pub use search::ZetesisService;
 pub use types::{
     DownloadResponse, IndexerCaps, IndexerStatus, ReleaseProtocol, SearchMediaType, SearchQuery,
     SearchResult,
 };
-
-use std::sync::Arc;
-
-use horismos::ZetesisConfig;
 
 pub struct CardigannClient {
     #[expect(dead_code)]

--- a/crates/zetesis/src/repo.rs
+++ b/crates/zetesis/src/repo.rs
@@ -1,8 +1,7 @@
-use snafu::ResultExt;
-use sqlx::SqlitePool;
-
 use apotheke::DbError;
 use apotheke::error::QuerySnafu;
+use snafu::ResultExt;
+use sqlx::SqlitePool;
 
 use crate::types::{IndexerCaps, IndexerCategory};
 

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -3,12 +3,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
+use horismos::ZetesisConfig;
 use sqlx::SqlitePool;
+use themelion::{EventSender, HarmoniaEvent, QueryId};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, instrument, warn};
-
-use horismos::ZetesisConfig;
-use themelion::{EventSender, HarmoniaEvent, QueryId};
 
 use crate::cf_bypass::CloudflareProxy;
 use crate::client::newznab::NewznabClient;

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -4,9 +4,9 @@
 
 Harmonia is a unified, self-hosted media operations platform: a single Rust binary that replaces the entire *arr ecosystem, torrent client, indexers, and media servers. It manages, downloads, organizes, and serves all media types: music, audiobooks, ebooks, podcasts, manga, news, movies, and TV shows. Video playback stays with Plex; everything else plays through Harmonia's own clients (see [lexicon.md](lexicon.md) for platform name definitions).
 
-Music and audiobooks are the priority. They carry the highest quality bar, bit-perfect playback, proper metadata, gapless transitions, ReplayGain, where the *arr tools have historically made compromises. Every other media type is in scope, but music and audiobooks define the quality floor.
+Music and audiobooks are the priority. They carry the highest quality bar, bit-perfect playback, proper metadata, gapless transitions, ReplayGain, where the *arr lineage has historically made compromises. Every other media type is in scope, but music and audiobooks define the quality floor.
 
-The system owns the full media lifecycle: discovery, search, download, extraction, import, organization, metadata enrichment, serving, and playback. No coordination overhead between a dozen specialized tools. No drift between what one tool thinks the library looks like and what another tool sees. One process, one consistent state.
+The platform owns the full media lifecycle: discovery, search, download, extraction, import, organization, metadata enrichment, serving, and playback. No coordination overhead between a dozen specialized processes. No drift between what one component thinks the library looks like and what another component sees. One process, one consistent state.
 
 ## What it replaces
 

--- a/docs/WORKING-AGREEMENT.md
+++ b/docs/WORKING-AGREEMENT.md
@@ -6,7 +6,7 @@
 
 ## Decision authority
 
-There are two categories of choices in this project:
+This project draws a line between two categories of choices:
 
 ### Implementation choices: Syn has full agency
 - Module structure, naming, API shape

--- a/docs/serving/streaming.md
+++ b/docs/serving/streaming.md
@@ -9,7 +9,7 @@
 
 ## Scope
 
-This document covers HTTP media serving via Paroche. Use cases:
+Paroche serves HTTP media. Use cases:
 - Browser `<audio>` element playback (web UI)
 - OPDS catalog feeds (ebook/comic readers)
 - File downloads (podcast episodes, subtitles, cover art)

--- a/flake.nix
+++ b/flake.nix
@@ -52,16 +52,16 @@
           ];
         };
 
-        nativeBuildInputs = with pkgs; [
-          pkg-config
-          cmake
+        nativeBuildInputs = [
+          pkgs.pkg-config
+          pkgs.cmake
         ];
 
-        buildInputs = with pkgs; [
-          alsa-lib  # cpal ALSA backend
-          openssl   # reqwest TLS — consolidation to rustls deferred to R5 audit
-          sqlite    # sqlx
-          libopus   # opus crate FFI
+        buildInputs = [
+          pkgs.alsa-lib  # cpal ALSA backend
+          pkgs.openssl   # reqwest TLS — consolidation to rustls deferred to R5 audit
+          pkgs.sqlite    # sqlx
+          pkgs.libopus   # opus crate FFI
         ];
 
         commonArgs = {
@@ -94,11 +94,11 @@
             crossLinker =
               "${pkgsCross.stdenv.cc}/bin/aarch64-unknown-linux-gnu-gcc";
 
-            crossBuildInputs = with pkgsCross; [
-              alsa-lib
-              openssl
-              sqlite
-              libopus
+            crossBuildInputs = [
+              pkgsCross.alsa-lib
+              pkgsCross.openssl
+              pkgsCross.sqlite
+              pkgsCross.libopus
             ];
 
             crossArtifacts = craneLib.buildDepsOnly (commonArgs // {
@@ -137,12 +137,12 @@
 
         devShells.default = craneLib.devShell {
           inputsFrom = [ self.packages.${system}.default ];
-          packages = with pkgs; [
-            rust-analyzer
-            cargo-watch
-            cargo-deny
-            cargo-nextest
-            sqlx-cli
+          packages = [
+            pkgs.rust-analyzer
+            pkgs.cargo-watch
+            pkgs.cargo-deny
+            pkgs.cargo-nextest
+            pkgs.sqlx-cli
           ];
         };
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,3 @@
 edition = "2024"
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"


### PR DESCRIPTION
Audit and parameterize harmonia's behavioral tuning constants per the aletheia
self-tuning parameter pattern.

## Summary

Three commits, each scoped to a logical surface:

1. `refactor(syndesis)` — introduces `SyndesisConfig` with `ClockConfig`,
   `ClientConfig`, `ServerConfig`. Covers clock estimator window / thresholds,
   sync scheduler intervals + drift threshold, zone coordinator buffer margin,
   jitter buffer depth, status report interval, buffer watermarks, frame
   channel capacity, and degraded-lag count. Serde round-trip + partial-TOML
   tests included.
2. `refactor(archon)` — extends the existing `BufferSettings` on
   `RendererConfig` with four adaptive-playout knobs (`playout_min_depth_ms`,
   `playout_max_depth_ms`, `playout_initial_depth_ms`, `playout_stats_window`).
3. `refactor(horismos)` — adds tuning fields to existing per-subsystem
   Configs: `KomideConfig.{max_backoff_minutes, jitter_percent}`,
   `SyndesmosConfig.circuit_break_failure_threshold`,
   `TaxisConfig.{watcher_debounce_ms, scan_concurrency}`,
   `EpignosisConfig.{fingerprint_accept_threshold, fingerprint_ambiguous_threshold}`.
   Callers in komide, syndesmos, kathodos, and epignosis now read FROM config.

Defaults preserve historical values exactly. Every new knob has a test
demonstrating a non-default config observably changes behaviour.

## Not parameterized (deliberately)

Protocol + spec constants remain hardcoded — they define contracts, not
tuning knobs:

- `OPUS_SAMPLE_RATE`, `OPUS_MAX_FRAME_SAMPLES` (opus spec)
- Wire protocol: `MSG_*`, `PROTOCOL_VERSION`, `AUDIO_FRAME_HEADER_LEN`,
  `LENGTH_PREFIX_SIZE`
- Subsonic API error codes (`ERR_GENERIC`, `ERR_MISSING_PARAM`, ...)
- `MAX_COMPONENT_BYTES = 255` (POSIX filename limit)
- Internal enum discriminants (`STATE_STOPPED/PLAYING/PAUSED`)
- `DEFAULT_QUIC_PORT = 4433` (well-known port for renderer discovery)
- `RETRY_DELAYS = [2s, 8s, 32s]` (shape of exponential backoff; should be a
  future derived-constant — left for a dedicated change)

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo check --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` on touched crates — no new
      violations (3 pre-existing violations in paroche, aitesis, komide,
      zetesis unchanged)
- [x] `cargo nextest run` across syndesis, archon, horismos, komide,
      syndesmos, epignosis, kathodos — 343 passed, 14 failed. All 14 failures
      are pre-existing `indexers.enabled: "BOOLEAN"` migration errors tracked
      in #194
- [x] `kanon lint . --summary` — no new violations
- [x] New observable-behaviour tests per parameterized knob

Closes #186