### PR TITLE
fix(docs): clarify desktop package boundary

### DIFF
--- a/docs/architecture/binary-modes.md
+++ b/docs/architecture/binary-modes.md
@@ -1,11 +1,13 @@
 # Binary modes
 
-Harmonia ships as a single binary (`archon`) with four execution modes,
-selected via subcommand. Each mode activates a subset of the system's subsystems.
+Harmonia ships its wired backend and audio entry points through the `archon`
+binary. Mode is selected via Clap subcommand, and each mode activates a subset
+of the system's subsystems. The Dioxus desktop client is a separate package
+under `crates/theatron/desktop/`; it is not an `archon` subcommand today.
 
 ## Modes
 
-### `Harmonia serve`
+### `harmonia serve`
 
 The server. Runs on the NAS or primary machine. Manages the library, API,
 acquisition, and streaming.
@@ -16,18 +18,16 @@ syndesmos, prostheke, syndesis (QUIC server endpoint).
 **Inactive:** akouo-core (server does not play audio locally).
 **Listens on:** HTTP (paroche, default :8096), QUIC (syndesis, default :7472).
 
-### `Harmonia desktop`
+### `harmonia db migrate`
 
-The Dioxus desktop client (proskenion, in `crates/theatron/desktop/`). Full UI,
-local audio playback, connects to a `harmonia serve` instance for library and
-acquisition.
+Database maintenance. Runs configured SQLite migrations against the databases
+defined in `harmonia.toml`.
 
-**Active subsystems:** akouo-core (local audio engine), horismos (local config).
-**Connects to:** A `harmonia serve` instance via HTTP API + QUIC audio stream.
-**Does NOT run:** Library management, acquisition, metadata enrichment; all
-delegated to the serve instance.
+**Active subsystems:** horismos (configuration), apotheke (SQLite pools and
+migrations).
+**Does NOT run:** HTTP API, acquisition, playback, renderer transport.
 
-### `Harmonia render`
+### `harmonia render`
 
 Headless audio renderer. Runs on Pi or dedicated audio endpoints. Receives
 audio over QUIC from a serve instance and outputs to local hardware.
@@ -40,7 +40,7 @@ streams FLAC frames).
 **Local DSP:** Renderer applies its own EQ, crossfeed, volume settings
 after receiving the stream.
 
-### `Harmonia play`
+### `harmonia play`
 
 CLI standalone player. No server, no network. Plays local files directly.
 
@@ -49,22 +49,39 @@ CLI standalone player. No server, no network. Plays local files directly.
 **Purpose:** Validates the audio engine end-to-end. Useful for quick playback
 and testing. No persistent state.
 
+### `harmonia migrate`
+
+Legacy library migration. Converts an existing media tree into Harmonia's
+canonical storage layout.
+
+**Active subsystems:** migration planner and filesystem operations.
+**Does NOT run:** Server routes, acquisition, playback, renderer transport.
+
 ## Mode selection
 
 Mode is selected at startup via Clap subcommand:
 
     harmonia serve [--config path]
-    harmonia desktop [--server url]
-    harmonia render --server url [--device hw:1]
-    harmonia play <file|directory|playlist>
+    harmonia db migrate [--config path]
+    harmonia render [--server addr] [--config path]
+    harmonia play <file> [--device name]
+    harmonia migrate --source path --target path --media-type music|books|audiobooks|podcasts
+
+## Desktop client
+
+The desktop client is planned as the standalone Dioxus package
+`crates/theatron/desktop/`, sharing API types through `theatron-core`. It
+connects to a `harmonia serve` instance for library and acquisition behavior and
+handles local UI and playback concerns. The package is intentionally excluded
+from the workspace while the Phase 3.5 desktop port remains in progress; build
+it directly when working on that track:
+
+    cargo check --manifest-path crates/theatron/desktop/Cargo.toml
+    cargo build --release --manifest-path crates/theatron/desktop/Cargo.toml
 
 ## Cargo features
 
-Each mode can be compiled independently via cargo features to produce
-smaller binaries for constrained targets:
+`archon` does not currently expose per-mode Cargo features. Build the full CLI
+binary with:
 
-    cargo build -p archon --features serve    # server-only
-    cargo build -p archon --features render   # renderer-only (Pi)
-    cargo build -p archon --features play     # CLI player only
-
-The default build includes all modes.
+    cargo build -p archon

--- a/docs/architecture/cargo.md
+++ b/docs/architecture/cargo.md
@@ -81,7 +81,7 @@ cargo metadata --format-version 1 | jq '.workspace_members | length'
 | **paroche** | lib | `crates/paroche/` | `StreamService` trait, `StreamResponse`, `OpdsFeed` | themelion, exousia, apotheke, horismos |
 | **syndesis** | lib | `crates/syndesis/` | `RendererService` trait, `RendererConn`, `ClockSync`, `JitterBuffer` | themelion, exousia, horismos |
 | **aitesis** | lib | `crates/aitesis/` | `RequestService` trait, `Request`, `RequestStatus`, `MonitorService` boundary | themelion, epignosis, exousia, apotheke |
-| **archon** | bin | `crates/archon/` | `main()`: assembles all subsystems, owns Aggelia channel lifecycle; four execution modes (`serve`, `desktop`, `render`, `play`) selected via Clap subcommand; see [binary-modes.md](binary-modes.md) | Workspace library crates |
+| **archon** | bin | `crates/archon/` | `main()`: assembles wired backend and audio entry points; exposes `serve`, `db`, `render`, `play`, and `migrate` Clap subcommands; see [binary-modes.md](binary-modes.md) | Workspace library crates |
 
 **Note on themelion:** Aggelia event types (`HarmoniaEvent` enum and channel handle types) live in `crates/themelion/src/aggelia/`. This is the shared leaf crate; all other crates already depend on it. The Aggelia broadcast channel itself is created in archon at startup and distributed as `Sender`/`Receiver` handles via constructor injection. No subsystem imports Aggelia as a separate crate.
 

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -31,4 +31,4 @@ share types with the backend without a code-generation layer. History is in git.
 The desktop talks to a `harmonia serve` instance over HTTP (REST + WebSocket)
 and, for audio, over QUIC via `syndesis`. See
 [`../architecture/binary-modes.md`](../architecture/binary-modes.md) for the
-`harmonia desktop` execution mode context.
+current `archon` subcommands and the standalone desktop package boundary.


### PR DESCRIPTION
## Summary
- remove the stale `harmonia desktop` archon subcommand claim from binary mode docs
- document the actual `archon` command surface, including `db migrate` and top-level `migrate`
- mark the Dioxus desktop as a standalone workspace-excluded package and remove stale per-mode feature examples

Closes #239.

## Gates
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harmonia-docs-239-target cargo check --workspace`
- `CARGO_TARGET_DIR=/tmp/harmonia-docs-239-target cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harmonia-docs-239-target cargo test --workspace`
- `kanon lint --summary --precision high docs/architecture/binary-modes.md`
- `kanon lint --summary --precision high docs/architecture/cargo.md`
- `kanon lint --summary --precision high docs/desktop/architecture.md`
- Kimi reviewer dispatch `0000019e5250c58cf214b1f7035fb1ff`: APPROVE, no findings