### PR TITLE
fix(search): wire live zetesis adapter

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -16,6 +16,7 @@ use kritike::DefaultCurationService;
 use paroche::state::{
     AppState, DynCurationService, DynDownloadEngine, DynExternalIntegration, DynMetadataResolver,
     DynQueueManager, DynRequestService, DynSearchService, DynSubtitleService, RequestServiceFut,
+    ServiceError, ServiceFut,
 };
 use prostheke::ProsthekeService;
 use prostheke::providers::Provider;
@@ -46,46 +47,113 @@ impl DynCurationService for NullCuration {}
 struct NullMetadata;
 impl DynMetadataResolver for NullMetadata {}
 
-// WHY: Adapter structs hold Arc handles to keep acquisition subsystems alive
-// for the lifetime of AppState. The INNER fields are read once route handlers
-// are wired in prompt 102.
-struct SearchAdapter(#[expect(dead_code)] Arc<ZetesisService>);
+struct SearchAdapter(Arc<ZetesisService>);
 impl DynSearchService for SearchAdapter {
-    fn search(
-        &self,
-        _query: serde_json::Value,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<serde_json::Value, paroche::state::ServiceError>,
-                > + Send,
-        >,
-    > {
-        Box::pin(async { Err(paroche::state::ServiceError::NotAvailable) })
+    fn search(&self, query: serde_json::Value) -> ServiceFut<serde_json::Value> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            let query = search_query_from_json(query)?;
+            let results = service
+                .search(query, CancellationToken::new())
+                .await
+                .map_err(search_error)?;
+            serde_json::to_value(serde_json::json!({ "results": results }))
+                .map_err(|error| ServiceError::Internal(error.to_string()))
+        })
     }
-    fn test_indexer(
-        &self,
-        _indexer_id: i64,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<serde_json::Value, paroche::state::ServiceError>,
-                > + Send,
-        >,
-    > {
-        Box::pin(async { Err(paroche::state::ServiceError::NotAvailable) })
+
+    fn test_indexer(&self, indexer_id: i64) -> ServiceFut<serde_json::Value> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            let status = service
+                .test_indexer(indexer_id, CancellationToken::new())
+                .await
+                .map_err(search_error)?;
+            serde_json::to_value(status).map_err(|error| ServiceError::Internal(error.to_string()))
+        })
     }
