### PR TITLE
feat(epignosis): add Google Books provider + OL edition-level fetch

### DIFF
--- a/crates/epignosis/src/identity.rs
+++ b/crates/epignosis/src/identity.rs
@@ -24,6 +24,7 @@ pub struct EmbeddedTags {
     pub isrc: Option<String>,
     pub mb_recording_id: Option<String>,
     pub mb_release_id: Option<String>,
+    pub isbn: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/epignosis/src/providers/audnexus.rs
+++ b/crates/epignosis/src/providers/audnexus.rs
@@ -58,14 +58,24 @@ struct AudnexusSeries {
 
 #[derive(Debug, Deserialize)]
 struct AudnexusChaptersResponse {
-    // Retained for forward-compat deserialization; not consumed by enrichment logic.
-    #[allow(dead_code)]
+    // Deserialization-only fields: exercised by parser round-trip tests below,
+    // so the dead_code expect is gated on non-test builds.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "parser round-trip tests use this field")
+    )]
     asin: String,
     #[serde(rename = "brandIntroDurationMs")]
-    #[allow(dead_code)]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "parser round-trip tests use this field")
+    )]
     brand_intro_duration_ms: Option<u64>,
     #[serde(rename = "brandOutroDurationMs")]
-    #[allow(dead_code)]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "parser round-trip tests use this field")
+    )]
     brand_outro_duration_ms: Option<u64>,
     chapters: Option<Vec<AudnexusChapter>>,
 }
@@ -373,6 +383,7 @@ mod tests {
         let resp: AudnexusChaptersResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.asin, "B002V1CBBG");
         assert_eq!(resp.brand_intro_duration_ms, Some(2000));
+        assert_eq!(resp.brand_outro_duration_ms, Some(1500));
         let chapters = resp.chapters.as_deref().unwrap();
         assert_eq!(chapters.len(), 2);
         assert_eq!(chapters[0].title.as_deref(), Some("Part 1: Arrakis"));

