### PR TITLE
fix(paroche): route requests through aitesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,6 +3520,7 @@ dependencies = [
 name = "paroche"
 version = "0.1.10"
 dependencies = [
+ "aitesis",
  "apotheke",
  "axum",
  "epignosis",

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use aitesis::{IdentityValidator, MonitorService, RequestService, UserRoleProvider};
 use apotheke::init_pools;
 use epignosis::EpignosisService;
 use epignosis::resolver::ProviderCredentials;
@@ -14,7 +15,7 @@ use komide::scheduler::FeedScheduler;
 use kritike::DefaultCurationService;
 use paroche::state::{
     AppState, DynCurationService, DynDownloadEngine, DynExternalIntegration, DynMetadataResolver,
-    DynQueueManager, DynRequestService, DynSearchService, DynSubtitleService,
+    DynQueueManager, DynRequestService, DynSearchService, DynSubtitleService, RequestServiceFut,
 };
 use prostheke::ProsthekeService;
 use prostheke::providers::Provider;
@@ -94,8 +95,209 @@ impl DynDownloadEngine for EngineAdapter {}
 struct QueueAdapter;
 impl DynQueueManager for QueueAdapter {}
 
-struct RequestAdapter;
-impl DynRequestService for RequestAdapter {}
+type LiveRequestService =
+    aitesis::AitesisServiceImpl<RequestRoleProvider, RequestIdentityValidator, RequestMonitor>;
+
+struct RequestAdapter(Arc<LiveRequestService>);
+impl DynRequestService for RequestAdapter {
+    fn submit_request(
+        &self,
+        user_id: themelion::UserId,
+        input: aitesis::CreateRequestInput,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .submit_request(user_id, input)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn approve(
+        &self,
+        request_id: themelion::RequestId,
+        admin_id: themelion::UserId,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .approve(request_id, admin_id)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn deny(
+        &self,
+        request_id: themelion::RequestId,
+        admin_id: themelion::UserId,
+        reason: Option<String>,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .deny(request_id, admin_id, reason)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn get_request(
+        &self,
+        request_id: themelion::RequestId,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move { service.get_request(request_id).await.map_err(Into::into) })
+    }
+
+    fn list_requests(
+        &self,
+        user_id: Option<themelion::UserId>,
+        status: Option<aitesis::RequestStatus>,
+    ) -> RequestServiceFut<'_, Vec<aitesis::MediaRequest>> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .list_requests(user_id, status)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn cancel_request(
+        &self,
+        request_id: themelion::RequestId,
+        user_id: themelion::UserId,
+    ) -> RequestServiceFut<'_, ()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .cancel_request(request_id, user_id)
+                .await
+                .map_err(Into::into)
+        })
+    }
+}
+
+struct RequestRoleProvider {
+    db: Arc<apotheke::DbPools>,
+}
+
+impl UserRoleProvider for RequestRoleProvider {
+    async fn role_of(
+        &self,
+        user_id: themelion::UserId,
+    ) -> Result<aitesis::UserRole, aitesis::AitesisError> {
+        let user = apotheke::repo::user::get_user(&self.db.read, user_id.as_bytes().as_slice())
+            .await
+            .context(aitesis::error::DatabaseSnafu)?;
+        let Some(user) = user else {
+            return aitesis::error::InsufficientPermissionSnafu.fail();
+        };
+        if user.is_active == 0 {
+            return aitesis::error::InsufficientPermissionSnafu.fail();
+        }
+        match exousia::UserRole::parse(&user.role) {
+            Some(exousia::UserRole::Admin) => Ok(aitesis::UserRole::Admin),
+            Some(exousia::UserRole::Member) => Ok(aitesis::UserRole::Member),
+            Some(_) | None => aitesis::error::InsufficientPermissionSnafu.fail(),
+        }
+    }
+}
+
+struct RequestIdentityValidator;
+
+impl IdentityValidator for RequestIdentityValidator {
+    async fn validate(
+        &self,
+        media_type: themelion::MediaType,
+        title: &str,
+        _external_id: Option<&str>,
+    ) -> Result<(), aitesis::AitesisError> {
+        if title.trim().is_empty() {
+            return aitesis::error::MediaIdentityInvalidSnafu {
+                detail: "title is required".to_string(),
+            }
+            .fail();
+        }
+        if matches!(media_type, themelion::MediaType::News) {
+            return aitesis::error::MediaIdentityInvalidSnafu {
+                detail: "news requests cannot be handed off to wanted media".to_string(),
+            }
+            .fail();
+        }
+        Ok(())
+    }
+}
+
+struct RequestMonitor {
+    db: Arc<apotheke::DbPools>,
+}
+
+impl MonitorService for RequestMonitor {
+    async fn create_want(
+        &self,
+        request: &aitesis::MediaRequest,
+    ) -> Result<themelion::WantId, aitesis::AitesisError> {
+        let Some((want_media_type, quality_media_type)) = request_media_types(request.media_type)
+        else {
+            return aitesis::error::MediaIdentityInvalidSnafu {
+                detail: format!(
+                    "{} requests cannot be handed off to wanted media",
+                    request.media_type
+                ),
+            }
+            .fail();
+        };
+        let profile =
+            apotheke::repo::quality::list_profiles_for_type(&self.db.read, quality_media_type)
+                .await
+                .context(aitesis::error::DatabaseSnafu)?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    aitesis::error::MediaIdentityInvalidSnafu {
+                        detail: format!("no quality profile for {quality_media_type}"),
+                    }
+                    .build()
+                })?;
+
+        let want_id = themelion::WantId::new();
+        apotheke::repo::want::insert_want(
+            &self.db.write,
+            &apotheke::repo::want::Want {
+                id: want_id.as_bytes().to_vec(),
+                media_type: want_media_type.to_string(),
+                title: request.title.clone(),
+                registry_id: None,
+                quality_profile_id: profile.id,
+                status: "searching".to_string(),
+                source: Some("request".to_string()),
+                source_ref: Some(request.id.as_uuid().to_string()),
+                added_at: jiff::Timestamp::now().to_string(),
+                fulfilled_at: None,
+            },
+        )
+        .await
+        .context(aitesis::error::DatabaseSnafu)?;
+        Ok(want_id)
+    }
+}
+
+fn request_media_types(media_type: themelion::MediaType) -> Option<(&'static str, &'static str)> {
+    match media_type {
+        themelion::MediaType::Music => Some(("music_album", "music")),
+        themelion::MediaType::Audiobook => Some(("audiobook", "audiobook")),
+        themelion::MediaType::Book => Some(("book", "book")),
+        themelion::MediaType::Comic => Some(("comic", "comic")),
+        themelion::MediaType::Podcast => Some(("podcast", "podcast")),
+        themelion::MediaType::Movie => Some(("movie", "movie")),
+        themelion::MediaType::Tv => Some(("tv_series", "tv")),
+        themelion::MediaType::News => None,
+        _ => None,
+    }
+}
 
 struct ExternalAdapter(#[expect(dead_code)] Arc<SyndesmosService>);
 impl DynExternalIntegration for ExternalAdapter {}
@@ -372,6 +574,17 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     );
     info!("prostheke (subtitles) initialized");
 