-    fn refresh_caps(
-        &self,
-        _indexer_id: i64,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<serde_json::Value, paroche::state::ServiceError>,
-                > + Send,
-        >,
-    > {
-        Box::pin(async { Err(paroche::state::ServiceError::NotAvailable) })
+
+    fn refresh_caps(&self, indexer_id: i64) -> ServiceFut<serde_json::Value> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            let caps = service
+                .refresh_caps(indexer_id, CancellationToken::new())
+                .await
+                .map_err(search_error)?;
+            serde_json::to_value(caps).map_err(|error| ServiceError::Internal(error.to_string()))
+        })
+    }
+}
+
+fn search_query_from_json(value: serde_json::Value) -> Result<zetesis::SearchQuery, ServiceError> {
+    if value.get("query_id").is_some() {
+        return Err(ServiceError::NotFound);
+    }
+
+    let media_type = value
+        .get("media_type")
+        .and_then(serde_json::Value::as_str)
+        .map(parse_search_media_type)
+        .transpose()?
+        .unwrap_or_default();
+
+    Ok(zetesis::SearchQuery {
+        query_text: json_string(&value, "query_text"),
+        media_type,
+        category_ids: value
+            .get("category_ids")
+            .and_then(serde_json::Value::as_array)
+            .map(|ids| {
+                ids.iter()
+                    .filter_map(serde_json::Value::as_u64)
+                    .filter_map(|id| u32::try_from(id).ok())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        imdb_id: json_string(&value, "imdb_id"),
+        tvdb_id: json_u32(&value, "tvdb_id"),
+        tmdb_id: json_u32(&value, "tmdb_id"),
+        artist: json_string(&value, "artist"),
+        album: json_string(&value, "album"),
+        author: json_string(&value, "author"),
+        season: json_u32(&value, "season"),
+        episode: json_u32(&value, "episode"),
+        limit: json_u32(&value, "limit").unwrap_or(100),
+        offset: json_u32(&value, "offset").unwrap_or_default(),
+    })
+}
+
+fn parse_search_media_type(media_type: &str) -> Result<zetesis::SearchMediaType, ServiceError> {
+    match media_type {
+        "any" => Ok(zetesis::SearchMediaType::Any),
+        "tv" | "series" => Ok(zetesis::SearchMediaType::Tv),
+        "movie" | "movies" => Ok(zetesis::SearchMediaType::Movie),
+        "music" | "album" | "music_album" => Ok(zetesis::SearchMediaType::Music),
+        "book" | "books" | "audiobook" | "comic" => Ok(zetesis::SearchMediaType::Book),
+        other => Err(ServiceError::Internal(format!(
+            "unsupported search media_type: {other}"
+        ))),
+    }
+}
+
+fn json_string(value: &serde_json::Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn json_u32(value: &serde_json::Value, key: &str) -> Option<u32> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|n| u32::try_from(n).ok())
+}
+
+fn search_error(error: zetesis::ZetesisError) -> ServiceError {
+    match error {
+        zetesis::ZetesisError::IndexerNotFound { .. } => ServiceError::NotFound,
+        other => ServiceError::Internal(other.to_string()),
     }
 }
 
@@ -743,6 +811,79 @@ fn validate_download_dir(config: &horismos::Config) -> Result<(), HostError> {
     }
     let _ = std::fs::remove_file(&test_file);
     Ok(())
+}
+
+#[cfg(test)]
+mod search_adapter_tests {
+    use std::sync::Arc;
+
+    use apotheke::migrate::MIGRATOR;
+    use paroche::state::{DynSearchService, ServiceError};
+    use serde_json::json;
+    use sqlx::SqlitePool;
+    use themelion::create_event_bus;
+
+    use super::{SearchAdapter, parse_search_media_type, search_query_from_json};
+
+    #[test]
+    fn search_query_from_json_maps_route_payload_to_zetesis_query() {
+        let query = search_query_from_json(json!({
+            "query_text": "Kind of Blue",
+            "media_type": "music",
+            "category_ids": [3000, 3010],
+            "artist": "Miles Davis",
+            "limit": 25,
+            "offset": 5
+        }))
+        .expect("valid search query");
+
+        assert_eq!(query.query_text.as_deref(), Some("Kind of Blue"));
+        assert_eq!(query.media_type, zetesis::SearchMediaType::Music);
+        assert_eq!(query.category_ids, vec![3000, 3010]);
+        assert_eq!(query.artist.as_deref(), Some("Miles Davis"));
+        assert_eq!(query.limit, 25);
+        assert_eq!(query.offset, 5);
+    }
+
+    #[test]
+    fn search_query_from_json_rejects_cached_result_lookup() {
+        let error = search_query_from_json(json!({ "query_id": "q-1" }))
+            .expect_err("cached result lookup is not backed by zetesis search fan-out");
+        assert!(matches!(error, ServiceError::NotFound));
+    }
+
+    #[test]
+    fn parse_search_media_type_rejects_unknown_values() {
+        let error = parse_search_media_type("podcast").expect_err("unsupported media type");
+        assert!(matches!(error, ServiceError::Internal(_)));
+    }
+
+    #[tokio::test]
+    async fn search_adapter_calls_live_zetesis_service() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite opens");
+        MIGRATOR.run(&pool).await.expect("migrations run");
+        let (event_tx, _) = create_event_bus(64);
+        let service = zetesis::ZetesisService::new(
+            pool.clone(),
+            pool,
+            Arc::new(zetesis::cf_bypass::noop::NoProxy),
+            horismos::ZetesisConfig::default(),
+            event_tx,
+        );
+        let adapter = SearchAdapter(Arc::new(service));
+
+        let result = adapter
+            .search(json!({ "query_text": "empty library", "media_type": "music" }))
+            .await
+            .expect("live zetesis search should return an empty result set without indexers");
+
+        assert_eq!(
+            result["results"].as_array().expect("results array").len(),
+            0
+        );
+    }
 }
 
 fn dirs_config_path() -> std::path::PathBuf {

--- a/crates/paroche/src/routes/indexer.rs
+++ b/crates/paroche/src/routes/indexer.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ParocheError;
 use crate::response::{ApiResponse, deleted};
-use crate::state::AppState;
+use crate::state::{AppState, ServiceError};
 
 // ---------------------------------------------------------------------------
 // Query / request / response types
@@ -287,7 +287,7 @@ pub async fn test_indexer(
         .search
         .test_indexer(id)
         .await
-        .map_err(|_| ParocheError::Unavailable)?;
+        .map_err(indexer_service_error)?;
 
     Ok(ApiResponse::ok(result))
 }
@@ -308,9 +308,17 @@ pub async fn refresh_caps(
         .search
         .refresh_caps(id)
         .await
-        .map_err(|_| ParocheError::Unavailable)?;
+        .map_err(indexer_service_error)?;
 
     Ok(ApiResponse::ok(caps))
+}
+
+fn indexer_service_error(error: ServiceError) -> ParocheError {
+    match error {
+        ServiceError::NotFound => ParocheError::NotFound,
+        ServiceError::NotAvailable => ParocheError::Unavailable,
+        ServiceError::Internal(_) => ParocheError::Internal,
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/paroche/src/routes/search.rs
+++ b/crates/paroche/src/routes/search.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ParocheError;
 use crate::response::ApiResponse;
-use crate::state::AppState;
+use crate::state::{AppState, ServiceError};
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -53,7 +53,7 @@ pub async fn search(
         .search
         .search(query)
         .await
-        .map_err(|_| ParocheError::Unavailable)?;
+        .map_err(search_service_error)?;
 
     Ok(ApiResponse::ok(results))
 }
@@ -72,9 +72,17 @@ pub async fn get_search_results(
         .search
         .search(query)
         .await
-        .map_err(|_| ParocheError::Unavailable)?;
+        .map_err(search_service_error)?;
 
     Ok(ApiResponse::ok(results))
+}
+
+fn search_service_error(error: ServiceError) -> ParocheError {
+    match error {
+        ServiceError::NotFound => ParocheError::NotFound,
+        ServiceError::NotAvailable => ParocheError::Unavailable,
+        ServiceError::Internal(_) => ParocheError::Internal,
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/zetesis/src/client/mod.rs
+++ b/crates/zetesis/src/client/mod.rs
@@ -40,6 +40,16 @@ pub trait DynIndexerClient: Send + Sync {
         query: &'a SearchQuery,
         ct: CancellationToken,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<SearchResult>, ZetesisError>> + Send + 'a>>;
+
+    fn caps_boxed(
+        &self,
+        ct: CancellationToken,
+    ) -> Pin<Box<dyn Future<Output = Result<IndexerCaps, ZetesisError>> + Send + '_>>;
+
+    fn test_boxed(
+        &self,
+        ct: CancellationToken,
+    ) -> Pin<Box<dyn Future<Output = Result<IndexerStatus, ZetesisError>> + Send + '_>>;
 }
 
 impl<T: IndexerClient> DynIndexerClient for T {
@@ -49,6 +59,20 @@ impl<T: IndexerClient> DynIndexerClient for T {
         ct: CancellationToken,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<SearchResult>, ZetesisError>> + Send + 'a>> {
         Box::pin(self.search(query, ct))
+    }
+
+    fn caps_boxed(
+        &self,
+        ct: CancellationToken,
+    ) -> Pin<Box<dyn Future<Output = Result<IndexerCaps, ZetesisError>> + Send + '_>> {
+        Box::pin(self.caps(ct))
+    }
+
+    fn test_boxed(
+        &self,
+        ct: CancellationToken,
+    ) -> Pin<Box<dyn Future<Output = Result<IndexerStatus, ZetesisError>> + Send + '_>> {
+        Box::pin(self.test(ct))
     }
 }
 

--- a/crates/zetesis/src/error.rs
+++ b/crates/zetesis/src/error.rs
@@ -51,6 +51,13 @@ pub enum ZetesisError {
         location: snafu::Location,
     },
 
+    #[snafu(display("indexer {indexer_id} was not found"))]
+    IndexerNotFound {
+        indexer_id: i64,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("Byparr did not respond within {timeout}s for {url}"))]
     CfProxyTimeout {
         url: String,

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -16,7 +16,7 @@ use crate::client::{DynIndexerClient, IndexerConfig};
 use crate::error::ZetesisError;
 use crate::rate_limit::RateLimiter;
 use crate::repo::{self, IndexerRow};
-use crate::types::{IndexerCaps, SearchMediaType, SearchQuery, SearchResult};
+use crate::types::{IndexerCaps, IndexerStatus, SearchMediaType, SearchQuery, SearchResult};
 
 pub struct ZetesisService {
     read_pool: SqlitePool,
@@ -60,7 +60,7 @@ impl ZetesisService {
     #[instrument(skip(self, ct))]
     pub async fn search(
         &self,
-        query: &SearchQuery,
+        query: SearchQuery,
         ct: CancellationToken,
     ) -> Result<Vec<SearchResult>, ZetesisError> {
         let query_id = QueryId::new();
@@ -74,7 +74,7 @@ impl ZetesisService {
             })?;
 
         // Step 2: Filter by search function support
-        let eligible = filter_by_capability(&indexers, query);
+        let eligible = filter_by_capability(&indexers, &query);
 
         info!(
             query_id = %query_id,
@@ -93,11 +93,11 @@ impl ZetesisService {
                 let cf = Arc::clone(&cf_proxy);
                 let h = http.clone();
                 let ct = ct.clone();
-                let q = query;
+                let q = query.clone();
                 async move {
                     rate_limiter.acquire(indexer.id).await;
-                    let client = make_client(indexer, h, cf, timeout);
-                    match client.search_boxed(q, ct).await {
+                    let client = make_client(&indexer, h, cf, timeout);
+                    match client.search_boxed(&q, ct).await {
                         Ok(results) => results,
                         Err(e) => {
                             warn!(
@@ -106,7 +106,7 @@ impl ZetesisService {
                                 error = %e,
                                 "search failed for indexer"
                             );
-                            self.handle_search_error(indexer, &e).await;
+                            self.handle_search_error(&indexer, &e).await;
                             Vec::new()
                         }
                     }
@@ -133,6 +133,90 @@ impl ZetesisService {
         );
 
         Ok(deduped)
+    }
+
+    pub async fn test_indexer(
+        &self,
+        indexer_id: i64,
+        ct: CancellationToken,
+    ) -> Result<IndexerStatus, ZetesisError> {
+        let indexer = self.load_indexer(indexer_id).await?;
+        let client = make_client(
+            &indexer,
+            self.http.clone(),
+            Arc::clone(&self.cf_proxy),
+            Duration::from_secs(self.config.request_timeout_secs),
+        );
+        let status = client.test_boxed(ct).await?;
+        let db_status = if status.healthy { "active" } else { "degraded" };
+        repo::update_indexer_status(&self.write_pool, indexer_id, db_status)
+            .await
+            .map_err(|e| ZetesisError::Database {
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        Ok(status)
+    }
+
+    pub async fn refresh_caps(
+        &self,
+        indexer_id: i64,
+        ct: CancellationToken,
+    ) -> Result<IndexerCaps, ZetesisError> {
+        let indexer = self.load_indexer(indexer_id).await?;
+        let client = make_client(
+            &indexer,
+            self.http.clone(),
+            Arc::clone(&self.cf_proxy),
+            Duration::from_secs(self.config.request_timeout_secs),
+        );
+        let caps = client
+            .caps_boxed(ct)
+            .await
+            .map_err(|source| ZetesisError::CapsUnavailable {
+                indexer_id,
+                source: Box::new(source),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let caps_json =
+            serde_json::to_string(&caps).map_err(|error| ZetesisError::ParseResponse {
+                url: indexer.url.clone(),
+                error: error.to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let now = jiff::Timestamp::now().to_string();
+        repo::update_indexer_caps(&self.write_pool, indexer_id, &caps_json, &now)
+            .await
+            .map_err(|e| ZetesisError::Database {
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        repo::upsert_indexer_categories(&self.write_pool, indexer_id, &caps)
+            .await
+            .map_err(|e| ZetesisError::Database {
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        repo::update_indexer_status(&self.write_pool, indexer_id, "active")
+            .await
+            .map_err(|e| ZetesisError::Database {
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        Ok(caps)
+    }
+
+    async fn load_indexer(&self, indexer_id: i64) -> Result<IndexerRow, ZetesisError> {
+        repo::get_indexer(&self.read_pool, indexer_id)
+            .await
+            .map_err(|e| ZetesisError::Database {
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?
+            .ok_or_else(|| ZetesisError::IndexerNotFound {
+                indexer_id,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })
     }
 
     async fn handle_search_error(&self, indexer: &IndexerRow, error: &ZetesisError) {
@@ -166,10 +250,7 @@ impl ZetesisService {
     }
 }
 
-fn filter_by_capability<'a>(
-    indexers: &'a [IndexerRow],
-    query: &SearchQuery,
-) -> Vec<&'a IndexerRow> {
+fn filter_by_capability(indexers: &[IndexerRow], query: &SearchQuery) -> Vec<IndexerRow> {
     let function_type = query.search_function();
 
     indexers
@@ -189,6 +270,7 @@ fn filter_by_capability<'a>(
 
             crate::types::supports_function(&caps, function_type)
         })
+        .cloned()
         .collect()
 }
 

--- a/crates/zetesis/src/types.rs
+++ b/crates/zetesis/src/types.rs
@@ -62,7 +62,7 @@ impl SearchMediaType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SearchResult {
     pub title: String,
     pub guid: Option<String>,
@@ -138,7 +138,7 @@ pub struct IndexerCategory {
     pub subcategories: Vec<IndexerCategory>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct IndexerStatus {
     pub healthy: bool,
     pub caps: Option<IndexerCaps>,


### PR DESCRIPTION
## Summary
- wire archon's serve-time search adapter to the live ZetesisService instead of returning NotAvailable
- expose ZetesisService indexer test/caps refresh methods for Paroche indexer routes
- add focused adapter tests for typed query conversion and empty live search results

Refs #241.

## Gates
- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- kanon lint --rust --summary --precision high .

## Reviewer
- Kimi reviewer dispatch 0000019e52be6c88f214b1f7035fb215: APPROVE with one minor style note.