### PR TITLE
fix(akouo-core): force PipeWire output rate

### DIFF
--- a/crates/akouo-core/src/output/cpal.rs
+++ b/crates/akouo-core/src/output/cpal.rs
@@ -5,6 +5,8 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use tracing::warn;
 
 use crate::error::OutputError;
+#[cfg(target_os = "linux")]
+use crate::output::pipewire;
 use crate::output::{
     AudioDataCallback, DeviceCapabilities, OutputBackend, OutputDevice, OutputParams,
 };
@@ -13,6 +15,8 @@ use crate::output::{
 pub struct CpalOutputBackend {
     host: cpal::Host,
     stream: Mutex<Option<cpal::Stream>>,
+    #[cfg(target_os = "linux")]
+    pipewire_rate_forced: Mutex<bool>,
 }
 
 impl CpalOutputBackend {
@@ -20,6 +24,8 @@ impl CpalOutputBackend {
         Self {
             host: cpal::default_host(),
             stream: Mutex::new(None),
+            #[cfg(target_os = "linux")]
+            pipewire_rate_forced: Mutex::new(false),
         }
     }
 }
@@ -124,6 +130,13 @@ impl OutputBackend for CpalOutputBackend {
             }
         }
 
+        #[cfg(target_os = "linux")]
+        {
+            for rate in pipewire::alsa_hardware_sample_rates()? {
+                sample_rates.insert(rate);
+            }
+        }
+
         Ok(DeviceCapabilities {
             supported_sample_rates: sample_rates.into_iter().collect(),
             supported_bit_depths: bit_depths.into_iter().collect(),
@@ -148,6 +161,8 @@ impl OutputBackend for CpalOutputBackend {
                 message: e.to_string(),
             })?;
 
+        let pipewire_rate_forced = force_pipewire_rate(params.sample_rate)?;
+
         let channels = usize::from(params.channels);
         // Pre-allocate f64 working buffer large enough for any callback invocation.
         // Fixed buffer size is requested; 8 192 samples covers 4 096 stereo frames.
@@ -164,33 +179,51 @@ impl OutputBackend for CpalOutputBackend {
             }
         };
 
-        let stream = device
-            .build_output_stream_raw(
-                &stream_config,
-                sample_format,
-                move |data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {
-                    let n_samples = data.len();
-                    // Use the pre-allocated buffer; if callback asks for more than we have
-                    // (shouldn't happen with fixed buffer), fill the rest with silence.
-                    let fill = n_samples.min(f64_buf.len());
-                    callback(&mut f64_buf[..fill]);
+        let stream = match device.build_output_stream_raw(
+            &stream_config,
+            sample_format,
+            move |data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {
+                let n_samples = data.len();
+                // Use the pre-allocated buffer; if callback asks for more than we have
+                // (shouldn't happen with fixed buffer), fill the rest with silence.
+                let fill = n_samples.min(f64_buf.len());
+                callback(&mut f64_buf[..fill]);
 
-                    // Track underruns: cpal asked for more samples than we could provide
-                    if fill < n_samples {
-                        underruns_rt.fetch_add(1, Ordering::Relaxed);
-                    }
+                // Track underruns: cpal asked for more samples than we could provide
+                if fill < n_samples {
+                    underruns_rt.fetch_add(1, Ordering::Relaxed);
+                }
 
-                    write_to_data(data, &f64_buf[..fill], n_samples, channels);
-                },
-                error_cb,
-                None,
-            )
-            .map_err(|e| OutputError::DeviceOpen {
-                device: device_name,
-                message: e.to_string(),
-            })?;
+                write_to_data(data, &f64_buf[..fill], n_samples, channels);
+            },
+            error_cb,
+            None,
+        ) {
+            Ok(stream) => stream,
+            Err(e) => {
+                if pipewire_rate_forced {
+                    let _ = reset_pipewire_rate();
+                }
+                return Err(OutputError::DeviceOpen {
+                    device: device_name,
+                    message: e.to_string(),
+                });
+            }
+        };
+
+        if let Err(e) = reapply_pipewire_rate_if_forced(params.sample_rate, pipewire_rate_forced) {
+            let _ = reset_pipewire_rate();
+            return Err(e);
+        }
 
         *self.stream.lock().unwrap_or_else(|e| e.into_inner()) = Some(stream);
+        #[cfg(target_os = "linux")]
+        {
+            *self
+                .pipewire_rate_forced
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = pipewire_rate_forced;
+        }
         Ok(())
     }
 
