### PR TITLE
fix(lint): clear 16 RUST/unwrap warnings

### DIFF
--- a/crates/paroche/src/subsonic/types.rs
+++ b/crates/paroche/src/subsonic/types.rs
@@ -47,40 +47,35 @@ fn json_base(status: &str) -> serde_json::Map<String, Value> {
     m
 }
 
-#[expect(
-    clippy::unwrap_used,
-    reason = "Response::builder with static 200 status and known-good headers is infallible; serde_json::to_string of json!() macro VALUES is infallible"
-)]
 pub fn respond_ok(format: Format, xml_inner: &str, json_key: Option<(&str, Value)>) -> Response {
     match format {
         Format::Xml => {
             let body = xml_wrapper("ok", xml_inner);
+            // INVARIANT: Response::builder with static status 200 and static Content-Type header is infallible.
             Response::builder()
                 .status(200)
                 .header("Content-Type", "text/xml; charset=UTF-8")
                 .body(Body::from(body))
-                .unwrap()
+                .expect("infallible: static 200 status + static Content-Type header") // INVARIANT: see comment above
         }
         Format::Json => {
             let mut obj = json_base("ok");
             if let Some((key, val)) = json_key {
                 obj.insert(key.to_string(), val);
             }
-            let body =
-                serde_json::to_string(&json!({ "subsonic-response": Value::Object(obj) })).unwrap();
+            // INVARIANT: serde_json::to_string of a json!() macro Value is infallible (no custom Serialize impls can fail).
+            let body = serde_json::to_string(&json!({ "subsonic-response": Value::Object(obj) }))
+                .expect("infallible: serde_json::to_string of json!() Value"); // INVARIANT: see comment above
+            // INVARIANT: Response::builder with static status 200 and static Content-Type header is infallible.
             Response::builder()
                 .status(200)
                 .header("Content-Type", "application/json")
                 .body(Body::from(body))
-                .unwrap()
+                .expect("infallible: static 200 status + static Content-Type header") // INVARIANT: see comment above
         }
     }
 }
 
-#[expect(
-    clippy::unwrap_used,
-    reason = "Response::builder with static 200 status and known-good headers is infallible; serde_json::to_string of json!() macro VALUES is infallible"
-)]
 pub fn respond_error(format: Format, code: u32, message: &str) -> Response {
     match format {
         Format::Xml => {
@@ -89,22 +84,25 @@ pub fn respond_error(format: Format, code: u32, message: &str) -> Response {
                 xml_escape(message)
             );
             let body = xml_wrapper("failed", &inner);
+            // INVARIANT: Response::builder with static status 200 and static Content-Type header is infallible.
             Response::builder()
                 .status(200)
                 .header("Content-Type", "text/xml; charset=UTF-8")
                 .body(Body::from(body))
-                .unwrap()
+                .expect("infallible: static 200 status + static Content-Type header") // INVARIANT: see comment above
         }
         Format::Json => {
             let mut obj = json_base("failed");
             obj.insert("error".into(), json!({ "code": code, "message": message }));
-            let body =
-                serde_json::to_string(&json!({ "subsonic-response": Value::Object(obj) })).unwrap();
+            // INVARIANT: serde_json::to_string of a json!() macro Value is infallible (no custom Serialize impls can fail).
+            let body = serde_json::to_string(&json!({ "subsonic-response": Value::Object(obj) }))
+                .expect("infallible: serde_json::to_string of json!() Value"); // INVARIANT: see comment above
+            // INVARIANT: Response::builder with static status 200 and static Content-Type header is infallible.
             Response::builder()
                 .status(200)
                 .header("Content-Type", "application/json")
                 .body(Body::from(body))
-                .unwrap()
+                .expect("infallible: static 200 status + static Content-Type header") // INVARIANT: see comment above
         }
     }
 }

