### PR TITLE
chore: expand NOTICE to canonical form (AI training prohibition)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,15 +1,22 @@
 Copyright (C) 2024-2026 Cody Kickertz
 
 This software is licensed under the GNU Affero General Public License,
-version 3 or later (AGPL-3.0-or-later). See the LICENSE file for the
-full license text.
+version 3 or later (AGPL-3.0-or-later). See LICENSE for the full text.
 
-SUPPLEMENTAL NOTICE
+SUPPLEMENTAL NOTICE — AI TRAINING PROHIBITION
 
-In addition to the terms of the AGPL-3.0-or-later license, the following
-restriction applies:
+Use of this work or its contents, in whole or in part, to train, fine-tune,
+distill, or otherwise improve machine learning or artificial intelligence
+models is expressly prohibited without prior written consent from the
+copyright holder. This prohibition applies regardless of the method of
+access (direct download, API, web scraping, or any other means) and
+regardless of whether the training is performed by the person who accessed
+the work or by a third party.
 
-Use of this work or its contents, in whole or in part, to train,
-fine-tune, distill, or otherwise improve machine learning or artificial
-intelligence models is expressly prohibited without prior written consent
-from the copyright holder.
+This prohibition constitutes a machine-readable opt-out of text and data
+mining under Article 4 of the EU Directive on Copyright in the Digital
+Single Market (2019/790).
+
+This notice is supplemental to the AGPL-3.0 license. It does not modify
+the AGPL-3.0 text (which the FSF prohibits). It is an additional condition
+from the copyright holder exercising rights not addressed by the AGPL.


### PR DESCRIPTION
## Summary

Aligns this repo's NOTICE with the fleet-canonical shape: AGPL-3.0-or-later + supplemental AI-training-prohibition with machine-readable EU DSM Article 4 opt-out citation.

## Files

- `NOTICE` (update/create)

## Test plan

- [x] NOTICE-only change; no code build affected
- [ ] Forge CI green (4-stage fmt/check/clippy/nextest) — trivial pass
