### PR TITLE
fix(akouo): return unsupported error for WavPack decoder

### DIFF
--- a/crates/akouo-core/src/decode/wavpack.rs
+++ b/crates/akouo-core/src/decode/wavpack.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
-use crate::decode::{AudioDecoder, DecodedFrame, GaplessInfo, StreamParams};
+use crate::decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams};
 use crate::error::DecodeError;
 
 /// WavPack decoder — not yet implemented.
@@ -20,31 +20,48 @@ use crate::error::DecodeError;
 /// wavpack-sys is added.
 pub struct WavPackDecoder;
 
+fn unsupported_codec() -> DecodeError {
+    DecodeError::UnsupportedCodec {
+        codec: Codec::Other("WavPack".to_string()),
+        location: snafu::Location::new(file!(), line!(), column!()),
+    }
+}
+
 impl AudioDecoder for WavPackDecoder {
     fn next_frame(
         &mut self,
     ) -> Pin<Box<dyn Future<Output = Result<Option<DecodedFrame>, DecodeError>> + Send + '_>> {
-        todo!("WavPack decode not yet implemented — extremely rare codec")
+        Box::pin(async { Err(unsupported_codec()) })
     }
 
     fn seek(
         &mut self,
         _position: Duration,
     ) -> Pin<Box<dyn Future<Output = Result<Duration, DecodeError>> + Send + '_>> {
-        todo!("WavPack seek not yet implemented — extremely rare codec")
+        Box::pin(async { Err(unsupported_codec()) })
     }
 
     fn stream_params(&self) -> StreamParams {
-        todo!("WavPack stream_params not yet implemented — extremely rare codec")
+        StreamParams {
+            codec: Codec::Other("WavPack".to_string()),
+            sample_rate: 0,
+            channels: 0,
+            bit_depth: None,
+            duration: None,
+            bitrate: None,
+        }
     }
 
     fn gapless_info(&self) -> Option<GaplessInfo> {
-        todo!("WavPack gapless_info not yet implemented — extremely rare codec")
+        None
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use super::{AudioDecoder, WavPackDecoder};
     use crate::decode::Codec;
     use crate::error::DecodeError;
 
@@ -59,5 +76,52 @@ mod tests {
             err.to_string().contains("WavPack"),
             "error must name the codec: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn wavpack_decoder_frame_returns_unsupported_codec() {
+        let mut decoder = WavPackDecoder;
+
+        let err = decoder
+            .next_frame()
+            .await
+            .expect_err("WavPack decoder must not produce frames without backend support");
+
+        assert!(matches!(
+            err,
+            DecodeError::UnsupportedCodec {
+                codec: Codec::Other(ref codec),
+                ..
+            } if codec == "WavPack"
+        ));
+    }
+
+    #[tokio::test]
+    async fn wavpack_decoder_seek_returns_unsupported_codec() {
+        let mut decoder = WavPackDecoder;
+
+        let err = decoder
+            .seek(Duration::from_secs(1))
+            .await
+            .expect_err("WavPack decoder must not seek without backend support");
+
+        assert!(matches!(
+            err,
+            DecodeError::UnsupportedCodec {
+                codec: Codec::Other(ref codec),
+                ..
+            } if codec == "WavPack"
+        ));
+    }
+
+    #[test]
+    fn wavpack_decoder_params_are_explicit_placeholder() {
+        let decoder = WavPackDecoder;
+
+        let params = decoder.stream_params();
+
+        assert_eq!(params.codec, Codec::Other("WavPack".to_string()));
+        assert_eq!(params.sample_rate, 0);
+        assert!(decoder.gapless_info().is_none());
     }
 }


### PR DESCRIPTION
## Summary
- replace WavPack decoder todo!() bodies with explicit UnsupportedCodec errors for frame/seek paths
- make stream_params and gapless_info return non-panicking placeholders
- add WavPack decoder tests for unsupported frame, seek, params, and gapless behavior

Closes #245.

## Gates
- cargo fmt --all -- --check
- git diff --check
- CARGO_TARGET_DIR=/tmp/harmonia-wavpack-target cargo check --workspace
- CARGO_TARGET_DIR=/tmp/harmonia-wavpack-target cargo clippy --workspace --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harmonia-wavpack-target cargo test --workspace
- kanon lint --rust --summary --precision high crates/akouo-core/src/decode/wavpack.rs
- Kimi reviewer dispatch 0000019e51f7b1d5f214b1f7035fb1ed: APPROVE, no findings