### PR TITLE
fix(clippy): clear 5 pre-existing too-many-args + unfulfilled expect errors

### DIFF
--- a/crates/aitesis/src/approval.rs
+++ b/crates/aitesis/src/approval.rs
@@ -84,12 +84,14 @@ where
     let now = jiff::Timestamp::now();
     crate::repo::update_status(
         pool,
-        &request_id,
-        RequestStatus::Monitoring,
-        Some(&admin_id),
-        Some(now),
-        None,
-        Some(&want_id),
+        crate::repo::UpdateStatusParams {
+            id: &request_id,
+            status: RequestStatus::Monitoring,
+            decided_by: Some(&admin_id),
+            decided_at: Some(now),
+            deny_reason: None,
+            want_id: Some(&want_id),
+        },
     )
     .await?;
 
@@ -132,12 +134,14 @@ pub(crate) async fn deny_request(
     let now = jiff::Timestamp::now();
     crate::repo::update_status(
         pool,
-        &request_id,
-        RequestStatus::Denied,
-        Some(&admin_id),
-        Some(now),
-        reason.as_deref(),
-        None,
+        crate::repo::UpdateStatusParams {
+            id: &request_id,
+            status: RequestStatus::Denied,
+            decided_by: Some(&admin_id),
+            decided_at: Some(now),
+            deny_reason: reason.as_deref(),
+            want_id: None,
+        },
     )
     .await?;
 

--- a/crates/aitesis/src/lib.rs
+++ b/crates/aitesis/src/lib.rs
@@ -164,12 +164,14 @@ where
             let want_id = self.monitor.create_want(&request).await?;
             repo::update_status(
                 &self.write,
-                &request.id,
-                RequestStatus::Monitoring,
-                Some(&user_id),
-                Some(jiff::Timestamp::now()),
-                None,
-                Some(&want_id),
+                repo::UpdateStatusParams {
+                    id: &request.id,
+                    status: RequestStatus::Monitoring,
+                    decided_by: Some(&user_id),
+                    decided_at: Some(jiff::Timestamp::now()),
+                    deny_reason: None,
+                    want_id: Some(&want_id),
+                },
             )
             .await?;
             return repo::get_request(&self.read, &request.id)
@@ -675,12 +677,14 @@ mod tests {
         // Simulate Episkope updating status to Fulfilled
         crate::repo::update_status(
             &pool,
-            &req.id,
-            RequestStatus::Fulfilled,
-            None,
-            None,
-            None,
-            None,
+            crate::repo::UpdateStatusParams {
+                id: &req.id,
+                status: RequestStatus::Fulfilled,
+                decided_by: None,
+                decided_at: None,
+                deny_reason: None,
+                want_id: None,
+            },
         )
         .await
         .unwrap();

--- a/crates/aitesis/src/repo.rs
+++ b/crates/aitesis/src/repo.rs
@@ -129,15 +129,32 @@ pub async fn get_request(
     Ok(row.and_then(RequestRow::into_domain))
 }
 
+/// Parameters for [`update_status`].
+///
+/// Groups the mutation inputs applied to a request row: the new status plus
+/// the admin decision metadata (decided-by / decided-at / deny-reason) and the
+/// optional linked want for Monitoring transitions.
+pub struct UpdateStatusParams<'a> {
+    pub id: &'a RequestId,
+    pub status: RequestStatus,
+    pub decided_by: Option<&'a UserId>,
+    pub decided_at: Option<jiff::Timestamp>,
+    pub deny_reason: Option<&'a str>,
+    pub want_id: Option<&'a WantId>,
+}
+
 pub async fn update_status(
     pool: &SqlitePool,
-    id: &RequestId,
-    status: RequestStatus,
-    decided_by: Option<&UserId>,
-    decided_at: Option<jiff::Timestamp>,
-    deny_reason: Option<&str>,
-    want_id: Option<&WantId>,
+    params: UpdateStatusParams<'_>,
 ) -> Result<(), crate::error::AitesisError> {
+    let UpdateStatusParams {
+        id,
+        status,
+        decided_by,
+        decided_at,
+        deny_reason,
+        want_id,
+    } = params;
     sqlx::query(
         "UPDATE requests
          SET status = ?, decided_by = ?, decided_at = ?, deny_reason = ?, want_id = ?
@@ -329,12 +346,14 @@ mod tests {
         let now = jiff::Timestamp::now();
         update_status(
             &pool,
-            &req_id,
-            RequestStatus::Approved,
-            Some(&admin_id),
-            Some(now),
-            None,
-            None,
+            UpdateStatusParams {
+                id: &req_id,
+                status: RequestStatus::Approved,
+                decided_by: Some(&admin_id),
+                decided_at: Some(now),
+                deny_reason: None,
+                want_id: None,
+            },
         )
         .await
         .unwrap();

--- a/crates/komide/src/service/mod.rs
+++ b/crates/komide/src/service/mod.rs
@@ -37,10 +37,6 @@ pub struct KomideService {
     client: reqwest::Client,
     pub(crate) config: KomideConfig,
     /// Stores (etag, last_modified) keyed by feed URL for conditional requests.
-    #[expect(
-        clippy::type_complexity,
-        reason = "map of (etag, last-modified) pairs; extracting a named struct would add indirection without clarity"
-    )]
     cache_validators: tokio::sync::Mutex<HashMap<String, (Option<String>, Option<String>)>>,
 }
 

--- a/crates/paroche/src/subsonic/browsing.rs
+++ b/crates/paroche/src/subsonic/browsing.rs
@@ -5,9 +5,9 @@ use serde_json::{Value, json};
 
 use super::auth::authenticate;
 use super::types::{
-    ERR_NOT_FOUND, SubsonicCommon, album_json, album_xml_elem, artist_xml, codec_content_type,
-    codec_suffix, index_letter, respond_error, respond_ok, song_json, song_xml_elem, uuid_bytes,
-    uuid_str,
+    AlbumElemParams, ERR_NOT_FOUND, SubsonicCommon, album_json, album_xml_elem, artist_xml,
+    codec_content_type, codec_suffix, index_letter, respond_error, respond_ok, song_json,
+    song_xml_elem, uuid_bytes, uuid_str,
 };
 use crate::state::AppState;
 
@@ -341,24 +341,17 @@ pub async fn get_artist(State(state): State<AppState>, Query(q): Query<IdQuery>)
         let (song_count, duration) = fetch_album_stats(&state, &a.id).await;
         let a_artist_id = a.artist_id.as_deref().map(uuid_str).unwrap_or_default();
         let a_artist = a.artist_name.as_deref().unwrap_or("");
-        xml_albums.push_str(&album_xml_elem(
-            &album_id,
-            &a.name,
-            a_artist,
-            &a_artist_id,
-            a.year,
+        let params = AlbumElemParams {
+            id: &album_id,
+            name: &a.name,
+            artist: a_artist,
+            artist_id: &a_artist_id,
+            year: a.year,
             song_count,
             duration,
-        ));
-        json_albums.push(album_json(
-            &album_id,
-            &a.name,
-            a_artist,
-            &a_artist_id,
-            a.year,
-            song_count,
-            duration,
-        ));
+        };
+        xml_albums.push_str(&album_xml_elem(params));
+        json_albums.push(album_json(params));
     }
 
     let xml = format!(

--- a/crates/paroche/src/subsonic/lists.rs
+++ b/crates/paroche/src/subsonic/lists.rs
@@ -5,8 +5,8 @@ use serde_json::{Value, json};
 
 use super::auth::authenticate;
 use super::types::{
-    SubsonicCommon, album_json, album_xml_elem, codec_content_type, codec_suffix, respond_ok,
-    song_json, song_xml_elem, uuid_str,
+    AlbumElemParams, SubsonicCommon, album_json, album_xml_elem, codec_content_type, codec_suffix,
+    respond_ok, song_json, song_xml_elem, uuid_str,
 };
 use crate::state::AppState;
 
@@ -139,24 +139,17 @@ pub async fn get_album_list2(
         let id = uuid_str(&a.id);
         let artist_id = a.artist_id.as_deref().map(uuid_str).unwrap_or_default();
         let artist_name = a.artist_name.as_deref().unwrap_or("");
-        xml_albums.push_str(&album_xml_elem(
-            &id,
-            &a.name,
-            artist_name,
-            &artist_id,
-            a.year,
-            a.song_count,
-            a.duration,
-        ));
-        json_albums.push(album_json(
-            &id,
-            &a.name,
-            artist_name,
-            &artist_id,
-            a.year,
-            a.song_count,
-            a.duration,
-        ));
+        let params = AlbumElemParams {
+            id: &id,
+            name: &a.name,
+            artist: artist_name,
+            artist_id: &artist_id,
+            year: a.year,
+            song_count: a.song_count,
+            duration: a.duration,
+        };
+        xml_albums.push_str(&album_xml_elem(params));
+        json_albums.push(album_json(params));
     }
 
     let xml = format!("<albumList2>{xml_albums}</albumList2>");
@@ -281,24 +274,17 @@ pub async fn get_starred2(State(state): State<AppState>, Query(q): Query<CommonQ
         let id = uuid_str(&a.id);
         let artist_id = a.artist_id.as_deref().map(uuid_str).unwrap_or_default();
         let artist_name = a.artist_name.as_deref().unwrap_or("");
-        xml_albums.push_str(&album_xml_elem(
-            &id,
-            &a.name,
-            artist_name,
-            &artist_id,
-            a.year,
-            a.song_count,
-            a.duration,
-        ));
-        json_albums.push(album_json(
-            &id,
-            &a.name,
-            artist_name,
-            &artist_id,
-            a.year,
-            a.song_count,
-            a.duration,
-        ));
+        let params = AlbumElemParams {
+            id: &id,
+            name: &a.name,
+            artist: artist_name,
+            artist_id: &artist_id,
+            year: a.year,
+            song_count: a.song_count,
+            duration: a.duration,
+        };
+        xml_albums.push_str(&album_xml_elem(params));
+        json_albums.push(album_json(params));
     }
 
     let xml = format!("<starred2>{xml_albums}{xml_songs}</starred2>");

--- a/crates/paroche/src/subsonic/types.rs
+++ b/crates/paroche/src/subsonic/types.rs
@@ -176,16 +176,34 @@ pub fn artist_xml(id: &str, name: &str, album_count: i64) -> String {
     )
 }
 
+/// Fields shared by Subsonic AlbumID3 XML / JSON element builders.
+///
+/// The Subsonic API defines AlbumID3 as a single flat record; both
+/// [`album_xml_elem`] and [`album_json`] emit the same fields in different
+/// encodings, so they share one parameter struct. `Copy` lets callers build
+/// the params once and hand the same value to both encoders.
+#[derive(Clone, Copy)]
+pub struct AlbumElemParams<'a> {
+    pub id: &'a str,
+    pub name: &'a str,
+    pub artist: &'a str,
+    pub artist_id: &'a str,
+    pub year: Option<i64>,
+    pub song_count: i64,
+    pub duration: i64,
+}
+
 /// Build Subsonic AlbumID3 XML element (without children).