--- a/crates/syndesis/src/client/buffer.rs
+++ b/crates/syndesis/src/client/buffer.rs
@@ -58,7 +58,11 @@ impl JitterBuffer {
             + self.depth_us;
 
         if now_us >= local_playout {
-            let frame = self.frames.remove(&seq).unwrap();
+            // INVARIANT: seq came from first_key_value() above; no intervening mutation removes it.
+            let frame = self
+                .frames
+                .remove(&seq)
+                .expect("key just read via first_key_value()"); // INVARIANT: see comment above
 
             if seq > self.next_sequence {
                 self.gap_count += seq - self.next_sequence;
@@ -104,8 +108,19 @@ impl JitterBuffer {
         if self.frames.len() < 2 {
             return 0;
         }
-        let first_ts = self.frames.values().next().unwrap().timestamp_us;
-        let last_ts = self.frames.values().next_back().unwrap().timestamp_us;
+        // INVARIANT: len() >= 2 (guarded above), so next() and next_back() both yield Some.
+        let first_ts = self
+            .frames
+            .values()
+            .next()
+            .expect("len >= 2 guard above") // INVARIANT: see comment above
+            .timestamp_us;
+        let last_ts = self
+            .frames
+            .values()
+            .next_back()
+            .expect("len >= 2 guard above") // INVARIANT: see comment above
+            .timestamp_us;
         ((last_ts.saturating_sub(first_ts)) / 1000) as u16
     }
 }

--- a/crates/syndesmos/src/retry.rs
+++ b/crates/syndesmos/src/retry.rs
@@ -64,7 +64,12 @@ impl CircuitBreaker {
 
     /// Returns true when the circuit is open and calls should be short-circuited.
     pub fn is_open(&self) -> bool {
-        let guard = self.tripped_at.lock().unwrap();
+        // INVARIANT: mutex poisoning is unrecoverable — a panicking holder would leave
+        // the breaker state inconsistent; propagate the panic rather than silently degrade.
+        let guard = self
+            .tripped_at
+            .lock()
+            .expect("mutex poisoning is unrecoverable"); // INVARIANT: see comment above
         match *guard {
             None => false,
             Some(tripped) => tripped.elapsed() < self.cooldown,
@@ -73,14 +78,22 @@ impl CircuitBreaker {
 
     pub fn on_success(&self) {
         self.consecutive_failures.store(0, Ordering::Relaxed);
-        let mut guard = self.tripped_at.lock().unwrap();
+        // INVARIANT: mutex poisoning is unrecoverable — see `is_open` above.
+        let mut guard = self
+            .tripped_at
+            .lock()
+            .expect("mutex poisoning is unrecoverable"); // INVARIANT: see comment above
         *guard = None;
     }
 
     pub fn on_failure(&self) {
         let prev = self.consecutive_failures.fetch_add(1, Ordering::Relaxed);
         if prev + 1 >= self.failure_threshold {
-            let mut guard = self.tripped_at.lock().unwrap();
+            // INVARIANT: mutex poisoning is unrecoverable — see `is_open` above.
+            let mut guard = self
+                .tripped_at
+                .lock()
+                .expect("mutex poisoning is unrecoverable"); // INVARIANT: see comment above
             if guard.is_none() {
                 *guard = Some(Instant::now());
             }
@@ -142,7 +155,9 @@ where
     }
 
     // All attempts exhausted.
-    Err(last_err.unwrap())
+    // INVARIANT: loop iterates `0..=RETRY_DELAYS.len()` (>= 1 iteration); every path either
+    // returns Ok early or sets `last_err = Some(err)`, so reaching here means last_err is Some.
+    Err(last_err.expect("loop set last_err on every non-Ok path")) // INVARIANT: see comment above
 }
 
 #[cfg(test)]

--- a/crates/syntaxis/src/queue.rs
+++ b/crates/syntaxis/src/queue.rs
@@ -90,16 +90,27 @@ impl PriorityQueue {
         }
         // WHY: Each tier is accessed independently to avoid holding mutable borrows
         // FROM the array iterator while calling self.insert().
+        // INVARIANT: `pos` in each branch came from `position()` on the same tier with
+        // no intervening mutation, so `remove(pos)` always yields Some.
         let found = if let Some(pos) = self.tier3.iter().position(|i| i.id == id) {
-            let mut item = self.tier3.remove(pos).unwrap();
+            let mut item = self
+                .tier3
+                .remove(pos)
+                .expect("pos from tier3.position() is in-bounds"); // INVARIANT: see comment above
             item.priority = new_priority;
             Some(item)
         } else if let Some(pos) = self.tier2.iter().position(|i| i.id == id) {
-            let mut item = self.tier2.remove(pos).unwrap();
+            let mut item = self
+                .tier2
+                .remove(pos)
+                .expect("pos from tier2.position() is in-bounds"); // INVARIANT: see comment above
             item.priority = new_priority;
             Some(item)
         } else if let Some(pos) = self.tier1.iter().position(|i| i.id == id) {
-            let mut item = self.tier1.remove(pos).unwrap();
+            let mut item = self
+                .tier1
+                .remove(pos)
+                .expect("pos from tier1.position() is in-bounds"); // INVARIANT: see comment above
             item.priority = new_priority;
             Some(item)
         } else {


### PR DESCRIPTION
## Summary

Clears all 16 RUST/unwrap warnings in harmonia library code. Part of the 77-warning cleanup arc unblocking 05e cutover. Sibling PRs address 14 TOML/inline-table-too-long, 3 RUST/indexing-slicing, and 44 RUST/non-exhaustive-enum warnings.

## Per-site decisions

| File:line | Decision | Rationale |
|---|---|---|
| paroche/src/subsonic/types.rs:58 | 4 expect+INVARIANT | Response::builder static 200 + static Content-Type infallible |
| paroche/src/subsonic/types.rs:69 | 4 expect+INVARIANT | serde_json::to_string of json!() Value infallible |
| paroche/src/subsonic/types.rs:75 | 4 expect+INVARIANT | Response::builder same invariant |
| paroche/src/subsonic/types.rs:94 | 4 expect+INVARIANT | Response::builder same invariant |
| paroche/src/subsonic/types.rs:103 | 4 expect+INVARIANT | serde_json::to_string same invariant |
| paroche/src/subsonic/types.rs:110 | 4 expect+INVARIANT | Response::builder same invariant |
| syndesis/src/client/buffer.rs:61 | 4 expect+INVARIANT | seq came from first_key_value() immediately above |
| syndesis/src/client/buffer.rs:107 | 4 expect+INVARIANT | len >= 2 guard above |
| syndesis/src/client/buffer.rs:108 | 4 expect+INVARIANT | len >= 2 guard above |
| syndesmos/src/retry.rs:67 | 5 mutex poison | mutex poisoning is unrecoverable |
| syndesmos/src/retry.rs:76 | 5 mutex poison | mutex poisoning is unrecoverable |
| syndesmos/src/retry.rs:83 | 5 mutex poison | mutex poisoning is unrecoverable |
| syndesmos/src/retry.rs:145 | 4 expect+INVARIANT | retry loop sets last_err on every non-Ok path |
| syntaxis/src/queue.rs:94 | 4 expect+INVARIANT | pos from tier3.position() in-bounds |
| syntaxis/src/queue.rs:98 | 4 expect+INVARIANT | pos from tier2.position() in-bounds |
| syntaxis/src/queue.rs:102 | 4 expect+INVARIANT | pos from tier1.position() in-bounds |

Zero `kanon:ignore` markers used. Every `.expect()` carries a line-local `// INVARIANT:` comment citing the specific code-visible invariant so both RUST/unwrap and RUST/expect rules skip cleanly.

## Verification

- `cargo check --workspace`: PASS
- `cargo nextest run --workspace`: 1075/1075 passed, 3 skipped
- `kanon lint`: 0 RUST/unwrap, 0 RUST/expect, 61 other pre-existing warnings (44 non-exhaustive-enum + 14 TOML + 3 indexing-slicing — sibling agents)
- `kanon gate --stamp`: FAILS on cargo clippy (pre-existing: komide type_complexity expect unfulfilled, zetesis too_many_arguments, paroche album_xml_elem/album_json too_many_arguments) and kanon lint (61 pre-existing warnings). Out of scope for this PR.

## Test plan

- [ ] Confirm CI picks up the push
- [ ] Verify no merge conflict with the 3 sibling warning-cleanup PRs (non-overlapping files)
- [ ] Merge after sibling PRs land to hit 0-warning state for 05e gate