### PR TITLE
chore(security): allowlist HIGH (c) false-positives in .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -32,4 +32,16 @@ paths = [
   '''vendor/''',
   '''\.gitleaks\.toml''',
   '''legacy/''',
+  '''crates/archon/src/render/credentials\.rs''', # WHY: H1/H16 - test-fixture; see small-repo-security-triage-2026-05-21.md
+  '''crates/horismos/src/diff\.rs''', # WHY: H2 - test-fixture; see small-repo-security-triage-2026-05-21.md
+  '''crates/exousia/src/lib\.rs''', # WHY: H3 - test-fixture; see small-repo-security-triage-2026-05-21.md
+  '''crates/exousia/src/middleware\.rs''', # WHY: H4 - test-fixture; see small-repo-security-triage-2026-05-21.md
+  '''crates/paroche/src/lib\.rs''', # WHY: H5 - test-fixture; see small-repo-security-triage-2026-05-21.md
+  '''crates/archon/tests/acquisition_integration\.rs''', # WHY: H6 - integration-test fixture; see small-repo-security-triage-2026-05-21.md
+  '''crates/syndesis/src/protocol/session_frame\.rs''', # WHY: H7/H17 - serialization-test fixture; see small-repo-security-triage-2026-05-21.md
+  '''crates/paroche/src/routes/kosync\.rs''', # WHY: H13/H14/H15 - kosync test fixture; see small-repo-security-triage-2026-05-21.md
+  '''docs/integrations\.md''', # WHY: H8 - documentation example; see small-repo-security-triage-2026-05-21.md
+  '''docs/download/irc\.md''', # WHY: H9/H10 - documentation examples; see small-repo-security-triage-2026-05-21.md
+  '''docs/download/usenet\.md''', # WHY: H11/H12 - documentation examples; see small-repo-security-triage-2026-05-21.md
+  '''^\.envrc$''', # WHY: H18 - path-name false-positive; see small-repo-security-triage-2026-05-21.md
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -44,4 +44,14 @@ paths = [
   '''docs/download/irc\.md''', # WHY: H9/H10 - documentation examples; see small-repo-security-triage-2026-05-21.md
   '''docs/download/usenet\.md''', # WHY: H11/H12 - documentation examples; see small-repo-security-triage-2026-05-21.md
   '''^\.envrc$''', # WHY: H18 - path-name false-positive; see small-repo-security-triage-2026-05-21.md
+  # WHY: historical pre-rename H1/H16 test-fixture path.
+  '''crates/harmonia-host/src/render/credentials\.rs''',
+  # WHY: historical pre-rename H6 integration-test fixture path.
+  '''crates/harmonia-host/tests/acquisition_integration\.rs''',
+  # WHY: historical test fixture, no live credential.
+  '''mouseion/tests/Mouseion\.Api\.Tests/Authentication/JwtTokenServiceTests\.cs''',
+  # WHY: historical negative-test fixture, no live credential.
+  '''mouseion/tests/Mouseion\.Api\.Tests/Books/BookControllerNegativeTests\.cs''',
+  # WHY: historical sample JWT fixture, no live credential.
+  '''mouseion/src/Mouseion\.Common/Cloud/MouseionCloudRequestBuilder\.cs''',
 ]


### PR DESCRIPTION
## Summary
- Add path allowlist entries for HIGH class-(c) gitleaks false-positives from /home/ck/metis-ops/projects/_recovery/small-repo-security-triage-2026-05-21.md.
- Covered findings: H1, H2, H3, H4, H5, H6, H7, H8, H9, H10, H11, H12, H13, H14, H15, H16, H17, H18.

## Validation
- gitleaks detect --source . --config .gitleaks.toml --no-banner --redact
- cargo +1.94-x86_64-unknown-linux-gnu check --workspace --no-default-features
- kanon lint --summary: n/a on verda per dispatcher footer