-pub fn album_xml_elem(
-    id: &str,
-    name: &str,
-    artist: &str,
-    artist_id: &str,
-    year: Option<i64>,
-    song_count: i64,
-    duration: i64,
-) -> String {
+pub fn album_xml_elem(params: AlbumElemParams<'_>) -> String {
+    let AlbumElemParams {
+        id,
+        name,
+        artist,
+        artist_id,
+        year,
+        song_count,
+        duration,
+    } = params;
     let year_attr = year.map(|y| format!(r#" year="{y}""#)).unwrap_or_default();
     format!(
         r#"<album id="{}" name="{}" artist="{}" artistId="{}" songCount="{song_count}" duration="{duration}"{year_attr} />"#,
@@ -239,15 +257,16 @@ pub fn song_xml_elem(
 }
 
 /// Build JSON object for an AlbumID3.
-pub fn album_json(
-    id: &str,
-    name: &str,
-    artist: &str,
-    artist_id: &str,
-    year: Option<i64>,
-    song_count: i64,
-    duration: i64,
-) -> Value {
+pub fn album_json(params: AlbumElemParams<'_>) -> Value {
+    let AlbumElemParams {
+        id,
+        name,
+        artist,
+        artist_id,
+        year,
+        song_count,
+        duration,
+    } = params;
     let mut m = serde_json::Map::new();
     m.insert("id".into(), json!(id));
     m.insert("name".into(), json!(name));

--- a/crates/zetesis/src/repo.rs
+++ b/crates/zetesis/src/repo.rs
@@ -21,15 +21,32 @@ pub struct IndexerRow {
     pub added_at: String,
 }
 
+/// Parameters for [`insert_indexer`].
+///
+/// Groups the columns written into the `indexers` row on insert. Columns with
+/// database defaults (`enabled`, `status`, `last_tested`, `caps_json`,
+/// `added_at`) are intentionally omitted.
+pub struct InsertIndexerParams<'a> {
+    pub name: &'a str,
+    pub url: &'a str,
+    pub protocol: &'a str,
+    pub api_key: Option<&'a str>,
+    pub cf_bypass: bool,
+    pub priority: i32,
+}
+
 pub async fn insert_indexer(
     pool: &SqlitePool,
-    name: &str,
-    url: &str,
-    protocol: &str,
-    api_key: Option<&str>,
-    cf_bypass: bool,
-    priority: i32,
+    params: InsertIndexerParams<'_>,
 ) -> Result<i64, DbError> {
+    let InsertIndexerParams {
+        name,
+        url,
+        protocol,
+        api_key,
+        cf_bypass,
+        priority,
+    } = params;
     let result = sqlx::query_scalar::<_, i64>(
         "INSERT INTO indexers (name, url, protocol, api_key, cf_bypass, priority)
          VALUES (?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
## Summary

Clears the 5 pre-existing clippy errors on `main` blocking Phase 05e cutover arc (#200 caps + #201 lint-sync). All fixed at source via params-struct extraction rather than bare allows, per operator policy.

## Changes

| Site | Before | After |
|---|---|---|
| `aitesis/repo.rs:132` `update_status` (7 args) | raw signature | `UpdateStatusParams<'a>` struct — 5 call sites migrated |
| `zetesis/repo.rs:24` `insert_indexer` (7 args) | raw signature | `InsertIndexerParams<'a>` struct — 0 internal callers |
| `paroche/subsonic/types.rs:181` `album_xml_elem` (7 args) | raw signature | shared `AlbumElemParams<'a>` (`Copy`) — 3 call sites |
| `paroche/subsonic/types.rs:243` `album_json` (7 args) | raw signature | shares `AlbumElemParams<'a>` — 3 call sites (same loops as above) |
| `komide/service/mod.rs:41` unfulfilled `#[expect(clippy::type_complexity)]` | dead expect | removed (type no longer trips lint under new threshold) |

Both `album_xml_elem` and `album_json` take the same 7 AlbumID3 fields, so they share one `Copy` params struct — call sites build once, pass to both. Net: `+159/-121` across 8 files.

## Gate status (fresh run on HEAD)

```
PASS  cargo fmt
PASS  cargo check
PASS  cargo clippy        (all 5 target errors cleared)
PASS  cargo nextest
FAIL  kanon lint          (1 pre-existing SECURITY/insecure-transport
                           at komide:572 — out of scope, see #203)
```

`cargo clippy --workspace --all-features` still fails in `archon` on the sd-notify 0.5 breaking change — that's covered by the separate `fix/sd-notify-0.5` branch in flight, independent of this PR.

## Related

- Blocks: #200 (caps), #201 (lint-sync)
- Depends on: `fix/sd-notify-0.5` (for full workspace clippy pass)
- Tracked: #203 (insecure-transport false positive on `validate_url`, pre-existing)

## Test plan

- [x] `cargo check -p aitesis -p zetesis -p paroche -p komide --all-targets`
- [x] `cargo clippy --all-targets --all-features -p aitesis -p zetesis -p paroche -p komide -- -D warnings`
- [x] `cargo nextest run` (via `kanon gate`)
- [x] `cargo fmt --check`
- [ ] CI on `github/main` merge queue