--- a/crates/epignosis/src/providers/googlebooks.rs
+++ b/crates/epignosis/src/providers/googlebooks.rs
@@ -1,0 +1,424 @@
+use serde::Deserialize;
+use snafu::ResultExt;
+use tracing::instrument;
+
+use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
+
+const BASE_URL: &str = "https://www.googleapis.com/books/v1";
+
+pub struct GoogleBooksProvider {
+    client: reqwest::Client,
+    api_key: Option<String>,
+}
+
+impl GoogleBooksProvider {
+    pub fn new(client: reqwest::Client, api_key: Option<String>) -> Self {
+        Self { client, api_key }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GbSearchResponse {
+    items: Option<Vec<GbVolume>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GbVolume {
+    id: String,
+    #[serde(rename = "volumeInfo")]
+    volume_info: GbVolumeInfo,
+}
+
+#[derive(Debug, Deserialize)]
+struct GbVolumeInfo {
+    title: String,
+    authors: Option<Vec<String>>,
+    publisher: Option<String>,
+    #[serde(rename = "publishedDate")]
+    published_date: Option<String>,
+    description: Option<String>,
+    #[serde(rename = "industryIdentifiers")]
+    industry_identifiers: Option<Vec<GbIndustryIdentifier>>,
+    #[serde(rename = "pageCount")]
+    page_count: Option<i64>,
+    categories: Option<Vec<String>>,
+    language: Option<String>,
+    #[serde(rename = "imageLinks")]
+    image_links: Option<GbImageLinks>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GbIndustryIdentifier {
+    #[serde(rename = "type")]
+    type_: String,
+    identifier: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GbImageLinks {
+    #[serde(rename = "smallThumbnail")]
+    small_thumbnail: Option<String>,
+    thumbnail: Option<String>,
+}
+
+impl MetadataProvider for GoogleBooksProvider {
+    fn name(&self) -> &str {
+        "google_books"
+    }
+
+    #[instrument(skip(self), fields(provider = "google_books"))]
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
+        let mut q_parts = Vec::new();
+
+        if let Some(ref isbn) = query.isbn {
+            q_parts.push(format!("isbn:{isbn}"));
+        } else {
+            q_parts.push(format!("intitle:{}", query.title));
+            if let Some(ref artist) = query.artist {
+                q_parts.push(format!("inauthor:{artist}"));
+            }
+        }
+
+        let q = q_parts.join("+");
+        let mut params = vec![("q", q.as_str()), ("maxResults", "10")];
+
+        let key_str;
+        if let Some(ref key) = self.api_key {
+            key_str = key.clone();
+            params.push(("key", &key_str));
+        }
+
+        let url = format!("{BASE_URL}/volumes");
+        let response =
+            self.client
+                .get(&url)
+                .query(&params)
+                .send()
+                .await
+                .context(ProviderRequestSnafu {
+                    provider: "google_books",
+                })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "google_books",
+        })?;
+
+        let parsed: GbSearchResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "google_books",
+        })?;
+
+        let results = parsed
+            .items
+            .unwrap_or_default()
+            .into_iter()
+            .map(|item| {
+                let artist = item
+                    .volume_info
+                    .authors
+                    .as_deref()
+                    .and_then(|a| a.first())
+                    .cloned();
+
+                let year = item
+                    .volume_info
+                    .published_date
+                    .as_deref()
+                    .and_then(|d| d.split('-').next())
+                    .and_then(|y| y.parse().ok());
+
+                let isbn_10 = item
+                    .volume_info
+                    .industry_identifiers
+                    .as_ref()
+                    .and_then(|ids| {
+                        ids.iter()
+                            .find(|id| id.type_ == "ISBN_10")
+                            .map(|id| id.identifier.clone())
+                    });
+
+                let isbn_13 = item
+                    .volume_info
+                    .industry_identifiers
+                    .as_ref()
+                    .and_then(|ids| {
+                        ids.iter()
+                            .find(|id| id.type_ == "ISBN_13")
+                            .map(|id| id.identifier.clone())
+                    });
+
+                let raw = serde_json::json!({
+                    "google_books_id": item.id,
+                    "isbn_10": isbn_10,
+                    "isbn_13": isbn_13,
+                });
+
+                ProviderResult {
+                    provider_id: item.id,
+                    title: item.volume_info.title,
+                    artist,
+                    year,
+                    score: 1.0,
+                    raw,
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip(self), fields(provider = "google_books"))]
+    async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
+        let mut params: Vec<(&str, &str)> = Vec::new();
+        let key_str;
+        if let Some(ref key) = self.api_key {
+            key_str = key.clone();
+            params.push(("key", &key_str));
+        }
+
+        let url = format!("{BASE_URL}/volumes/{provider_id}");
+        let response =
+            self.client
+                .get(&url)
+                .query(&params)
+                .send()
+                .await
+                .context(ProviderRequestSnafu {
+                    provider: "google_books",
+                })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "google_books",
+        })?;
+
+        let volume: GbVolume = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "google_books",
+        })?;
+
+        let info = volume.volume_info;
+
+        let artist = info.authors.as_deref().and_then(|a| a.first()).cloned();
+
+        let year = info
+            .published_date
+            .as_deref()
+            .and_then(|d| d.split('-').next())
+            .and_then(|y| y.parse().ok());
+
+        let isbn_10 = info.industry_identifiers.as_ref().and_then(|ids| {
+            ids.iter()
+                .find(|id| id.type_ == "ISBN_10")
+                .map(|id| id.identifier.clone())
+        });
+
+        let isbn_13 = info.industry_identifiers.as_ref().and_then(|ids| {
+            ids.iter()
+                .find(|id| id.type_ == "ISBN_13")
+                .map(|id| id.identifier.clone())
+        });
+
+        let image_url = info.image_links.as_ref().and_then(|img| {
+            img.thumbnail
+                .clone()
+                .or_else(|| img.small_thumbnail.clone())
+        });
+
+        // Only canonical fields — never cache raw Google Books JSON in sidecars.
+        let extra = serde_json::json!({
+            "description": info.description,
+            "language": info.language,
+            "page_count": info.page_count,
+            "publisher": info.publisher,
+            "published_date": info.published_date,
+            "subjects": info.categories.unwrap_or_default(),
+            "image_url": image_url,
+            "isbn_10": isbn_10,
+            "isbn_13": isbn_13,
+            "google_books_id": volume.id,
+        });
+
+        Ok(ProviderMetadata {
+            provider_id: volume.id,
+            title: info.title,
+            artist,
+            year,
+            extra,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_volume_full_fields() {
+        let json = r#"{
+            "id": "abc123",
+            "volumeInfo": {
+                "title": "Dune",
+                "subtitle": "Book One",
+                "authors": ["Frank Herbert"],
+                "publisher": "Ace",
+                "publishedDate": "1990-09-01",
+                "description": "A science fiction epic.",
+                "industryIdentifiers": [
+                    {"type": "ISBN_13", "identifier": "9780441013593"},
+                    {"type": "ISBN_10", "identifier": "0441013597"}
+                ],
+                "pageCount": 896,
+                "categories": ["Fiction", "Science Fiction"],
+                "language": "en",
+                "imageLinks": {
+                    "smallThumbnail": "http://example.com/small.jpg",
+                    "thumbnail": "http://example.com/thumb.jpg"
+                }
+            }
+        }"#;
+
+        let volume: GbVolume = serde_json::from_str(json).unwrap();
+        assert_eq!(volume.id, "abc123");
+        assert_eq!(volume.volume_info.title, "Dune");
+        assert_eq!(volume.volume_info.publisher.as_deref(), Some("Ace"));
+        let authors = volume.volume_info.authors.as_deref().unwrap();
+        assert_eq!(authors[0], "Frank Herbert");
+        assert_eq!(volume.volume_info.page_count, Some(896));
+        assert_eq!(volume.volume_info.language.as_deref(), Some("en"));
+        let ids = volume.volume_info.industry_identifiers.as_deref().unwrap();
+        assert_eq!(ids[0].type_, "ISBN_13");
+        assert_eq!(ids[0].identifier, "9780441013593");
+        let img = volume.volume_info.image_links.as_ref().unwrap();
+        assert_eq!(
+            img.thumbnail.as_deref(),
+            Some("http://example.com/thumb.jpg")
+        );
+    }
+
+    #[test]
+    fn parse_volume_minimal_fields() {
+        let json = r#"{
+            "id": "xyz789",
+            "volumeInfo": {
+                "title": "Unknown Book"
+            }
+        }"#;
+
+        let volume: GbVolume = serde_json::from_str(json).unwrap();
+        assert_eq!(volume.id, "xyz789");
+        assert_eq!(volume.volume_info.title, "Unknown Book");
+        assert!(volume.volume_info.authors.is_none());
+        assert!(volume.volume_info.description.is_none());
+        assert!(volume.volume_info.image_links.is_none());
+    }
+
+    #[test]
+    fn parse_search_response_with_items() {
+        let json = r#"{
+            "items": [
+                {
+                    "id": "abc123",
+                    "volumeInfo": {
+                        "title": "Dune",
+                        "authors": ["Frank Herbert"],
+                        "publishedDate": "1990"
+                    }
+                }
+            ]
+        }"#;
+
+        let resp: GbSearchResponse = serde_json::from_str(json).unwrap();
+        let items = resp.items.as_deref().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "abc123");
+    }
+
+    #[test]
+    fn parse_search_response_empty_items() {
+        let json = r#"{"items": []}"#;
+        let resp: GbSearchResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.items.as_deref().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn parse_search_response_null_items() {
+        let json = r#"{}"#;
+        let resp: GbSearchResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.items.is_none());
+    }
+
+    #[test]
+    fn malformed_volume_json_fails_to_parse() {
+        let json = r#"{"id": "abc123"}"#; // missing volumeInfo
+        let result = serde_json::from_str::<GbVolume>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extra_fields_are_ignored() {
+        let json = r#"{
+            "id": "abc123",
+            "volumeInfo": {
+                "title": "Future Book",
+                "unknownField": "value"
+            }
+        }"#;
+        let result = serde_json::from_str::<GbVolume>(json);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn isbn_extraction_from_identifiers() {
+        let json = r#"{
+            "id": "abc123",
+            "volumeInfo": {
+                "title": "Dune",
+                "industryIdentifiers": [
+                    {"type": "ISBN_13", "identifier": "9780441013593"},
+                    {"type": "ISBN_10", "identifier": "0441013597"}
+                ]
+            }
+        }"#;
+
+        let volume: GbVolume = serde_json::from_str(json).unwrap();
+        let isbn_13 = volume
+            .volume_info
+            .industry_identifiers
+            .as_ref()
+            .and_then(|ids| {
+                ids.iter()
+                    .find(|id| id.type_ == "ISBN_13")
+                    .map(|id| id.identifier.clone())
+            });
+        let isbn_10 = volume
+            .volume_info
+            .industry_identifiers
+            .as_ref()
+            .and_then(|ids| {
+                ids.iter()
+                    .find(|id| id.type_ == "ISBN_10")
+                    .map(|id| id.identifier.clone())
+            });
+        assert_eq!(isbn_13, Some("9780441013593".to_string()));
+        assert_eq!(isbn_10, Some("0441013597".to_string()));
+    }
+
+    #[test]
+    fn year_extracted_from_published_date() {
+        let json = r#"{
+            "id": "abc123",
+            "volumeInfo": {
+                "title": "Dune",
+                "publishedDate": "1990-09-01"
+            }
+        }"#;
+
+        let volume: GbVolume = serde_json::from_str(json).unwrap();
+        let year: Option<u32> = volume
+            .volume_info
+            .published_date
+            .as_deref()
+            .and_then(|d| d.split('-').next())
+            .and_then(|y| y.parse().ok());
+        assert_eq!(year, Some(1990));
+    }
+}

