### PR TITLE
fix(lint): add #[non_exhaustive] to 44 public enums + wildcard arms

### DIFF
--- a/crates/aitesis/src/error.rs
+++ b/crates/aitesis/src/error.rs
@@ -5,6 +5,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum AitesisError {
     #[snafu(display("request LIMIT exceeded"))]
     RequestLimitExceeded {

--- a/crates/aitesis/src/types.rs
+++ b/crates/aitesis/src/types.rs
@@ -77,6 +77,7 @@ pub struct CreateRequestInput {
 
 /// Role of a user within the household — determines auto-approval and limit exemptions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum UserRole {
     Admin,
     Member,

--- a/crates/akouo-core/src/gapless/mod.rs
+++ b/crates/akouo-core/src/gapless/mod.rs
@@ -31,6 +31,7 @@ impl Default for TransitionMode {
 
 /// Which end of the frame buffer to trim encoder delay FROM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TrimPosition {
     /// Trim encoder priming samples FROM the start of the track.
     Start,

--- a/crates/apotheke/src/error.rs
+++ b/crates/apotheke/src/error.rs
@@ -2,6 +2,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum DbError {
     #[snafu(display("database pool initialization failed: {source}"))]
     PoolInit {

--- a/crates/apotheke/src/repo/play_history/mod.rs
+++ b/crates/apotheke/src/repo/play_history/mod.rs
@@ -10,6 +10,7 @@ use crate::error::{DbError, QuerySnafu};
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PlaySource {
     Local,
     Subsonic,

--- a/crates/ergasia/src/error.rs
+++ b/crates/ergasia/src/error.rs
@@ -5,6 +5,7 @@ use themelion::ids::DownloadId;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum ErgasiaError {
     #[snafu(display("failed to initialize librqbit session"))]
     SessionInit {

--- a/crates/exousia/src/error.rs
+++ b/crates/exousia/src/error.rs
@@ -2,6 +2,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum ExousiaError {
     #[snafu(display("invalid credentials"))]
     InvalidCredentials {

--- a/crates/exousia/src/middleware.rs
+++ b/crates/exousia/src/middleware.rs
@@ -25,6 +25,7 @@ fn correlation_id() -> String {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum AuthMethod {
     Bearer,
     ApiKey,

--- a/crates/horismos/src/error.rs
+++ b/crates/horismos/src/error.rs
@@ -2,6 +2,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum HorismosError {
     #[snafu(display("configuration parse error: {source}"))]
     ConfigParse {

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -60,6 +60,7 @@ impl Default for ParocheConfig {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum WatcherMode {
     #[default]
     Auto,
@@ -69,6 +70,7 @@ pub enum WatcherMode {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum MediaType {
     #[default]
     Music,

--- a/crates/kathodos/src/alias.rs
+++ b/crates/kathodos/src/alias.rs
@@ -7,6 +7,7 @@ use crate::sanitize::sanitize_component as sanitize_path_segment;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum AliasError {
     #[snafu(display("alias '{alias}' conflicts with real directory at {path:?}"))]
     ConflictsWithDirectory {

--- a/crates/kathodos/src/error.rs
+++ b/crates/kathodos/src/error.rs
@@ -21,6 +21,7 @@ unsafe impl Sync for EpignosisError {}
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum TaxisError {
     #[snafu(display("scanner init failed: {source}"))]
     ScannerInit {

--- a/crates/kathodos/src/import/conflict.rs
+++ b/crates/kathodos/src/import/conflict.rs
@@ -5,6 +5,7 @@ use crate::error::TaxisError;
 pub(crate) const DEFAULT_MAX_SUFFIX: usize = 99;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConflictOutcome {
     /// Target path does not exist — proceed as-is.
     Clear(PathBuf),

--- a/crates/kathodos/src/import/fileops.rs
+++ b/crates/kathodos/src/import/fileops.rs
@@ -133,6 +133,7 @@ fn is_cross_device(e: &std::io::Error) -> bool {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FileOpResult {
     Hardlinked,
     Copied,

--- a/crates/kathodos/src/import/identify.rs
+++ b/crates/kathodos/src/import/identify.rs
@@ -7,6 +7,13 @@ pub fn resolve_media_type(lib_type: &LibMediaType) -> MediaType {
         LibMediaType::Music => MediaType::Music,
         LibMediaType::Video => MediaType::Movie,
         LibMediaType::Book => MediaType::Book,
+        _ => unreachable!(
+            "unhandled horismos::MediaType variant in resolve_media_type — \
+             was a new variant added without updating this matcher? \
+             at {}:{}",
+            file!(),
+            line!()
+        ),
     }
 }
 

--- a/crates/kathodos/src/import/mod.rs
+++ b/crates/kathodos/src/import/mod.rs
@@ -28,6 +28,7 @@ pub struct ImportSource {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ImportOrigin {
     Scanner,
     Download {
@@ -47,6 +48,7 @@ pub struct ImportResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ImportOperation {
     Added,
     Upgraded,

--- a/crates/kathodos/src/import/template.rs
+++ b/crates/kathodos/src/import/template.rs
@@ -58,6 +58,7 @@ fn valid_tokens(media_type: MediaType) -> &'static [&'static str] {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum TemplateSegment {
     Literal(String),
     Token {

--- a/crates/kathodos/src/scanner/watcher.rs
+++ b/crates/kathodos/src/scanner/watcher.rs
@@ -13,11 +13,13 @@ const NETWORK_FS_TYPES: &[&str] = &["nfs", "nfs4", "cifs", "smbfs", "smb", "fuse
 
 /// Runtime watcher mode after auto-detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ActiveWatcherMode {
     Inotify,
     Poll,
 }
 
+#[non_exhaustive]
 pub enum AnyWatcher {
     Recommended(RecommendedWatcher),
     Poll(PollWatcher),
@@ -44,6 +46,13 @@ pub fn detect_watcher_mode_at(
                 ActiveWatcherMode::Inotify
             }
         }
+        _ => unreachable!(
+            "unhandled horismos::WatcherMode variant in detect_watcher_mode_at — \
+             was a new variant added without updating this matcher? \
+             at {}:{}",
+            file!(),
+            line!()
+        ),
     }
 }
 

--- a/crates/kathodos/src/sidecar.rs
+++ b/crates/kathodos/src/sidecar.rs
@@ -9,6 +9,7 @@ use snafu::{ResultExt, Snafu};
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum SidecarError {
     #[snafu(display("failed to read sidecar {path:?}: {source}"))]
     Read {

--- a/crates/kathodos/src/template.rs
+++ b/crates/kathodos/src/template.rs
@@ -14,6 +14,7 @@ use crate::sanitize::sanitize_component;
 /// `[{YYYY}] {Title}` without any type annotation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ReleaseType {
     /// Standard studio album — no type tag in the directory name.
     Album,

--- a/crates/komide/src/error.rs
+++ b/crates/komide/src/error.rs
@@ -3,6 +3,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum KomideError {
     #[snafu(display("feed parse failed: {source}"))]
     FeedParse {

--- a/crates/komide/src/fetch.rs
+++ b/crates/komide/src/fetch.rs
@@ -3,6 +3,7 @@ use snafu::ResultExt;
 
 use crate::error::{EpisodeDownloadSnafu, EpisodeIoSnafu, FeedFetchSnafu, KomideError};
 
+#[non_exhaustive]
 pub enum FetchResult {
     Content {
         bytes: Vec<u8>,

--- a/crates/kritike/src/error.rs
+++ b/crates/kritike/src/error.rs
@@ -3,6 +3,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum KritikeError {
     #[snafu(display("quality profile {id} not found"))]
     ProfileNotFound {

--- a/crates/paroche/src/error.rs
+++ b/crates/paroche/src/error.rs
@@ -18,6 +18,7 @@ fn new_correlation_id() -> String {
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum ParocheError {
     #[snafu(display("resource not found"))]
     NotFound,

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -31,6 +31,7 @@ pub type ServiceFut<T> = Pin<Box<dyn Future<Output = Result<T, ServiceError>> + 
 
 /// Error type returned by acquisition service trait methods.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ServiceError {
     /// The backing service is not wired up.
     NotAvailable,

--- a/crates/paroche/src/subsonic/types.rs
+++ b/crates/paroche/src/subsonic/types.rs
@@ -13,6 +13,7 @@ pub const ERR_WRONG_CREDS: u32 = 40;
 pub const ERR_NOT_FOUND: u32 = 70;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Format {
     Xml,
     Json,

--- a/crates/prostheke/src/error.rs
+++ b/crates/prostheke/src/error.rs
@@ -5,6 +5,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum ProsthekeError {
     #[snafu(display("subtitle acquisition failed: {detail}"))]
     AcquisitionFailed {

--- a/crates/prostheke/src/providers/mod.rs
+++ b/crates/prostheke/src/providers/mod.rs
@@ -48,6 +48,7 @@ pub trait SubtitleProvider: Send + Sync {
 ///
 /// Add a new variant when introducing an additional subtitle source. Static
 /// dispatch avoids vtable overhead and dyn-compatibility concerns with async fn.
+#[non_exhaustive]
 pub enum Provider {
     OpenSubtitles(OpenSubtitlesProvider),
     Addic7ed(Addic7edProvider),

--- a/crates/syndesis/src/error.rs
+++ b/crates/syndesis/src/error.rs
@@ -3,6 +3,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum SyndesisError {
     #[snafu(display("protocol error: {reason}"))]
     Protocol {

--- a/crates/syndesis/src/protocol/frame.rs
+++ b/crates/syndesis/src/protocol/frame.rs
@@ -61,6 +61,7 @@ pub struct Command {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Frame {
     Audio(AudioFrame),
     ClockSync(ClockSync),

--- a/crates/syndesis/src/protocol/mod.rs
+++ b/crates/syndesis/src/protocol/mod.rs
@@ -7,6 +7,7 @@ pub const PROTOCOL_VERSION: u8 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum FrameType {
     AudioFrame = 0x01,
     ClockSync = 0x02,
@@ -34,6 +35,7 @@ impl FrameType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum AudioCodec {
     Flac = 0x01,
     Pcm = 0x02,
@@ -51,6 +53,7 @@ impl AudioCodec {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum DeviceState {
     Active = 0x01,
     Idle = 0x02,
@@ -72,6 +75,7 @@ impl DeviceState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum CommandKind {
     Pause = 0x01,
     Resume = 0x02,

--- a/crates/syndesis/src/protocol/session_frame.rs
+++ b/crates/syndesis/src/protocol/session_frame.rs
@@ -48,6 +48,7 @@ pub struct SessionRejected {
 /// Top-level protocol frame envelope.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum Frame {
     SessionInit(SessionInit),
     PairingChallenge(PairingChallenge),

--- a/crates/syndesis/src/server/auth.rs
+++ b/crates/syndesis/src/server/auth.rs
@@ -11,6 +11,7 @@ use crate::protocol::session_frame::{
 };
 
 /// Outcome of processing a `SessionInit` frame.
+#[non_exhaustive]
 pub enum SessionOutcome {
     /// Renderer authenticated with an existing API key.
     Authenticated(Renderer),

--- a/crates/syndesis/src/server/zone.rs
+++ b/crates/syndesis/src/server/zone.rs
@@ -24,6 +24,7 @@ struct ZoneMember {
 
 /// Streaming state for a zone.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ZonePlayState {
     Playing,
     Paused,

--- a/crates/syntaxis/src/error.rs
+++ b/crates/syntaxis/src/error.rs
@@ -6,6 +6,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum SyntaxisError {
     #[snafu(display("failed to enqueue download: {reason}"))]
     EnqueueFailed {

--- a/crates/theatron/core/src/api/client.rs
+++ b/crates/theatron/core/src/api/client.rs
@@ -7,6 +7,7 @@ use crate::types::{ApiResponse, ListParams, PaginatedResponse};
 
 /// Errors FROM API requests.
 #[derive(Debug, snafu::Snafu)]
+#[non_exhaustive]
 pub enum ApiError {
     /// HTTP request failed.
     #[snafu(display("request failed: {source}"))]

--- a/crates/theatron/core/src/types.rs
+++ b/crates/theatron/core/src/types.rs
@@ -48,6 +48,7 @@ impl Default for ListParams {
 
 /// Server health status.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConnectionStatus {
     /// Not connected to any server.
     #[default]

--- a/crates/themelion/src/error.rs
+++ b/crates/themelion/src/error.rs
@@ -1,6 +1,7 @@
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
+#[non_exhaustive]
 pub enum CommonError {
     #[snafu(display("invalid media type: {value}"))]
     InvalidMediaType {

--- a/crates/zetesis/src/error.rs
+++ b/crates/zetesis/src/error.rs
@@ -3,6 +3,7 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
+#[non_exhaustive]
 pub enum ZetesisError {
     #[snafu(display("HTTP request to indexer {url} failed"))]
     HttpRequest {


### PR DESCRIPTION
## Summary

- Adds `#[non_exhaustive]` to 44 public enums across 16 crates (aitesis, akouo-core, apotheke, ergasia, exousia, horismos, kathodos, komide, kritike, paroche, prostheke, syndesis, syntaxis, theatron-core, themelion, zetesis) to clear `RUST/non-exhaustive-enum` warnings
- Wildcard match arms added in 2 cross-crate sites that destructure `horismos::MediaType` and `horismos::WatcherMode` (both in kathodos)
- Within-crate matches unchanged — `#[non_exhaustive]` only forces wildcard arms across crate boundaries

## Rationale

Forward-compat hygiene for the internal closed-system workspace: adding a variant to a public enum later won't break downstream `match` exhaustiveness in semver-stable releases.

## Cross-crate break resolution

Both breaks hit `horismos::*` enums consumed from `kathodos`. Chose `unreachable!()` with file/line context — these are state-machine/classification enums where forgetting to update a downstream matcher is a programming error, not a runtime condition to silently absorb.

- `kathodos/src/import/identify.rs::resolve_media_type` — maps `horismos::MediaType` to `themelion::MediaType`; added `_ => unreachable!("unhandled horismos::MediaType variant in resolve_media_type — ...")`
- `kathodos/src/scanner/watcher.rs::detect_watcher_mode_at` — branches on `horismos::WatcherMode`; same pattern

## Scope

- Part of the harmonia 77-warning cleanup arc unblocking 05e cutover (non-exhaustive-enum slice)
- Does NOT touch: 16 unwrap, 14 TOML, 3 indexing-slicing sites (sibling agents)

## Test plan

- [x] `cargo check --workspace --tests --examples --benches` passes
- [x] `cargo nextest run --workspace` — 1075 tests pass (3 skipped)
- [x] `kanon lint . | grep RUST/non-exhaustive-enum` returns 0 matches (down from 44)
- [x] `kanon gate` expected to still fail on 33 pre-existing warnings (TOML, unwrap, indexing-slicing, clippy `too_many_arguments`, stale `clippy::type_complexity` expectations) — none introduced by this PR

## Gate state

`kanon gate --stamp` → FAIL on 2 pre-existing steps (`cargo clippy`, `kanon lint`), all tied to the other 33 warnings owned by sibling cleanup agents. Verified by git-stash comparison that every clippy/lint error reproduces on pristine branch base. No Gate-Passed trailer per task spec.