### PR TITLE
chore(lint): expand 14 inline TOML tables exceeding 80 cols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,18 @@ tokio           = { version = "1", features = ["full"] }
 # ── HTTP server ────────────────────────────────────────────────────────────────
 axum            = { version = "0.8", features = ["ws"] }
 tower           = "0.5"
-tower-http      = { version = "0.6", features = ["trace", "cors", "compression-full"] }
+tower-http = { version = "0.6", features = [
+  "trace",
+  "cors",
+  "compression-full",
+] }
 
 # ── HTTP client ────────────────────────────────────────────────────────────────
-reqwest         = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+  "stream",
+] }
 
 # ── Serialization ──────────────────────────────────────────────────────────────
 serde           = { version = "1", features = ["derive"] }
@@ -81,7 +89,12 @@ tracing             = "0.1"
 tracing-subscriber  = { version = "0.3", features = ["env-filter", "json"] }
 
 # ── Database ───────────────────────────────────────────────────────────────────
-sqlx            = { version = "0.8.6", features = ["sqlite", "runtime-tokio", "macros", "migrate"] }
+sqlx = { version = "0.8.6", features = [
+  "sqlite",
+  "runtime-tokio",
+  "macros",
+  "migrate",
+] }
 
 # ── Auth ───────────────────────────────────────────────────────────────────────
 jsonwebtoken    = { version = "10", features = ["rust_crypto"] }
@@ -119,7 +132,10 @@ fast_image_resize   = "6.0"
 
 # ── QUIC transport ─────────────────────────────────────────────────────────────
 quinn           = "0.11"
-rustls          = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rustls = { version = "0.23", default-features = false, features = [
+  "ring",
+  "std",
+] }
 rcgen           = { version = "0.14", features = ["pem"] }
 
 # ── mDNS discovery ────────────────────────────────────────────────────────────

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -15,7 +15,13 @@ epignosis.workspace = true
 kritike.workspace = true
 axum.workspace = true
 tower.workspace = true
-tower-http = { version = "0.6", features = ["trace", "cors", "compression-full", "fs", "timeout"] }
+tower-http = { version = "0.6", features = [
+  "trace",
+  "cors",
+  "compression-full",
+  "fs",
+  "timeout",
+] }
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/syndesis/Cargo.toml
+++ b/crates/syndesis/Cargo.toml
@@ -16,7 +16,10 @@ quinn.workspace = true
 rand.workspace = true
 rand_core.workspace = true
 rcgen.workspace = true
-rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
+rustls = { version = "0.23", default-features = false, features = [
+  "std",
+  "ring",
+] }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/syndesmos/Cargo.toml
+++ b/crates/syndesmos/Cargo.toml
@@ -21,4 +21,8 @@ jiff.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
+tokio = { workspace = true, features = [
+  "rt-multi-thread",
+  "macros",
+  "test-util",
+] }

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -16,7 +16,10 @@ dioxus = { version = "0.7", features = ["desktop", "router"] }
 tokio = { version = "1", features = ["full"] }
 
 # HTTP client
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -7,12 +7,30 @@ all-features = false
 
 [advisories]
 ignore = [
-    { id = "RUSTSEC-2023-0071", reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use" },
-    { id = "RUSTSEC-2025-0012", reason = "backoff unmaintained — transitive dep via librqbit" },
-    { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol" },
-    { id = "RUSTSEC-2025-0060", reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper" },
-    { id = "RUSTSEC-2024-0384", reason = "instant unmaintained — transitive dep via backoff/librqbit, no alternative" },
-    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis" },
+    {
+      id = "RUSTSEC-2023-0071",
+      reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use",
+    },
+    {
+      id = "RUSTSEC-2025-0012",
+      reason = "backoff unmaintained — transitive dep via librqbit",
+    },
+    {
+      id = "RUSTSEC-2025-0141",
+      reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol",
+    },
+    {
+      id = "RUSTSEC-2025-0060",
+      reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper",
+    },
+    {
+      id = "RUSTSEC-2024-0384",
+      reason = "instant unmaintained — transitive dep via backoff/librqbit, no alternative",
+    },
+    {
+      id = "RUSTSEC-2024-0436",
+      reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis",
+    },
 ]
 
 [licenses]


### PR DESCRIPTION
Pure reformat. Part of the 77-warning cleanup unblocking 05e cutover gate.

## Changes
- 4 workspace Cargo.toml sites (lines 64, 67, 84, 122)
- 4 per-crate Cargo.toml sites (paroche, syndesis, syndesmos, theatron/desktop)
- 6 deny.toml sites ([licenses]/[bans])

No semantic change.