@@ -221,6 +254,35 @@ impl OutputBackend for CpalOutputBackend {
     async fn close(&mut self) -> Result<(), OutputError> {
         // Dropping the cpal::Stream stops playback and releases the device handle.
         *self.stream.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        self.reset_pipewire_rate_if_forced()
+    }
+}
+
+impl Drop for CpalOutputBackend {
+    fn drop(&mut self) {
+        #[cfg(target_os = "linux")]
+        let _ = self.reset_pipewire_rate_if_forced();
+    }
+}
+
+impl CpalOutputBackend {
+    #[cfg(target_os = "linux")]
+    fn reset_pipewire_rate_if_forced(&self) -> Result<(), OutputError> {
+        let mut forced = self
+            .pipewire_rate_forced
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if !*forced {
+            return Ok(());
+        }
+
+        pipewire::reset_pipewire_rate()?;
+        *forced = false;
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn reset_pipewire_rate_if_forced(&self) -> Result<(), OutputError> {
         Ok(())
     }
 }
@@ -250,6 +312,45 @@ fn resolve_device(host: &cpal::Host, device_id: Option<&str>) -> Result<cpal::De
             })
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn force_pipewire_rate(sample_rate: u32) -> Result<bool, OutputError> {
+    match pipewire::force_pipewire_rate_if_available(sample_rate) {
+        Ok(false) => {
+            warn!("pw-metadata not available; PipeWire clock rate was not forced");
+            Ok(false)
+        }
+        other => other,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn force_pipewire_rate(_sample_rate: u32) -> Result<bool, OutputError> {
+    Ok(false)
+}
+
+#[cfg(target_os = "linux")]
+fn reapply_pipewire_rate_if_forced(sample_rate: u32, forced: bool) -> Result<(), OutputError> {
+    if forced {
+        pipewire::force_pipewire_rate(sample_rate)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn reapply_pipewire_rate_if_forced(_sample_rate: u32, _forced: bool) -> Result<(), OutputError> {
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn reset_pipewire_rate() -> Result<(), OutputError> {
+    pipewire::reset_pipewire_rate()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn reset_pipewire_rate() -> Result<(), OutputError> {
+    Ok(())
 }
 
 /// Finds the best matching cpal `StreamConfig` and `SampleFormat` for the requested params.
@@ -291,7 +392,12 @@ fn find_stream_config(
     let best = supported
         .into_iter()
         .min_by_key(|c| format_rank(c.sample_format()))
-        .unwrap_or_else(|| unreachable!("supported is non-empty; checked above"));
+        .ok_or_else(|| OutputError::FormatUnsupported {
+            message: format!(
+                "no config supports {}Hz {}ch",
+                params.sample_rate, params.channels
+            ),
+        })?;
 
     let sample_format = best.sample_format();
     let config = cpal::StreamConfig {

--- a/crates/akouo-core/src/output/format.rs
+++ b/crates/akouo-core/src/output/format.rs
@@ -92,15 +92,53 @@ fn select_sample_rate(caps: &DeviceCapabilities, source_rate: u32) -> (u32, bool
     if caps.supported_sample_rates.contains(&source_rate) {
         return (source_rate, false);
     }
-    // Pick highest supported rate at or below 192 kHz
-    let target = caps
+
+    let source_family = clock_family(source_rate);
+    let target = same_family_fallback(caps, source_family, source_rate).unwrap_or_else(|| {
+        // Pick highest supported rate at or below 192 kHz.
+        caps.supported_sample_rates
+            .iter()
+            .filter(|&&r| r <= 192_000)
+            .max()
+            .copied()
+            .unwrap_or(source_rate)
+    });
+    (target, target != source_rate)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClockFamily {
+    Family441,
+    Family48,
+}
+
+fn clock_family(rate: u32) -> Option<ClockFamily> {
+    if rate != 0 && (rate % 44_100 == 0 || 44_100 % rate == 0) {
+        Some(ClockFamily::Family441)
+    } else if rate != 0 && (rate % 48_000 == 0 || 48_000 % rate == 0) {
+        Some(ClockFamily::Family48)
+    } else {
+        None
+    }
+}
+
+fn same_family_fallback(
+    caps: &DeviceCapabilities,
+    source_family: Option<ClockFamily>,
+    source_rate: u32,
+) -> Option<u32> {
+    let family = source_family?;
+    let same_family_rates = caps
         .supported_sample_rates
         .iter()
-        .filter(|&&r| r <= 192_000)
-        .max()
         .copied()
-        .unwrap_or(source_rate);
-    (target, target != source_rate)
+        .filter(|&r| r <= 192_000 && clock_family(r) == Some(family));
+
+    same_family_rates
+        .clone()
+        .filter(|&r| r <= source_rate)
+        .max()
+        .or_else(|| same_family_rates.filter(|&r| r > source_rate).min())
 }
 
 fn select_bit_depth(caps: &DeviceCapabilities, requested: u32) -> u32 {
@@ -219,6 +257,30 @@ mod tests {
         )
         .unwrap();
         assert_eq!(params.sample_rate, 48000);
+        assert!(params.needs_resample);
+    }
+
+    #[test]
+    fn negotiate_prefers_same_clock_family_fallback() {
+        let params = negotiate_format(
+            &caps(&[44100, 48000], &[16, 24]),
+            &stream(88200),
+            &OutputConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(params.sample_rate, 44100);
+        assert!(params.needs_resample);
+    }
+
+    #[test]
+    fn negotiate_uses_same_family_upsample_before_cross_family() {
+        let params = negotiate_format(
+            &caps(&[44100, 192000], &[16, 24]),
+            &stream(96000),
+            &OutputConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(params.sample_rate, 192000);
         assert!(params.needs_resample);
     }
 

--- a/crates/akouo-core/src/output/mod.rs
+++ b/crates/akouo-core/src/output/mod.rs
@@ -5,6 +5,8 @@
 )]
 pub mod cpal;
 pub mod format;
+#[cfg(all(feature = "native-output", target_os = "linux"))]
+pub mod pipewire;
 pub mod resample;
 
 use crate::error::OutputError;

--- a/crates/akouo-core/src/output/pipewire.rs
+++ b/crates/akouo-core/src/output/pipewire.rs
@@ -1,0 +1,237 @@
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use crate::error::OutputError;
+
+const PIPEWIRE_SETTINGS: &str = "settings";
+const FORCE_RATE_KEY: &str = "clock.force-rate";
+const VERIFY_TIMEOUT: Duration = Duration::from_millis(1_500);
+const VERIFY_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Force PipeWire's graph clock rate and verify it took effect.
+///
+/// This intentionally does not set `clock.force-quantum`; forcing quantum can
+/// desynchronize cpal/rodio mixer threads and cause high-rate underruns.
+pub fn force_pipewire_rate(rate: u32) -> Result<(), OutputError> {
+    set_pipewire_rate(rate)?;
+    verify_pipewire_rate(rate)
+}
+
+/// Forces PipeWire rate only when `pw-metadata` is available on this host.
+///
+/// Missing `pw-metadata` means either PipeWire is absent or the runtime package is
+/// incomplete. In both cases playback should continue through cpal's normal path.
+pub fn force_pipewire_rate_if_available(rate: u32) -> Result<bool, OutputError> {
+    if !command_available("pw-metadata") {
+        return Ok(false);
+    }
+    force_pipewire_rate(rate)?;
+    Ok(true)
+}
+
+/// Reset PipeWire's forced clock rate so other applications are not stranded.
+pub fn reset_pipewire_rate() -> Result<(), OutputError> {
+    set_pipewire_rate(0)
+}
+
+/// Enumerates discrete hardware sample rates from ALSA USB stream descriptors.
+pub fn alsa_hardware_sample_rates() -> Result<Vec<u32>, OutputError> {
+    let root = Path::new("/proc/asound");
+    let Ok(cards) = fs::read_dir(root) else {
+        return Ok(Vec::new());
+    };
+
+    let mut rates = BTreeSet::new();
+    for card in cards {
+        let card = card.map_err(|e| OutputError::StreamError {
+            message: format!("failed to read /proc/asound entry: {e}"),
+        })?;
+        let card_name = card.file_name();
+        if !card_name.to_string_lossy().starts_with("card") {
+            continue;
+        }
+
+        let stream = card.path().join("stream0");
+        match fs::read_to_string(&stream) {
+            Ok(contents) => rates.extend(parse_alsa_stream_sample_rates(&contents)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(OutputError::StreamError {
+                    message: format!("failed to read {}: {e}", stream.display()),
+                });
+            }
+        }
+    }
+
+    Ok(rates.into_iter().collect())
+}
+
+fn set_pipewire_rate(rate: u32) -> Result<(), OutputError> {
+    let rate = rate.to_string();
+    let output = Command::new("pw-metadata")
+        .args([OsStr::new("-n"), OsStr::new(PIPEWIRE_SETTINGS)])
+        .args([
+            OsStr::new("0"),
+            OsStr::new(FORCE_RATE_KEY),
+            OsStr::new(rate.as_str()),
+        ])
+        .output()
+        .map_err(|e| OutputError::StreamError {
+            message: format!("failed to execute pw-metadata: {e}"),
+        })?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(OutputError::StreamError {
+        message: format!(
+            "pw-metadata failed to set {FORCE_RATE_KEY}: {}",
+            command_output_text(&output)
+        ),
+    })
+}
+
+fn verify_pipewire_rate(expected: u32) -> Result<(), OutputError> {
+    let deadline = Instant::now() + VERIFY_TIMEOUT;
+    loop {
+        match read_pipewire_rate()? {
+            Some(actual) if actual == expected => return Ok(()),
+            _ if Instant::now() >= deadline => {
+                return Err(OutputError::StreamError {
+                    message: format!(
+                        "PipeWire did not apply {FORCE_RATE_KEY}={expected} within {VERIFY_TIMEOUT:?}"
+                    ),
+                });
+            }
+            _ => std::thread::sleep(VERIFY_INTERVAL),
+        }
+    }
+}
+
+fn read_pipewire_rate() -> Result<Option<u32>, OutputError> {
+    let output = Command::new("pw-metadata")
+        .args([OsStr::new("-n"), OsStr::new(PIPEWIRE_SETTINGS)])
+        .args([OsStr::new("0"), OsStr::new(FORCE_RATE_KEY)])
+        .output()
+        .map_err(|e| OutputError::StreamError {
+            message: format!("failed to execute pw-metadata: {e}"),
+        })?;
+
+    if !output.status.success() {
+        return Err(OutputError::StreamError {
+            message: format!(
+                "pw-metadata failed to read {FORCE_RATE_KEY}: {}",
+                command_output_text(&output)
+            ),
+        });
+    }
+
+    let text = command_output_text(&output);
+    Ok(parse_pipewire_rate(&text))
+}
+
+fn command_available(command: &str) -> bool {
+    std::env::var_os("PATH")
+        .is_some_and(|paths| std::env::split_paths(&paths).any(|path| path.join(command).is_file()))
+}
+
+fn command_output_text(output: &std::process::Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!("{stdout}{stderr}").trim().to_owned()
+}
+
+fn parse_pipewire_rate(text: &str) -> Option<u32> {
+    for line in text.lines().filter(|line| line.contains(FORCE_RATE_KEY)) {
+        if let Some(rate) = last_u32_in(line) {
+            return Some(rate);
+        }
+    }
+
+    text.trim().parse().ok()
+}
+
+fn parse_alsa_stream_sample_rates(contents: &str) -> Vec<u32> {
+    let mut rates = BTreeSet::new();
+    for line in contents.lines() {
+        let Some(rate_list) = line.trim_start().strip_prefix("Rates:") else {
+            continue;
+        };
+        if rate_list.contains("continuous") {
+            continue;
+        }
+        for rate in u32_values(rate_list) {
+            rates.insert(rate);
+        }
+    }
+    rates.into_iter().collect()
+}
+
+fn last_u32_in(text: &str) -> Option<u32> {
+    u32_values(text).last()
+}
+
+fn u32_values(text: &str) -> impl Iterator<Item = u32> + '_ {
+    text.split(|c: char| !c.is_ascii_digit())
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| s.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pipewire_metadata_value_line() {
+        let text = "update: id:0 key:'clock.force-rate' type:'Spa:String:JSON' value:'96000'";
+        assert_eq!(parse_pipewire_rate(text), Some(96000));
+    }
+
+    #[test]
+    fn parses_plain_pipewire_metadata_value() {
+        assert_eq!(parse_pipewire_rate("48000\n"), Some(48000));
+    }
+
+    #[test]
+    fn parses_discrete_alsa_stream_rates() {
+        let stream = r#"
+Playback:
+  Altset 1
+    Format: S24_3LE
+    Channels: 2
+    Rates: 44100, 48000, 88200, 96000, 176400, 192000
+  Altset 2
+    Rates: 352800, 384000
+"#;
+        assert_eq!(
+            parse_alsa_stream_sample_rates(stream),
+            vec![44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000]
+        );
+    }
+
+    #[test]
+    fn skips_continuous_alsa_rate_ranges() {
+        let stream = "Rates: 44100 - 192000 (continuous)\n";
+        assert!(parse_alsa_stream_sample_rates(stream).is_empty());
+    }
+
+    #[test]
+    #[ignore = "requires PipeWire pw-metadata and ALSA audio hardware"]
+    fn force_pipewire_rate_roundtrip() {
+        let rate = alsa_hardware_sample_rates()
+            .unwrap()
+            .into_iter()
+            .find(|&rate| rate != 0)
+            .unwrap_or(48_000);
+
+        force_pipewire_rate(rate).unwrap();
+        assert_eq!(read_pipewire_rate().unwrap(), Some(rate));
+        reset_pipewire_rate().unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- add Linux-only PipeWire clock.force-rate enforcement around cpal stream creation
- parse discrete ALSA /proc/asound/card*/stream0 hardware rates into output capabilities
- prefer same 44.1/48 kHz clock-family fallback during sample-rate negotiation

Closes #250.

## Gates
- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- kanon lint --rust --summary --precision high crates/akouo-core/src/output
- kimi-reviewer APPROVE: 0000019e52ec9367f214b1f7035fb21d