+    // Layer 5: Aitesis (household request workflow)
+    let request_service = Arc::new(aitesis::AitesisServiceImpl::new(
+        db.read.clone(),
+        db.write.clone(),
+        config.aitesis.clone(),
+        RequestRoleProvider { db: db.clone() },
+        RequestIdentityValidator,
+        RequestMonitor { db: db.clone() },
+    ));
+    info!("aitesis (media requests) initialized");
+
     // ── End acquisition startup ─────────────────────────────────────────────
 
     // 12. Start renderer QUIC server
@@ -419,7 +632,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         search: Arc::new(SearchAdapter(zetesis)),
         download_engine: Arc::new(EngineAdapter(ergasia_session)),
         queue: Arc::new(QueueAdapter),
-        requests: Arc::new(RequestAdapter),
+        requests: Arc::new(RequestAdapter(request_service)),
         external: Arc::new(ExternalAdapter(syndesmos_svc)),
         subtitles: Arc::new(SubtitleAdapter),
         renderers: renderer_registry,

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -7,15 +7,19 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
+use aitesis::{IdentityValidator, MonitorService, RequestService, UserRoleProvider};
 use apotheke::DbPools;
 use apotheke::migrate::MIGRATOR;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use ergasia::{DownloadProgress, DownloadState, ErgasiaError, ExtractionResult};
 use exousia::{AuthService, CreateUserRequest, ExousiaServiceImpl, UserRole};
-use horismos::{Config, ExousiaConfig};
-use paroche::state::{AppState, DynSearchService, ServiceFut};
+use horismos::{AitesisConfig, Config, ExousiaConfig};
+use paroche::state::{
+    AppState, DynRequestService, DynSearchService, RequestServiceFut, ServiceFut,
+};
 use serde_json::{Value, json};
+use snafu::ResultExt;
 use sqlx::SqlitePool;
 use syntaxis::{CompletedDownload, ImportService};
 use themelion::create_event_bus;
@@ -113,6 +117,141 @@ impl ImportService for MockImportService {
     }
 }
 
