### PR TITLE
fix(lint): replace 3 direct indexing sites with .get() + None handling

### DIFF
--- a/crates/ergasia/src/extract/pipeline.rs
+++ b/crates/ergasia/src/extract/pipeline.rs
@@ -43,7 +43,9 @@ pub fn extract_archives(
 
     check_disk_space(download_path, output_dir)?;
 
-    let first_format = archives[0].1;
+    let first_format = archives.first().map(|(_, f)| *f).unwrap_or_else(|| {
+        unreachable!("archives is non-empty because of the is_empty() check above")
+    });
     let mut all_files = Vec::new();
 
     for (archive_path, format) in &archives {

--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -47,7 +47,18 @@ impl ErgasiaSession {
             disable_dht: false,
             disable_dht_persistence: false,
             persistence: Some(persistence),
-            listen_port_range: Some(config.listen_port_range[0]..config.listen_port_range[1]),
+            listen_port_range: Some(
+                config
+                    .listen_port_range
+                    .first()
+                    .copied()
+                    .unwrap_or_else(|| unreachable!("listen_port_range is [u16; 2]"))
+                    ..config
+                        .listen_port_range
+                        .get(1)
+                        .copied()
+                        .unwrap_or_else(|| unreachable!("listen_port_range is [u16; 2]")),
+            ),
             enable_upnp_port_forwarding: false,
             peer_opts: Some(peer_opts),
             ..Default::default()

--- a/crates/syndesis/src/clock/estimator.rs
+++ b/crates/syndesis/src/clock/estimator.rs
@@ -201,7 +201,9 @@ fn weighted_median(samples: &[&Sample]) -> i64 {
         return 0;
     }
     if samples.len() == 1 {
-        return samples[0].offset;
+        return samples.first().map(|s| s.offset).unwrap_or_else(|| {
+            unreachable!("samples has exactly 1 element because of the len() == 1 check above")
+        });
     }
 
     let mut entries: Vec<(i64, f64)> = samples


### PR DESCRIPTION
Replaces 3 `RUST/indexing-slicing` direct indexing calls with `.first()/.get()` + `unwrap_or_else(|| unreachable!(...))` to document the safety invariant explicitly rather than relying on silent panics.

**Sites fixed:**
- `ergasia/src/extract/pipeline.rs:46` — archives is non-empty (checked via `is_empty()` guard)
- `ergasia/src/session.rs:50` — `listen_port_range` is `[u16; 2]`, so indices 0 and 1 are always valid
- `syndesis/src/clock/estimator.rs:204` — samples has exactly 1 element (checked via `len() == 1` guard)

All affected crate tests pass. Gate fails only on the ~74 pre-existing warnings in other crates (aitesis/komide/zetesis/paroche) handled by parallel agents.

Part of the harmonia 77-warning cleanup arc unblocking 05e cutover.