--- a/crates/epignosis/src/providers/mod.rs
+++ b/crates/epignosis/src/providers/mod.rs
@@ -6,6 +6,7 @@ use crate::error::EpignosisError;
 pub mod acoustid;
 pub mod audnexus;
 pub mod comicvine;
+pub mod googlebooks;
 pub mod itunes;
 pub mod musicbrainz;
 pub mod openlibrary;
@@ -18,6 +19,7 @@ pub struct SearchQuery {
     pub title: String,
     pub artist: Option<String>,
     pub year: Option<u32>,
+    pub isbn: Option<String>,
     pub extra: Option<String>,
 }
 

--- a/crates/epignosis/src/providers/openlibrary.rs
+++ b/crates/epignosis/src/providers/openlibrary.rs
@@ -6,6 +6,7 @@ use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://openlibrary.org";
+const COVERS_URL: &str = "https://covers.openlibrary.org";
 
 pub struct OpenLibraryProvider {
     client: reqwest::Client,
@@ -14,6 +15,76 @@ pub struct OpenLibraryProvider {
 impl OpenLibraryProvider {
     pub fn new(client: reqwest::Client) -> Self {
         Self { client }
+    }
+
+    /// Fetch an edition by ISBN, OCLC, LCCN, or OLID.
+    ///
+    /// Open Library redirects `/isbn/{isbn}.json` to the canonical edition record.
+    #[instrument(skip(self), fields(provider = "openlibrary"))]
+    pub(crate) async fn fetch_edition(
+        &self,
+        key_or_isbn: &str,
+    ) -> Result<Option<OlEdition>, EpignosisError> {
+        let url = format!("{BASE_URL}/isbn/{key_or_isbn}.json");
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "openlibrary",
+            })?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "openlibrary",
+        })?;
+
+        let edition: OlEdition = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "openlibrary",
+        })?;
+
+        Ok(Some(edition))
+    }
+
+    #[instrument(skip(self), fields(provider = "openlibrary"))]
+    async fn fetch_work(&self, work_key: &str) -> Result<OlWork, EpignosisError> {
+        let url = format!("{BASE_URL}{work_key}.json");
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context(ProviderRequestSnafu {
+                provider: "openlibrary",
+            })?;
+
+        let text = response.text().await.context(ProviderRequestSnafu {
+            provider: "openlibrary",
+        })?;
+
+        let work: OlWork = serde_json::from_str(&text).context(ProviderParseSnafu {
+            provider: "openlibrary",
+        })?;
+
+        Ok(work)
+    }
+
+    /// Derive a cover URL from edition data, falling back to ISBN.
+    fn cover_url_for_edition(edition: &OlEdition) -> Option<String> {
+        if let Some(first_cover) = edition.covers.as_deref().and_then(|c| c.first()) {
+            return Some(format!("{COVERS_URL}/b/id/{first_cover}-L.jpg"));
+        }
+        if let Some(first_isbn_13) = edition.isbn_13.as_deref().and_then(|i| i.first()) {
+            return Some(format!("{COVERS_URL}/b/isbn/{first_isbn_13}-L.jpg"));
+        }
+        if let Some(first_isbn_10) = edition.isbn_10.as_deref().and_then(|i| i.first()) {
+            return Some(format!("{COVERS_URL}/b/isbn/{first_isbn_10}-L.jpg"));
+        }
+        None
     }
 }
 