+// ── Mock request service boundary ────────────────────────────────────────────
+
+type MockRequestService =
+    aitesis::AitesisServiceImpl<MockRequestRoles, MockRequestIdentity, MockRequestMonitor>;
+
+struct MockRequestAdapter(Arc<MockRequestService>);
+
+impl DynRequestService for MockRequestAdapter {
+    fn submit_request(
+        &self,
+        user_id: themelion::UserId,
+        input: aitesis::CreateRequestInput,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .submit_request(user_id, input)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn approve(
+        &self,
+        request_id: themelion::RequestId,
+        admin_id: themelion::UserId,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .approve(request_id, admin_id)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn deny(
+        &self,
+        request_id: themelion::RequestId,
+        admin_id: themelion::UserId,
+        reason: Option<String>,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .deny(request_id, admin_id, reason)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn get_request(
+        &self,
+        request_id: themelion::RequestId,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move { service.get_request(request_id).await.map_err(Into::into) })
+    }
+
+    fn list_requests(
+        &self,
+        user_id: Option<themelion::UserId>,
+        status: Option<aitesis::RequestStatus>,
+    ) -> RequestServiceFut<'_, Vec<aitesis::MediaRequest>> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .list_requests(user_id, status)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn cancel_request(
+        &self,
+        request_id: themelion::RequestId,
+        user_id: themelion::UserId,
+    ) -> RequestServiceFut<'_, ()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .cancel_request(request_id, user_id)
+                .await
+                .map_err(Into::into)
+        })
+    }
+}
+
+struct MockRequestRoles {
+    pool: SqlitePool,
+}
+
+impl UserRoleProvider for MockRequestRoles {
+    async fn role_of(
+        &self,
+        user_id: themelion::UserId,
+    ) -> Result<aitesis::UserRole, aitesis::AitesisError> {
+        let user = apotheke::repo::user::get_user(&self.pool, user_id.as_bytes().as_slice())
+            .await
+            .context(aitesis::error::DatabaseSnafu)?;
+        let Some(user) = user else {
+            return aitesis::error::InsufficientPermissionSnafu.fail();
+        };
+        match exousia::UserRole::parse(&user.role) {
+            Some(exousia::UserRole::Admin) => Ok(aitesis::UserRole::Admin),
+            Some(exousia::UserRole::Member) => Ok(aitesis::UserRole::Member),
+            Some(_) | None => aitesis::error::InsufficientPermissionSnafu.fail(),
+        }
+    }
+}
+
+struct MockRequestIdentity;
+
+impl IdentityValidator for MockRequestIdentity {
+    async fn validate(
+        &self,
+        _media_type: themelion::MediaType,
+        _title: &str,
+        _external_id: Option<&str>,
+    ) -> Result<(), aitesis::AitesisError> {
+        Ok(())
+    }
+}
+
+struct MockRequestMonitor;
+
+impl MonitorService for MockRequestMonitor {
+    async fn create_want(
+        &self,
+        _request: &aitesis::MediaRequest,
+    ) -> Result<themelion::WantId, aitesis::AitesisError> {
+        Ok(themelion::WantId::new())
+    }
+}
+
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
 type TestError = Box<dyn std::error::Error + Send + Sync>; // kanon:ignore RUST/box-dyn-error -- integration test helper, surfaces any error source without requiring conversion impls
@@ -129,7 +268,13 @@ async fn test_state() -> Result<(AppState, Arc<ExousiaServiceImpl>, SqlitePool),
         read: pool.clone(),
         write: pool.clone(),
     });
-    let config = Arc::new(Config::default());
+    let config = Arc::new(Config {
+        aitesis: AitesisConfig {
+            auto_approve_admins: false,
+            ..AitesisConfig::default()
+        },
+        ..Config::default()
+    });
     let (event_tx, _) = create_event_bus(64);
     let exousia_config = ExousiaConfig {
         access_token_ttl_secs: 900,
@@ -140,6 +285,16 @@ async fn test_state() -> Result<(AppState, Arc<ExousiaServiceImpl>, SqlitePool),
     let import = paroche::state::make_import_service(|| async { Ok(vec![]) });
     let mut state = AppState::with_stubs(pools, config, event_tx, auth.clone(), import);
     state.search = Arc::new(MockSearchService);
+    state.requests = Arc::new(MockRequestAdapter(Arc::new(
+        aitesis::AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            state.config.aitesis.clone(),
+            MockRequestRoles { pool: pool.clone() },
+            MockRequestIdentity,
+            MockRequestMonitor,
+        ),
+    )));
     Ok((state, auth, pool))
 }
 
@@ -494,7 +649,7 @@ async fn approve_request_requires_admin() -> Result<(), TestError> {
         .await?;
     assert_eq!(resp.status(), StatusCode::OK);
     let json = body_json(resp).await?;
-    assert_eq!(json["data"]["status"], "approved");
+    assert_eq!(json["data"]["status"], "monitoring");
     Ok(())
 }
 

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -7,6 +7,7 @@ description = "Paroche — Axum HTTP server, media streaming, and WebSocket even
 
 [dependencies]
 themelion.workspace = true
+aitesis.workspace = true
 apotheke.workspace = true
 horismos.workspace = true
 exousia.workspace = true

--- a/crates/paroche/src/routes/request.rs
+++ b/crates/paroche/src/routes/request.rs
@@ -1,45 +1,22 @@
-/// Media request workflow endpoints.
+//! Media request workflow endpoints.
+
+use aitesis::{CreateRequestInput, MediaRequest, RequestStatus};
 use axum::{
     Json,
     extract::{Path, Query, State},
 };
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
+use themelion::{MediaType, RequestId, UserId};
 use uuid::Uuid;
 
 use crate::error::ParocheError;
 use crate::response::{ApiResponse, deleted};
-use crate::state::AppState;
+use crate::state::{AppState, RequestServiceError};
 
 // ---------------------------------------------------------------------------
-// Row / response types
+// Response conversion
 // ---------------------------------------------------------------------------
