### PR TITLE
fix(nix): manage ebook conversion tools

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Agents: for a compressed crate map and technology index, load
 - [PROJECT.md](PROJECT.md): Project overview and phase status
 - [LESSONS.md](LESSONS.md): Operational rules from real failures
 - [WORKING-AGREEMENT.md](WORKING-AGREEMENT.md): Syn + Cody collaboration protocol
-- [../standards/STANDARDS.md](../standards/STANDARDS.md): Code standards (kanon-synced)
+- [../standards/README.md](../standards/README.md): Code standards (kanon-synced)
 
 ## Architecture
 
@@ -51,6 +51,7 @@ Agents: for a compressed crate map and technology index, load
 - [media/metadata-providers.md](media/metadata-providers.md): Provider strategy + rate limiting
 - [media/scanner.md](media/scanner.md): Library scanner design
 - [media/import-rename.md](media/import-rename.md): Import and rename pipeline
+- [media/ebook-conversion.md](media/ebook-conversion.md): Managed ebook conversion subprocesses
 - [media/music.md](media/music.md): Music-specific design (MusicBrainz, ReplayGain)
 - [media/audiobooks.md](media/audiobooks.md): Audiobook-specific design
 - [media/news.md](media/news.md): News feed design (RSS/Atom)

--- a/docs/media/ebook-conversion.md
+++ b/docs/media/ebook-conversion.md
@@ -1,0 +1,23 @@
+# Ebook conversion
+
+Harmonia's ebook conversion crate is a controlled subprocess boundary. It does
+not vendor conversion engines into the Rust workspace; it shells out to the
+following binaries:
+
+| Binary | Nix package | Used for |
+| --- | --- | --- |
+| `ebook-convert` | `calibre` | General ebook conversion, including non-Kobo EPUB output |
+| `kepubify` | `kepubify` | EPUB to Kobo KEPUB conversion |
+| `pandoc` | `pandoc` | DOCX/ODT to EPUB conversion |
+
+The canonical deployment path is the Harmonia flake package. The native Nix
+package wraps `$out/bin/harmonia` with a `PATH` that includes those three
+packages, so production deployments do not depend on host-global binaries.
+Versions are pinned by the repository `flake.lock` through the `nixpkgs` input.
+
+Development shells include the same packages. Non-Nix deployments must provide
+compatible binaries on `PATH`; otherwise conversion fails with
+`ConvertError::BinaryNotFound` before any output file is reported as successful.
+
+These tools are runtime dependencies for conversion only. They are deliberately
+not Cargo dependencies, and `cargo-deny` cannot audit or pin them.

--- a/docs/nix-deployment.md
+++ b/docs/nix-deployment.md
@@ -102,3 +102,8 @@ To use the package in your own NixOS config without the module:
 nixpkgs.overlays = [ inputs.harmonia.overlays.default ];
 environment.systemPackages = [ pkgs.harmonia ];
 ```
+
+The native flake package wraps the `harmonia` binary with ebook conversion tools
+on `PATH`: `ebook-convert` from Calibre, `kepubify`, and `pandoc`. See
+[`media/ebook-conversion.md`](media/ebook-conversion.md) for the runtime
+contract.

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,12 @@
           pkgs.libopus   # opus crate FFI
         ];
 
+        ebookConversionTools = [
+          pkgs.calibre  # ebook-convert
+          pkgs.kepubify
+          pkgs.pandoc
+        ];
+
         commonArgs = {
           inherit src nativeBuildInputs buildInputs;
           strictDeps = true;
@@ -79,6 +85,11 @@
 
         nativePkg = craneLib.buildPackage (commonArgs // {
           inherit cargoArtifacts;
+          nativeBuildInputs = nativeBuildInputs ++ [ pkgs.makeWrapper ];
+          postInstall = ''
+            wrapProgram "$out/bin/harmonia" \
+              --prefix PATH : ${lib.makeBinPath ebookConversionTools}
+          '';
         });
 
         # Cross-compilation is only meaningful from an x86_64-linux host.
@@ -143,7 +154,7 @@
             pkgs.cargo-deny
             pkgs.cargo-nextest
             pkgs.sqlx-cli
-          ];
+          ] ++ ebookConversionTools;
         };
 
         checks = {


### PR DESCRIPTION
## Summary
- wrap the native Harmonia package with Calibre, kepubify, and pandoc on PATH for ebook conversion
- add the same tools to the development shell
- document the ebook conversion subprocess/runtime dependency contract
- fix a stale standards link in the touched docs index

Fixes #246.

## Gates
- cargo fmt --all -- --check
- git diff --check main...HEAD
- CARGO_TARGET_DIR=/tmp/harmonia-import-target cargo check --workspace
- CARGO_TARGET_DIR=/tmp/harmonia-import-target cargo clippy --workspace --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harmonia-import-target cargo test --workspace
- kanon lint --summary --precision high flake.nix
- kanon lint --summary --precision high docs/README.md
- kanon lint --summary --precision high docs/media/ebook-conversion.md
- kanon lint --summary --precision high docs/nix-deployment.md

Nix evaluation was not run locally because nix is not installed in this wrapper environment.

## Reviewer
- Kimi reviewer dispatch 0000019e521bfd57f214b1f7035fb1f6: APPROVE, no findings
