### PR TITLE
fix(ci): pre-stage forge-CI memory caps for Phase 05e cutover

### DIFF
--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -1,0 +1,36 @@
+# Forge CI pipeline for forkwright/harmonia.
+#
+# Mirrors the hardcoded default Rust gate (fmt → check → clippy → nextest
+# → lint) but pins per-stage build + test concurrency to 8. Without this
+# cap, cargo defaults to num_cpus (64 on this Threadripper) and parallel
+# rustc + nextest processes peak well over 100GB of RSS — enough to OOM
+# menos when any other fleet work is running. 8 is the budget that keeps
+# a single CI run under ~25GB peak, low enough that serial drains don't
+# OOM even with aletheia.service and the dispatch fleet resident.
+#
+# Keep in sync with `crates/archeion/src/ci_config.rs::default_rust_gate`
+# when the upstream default changes — only the `--jobs` / `--test-threads`
+# flags should differ.
+
+[pipeline]
+stages = ["cargo fmt", "cargo check", "cargo clippy", "cargo nextest", "kanon lint"]
+
+[stages."cargo fmt"]
+cmd = "cargo fmt --all -- --check"
+timeout_secs = 300
+
+[stages."cargo check"]
+cmd = "cargo check --workspace --all-targets --jobs 8"
+timeout_secs = 900
+
+[stages."cargo clippy"]
+cmd = "cargo clippy --workspace --all-targets --jobs 8 -- -D warnings"
+timeout_secs = 900
+
+[stages."cargo nextest"]
+cmd = "cargo nextest run --workspace --build-jobs 8 --test-threads 8"
+timeout_secs = 1800
+
+[stages."kanon lint"]
+cmd = "kanon lint . --summary"
+timeout_secs = 600


### PR DESCRIPTION
## Summary

Ships `.kanon-ci.toml` (copied verbatim from forkwright/kanon commit [`1046068b`](https://github.com/forkwright/kanon/commit/1046068b0555455846374bf07bc2f3e72c1ffbcf)) that caps cargo `--jobs` / `--build-jobs` / `--test-threads` to 8 so a full-workspace forge CI run stays under ~25GB peak RSS.

Without the caps, cargo defaults to `num_cpus` (64 on the menos Threadripper) and parallel rustc + nextest peak >100GB RSS, OOM-killing `kanon-server.service` — see `~/dianoia/inbox/2026-04-19-kanon-server-oom-cascade.md` and forkwright/kanon#7.

## Why now

`harmonia` is not yet cut over to forge-native PRs, so `.kanon-ci.toml` is a no-op today. Phase 05e will bring forge CI online for this repo — these caps must be in place **before** cutover or the first post-cutover push will OOM menos.

## What

- Add `.kanon-ci.toml` at repo root
- Config copied verbatim from kanon's version (default Rust gate: fmt → check → clippy → nextest → lint)
- No harmonia-specific divergence

## Test plan

- [ ] No-op until Phase 05e cutover — nothing to verify on GitHub CI
- [ ] Post-cutover: first forge CI run stays under 25GB peak RSS