-
-fn bytes_to_uuid_str(bytes: &[u8]) -> String {
-    Uuid::from_slice(bytes)
-        .map(|u| u.to_string())
-        .unwrap_or_default()
-}
-
-#[derive(Debug, Clone, sqlx::FromRow)]
-struct RequestRow {
-    id: Vec<u8>,
-    user_id: Vec<u8>,
-    media_type: String,
-    title: String,
-    external_id: Option<String>,
-    status: String,
-    decided_by: Option<Vec<u8>>,
-    decided_at: Option<String>,
-    deny_reason: Option<String>,
-    want_id: Option<Vec<u8>>,
-    created_at: String,
-}
-
-const SELECT_REQUEST: &str = "\
-    SELECT id, user_id, media_type, title, external_id, status, \
-           decided_by, decided_at, deny_reason, want_id, created_at \
-    FROM requests";
 
 #[derive(Serialize)]
 pub struct RequestResponse {
@@ -56,21 +33,70 @@ pub struct RequestResponse {
     pub created_at: String,
 }
 
-impl From<RequestRow> for RequestResponse {
-    fn from(r: RequestRow) -> Self {
+impl From<MediaRequest> for RequestResponse {
+    fn from(request: MediaRequest) -> Self {
         Self {
-            id: bytes_to_uuid_str(&r.id),
-            user_id: bytes_to_uuid_str(&r.user_id),
-            media_type: r.media_type,
-            title: r.title,
-            external_id: r.external_id,
-            status: r.status,
-            decided_by: r.decided_by.as_deref().map(bytes_to_uuid_str),
-            decided_at: r.decided_at,
-            deny_reason: r.deny_reason,
-            want_id: r.want_id.as_deref().map(bytes_to_uuid_str),
-            created_at: r.created_at,
+            id: request.id.as_uuid().to_string(),
+            user_id: request.user_id.as_uuid().to_string(),
+            media_type: request.media_type.to_string(),
+            title: request.title,
+            external_id: request.external_id,
+            status: request.status.as_str().to_string(),
+            decided_by: request.decided_by.map(|id| id.as_uuid().to_string()),
+            decided_at: request.decided_at.map(|ts| ts.to_string()),
+            deny_reason: request.deny_reason,
+            want_id: request.want_id.map(|id| id.as_uuid().to_string()),
+            created_at: request.created_at.to_string(),
         }
+    }
+}
+
+fn parse_request_id(id: &str) -> Result<RequestId, ParocheError> {
+    Uuid::parse_str(id)
+        .map(RequestId::from_uuid)
+        .map_err(|_| ParocheError::InvalidId)
+}
+
+fn parse_user_id(id: &str) -> Result<UserId, ParocheError> {
+    Uuid::parse_str(id)
+        .map(UserId::from_uuid)
+        .map_err(|_| ParocheError::InvalidId)
+}
+
+fn parse_media_type(value: &str) -> Result<MediaType, ParocheError> {
+    match value {
+        "music_album" => return Ok(MediaType::Music),
+        "tv_series" => return Ok(MediaType::Tv),
+        _ => {}
+    }
+    serde_json::from_value(serde_json::Value::String(value.to_string())).map_err(|_| {
+        ParocheError::Validation {
+            message: format!("unsupported media_type: {value}"),
+        }
+    })
+}
+
+fn parse_request_status(value: &str) -> Result<RequestStatus, ParocheError> {
+    RequestStatus::parse(value).ok_or_else(|| ParocheError::Validation {
+        message: format!("unsupported request status: {value}"),
+    })
+}
+
+fn map_request_service_error(error: RequestServiceError) -> ParocheError {
+    match error {
+        RequestServiceError::NotAvailable => ParocheError::Unavailable,
+        RequestServiceError::Domain(error) => match error {
+            aitesis::AitesisError::RequestLimitExceeded { .. } => ParocheError::RateLimited,
+            aitesis::AitesisError::RequestNotFound { .. } => ParocheError::NotFound,
+            aitesis::AitesisError::RequestAlreadyExists { .. }
+            | aitesis::AitesisError::MediaIdentityInvalid { .. }
+            | aitesis::AitesisError::InvalidTransition { .. } => ParocheError::Validation {
+                message: error.to_string(),
+            },
+            aitesis::AitesisError::InsufficientPermission { .. } => ParocheError::Forbidden,
+            aitesis::AitesisError::Database { source, .. } => ParocheError::Database { source },
+            _ => ParocheError::Internal,
+        },
     }
 }
 
@@ -119,59 +145,25 @@ pub async fn list_requests(
     let page = filter.page.max(1);
     let offset = (page - 1) * per_page;
 
-    let rows = match (&filter.user_id, &filter.status) {
-        (Some(uid), Some(status)) => {
-            let uuid = Uuid::parse_str(uid).map_err(|_| ParocheError::InvalidId)?;
-            let q = format!(
-                "{SELECT_REQUEST} WHERE user_id = ? AND status = ? \
-                 ORDER BY created_at DESC LIMIT ? OFFSET ?"
-            );
-            sqlx::query_as::<_, RequestRow>(&q)
-                .bind(uuid.as_bytes().as_slice())
-                .bind(status)
-                .bind(per_page as i64)
-                .bind(offset as i64)
-                .fetch_all(&state.db.read)
-                .await
-        }
-        (Some(uid), None) => {
-            let uuid = Uuid::parse_str(uid).map_err(|_| ParocheError::InvalidId)?;
-            let q = format!(
-                "{SELECT_REQUEST} WHERE user_id = ? \
-                 ORDER BY created_at DESC LIMIT ? OFFSET ?"
-            );
-            sqlx::query_as::<_, RequestRow>(&q)
-                .bind(uuid.as_bytes().as_slice())
-                .bind(per_page as i64)
-                .bind(offset as i64)
-                .fetch_all(&state.db.read)
-                .await
-        }
-        (None, Some(status)) => {
-            let q = format!(
-                "{SELECT_REQUEST} WHERE status = ? \
-                 ORDER BY created_at DESC LIMIT ? OFFSET ?"
-            );
-            sqlx::query_as::<_, RequestRow>(&q)
-                .bind(status)
-                .bind(per_page as i64)
-                .bind(offset as i64)
-                .fetch_all(&state.db.read)
-                .await
-        }
-        (None, None) => {
-            let q = format!("{SELECT_REQUEST} ORDER BY created_at DESC LIMIT ? OFFSET ?");
-            sqlx::query_as::<_, RequestRow>(&q)
-                .bind(per_page as i64)
-                .bind(offset as i64)
-                .fetch_all(&state.db.read)
-                .await
-        }
-    }
-    .map_err(|_| ParocheError::Internal)?;
+    let user_id = filter.user_id.as_deref().map(parse_user_id).transpose()?;
+    let status = filter
+        .status
+        .as_deref()
+        .map(parse_request_status)
+        .transpose()?;
+    let requests = state
+        .requests
+        .list_requests(user_id, status)
+        .await
+        .map_err(map_request_service_error)?;
 
-    let total = rows.len() as u64;
-    let data: Vec<RequestResponse> = rows.into_iter().map(Into::into).collect();
+    let total = requests.len() as u64;
+    let data: Vec<RequestResponse> = requests
+        .into_iter()
+        .skip(offset as usize)
+        .take(per_page as usize)
+        .map(Into::into)
+        .collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }
 
@@ -180,18 +172,14 @@ pub async fn get_request(
     _auth: AuthenticatedUser,
     Path(id): Path<String>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
-    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
-    let id_bytes = uuid.as_bytes().to_vec();
-
-    let q = format!("{SELECT_REQUEST} WHERE id = ?");
-    let row = sqlx::query_as::<_, RequestRow>(&q)
-        .bind(&id_bytes)
-        .fetch_optional(&state.db.read)
+    let request_id = parse_request_id(&id)?;
+    let request = state
+        .requests
+        .get_request(request_id)
         .await
-        .map_err(|_| ParocheError::Internal)?
-        .ok_or(ParocheError::NotFound)?;
+        .map_err(map_request_service_error)?;
 
-    Ok(ApiResponse::ok(RequestResponse::from(row)))
+    Ok(ApiResponse::ok(RequestResponse::from(request)))
 }
 
 pub async fn submit_request(
@@ -210,33 +198,18 @@ pub async fn submit_request(
         });
     }
 
-    let id = Uuid::now_v7().as_bytes().to_vec();
-    let user_id = auth.user_id.as_bytes().to_vec();
-    let now = crate::routes::music::chrono_now_pub();
-
-    sqlx::query(
-        "INSERT INTO requests \
-         (id, user_id, media_type, title, external_id, status, created_at) \
-         VALUES (?, ?, ?, ?, ?, 'submitted', ?)",
-    )
-    .bind(&id)
-    .bind(&user_id)
-    .bind(&body.media_type)
-    .bind(&body.title)
-    .bind(&body.external_id)
-    .bind(&now)
-    .execute(&state.db.write)
-    .await
-    .map_err(|_| ParocheError::Internal)?;
-
-    let q = format!("{SELECT_REQUEST} WHERE id = ?");
-    let row = sqlx::query_as::<_, RequestRow>(&q)
-        .bind(&id)
-        .fetch_one(&state.db.read)
+    let input = CreateRequestInput {
+        media_type: parse_media_type(body.media_type.trim())?,
+        title: body.title,
+        external_id: body.external_id,
+    };
+    let request = state
+        .requests
+        .submit_request(auth.user_id, input)
         .await
-        .map_err(|_| ParocheError::Internal)?;
+        .map_err(map_request_service_error)?;
 
-    Ok(ApiResponse::created(RequestResponse::from(row)))
+    Ok(ApiResponse::created(RequestResponse::from(request)))
 }
 
 pub async fn approve_request(
@@ -244,35 +217,12 @@ pub async fn approve_request(
     admin: RequireAdmin,
     Path(id): Path<String>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
-    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
-    let id_bytes = uuid.as_bytes().to_vec();
-    let admin_id = admin.0.user_id.as_bytes().to_vec();
-    let now = crate::routes::music::chrono_now_pub();
-
-    let q = format!("{SELECT_REQUEST} WHERE id = ?");
-    sqlx::query_as::<_, RequestRow>(&q)
-        .bind(&id_bytes)
-        .fetch_optional(&state.db.read)
+    let request_id = parse_request_id(&id)?;
+    let updated = state
+        .requests
+        .approve(request_id, admin.0.user_id)
         .await
-        .map_err(|_| ParocheError::Internal)?
-        .ok_or(ParocheError::NotFound)?;
-
-    sqlx::query(
-        "UPDATE requests SET status = 'approved', decided_by = ?, decided_at = ? WHERE id = ?",
-    )
-    .bind(&admin_id)
-    .bind(&now)
-    .bind(&id_bytes)
-    .execute(&state.db.write)
-    .await
-    .map_err(|_| ParocheError::Internal)?;
-
-    let q2 = format!("{SELECT_REQUEST} WHERE id = ?");
-    let updated = sqlx::query_as::<_, RequestRow>(&q2)
-        .bind(&id_bytes)
-        .fetch_one(&state.db.read)
-        .await
-        .map_err(|_| ParocheError::Internal)?;
+        .map_err(map_request_service_error)?;
 
     Ok(ApiResponse::ok(RequestResponse::from(updated)))
 }
@@ -283,37 +233,12 @@ pub async fn deny_request(
     Path(id): Path<String>,
     Json(body): Json<DenyRequestBody>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
-    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
-    let id_bytes = uuid.as_bytes().to_vec();
-    let admin_id = admin.0.user_id.as_bytes().to_vec();
-    let now = crate::routes::music::chrono_now_pub();
-
-    let q = format!("{SELECT_REQUEST} WHERE id = ?");
-    sqlx::query_as::<_, RequestRow>(&q)
-        .bind(&id_bytes)
-        .fetch_optional(&state.db.read)
+    let request_id = parse_request_id(&id)?;
+    let updated = state
+        .requests
+        .deny(request_id, admin.0.user_id, body.reason)
         .await
-        .map_err(|_| ParocheError::Internal)?
-        .ok_or(ParocheError::NotFound)?;
-
-    sqlx::query(
-        "UPDATE requests SET status = 'denied', decided_by = ?, decided_at = ?, \
-         deny_reason = ? WHERE id = ?",
-    )
-    .bind(&admin_id)
-    .bind(&now)
-    .bind(&body.reason)
-    .bind(&id_bytes)
-    .execute(&state.db.write)
-    .await
-    .map_err(|_| ParocheError::Internal)?;
-
-    let q2 = format!("{SELECT_REQUEST} WHERE id = ?");
-    let updated = sqlx::query_as::<_, RequestRow>(&q2)
-        .bind(&id_bytes)
-        .fetch_one(&state.db.read)
-        .await
-        .map_err(|_| ParocheError::Internal)?;
+        .map_err(map_request_service_error)?;
 
     Ok(ApiResponse::ok(RequestResponse::from(updated)))
 }
@@ -323,28 +248,12 @@ pub async fn cancel_request(
     auth: AuthenticatedUser,
     Path(id): Path<String>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
-    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
-    let id_bytes = uuid.as_bytes().to_vec();
-    let user_id = auth.user_id.as_bytes().to_vec();
-
-    let q = format!("{SELECT_REQUEST} WHERE id = ?");
-    let row = sqlx::query_as::<_, RequestRow>(&q)
-        .bind(&id_bytes)
-        .fetch_optional(&state.db.read)
+    let request_id = parse_request_id(&id)?;
+    state
+        .requests
+        .cancel_request(request_id, auth.user_id)
         .await
-        .map_err(|_| ParocheError::Internal)?
-        .ok_or(ParocheError::NotFound)?;
-
-    // Only the requesting user (or admin via separate endpoint) can cancel.
-    if row.user_id != user_id {
-        return Err(ParocheError::Forbidden);
-    }
-
-    sqlx::query("DELETE FROM requests WHERE id = ?")
-        .bind(&id_bytes)
-        .execute(&state.db.write)
-        .await
-        .map_err(|_| ParocheError::Internal)?;
+        .map_err(map_request_service_error)?;
 
     Ok(deleted())
 }
@@ -360,4 +269,200 @@ pub fn request_routes() -> axum::Router<AppState> {
         .route("/{id}", get(get_request).delete(cancel_request))
         .route("/{id}/approve", post(approve_request))
         .route("/{id}/deny", post(deny_request))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use aitesis::{IdentityValidator, MonitorService, RequestService, UserRoleProvider};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use exousia::{AuthService, CreateUserRequest, UserRole};
+    use serde_json::json;
+    use themelion::{UserId, WantId};
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helpers::test_state;
+
+    type TestRequestService = aitesis::AitesisServiceImpl<TestRoles, TestIdentity, TestMonitor>;
+
+    struct TestRequestAdapter(Arc<TestRequestService>);
+
+    impl crate::state::DynRequestService for TestRequestAdapter {
+        fn submit_request(
+            &self,
+            user_id: UserId,
+            input: aitesis::CreateRequestInput,
+        ) -> crate::state::RequestServiceFut<'_, aitesis::MediaRequest> {
+            let service = Arc::clone(&self.0);
+            Box::pin(async move {
+                service
+                    .submit_request(user_id, input)
+                    .await
+                    .map_err(Into::into)
+            })
+        }
+
+        fn approve(
+            &self,
+            request_id: themelion::RequestId,
+            admin_id: UserId,
+        ) -> crate::state::RequestServiceFut<'_, aitesis::MediaRequest> {
+            let service = Arc::clone(&self.0);
+            Box::pin(async move {
+                service
+                    .approve(request_id, admin_id)
+                    .await
+                    .map_err(Into::into)
+            })
+        }
+
+        fn deny(
+            &self,
+            request_id: themelion::RequestId,
+            admin_id: UserId,
+            reason: Option<String>,
+        ) -> crate::state::RequestServiceFut<'_, aitesis::MediaRequest> {
+            let service = Arc::clone(&self.0);
+            Box::pin(async move {
+                service
+                    .deny(request_id, admin_id, reason)
+                    .await
+                    .map_err(Into::into)
+            })
+        }
+
+        fn get_request(
+            &self,
+            request_id: themelion::RequestId,
+        ) -> crate::state::RequestServiceFut<'_, aitesis::MediaRequest> {
+            let service = Arc::clone(&self.0);
+            Box::pin(async move { service.get_request(request_id).await.map_err(Into::into) })
+        }
+
+        fn list_requests(
+            &self,
+            user_id: Option<UserId>,
+            status: Option<aitesis::RequestStatus>,
+        ) -> crate::state::RequestServiceFut<'_, Vec<aitesis::MediaRequest>> {
+            let service = Arc::clone(&self.0);
+            Box::pin(async move {
+                service
+                    .list_requests(user_id, status)
+                    .await
+                    .map_err(Into::into)
+            })
+        }
+
+        fn cancel_request(
+            &self,
+            request_id: themelion::RequestId,
+            user_id: UserId,
+        ) -> crate::state::RequestServiceFut<'_, ()> {
+            let service = Arc::clone(&self.0);
+            Box::pin(async move {
+                service
+                    .cancel_request(request_id, user_id)
+                    .await
+                    .map_err(Into::into)
+            })
+        }
+    }
+
+    struct TestRoles;
+
+    impl UserRoleProvider for TestRoles {
+        async fn role_of(
+            &self,
+            _user_id: UserId,
+        ) -> Result<aitesis::UserRole, aitesis::AitesisError> {
+            Ok(aitesis::UserRole::Member)
+        }
+    }
+
+    struct TestIdentity;
+
+    impl IdentityValidator for TestIdentity {
+        async fn validate(
+            &self,
+            _media_type: MediaType,
+            _title: &str,
+            _external_id: Option<&str>,
+        ) -> Result<(), aitesis::AitesisError> {
+            Ok(())
+        }
+    }
+
+    struct TestMonitor;
+
+    impl MonitorService for TestMonitor {
+        async fn create_want(
+            &self,
+            _request: &aitesis::MediaRequest,
+        ) -> Result<WantId, aitesis::AitesisError> {
+            Ok(WantId::new())
+        }
+    }
+
+    async fn post_request(
+        app: &axum::Router,
+        token: &str,
+    ) -> Result<StatusCode, Box<dyn std::error::Error + Send + Sync>> {
+        let body = json!({
+            "media_type": "music",
+            "title": "Kind of Blue",
+            "external_id": null
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/requests")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(serde_json::to_vec(&body)?))?,
+            )
+            .await?;
+        Ok(resp.status())
+    }
+
+    #[tokio::test]
+    async fn submit_request_enforces_aitesis_pending_limit()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let (mut state, auth) = test_state().await;
+        let config = horismos::AitesisConfig {
+            max_pending_per_user: 1,
+            max_requests_per_day: 100,
+            auto_approve_admins: false,
+        };
+        let service = Arc::new(aitesis::AitesisServiceImpl::new(
+            state.db.read.clone(),
+            state.db.write.clone(),
+            config,
+            TestRoles,
+            TestIdentity,
+            TestMonitor,
+        ));
+        state.requests = Arc::new(TestRequestAdapter(service));
+
+        auth.create_user(CreateUserRequest {
+            username: "requester".to_string(),
+            display_name: "Requester".to_string(),
+            password: "password123".to_string(),
+            role: UserRole::Member,
+        })
+        .await?;
+        let token = auth.login("requester", "password123").await?.access_token;
+        let app = crate::build_router(state);
+
+        assert_eq!(post_request(&app, &token).await?, StatusCode::CREATED);
+        assert_eq!(
+            post_request(&app, &token).await?,
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        Ok(())
+    }
 }

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -29,6 +29,10 @@ pub trait DynMetadataResolver: Send + Sync {}
 /// Boxed future type for dyn-safe acquisition service methods.
 pub type ServiceFut<T> = Pin<Box<dyn Future<Output = Result<T, ServiceError>> + Send>>;
 
