### PR TITLE
fix(epignosis/openlibrary): lowercase `limit` param (Solr ignores uppercase)

### DIFF
--- a/crates/epignosis/src/providers/openlibrary.rs
+++ b/crates/epignosis/src/providers/openlibrary.rs
@@ -62,7 +62,7 @@ impl MetadataProvider for OpenLibraryProvider {
     #[instrument(skip(self), fields(provider = "openlibrary"))]
     async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
         let url = format!("{BASE_URL}/search.json");
-        let mut params = vec![("title", query.title.as_str()), ("LIMIT", "10")];
+        let mut params = vec![("title", query.title.as_str()), ("limit", "10")];
         let author_str;
         if let Some(artist) = &query.artist {
             author_str = artist.clone();


### PR DESCRIPTION
## Summary

Open Library's Solr backend treats query parameter names as case-sensitive. The existing code at `crates/epignosis/src/providers/openlibrary.rs:65` passed `"LIMIT"` (uppercase); Solr silently drops unknown parameters and returns its default page size instead of the requested 10. Every `search()` call was over-fetching.

## Finding source

Research report for issue #210 at `/tmp/research-harmonia-210-ebook-metadata.md` called this out as a real pre-existing bug worth fixing inline during the #210 expansion arc.

## Test plan

- [x] One-line casing fix
- [ ] Forge CI green

Related: #210
