### PR TITLE
fix(archon): run db migrate command

### DIFF
--- a/crates/archon/src/cli.rs
+++ b/crates/archon/src/cli.rs
@@ -5,13 +5,13 @@ use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(name = "harmonia", version, about = "Personal media system")]
-pub struct Cli {
+pub(crate) struct Cli {
     #[command(subcommand)]
-    pub command: Command,
+    pub(crate) command: Command,
 }
 
 #[derive(Subcommand)]
-pub enum Command {
+pub(crate) enum Command {
     /// Start the media server
     Serve(ServeArgs),
     /// Database management
@@ -25,87 +25,94 @@ pub enum Command {
 }
 
 #[derive(Args)]
-pub struct ServeArgs {
+pub(crate) struct ServeArgs {
     /// Path to harmonia.toml
     #[arg(short, long, default_value = "harmonia.toml")]
-    pub config: PathBuf,
+    pub(crate) config: PathBuf,
 
     /// Listen address override
     #[arg(long)]
-    pub listen: Option<String>,
+    pub(crate) listen: Option<String>,
 
     /// Port override
     #[arg(short, long)]
-    pub port: Option<u16>,
+    pub(crate) port: Option<u16>,
 }
 
 #[derive(Args)]
-pub struct DbArgs {
+pub(crate) struct DbArgs {
     /// Database subcommand
     #[command(subcommand)]
-    pub command: DbCommand,
+    pub(crate) command: DbCommand,
 }
 
 #[derive(Args)]
-pub struct PlayArgs {
+pub(crate) struct PlayArgs {
     /// Path to an audio file
-    pub file: PathBuf,
+    pub(crate) file: PathBuf,
 
     /// Audio output device name (uses default if omitted)
     #[arg(long)]
-    pub device: Option<String>,
+    pub(crate) device: Option<String>,
 }
 
 #[derive(Args)]
-pub struct RenderArgs {
+pub(crate) struct RenderArgs {
     /// Explicit server address (skips mDNS discovery)
     #[arg(long)]
-    pub server: Option<SocketAddr>,
+    pub(crate) server: Option<SocketAddr>,
 
     /// Directory for TLS certificates and pairing credentials
     #[arg(long, default_value = "~/.config/harmonia/renderer")]
-    pub cert_dir: PathBuf,
+    pub(crate) cert_dir: PathBuf,
 
     /// Renderer display name (defaults to hostname)
     #[arg(long)]
-    pub name: Option<String>,
+    pub(crate) name: Option<String>,
 
     /// Path to renderer TOML config file
     #[arg(long)]
-    pub config: Option<PathBuf>,
+    pub(crate) config: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
-pub enum DbCommand {
+pub(crate) enum DbCommand {
     /// Run pending migrations
-    Migrate,
+    Migrate(DbMigrateArgs),
 }
 
 #[derive(Args, Debug)]
-pub struct MigrateArgs {
+pub(crate) struct DbMigrateArgs {
+    /// Path to harmonia.toml
+    #[arg(short, long, default_value = "harmonia.toml")]
+    pub(crate) config: PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct MigrateArgs {
     /// Source directory containing legacy media
     #[arg(long)]
-    pub source: PathBuf,
+    pub(crate) source: PathBuf,
 
     /// Target directory for canonical output
     #[arg(long)]
-    pub target: PathBuf,
+    pub(crate) target: PathBuf,
 
     /// Media type to migrate
     #[arg(long, value_enum)]
-    pub media_type: CliMediaType,
+    pub(crate) media_type: CliMediaType,
 
     /// Dry run — show what would be done without moving files
     #[arg(long)]
-    pub dry_run: bool,
+    pub(crate) dry_run: bool,
 
     /// Copy instead of move (preserves source)
     #[arg(long)]
-    pub copy: bool,
+    pub(crate) copy: bool,
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
-pub enum CliMediaType {
+pub(crate) enum CliMediaType {
     Music,
     Books,
     Audiobooks,
@@ -171,7 +178,24 @@ mod tests {
         let Command::Db(db) = cli.command else {
             panic!("expected Db command");
         };
-        assert!(matches!(db.command, DbCommand::Migrate));
+        let DbCommand::Migrate(args) = db.command;
+        assert_eq!(args.config, PathBuf::from("harmonia.toml"));
+    }
+
+    #[test]
+    fn db_migrate_config_override_parses() {
+        let cli = Cli::parse_from([
+            "harmonia",
+            "db",
+            "migrate",
+            "--config",
+            "/etc/harmonia.toml",
+        ]);
+        let Command::Db(db) = cli.command else {
+            panic!("expected Db command");
+        };
+        let DbCommand::Migrate(args) = db.command;
+        assert_eq!(args.config, PathBuf::from("/etc/harmonia.toml"));
     }
 
     #[test]

--- a/crates/archon/src/db.rs
+++ b/crates/archon/src/db.rs
@@ -1,0 +1,85 @@
+use std::io::Write;
+
+use snafu::ResultExt;
+
+use crate::cli::DbMigrateArgs;
+use crate::error::{ConfigSnafu, DatabaseSnafu, HostError, OutputSnafu};
+
+pub(crate) async fn run_db_migrate(
+    args: DbMigrateArgs,
+    out: &mut impl Write,
+) -> Result<(), HostError> {
+    let (config, warnings) =
+        horismos::load_config(Some(args.config.as_path())).context(ConfigSnafu)?;
+
+    for warning in &warnings {
+        writeln!(
+            out,
+            "config warning: [{}] {}",
+            warning.field, warning.message
+        )
+        .context(OutputSnafu {
+            operation: "write database migration config warning",
+        })?;
+    }
+
+    let db_path = config.database.db_path.to_string_lossy();
+    let pools = apotheke::init_pools(&db_path)
+        .await
+        .context(DatabaseSnafu)?;
+    pools.read.close().await;
+    pools.write.close().await;
+
+    writeln!(
+        out,
+        "database migrations applied: {}",
+        config.database.db_path.display()
+    )
+    .context(OutputSnafu {
+        operation: "write database migration summary",
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_jwt_secret() -> &'static str {
+        "db-migrate-test-secret-that-is-at-least-32-bytes"
+    }
+
+    #[tokio::test]
+    async fn run_db_migrate_applies_migrations_to_configured_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("harmonia.toml");
+        let db_path = dir.path().join("harmonia.db");
+
+        std::fs::write(
+            &config_path,
+            format!(
+                "[exousia]\njwt_secret = \"{}\"\n\n[database]\ndb_path = \"{}\"\n",
+                valid_jwt_secret(),
+                db_path.display()
+            ),
+        )
+        .unwrap();
+
+        let mut out = Vec::new();
+        run_db_migrate(
+            DbMigrateArgs {
+                config: config_path,
+            },
+            &mut out,
+        )
+        .await
+        .unwrap();
+
+        let output = String::from_utf8(out).unwrap();
+        assert!(
+            output.contains("database migrations applied"),
+            "expected migration summary, got: {output}"
+        );
+        assert!(db_path.exists());
+    }
+}

--- a/crates/archon/src/error.rs
+++ b/crates/archon/src/error.rs
@@ -40,6 +40,14 @@ pub enum HostError {
         location: snafu::Location,
     },
 
+    #[snafu(display("output error during {operation}: {source}"))]
+    Output {
+        operation: &'static str,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("auth error: {source}"))]
     Auth {
         #[snafu(source(from(exousia::ExousiaError, Box::new)))]

--- a/crates/archon/src/main.rs
+++ b/crates/archon/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod db;
 mod error;
 mod migrate;
 mod play;
@@ -19,10 +20,7 @@ async fn main() {
     let result = match cli.command {
         Command::Serve(args) => serve::run_serve(args, &mut stdout_lock).await,
         Command::Db(db_args) => match db_args.command {
-            cli::DbCommand::Migrate => {
-                eprintln!("Database migration runs automatically on serve startup.");
-                Ok(())
-            }
+            cli::DbCommand::Migrate(args) => db::run_db_migrate(args, &mut stdout_lock).await,
         },
         Command::Play(args) => play::run_play(args, &mut stdout_lock).await,
         Command::Render(args) => {


### PR DESCRIPTION
## Summary
- wire harmonia db migrate to load the selected config and initialize apotheke pools
- run configured SQLite migrations instead of returning success without work
- add db migrate config parsing tests and a migration execution test

Closes #244.

## Gates
- cargo fmt --all -- --check
- git diff --check
- CARGO_TARGET_DIR=/tmp/harmonia-db-target cargo check --workspace
- CARGO_TARGET_DIR=/tmp/harmonia-db-target cargo clippy --workspace --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harmonia-db-target cargo test --workspace
- kanon lint --rust --summary --precision high crates/archon/src/cli.rs
- kanon lint --rust --summary --precision high crates/archon/src/db.rs
- kanon lint --rust --summary --precision high crates/archon/src/error.rs
- kanon lint --rust --summary --precision high crates/archon/src/main.rs
- Kimi reviewer dispatch 0000019e5205e9daf214b1f7035fb1f0: APPROVE, no findings