+/// Boxed future type for dyn-safe request service methods.
+pub type RequestServiceFut<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, RequestServiceError>> + Send + 'a>>;
+
 /// Error type returned by acquisition service trait methods.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -41,6 +45,22 @@ pub enum ServiceError {
     Internal(String),
 }
 
+/// Error type returned by request service trait methods.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum RequestServiceError {
+    /// The backing request service is not wired up.
+    NotAvailable,
+    /// The Aitesis domain service rejected the operation.
+    Domain(aitesis::AitesisError),
+}
+
+impl From<aitesis::AitesisError> for RequestServiceError {
+    fn from(error: aitesis::AitesisError) -> Self {
+        Self::Domain(error)
+    }
+}
+
 /// Search across indexers via zetesis.
 pub trait DynSearchService: Send + Sync {
     fn search(&self, query: serde_json::Value) -> ServiceFut<serde_json::Value>;
@@ -50,7 +70,45 @@ pub trait DynSearchService: Send + Sync {
 
 pub trait DynDownloadEngine: Send + Sync {}
 pub trait DynQueueManager: Send + Sync {}
-pub trait DynRequestService: Send + Sync {}
+
+/// Media-request lifecycle via Aitesis.
+pub trait DynRequestService: Send + Sync {
+    fn submit_request(
+        &self,
+        user_id: themelion::UserId,
+        input: aitesis::CreateRequestInput,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest>;
+
+    fn approve(
+        &self,
+        request_id: themelion::RequestId,
+        admin_id: themelion::UserId,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest>;
+
+    fn deny(
+        &self,
+        request_id: themelion::RequestId,
+        admin_id: themelion::UserId,
+        reason: Option<String>,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest>;
+
+    fn get_request(
+        &self,
+        request_id: themelion::RequestId,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest>;
+
+    fn list_requests(
+        &self,
+        user_id: Option<themelion::UserId>,
+        status: Option<aitesis::RequestStatus>,
+    ) -> RequestServiceFut<'_, Vec<aitesis::MediaRequest>>;
+
+    fn cancel_request(
+        &self,
+        request_id: themelion::RequestId,
+        user_id: themelion::UserId,
+    ) -> RequestServiceFut<'_, ()>;
+}
 pub trait DynExternalIntegration: Send + Sync {}
 
 /// Subtitle acquisition via prostheke.
@@ -123,7 +181,55 @@ struct NullQueueManager;
 impl DynQueueManager for NullQueueManager {}
 
 struct NullRequestService;
-impl DynRequestService for NullRequestService {}
+impl DynRequestService for NullRequestService {
+    fn submit_request(
+        &self,
+        _user_id: themelion::UserId,
+        _input: aitesis::CreateRequestInput,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        Box::pin(async { Err(RequestServiceError::NotAvailable) })
+    }
+
+    fn approve(
+        &self,
+        _request_id: themelion::RequestId,
+        _admin_id: themelion::UserId,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        Box::pin(async { Err(RequestServiceError::NotAvailable) })
+    }
+
+    fn deny(
+        &self,
+        _request_id: themelion::RequestId,
+        _admin_id: themelion::UserId,
+        _reason: Option<String>,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        Box::pin(async { Err(RequestServiceError::NotAvailable) })
+    }
+
+    fn get_request(
+        &self,
+        _request_id: themelion::RequestId,
+    ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
+        Box::pin(async { Err(RequestServiceError::NotAvailable) })
+    }
+
+    fn list_requests(
+        &self,
+        _user_id: Option<themelion::UserId>,
+        _status: Option<aitesis::RequestStatus>,
+    ) -> RequestServiceFut<'_, Vec<aitesis::MediaRequest>> {
+        Box::pin(async { Err(RequestServiceError::NotAvailable) })
+    }
+
+    fn cancel_request(
+        &self,
+        _request_id: themelion::RequestId,
+        _user_id: themelion::UserId,
+    ) -> RequestServiceFut<'_, ()> {
+        Box::pin(async { Err(RequestServiceError::NotAvailable) })
+    }
+}
 
 struct NullExternalIntegration;
 impl DynExternalIntegration for NullExternalIntegration {}


### PR DESCRIPTION
## Summary

- Route request REST handlers through the Aitesis-backed `state.requests` boundary instead of raw SQL.
- Wire Archon serve startup to a real `AitesisServiceImpl`, including Exousia role lookup and wanted-media handoff on approval.
- Add HTTP regression coverage proving Aitesis pending-request limits surface as `429 TOO_MANY_REQUESTS`.

Closes #247.

## Gates

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harmonia-request-service-routes-target cargo check --workspace`
- `CARGO_TARGET_DIR=/tmp/harmonia-request-service-routes-target cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harmonia-request-service-routes-target cargo test --workspace`
- `kanon lint --summary --precision high` on each touched file
- Kimi reviewer `0000019e529684ddf214b1f7035fb20c`: APPROVE

Gate-Passed: cargo fmt --all -- --check; git diff --check; cargo check --workspace; cargo clippy --workspace --all-targets -- -D warnings; cargo test --workspace; kanon lint touched files; kimi reviewer APPROVE 0000019e529684ddf214b1f7035fb20c
