### PR TITLE
fix(archon): replace production unwraps

### DIFF
--- a/crates/archon/src/migrate.rs
+++ b/crates/archon/src/migrate.rs
@@ -472,8 +472,8 @@ fn parse_track_stem(stem: &str) -> (Option<u32>, String) {
 
     let mut chars = stem.chars().peekable();
     let mut num_str = String::new();
-    while chars.peek().is_some_and(|c| c.is_ascii_digit()) {
-        num_str.push(chars.next().unwrap());
+    while let Some(c) = chars.next_if(|c| c.is_ascii_digit()) {
+        num_str.push(c);
     }
 
     if !num_str.is_empty() {

--- a/crates/archon/src/render/runner.rs
+++ b/crates/archon/src/render/runner.rs
@@ -160,12 +160,13 @@ async fn connect_and_run(
     dsp_rx: watch::Receiver<akouo_core::DspConfig>,
     shutdown: CancellationToken,
 ) -> Result<(), RenderError> {
-    let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap()).map_err(|e| {
-        RenderError::Connection {
-            message: e.to_string(),
-            location: snafu::location!(),
-        }
-    })?;
+    let mut endpoint =
+        quinn::Endpoint::client(SocketAddr::from(([0, 0, 0, 0], 0))).map_err(|e| {
+            RenderError::Connection {
+                message: e.to_string(),
+                location: snafu::location!(),
+            }
+        })?;
     endpoint.set_default_client_config(client_config.clone());
 
     info!(server = %server_addr, "connecting");


### PR DESCRIPTION
## Summary
- Replace the two production unwraps identified by the audit.

## Validation
- `rg -n 'chars\\.next\\(\\)\\.unwrap\\(\\)|0\\.0\\.0\\.0:0.*unwrap' crates/archon/src/migrate.rs crates/archon/src/render/runner.rs` returned no matches\n- `cargo +1.94 fmt --check` passed\n- `kanon lint --summary crates/archon/src/migrate.rs` hit pre-existing baseline findings: file-too-long and no-silent-result-swallow\n- `cargo +1.94 check -p archon` is blocked by baseline dependency error in `crates/paroche/src/routes/kosync.rs:83` (`LowerHex` not implemented for `hasher.finalize()` output) before archon validation\n\nCloses #235