### PR TITLE
fix(serve): wire live marker services

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -42,11 +42,11 @@ use crate::startup::{ensure_admin_user, init_tracing};
 
 // ── Dyn-trait adapters ──────────────────────────────────────────────────────
 
-struct NullCuration;
-impl DynCurationService for NullCuration {}
+struct CurationAdapter(#[expect(dead_code)] Arc<DefaultCurationService>);
+impl DynCurationService for CurationAdapter {}
 
-struct NullMetadata;
-impl DynMetadataResolver for NullMetadata {}
+struct MetadataAdapter(#[expect(dead_code)] Arc<EpignosisService>);
+impl DynMetadataResolver for MetadataAdapter {}
 
 struct SearchAdapter(Arc<ZetesisService>);
 impl DynSearchService for SearchAdapter {
@@ -595,11 +595,16 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     ensure_admin_user(&auth, &db, out).await?;
 
     // 8. Create metadata resolver
-    let _metadata_service =
-        EpignosisService::new(config.epignosis.clone(), ProviderCredentials::default());
+    let metadata_service = Arc::new(EpignosisService::new(
+        config.epignosis.clone(),
+        ProviderCredentials::default(),
+    ));
 
     // 9. Create curation service
-    let _curation_service = DefaultCurationService::new(db.read.clone(), event_tx.clone());
+    let curation_service = Arc::new(DefaultCurationService::new(
+        db.read.clone(),
+        event_tx.clone(),
+    ));
 
     // 10. Start scanner  -  background task
     let scanner = ScannerManager::start(&config.taxis, event_tx.clone())
@@ -748,8 +753,8 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         event_tx,
         auth,
         import,
-        metadata: Arc::new(NullMetadata),
-        curation: Arc::new(NullCuration),
+        metadata: Arc::new(MetadataAdapter(metadata_service)),
+        curation: Arc::new(CurationAdapter(curation_service)),
         search: Arc::new(SearchAdapter(zetesis)),
         download_engine: Arc::new(EngineAdapter(ergasia_session)),
         queue: Arc::new(QueueAdapter),


### PR DESCRIPTION
## Summary

- Preserve the live Epignosis metadata resolver and Kritike curation service created during `serve` startup.
- Replace production `NullMetadata` and `NullCuration` AppState wiring with marker adapters that hold those live services.
- Leave `paroche::state::with_stubs` null marker services unchanged for tests/stub construction.

Refs #241.

## Gates

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `kanon lint --rust --summary --precision high .`

## Review

- Kimi reviewer dispatch `0000019e52d60e66f214b1f7035fb21a`: `APPROVE`, no findings
