### PR TITLE
fix(archon): sd-notify 0.5 dropped unset_env arg — update callsites

### DIFF
--- a/crates/archon/src/render/runner.rs
+++ b/crates/archon/src/render/runner.rs
@@ -10,11 +10,11 @@ mod watchdog {
     use std::time::Duration;
 
     pub(super) fn notify_ready() {
-        let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]);
+        let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
     }
 
     pub(super) fn notify_stopping() {
-        let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Stopping]);
+        let _ = sd_notify::notify(&[sd_notify::NotifyState::Stopping]);
     }
 
     // WHY: WatchdogSec=30 in the unit file; we ping at half that interval so the
@@ -22,7 +22,7 @@ mod watchdog {
     pub(super) const WATCHDOG_INTERVAL: Duration = Duration::from_secs(15);
 
     pub(super) fn notify_watchdog() {
-        let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Watchdog]);
+        let _ = sd_notify::notify(&[sd_notify::NotifyState::Watchdog]);
     }
 
     pub(super) fn active() -> bool {


### PR DESCRIPTION
## Summary

`sd-notify` 0.5.0 changed `notify()` signature from `notify(unset_env: bool, state: &[NotifyState])` to `notify(state: &[NotifyState])`. `Cargo.lock` already pins 0.5.0, but `crates/archon/src/render/runner.rs` still called the 2-arg form at lines 13/17/25. Result: `cargo check` fails on the entire harmonia workspace with 3x `error[E0061]`, which blocks `kanon gate` on every PR branch.

## Change

Three one-line edits in `crates/archon/src/render/runner.rs`: drop the leading `false` (unset_env) arg from each `sd_notify::notify()` call. All three sites passed `unset_env=false`, which is now the only supported behavior in 0.5, so there is no behavioral change.

- Line 13: `notify_ready()` — `NotifyState::Ready`
- Line 17: `notify_stopping()` — `NotifyState::Stopping`
- Line 25: `notify_watchdog()` — `NotifyState::Watchdog`

Confirmed via `git grep sd_notify` that these are the only call sites in the workspace.

## Unblocks

- PR #200 (forge-CI memory caps) — gate failing on cargo check before reaching any lint stage
- PR #201 (forge→GitHub lint sync) — same
- Any future harmonia PR — kanon gate cannot run until the workspace compiles

## Verification

- `cargo check -p archon`: clean
- `cargo nextest run -p archon`: 97/97 passed
- `kanon gate --stamp`: `cargo fmt`, `cargo check`, `cargo nextest` all PASS. `cargo clippy` + `kanon lint` FAIL on pre-existing unrelated debt in `komide`, `aitesis`, `zetesis`, `paroche` (too-many-arguments, unfulfilled lint-expectation, non-exhaustive-enum, unwrap, etc.) — explicitly out of scope for this fix. That pre-existing debt is what this PR enables the fleet to start addressing now that the workspace compiles again.

## Test plan

- [x] `cargo check -p archon` compiles clean
- [x] `cargo nextest run -p archon` — 97/97 pass
- [ ] Merge before PR #200 and PR #201 so their gates can progress past `cargo check`
