### PR TITLE
fix(kritike): remove unwired import registration stub

### DIFF
--- a/crates/kritike/src/lib.rs
+++ b/crates/kritike/src/lib.rs
@@ -33,14 +33,6 @@ pub trait CurationService: Send + Sync {
         candidate_score: i32,
     ) -> Result<UpgradeDecision, KritikeError>;
 
-    /// Register an imported item for quality tracking.
-    async fn register_import(
-        &self,
-        media_id: MediaId,
-        media_type: MediaType,
-        quality_score: i32,
-    ) -> Result<(), KritikeError>;
-
     /// Generate library health report.
     async fn health_report(&self) -> Result<HealthReport, KritikeError>;
 }
@@ -85,17 +77,6 @@ impl CurationService for DefaultCurationService {
         }
 
         Ok(decision)
-    }
-
-    #[instrument(skip(self), fields(media_id = %media_id, media_type = %media_type, quality_score = quality_score))]
-    async fn register_import(
-        &self,
-        media_id: MediaId,
-        media_type: MediaType,
-        quality_score: i32,
-    ) -> Result<(), KritikeError> {
-        tracing::info!(%media_id, %media_type, quality_score, "import registered for quality tracking");
-        Ok(())
     }
 
     #[instrument(skip(self))]


### PR DESCRIPTION
## Summary
- remove the no-op register_import method from the CurationService trait
- remove the DefaultCurationService implementation that logged and returned Ok without persistence
- leave the real DB-backed curation methods intact

Fixes #243.

## Rationale
The existing method signature had only media_id, media_type, and quality_score, but the actual quality/upgrade tracking path is backed by haves and needs want/file/release context. Issue #243 allowed removing the method until a real registration API can be implemented.

## Gates
- cargo fmt --all -- --check
- git diff --check
- CARGO_TARGET_DIR=/tmp/harmonia-import-target cargo check --workspace
- CARGO_TARGET_DIR=/tmp/harmonia-import-target cargo clippy --workspace --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harmonia-import-target cargo test --workspace
- kanon lint --rust --summary --precision high crates/kritike/src/lib.rs

## Reviewer
- Kimi reviewer dispatch 0000019e52230b0af214b1f7035fb1f8: APPROVE, no findings