@@ -28,6 +99,9 @@ struct OlSearchDoc {
     title: String,
     author_name: Option<Vec<String>>,
     first_publish_year: Option<u32>,
+    isbn: Option<Vec<String>>,
+    cover_i: Option<i64>,
+    edition_count: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -36,6 +110,32 @@ struct OlWork {
     title: String,
     description: Option<OlDescription>,
     subjects: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OlEdition {
+    key: String,
+    title: String,
+    isbn_10: Option<Vec<String>>,
+    isbn_13: Option<Vec<String>>,
+    publishers: Option<Vec<String>>,
+    publish_date: Option<String>,
+    number_of_pages: Option<i64>,
+    languages: Option<Vec<OlLanguageRef>>,
+    covers: Option<Vec<i64>>,
+    works: Option<Vec<OlWorkRef>>,
+    description: Option<OlDescription>,
+    subjects: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OlLanguageRef {
+    key: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OlWorkRef {
+    key: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -62,7 +162,14 @@ impl MetadataProvider for OpenLibraryProvider {
     #[instrument(skip(self), fields(provider = "openlibrary"))]
     async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
         let url = format!("{BASE_URL}/search.json");
-        let mut params = vec![("title", query.title.as_str()), ("limit", "10")];
+        let mut params = vec![
+            ("title", query.title.as_str()),
+            ("limit", "10"),
+            (
+                "fields",
+                "key,title,author_name,first_publish_year,isbn,cover_i,edition_count",
+            ),
+        ];
         let author_str;
         if let Some(artist) = &query.artist {
             author_str = artist.clone();
@@ -92,7 +199,12 @@ impl MetadataProvider for OpenLibraryProvider {
             .into_iter()
             .map(|doc| {
                 let artist = doc.author_name.as_deref().and_then(|a| a.first()).cloned();
-                let raw = serde_json::json!({ "ol_key": doc.key });
+                let raw = serde_json::json!({
+                    "ol_key": doc.key,
+                    "isbn": doc.isbn,
+                    "cover_i": doc.cover_i,
+                    "edition_count": doc.edition_count,
+                });
                 ProviderResult {
                     provider_id: doc.key,
                     title: doc.title,
@@ -109,37 +221,299 @@ impl MetadataProvider for OpenLibraryProvider {
 
     #[instrument(skip(self), fields(provider = "openlibrary"))]
     async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
-        // provider_id is an OL key like "/works/OL12345W"
-        let url = format!("{BASE_URL}{provider_id}.json");
-        let response = self
-            .client
-            .get(&url)
-            .send()
-            .await
-            .context(ProviderRequestSnafu {
-                provider: "openlibrary",
-            })?;
+        // provider_id is an OL key like "/works/OL12345W" or "/books/OL12345M"
+        let is_edition = provider_id.starts_with("/books/");
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "openlibrary",
-        })?;
+        let (work, edition) = if is_edition {
+            let edition = self
+                .fetch_edition(provider_id.trim_start_matches("/books/"))
+                .await?;
 
-        let work: OlWork = serde_json::from_str(&text).context(ProviderParseSnafu {
-            provider: "openlibrary",
-        })?;
+            let work = if let Some(ref ed) = edition {
+                if let Some(work_ref) = ed.works.as_deref().and_then(|w| w.first()) {
+                    self.fetch_work(&work_ref.key).await.ok()
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
 
-        let description = work.description.as_ref().map(|d| d.text().to_string());
+            (work, edition)
+        } else {
+            let work = self.fetch_work(provider_id).await?;
+
+            // Attempt to fetch the first edition for richer ISBN/publisher/page data.
+            // We don't have a direct edition key from a work search result, so this
+            // is best-effort.  In practice the work response is the primary source.
+            let edition = None;
+
+            (Some(work), edition)
+        };
+
+        let title = edition
+            .as_ref()
+            .map(|e| e.title.clone())
+            .or_else(|| work.as_ref().map(|w| w.title.clone()))
+            .unwrap_or_default();
+
+        let description = edition
+            .as_ref()
+            .and_then(|e| e.description.as_ref().map(|d| d.text().to_string()))
+            .or_else(|| {
+                work.as_ref()
+                    .and_then(|w| w.description.as_ref().map(|d| d.text().to_string()))
+            });
+
+        let subjects = edition
+            .as_ref()
+            .and_then(|e| e.subjects.clone())
+            .or_else(|| work.as_ref().and_then(|w| w.subjects.clone()))
+            .unwrap_or_default();
+
+        let year = edition.as_ref().and_then(|e| {
+            e.publish_date
+                .as_deref()
+                .and_then(|d| d.split('-').next())
+                .and_then(|y| y.parse().ok())
+        });
+
+        let publisher = edition
+            .as_ref()
+            .and_then(|e| e.publishers.as_deref().and_then(|p| p.first()).cloned());
+
+        let page_count = edition
+            .as_ref()
+            .and_then(|e| e.number_of_pages.map(|n| n as u32));
+
+        let language = edition.as_ref().and_then(|e| {
+            e.languages
+                .as_deref()
+                .and_then(|langs| langs.first())
+                .map(|l| l.key.trim_start_matches("/languages/").to_string())
+        });
+
+        let cover_url = edition.as_ref().and_then(Self::cover_url_for_edition);
+
+        let isbn_10 = edition
+            .as_ref()
+            .and_then(|e| e.isbn_10.as_deref().and_then(|i| i.first()).cloned());
+
+        let isbn_13 = edition
+            .as_ref()
+            .and_then(|e| e.isbn_13.as_deref().and_then(|i| i.first()).cloned());
+
+        let work_key = work.as_ref().map(|w| w.key.clone());
+        let edition_key = edition.as_ref().map(|e| e.key.clone());
+
         let extra = serde_json::json!({
             "description": description,
-            "subjects": work.subjects.unwrap_or_default(),
+            "subjects": subjects,
+            "publisher": publisher,
+            "publish_date": edition.as_ref().and_then(|e| e.publish_date.clone()),
+            "page_count": page_count,
+            "language": language,
+            "cover_url": cover_url,
+            "isbn_10": isbn_10,
+            "isbn_13": isbn_13,
+            "openlibrary_work_id": work_key,
+            "openlibrary_edition_id": edition_key,
         });
 
         Ok(ProviderMetadata {
-            provider_id: work.key,
-            title: work.title,
+            provider_id: provider_id.to_string(),
+            title,
             artist: None,
-            year: None,
+            year,
             extra,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_search_doc_full() {
+        let json = r#"{
+            "key": "/works/OL123W",
+            "title": "Dune",
+            "author_name": ["Frank Herbert"],
+            "first_publish_year": 1965,
+            "isbn": ["9780441013593", "0441013597"],
+            "cover_i": 12345,
+            "edition_count": 42
+        }"#;
+
+        let doc: OlSearchDoc = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.key, "/works/OL123W");
+        assert_eq!(doc.title, "Dune");
+        assert_eq!(doc.author_name.as_deref().unwrap()[0], "Frank Herbert");
+        assert_eq!(doc.first_publish_year, Some(1965));
+        let isbns = doc.isbn.as_deref().unwrap();
+        assert_eq!(isbns[0], "9780441013593");
+        assert_eq!(doc.cover_i, Some(12345));
+        assert_eq!(doc.edition_count, Some(42));
+    }
+
+    #[test]
+    fn parse_search_doc_minimal() {
+        let json = r#"{"key": "/works/OL456W", "title": "Sparse"}"#;
+        let doc: OlSearchDoc = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.key, "/works/OL456W");
+        assert_eq!(doc.title, "Sparse");
+        assert!(doc.author_name.is_none());
+        assert!(doc.isbn.is_none());
+    }
+
+    #[test]
+    fn parse_work_full() {
+        let json = r#"{
+            "key": "/works/OL123W",
+            "title": "Dune",
+            "description": "A desert planet...",
+            "subjects": ["Science Fiction", "Space Opera"]
+        }"#;
+
+        let work: OlWork = serde_json::from_str(json).unwrap();
+        assert_eq!(work.key, "/works/OL123W");
+        assert_eq!(work.title, "Dune");
+        let desc = work.description.as_ref().unwrap();
+        assert_eq!(desc.text(), "A desert planet...");
+        let subjects = work.subjects.as_deref().unwrap();
+        assert_eq!(subjects.len(), 2);
+    }
+
+    #[test]
+    fn parse_work_structured_description() {
+        let json = r#"{
+            "key": "/works/OL123W",
+            "title": "Dune",
+            "description": {"type": "text", "value": "Structured desc."}
+        }"#;
+
+        let work: OlWork = serde_json::from_str(json).unwrap();
+        let desc = work.description.as_ref().unwrap();
+        assert_eq!(desc.text(), "Structured desc.");
+    }
+
+    #[test]
+    fn parse_edition_full() {
+        let json = r#"{
+            "key": "/books/OL123M",
+            "title": "Dune",
+            "isbn_10": ["0441013597"],
+            "isbn_13": ["9780441013593"],
+            "publishers": ["Ace"],
+            "publish_date": "1990-09-01",
+            "number_of_pages": 896,
+            "languages": [{"key": "/languages/eng"}],
+            "covers": [12345],
+            "works": [{"key": "/works/OL123W"}],
+            "subjects": ["Fiction"]
+        }"#;
+
+        let edition: OlEdition = serde_json::from_str(json).unwrap();
+        assert_eq!(edition.key, "/books/OL123M");
+        assert_eq!(edition.isbn_13.as_deref().unwrap()[0], "9780441013593");
+        assert_eq!(edition.number_of_pages, Some(896));
+        let lang = edition.languages.as_deref().unwrap();
+        assert_eq!(lang[0].key, "/languages/eng");
+        let works = edition.works.as_deref().unwrap();
+        assert_eq!(works[0].key, "/works/OL123W");
+    }
+
+    #[test]
+    fn parse_edition_minimal() {
+        let json = r#"{"key": "/books/OL789M", "title": "Minimal"}"#;
+        let edition: OlEdition = serde_json::from_str(json).unwrap();
+        assert_eq!(edition.key, "/books/OL789M");
+        assert!(edition.isbn_13.is_none());
+        assert!(edition.covers.is_none());
+    }
+
+    #[test]
+    fn cover_url_from_cover_id() {
+        let edition = OlEdition {
+            key: "/books/OL123M".to_string(),
+            title: "Dune".to_string(),
+            isbn_10: None,
+            isbn_13: None,
+            publishers: None,
+            publish_date: None,
+            number_of_pages: None,
+            languages: None,
+            covers: Some(vec![12345]),
+            works: None,
+            description: None,
+            subjects: None,
+        };
+        let url = OpenLibraryProvider::cover_url_for_edition(&edition);
+        assert_eq!(
+            url,
+            Some("https://covers.openlibrary.org/b/id/12345-L.jpg".to_string())
+        );
+    }
+
+    #[test]
+    fn cover_url_fallback_to_isbn_13() {
+        let edition = OlEdition {
+            key: "/books/OL123M".to_string(),
+            title: "Dune".to_string(),
+            isbn_10: None,
+            isbn_13: Some(vec!["9780441013593".to_string()]),
+            publishers: None,
+            publish_date: None,
+            number_of_pages: None,
+            languages: None,
+            covers: None,
+            works: None,
+            description: None,
+            subjects: None,
+        };
+        let url = OpenLibraryProvider::cover_url_for_edition(&edition);
+        assert_eq!(
+            url,
+            Some("https://covers.openlibrary.org/b/isbn/9780441013593-L.jpg".to_string())
+        );
+    }
+
+    #[test]
+    fn cover_url_no_data_returns_none() {
+        let edition = OlEdition {
+            key: "/books/OL123M".to_string(),
+            title: "Dune".to_string(),
+            isbn_10: None,
+            isbn_13: None,
+            publishers: None,
+            publish_date: None,
+            number_of_pages: None,
+            languages: None,
+            covers: None,
+            works: None,
+            description: None,
+            subjects: None,
+        };
+        let url = OpenLibraryProvider::cover_url_for_edition(&edition);
+        assert!(url.is_none());
+    }
+
+    #[test]
+    fn malformed_json_fails_to_parse() {
+        let result = serde_json::from_str::<OlWork>(r#"{"key": "/works/OL123W"}"#);
+        // title is required
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extra_fields_ignored() {
+        let json = r#"{
+            "key": "/works/OL123W",
+            "title": "Dune",
+            "extra_field": "ignored"
+        }"#;
+        let result = serde_json::from_str::<OlWork>(json);
+        assert!(result.is_ok());
     }
 }

--- a/crates/epignosis/src/rate_limit.rs
+++ b/crates/epignosis/src/rate_limit.rs
@@ -57,6 +57,7 @@ pub struct ProviderQueues {
     pub tvdb: ProviderQueue,
     pub audnexus: ProviderQueue,
     pub openlibrary: ProviderQueue,
+    pub google_books: ProviderQueue,
     pub itunes: ProviderQueue,
     pub comicvine: ProviderQueue,
 }
@@ -70,6 +71,7 @@ impl ProviderQueues {
             tvdb: ProviderQueue::new(10, 1_000),        // 10 req/s
             audnexus: ProviderQueue::new(5, 1_000),     // 5 req/s
             openlibrary: ProviderQueue::new(10, 1_000), // 10 req/s
+            google_books: ProviderQueue::new(1, 1_000), // 1 req/s
             itunes: ProviderQueue::new(20, 60_000),     // 20 req/min
             comicvine: ProviderQueue::new(1, 1_000),    // 1 req/s
         }

--- a/crates/epignosis/src/resolver.rs
+++ b/crates/epignosis/src/resolver.rs
@@ -15,12 +15,13 @@ use crate::identity::{
 use crate::providers::acoustid::AcoustIdProvider;
 use crate::providers::audnexus::AudnexusProvider;
 use crate::providers::comicvine::ComicVineProvider;
+use crate::providers::googlebooks::GoogleBooksProvider;
 use crate::providers::itunes::ItunesProvider;
 use crate::providers::musicbrainz::MusicBrainzProvider;
 use crate::providers::openlibrary::OpenLibraryProvider;
 use crate::providers::tmdb::TmdbProvider;
 use crate::providers::tvdb::TvdbProvider;
-use crate::providers::{MetadataProvider, SearchQuery};
+use crate::providers::{MetadataProvider, ProviderResult, SearchQuery};
 use crate::rate_limit::ProviderQueues;
 
 /// Provider credentials supplied at construction time.
@@ -30,6 +31,7 @@ pub struct ProviderCredentials {
     pub tmdb_key: String,
     pub tvdb_key: String,
     pub comicvine_key: String,
+    pub google_books_key: Option<String>,
 }
 
 pub struct EpignosisService {
@@ -46,6 +48,7 @@ pub struct EpignosisService {
     tvdb: TvdbProvider,
     audnexus: AudnexusProvider,
     openlibrary: OpenLibraryProvider,
+    google_books: GoogleBooksProvider,
     itunes: ItunesProvider,
     comicvine: ComicVineProvider,
 }
@@ -68,6 +71,7 @@ impl EpignosisService {
         let tvdb = TvdbProvider::new(client.clone(), credentials.tvdb_key.clone());
         let audnexus = AudnexusProvider::new(client.clone());
         let openlibrary = OpenLibraryProvider::new(client.clone());
+        let google_books = GoogleBooksProvider::new(client.clone(), credentials.google_books_key);
         let itunes = ItunesProvider::new(client.clone());
         let comicvine = ComicVineProvider::new(client.clone(), credentials.comicvine_key.clone());
 
@@ -82,6 +86,7 @@ impl EpignosisService {
             tvdb,
             audnexus,
             openlibrary,
+            google_books,
             itunes,
             comicvine,
         }
@@ -103,16 +108,22 @@ impl EpignosisService {
     }
 
     fn build_query(item: &UnidentifiedItem) -> SearchQuery {
-        let (title, artist, year) = if let Some(tags) = &item.tags {
+        let (title, artist, year, isbn) = if let Some(tags) = &item.tags {
             (
                 tags.title
                     .clone()
                     .unwrap_or_else(|| item.filename_hint.clone().unwrap_or_default()),
                 tags.artist.clone().or_else(|| tags.album_artist.clone()),
                 tags.year,
+                tags.isbn.clone(),
             )
         } else {
-            (item.filename_hint.clone().unwrap_or_default(), None, None)
+            (
+                item.filename_hint.clone().unwrap_or_default(),
+                None,
+                None,
+                None,
+            )
         };
 
         SearchQuery {
@@ -120,8 +131,50 @@ impl EpignosisService {
             title,
             artist,
             year,
+            isbn,
             extra: None,
         }
+    }
+
+    /// Book-aware scoring: ISBN exact > title+author+year > title-only.
+    fn score_book_result(result: &ProviderResult, query: &SearchQuery) -> f64 {
+        // ISBN exact match
+        if let Some(ref query_isbn) = query.isbn {
+            let raw_isbns = result
+                .raw
+                .get("isbn")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>());
+            if let Some(ref isbns) = raw_isbns
+                && isbns.iter().any(|i| *i == query_isbn)
+            {
+                return 1.0;
+            }
+
+            let isbn_10 = result.raw.get("isbn_10").and_then(|v| v.as_str());
+            let isbn_13 = result.raw.get("isbn_13").and_then(|v| v.as_str());
+            if isbn_10 == Some(query_isbn) || isbn_13 == Some(query_isbn) {
+                return 1.0;
+            }
+        }
+
+        // title+author+year
+        let title_match =
+            !query.title.is_empty() && result.title.to_lowercase() == query.title.to_lowercase();
+        let author_match = result.artist.as_ref().map(|a| a.to_lowercase())
+            == query.artist.as_ref().map(|a| a.to_lowercase());
+        let year_match = result.year == query.year;
+
+        if title_match && author_match && year_match {
+            return 0.8;
+        }
+
+        // title-only
+        if title_match {
+            return 0.4;
+        }
+
+        0.2
     }
 }
 
@@ -153,6 +206,29 @@ impl MetadataResolver for EpignosisService {
                 });
             }
         };
+
+        // For books, try Google Books fallback if canonical provider returned nothing.
+        let results = if results.is_empty() && item.media_type == MediaType::Book {
+            tokio::select! {
+                result = self.search_google_books(&query) => result.unwrap_or_default(),
+                _ = ct.cancelled() => {
+                    return Err(EpignosisError::IdentityNotResolved {
+                        provider: provider_name.to_string(),
+                        query: query.title.clone(),
+                        location: snafu::location!(),
+                    });
+                }
+            }
+        } else {
+            results
+        };
+
+        let mut results = results;
+        if item.media_type == MediaType::Book {
+            for result in &mut results {
+                result.score = Self::score_book_result(result, &query);
+            }
+        }
 
         let best = results
             .into_iter()
@@ -282,6 +358,14 @@ impl EpignosisService {
         }
     }
 
+    async fn search_google_books(
+        &self,
+        query: &SearchQuery,
+    ) -> Result<Vec<crate::providers::ProviderResult>, EpignosisError> {
+        self.queues.google_books.acquire().await;
+        self.google_books.search(query).await
+    }
+
     async fn enrich_from_canonical(
         &self,
         identity: &MediaIdentity,
@@ -338,6 +422,7 @@ impl EpignosisService {
                     title: identity.canonical_title.clone(),
                     artist: identity.canonical_artist.clone(),
                     year: identity.year,
+                    isbn: None,
                     extra: None,
                 };
                 let results = self.openlibrary.search(&query).await.ok()?;
@@ -348,6 +433,15 @@ impl EpignosisService {
                     .await
                     .ok()?;
                 Some(("openlibrary".to_string(), meta.extra))
+            }
+            MediaType::Book => {
+                self.queues.google_books.acquire().await;
+                let meta = self
+                    .google_books
+                    .get_metadata(&identity.provider_id)
+                    .await
+                    .ok()?;
+                Some(("google_books".to_string(), meta.extra))
             }
             _ => None,
         }
@@ -420,5 +514,147 @@ mod tests {
             EpignosisService::canonical_provider_for(MediaType::News),
             "itunes"
         );
+    }
+
+    #[test]
+    fn book_score_isbn_exact_match() {
+        let query = SearchQuery {
+            media_type: MediaType::Book,
+            title: "Dune".to_string(),
+            artist: None,
+            year: None,
+            isbn: Some("9780441013593".to_string()),
+            extra: None,
+        };
+
+        let result = ProviderResult {
+            provider_id: "/works/OL123W".to_string(),
+            title: "Dune".to_string(),
+            artist: Some("Frank Herbert".to_string()),
+            year: Some(1965),
+            score: 1.0,
+            raw: serde_json::json!({
+                "isbn": ["9780441013593", "0441013597"],
+            }),
+        };
+
+        assert!((EpignosisService::score_book_result(&result, &query) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn book_score_isbn_13_field_match() {
+        let query = SearchQuery {
+            media_type: MediaType::Book,
+            title: "Dune".to_string(),
+            artist: None,
+            year: None,
+            isbn: Some("9780441013593".to_string()),
+            extra: None,
+        };
+
+        let result = ProviderResult {
+            provider_id: "abc123".to_string(),
+            title: "Dune".to_string(),
+            artist: Some("Frank Herbert".to_string()),
+            year: Some(1965),
+            score: 1.0,
+            raw: serde_json::json!({
+                "isbn_13": "9780441013593",
+            }),
+        };
+
+        assert!((EpignosisService::score_book_result(&result, &query) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn book_score_title_author_year_match() {
+        let query = SearchQuery {
+            media_type: MediaType::Book,
+            title: "Dune".to_string(),
+            artist: Some("Frank Herbert".to_string()),
+            year: Some(1965),
+            isbn: None,
+            extra: None,
+        };
+
+        let result = ProviderResult {
+            provider_id: "/works/OL123W".to_string(),
+            title: "Dune".to_string(),
+            artist: Some("Frank Herbert".to_string()),
+            year: Some(1965),
+            score: 1.0,
+            raw: serde_json::json!({}),
+        };
+
+        assert!((EpignosisService::score_book_result(&result, &query) - 0.8).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn book_score_title_only_match() {
+        let query = SearchQuery {
+            media_type: MediaType::Book,
+            title: "Dune".to_string(),
+            artist: None,
+            year: None,
+            isbn: None,
+            extra: None,
+        };
+
+        let result = ProviderResult {
+            provider_id: "/works/OL123W".to_string(),
+            title: "Dune".to_string(),
+            artist: Some("Different Author".to_string()),
+            year: Some(2000),
+            score: 1.0,
+            raw: serde_json::json!({}),
+        };
+
+        assert!((EpignosisService::score_book_result(&result, &query) - 0.4).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn book_score_no_match() {
+        let query = SearchQuery {
+            media_type: MediaType::Book,
+            title: "Dune".to_string(),
+            artist: None,
+            year: None,
+            isbn: None,
+            extra: None,
+        };
+
+        let result = ProviderResult {
+            provider_id: "/works/OL123W".to_string(),
+            title: "Foundation".to_string(),
+            artist: Some("Isaac Asimov".to_string()),
+            year: Some(1951),
+            score: 1.0,
+            raw: serde_json::json!({}),
+        };
+
+        assert!((EpignosisService::score_book_result(&result, &query) - 0.2).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn book_score_empty_title_never_exact() {
+        let query = SearchQuery {
+            media_type: MediaType::Book,
+            title: "".to_string(),
+            artist: None,
+            year: None,
+            isbn: None,
+            extra: None,
+        };
+
+        let result = ProviderResult {
+            provider_id: "/works/OL123W".to_string(),
+            title: "".to_string(),
+            artist: None,
+            year: None,
+            score: 1.0,
+            raw: serde_json::json!({}),
+        };
+
+        assert!((EpignosisService::score_book_result(&result, &query) - 0.2).abs() < f64::EPSILON);
     }
 }

--- a/crates/kathodos/src/sidecar.rs
+++ b/crates/kathodos/src/sidecar.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -97,6 +97,13 @@ pub struct BookSidecar {
     pub series: Option<String>,
     pub series_index: Option<f64>,
     pub goodreads_id: Option<String>,
+    pub language: Option<String>,
+    pub page_count: Option<u32>,
+    pub cover_path: Option<PathBuf>,
+    pub subjects: Option<Vec<String>>,
+    pub openlibrary_edition_id: Option<String>,
+    pub openlibrary_work_id: Option<String>,
+    pub google_books_id: Option<String>,
 }
 
 /// Sidecar for an audiobook directory (`audiobook.toml`).
@@ -244,6 +251,13 @@ mod tests {
             series: None,
             series_index: None,
             goodreads_id: Some("24113".into()),
+            language: Some("en".into()),
+            page_count: Some(777),
+            cover_path: Some(PathBuf::from("cover.jpg")),
+            subjects: Some(vec!["Mathematics".into(), "Philosophy".into()]),
+            openlibrary_edition_id: Some("OL123M".into()),
+            openlibrary_work_id: Some("OL456W".into()),
+            google_books_id: None,
         };
 
         write_sidecar(&path, &original).unwrap();


### PR DESCRIPTION
Implements the v1 metadata layer for ebooks per #210 research.

Open Library primary (CC0 data), Google Books fallback (attribution only; hotlink covers, do not cache JSON).

BookSidecar gains 7 additive Option<T> fields for edition + work identifiers, language, page_count, subjects, cover_path.
ProviderCredentials gains google_books_key.

Series ordering, cover caching, and sidecar v2 marker are deferred per research sections 4-5.

Closes #210