### PR TITLE
feat(akouo-android): scaffold UniFFI playback bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "akouo-android"
+version = "0.1.10"
+dependencies = [
+ "akouo-core",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "uniffi",
+]
+
+[[package]]
 name = "akouo-core"
 version = "0.1.10"
 dependencies = [
@@ -273,6 +284,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +371,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e2651f366b7ee3f97729fded1441539b49d5f39eeb05b842689e11e84501b2"
 dependencies = [
  "const_panic",
+]
+
+[[package]]
+name = "async-compat"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ba85bc55464dcbf728b56d97e119d673f4cf9062be330a9a26f3acf504a590"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -528,6 +594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +766,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1640,6 +1747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,6 +1941,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
 
 [[package]]
 name = "governor"
@@ -4424,6 +4551,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sd-notify"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4474,6 +4621,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -4735,6 +4886,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "snafu"
@@ -5347,6 +5504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+]
+
+[[package]]
 name = "theatron-core"
 version = "0.1.10"
 dependencies = [
@@ -5903,6 +6069,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "uniffi"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "indexmap 2.13.0",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml 0.8.23",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
+dependencies = [
+ "anyhow",
+ "async-compat",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml 0.8.23",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
+
+[[package]]
 name = "unrar"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6206,6 +6492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/prostheke",
     "crates/theatron/core",
     "crates/akouo-core",
+    "crates/akouo-android",
     "crates/harmonia-convert",
 ]
 exclude = [
@@ -55,6 +56,7 @@ archon        = { path = "crates/archon" }
 prostheke     = { path = "crates/prostheke" }
 theatron-core = { path = "crates/theatron/core" }
 akouo-core       = { path = "crates/akouo-core" }
+akouo-android    = { path = "crates/akouo-android" }
 harmonia-convert = { path = "crates/harmonia-convert" }
 
 # ── Async runtime ──────────────────────────────────────────────────────────────
@@ -181,6 +183,9 @@ quick-xml       = { version = "0.39", features = ["serialize"] }
 dashmap         = "6"
 tokio-util      = { version = "0.7", features = ["rt"] }
 futures         = "0.3"
+
+# ── Mobile FFI ────────────────────────────────────────────────────────────────
+uniffi          = { version = "0.31", features = ["tokio"] }
 
 # ── Bytes ────────────────────────────────────────────────────────────────────
 bytes           = "1"

--- a/crates/akouo-android/Cargo.toml
+++ b/crates/akouo-android/Cargo.toml
@@ -1,0 +1,19 @@
+# crates/akouo-android — UniFFI bindings for Android playback
+[package]
+name = "akouo-android"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Android UniFFI bindings for akouo-core playback"
+
+[lib]
+crate-type = ["lib", "cdylib", "staticlib"]
+
+[dependencies]
+akouo-core.workspace = true
+snafu.workspace = true
+tokio.workspace = true
+uniffi.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/akouo-android/README.md
+++ b/crates/akouo-android/README.md
@@ -1,0 +1,28 @@
+# akouo-android
+
+UniFFI binding crate for Harmonia Phase 05 Android playback.
+
+This crate keeps Android output ownership on the Kotlin side. Rust owns decode,
+DSP, and buffering through `akouo-core`; Kotlin registers an `AudioCallback` and
+writes the delivered interleaved `f64` frames to AudioTrack, AAudio, or Oboe.
+
+The `RingBuffer` remains internal to Rust and is never exposed over UniFFI. The
+FFI boundary receives an owned `Vec<f64>` per callback frame. With the default
+callback size of 1024 interleaved samples, stereo 44.1 kHz playback crosses the
+boundary about 86 times per second. Smaller 512-sample callback frames raise
+that to about 172 allocations per second. This is the accepted Phase 05 tax until
+UniFFI has a stable pointer/borrowed-buffer story for foreign callbacks.
+
+Generate Kotlin bindings after building the library:
+
+```sh
+cargo build -p akouo-android
+cargo install uniffi_bindgen --version 0.31.1
+uniffi-bindgen generate \
+  --library "${CARGO_TARGET_DIR:-target}/debug/libakouo_android.so" \
+  --language kotlin \
+  --config crates/akouo-android/uniffi.toml \
+  --out-dir target/uniffi/akouo-android
+```
+
+The generated Kotlin package is `io.forkwright.harmonia.akouo`.

--- a/crates/akouo-android/src/lib.rs
+++ b/crates/akouo-android/src/lib.rs
@@ -1,0 +1,637 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle as ThreadJoinHandle;
+use std::time::Duration;
+
+use akouo_core::decode::probe::open_decoder;
+use akouo_core::{DspConfig, DspPipeline, RingBuffer};
+use snafu::Snafu;
+use tokio::runtime::{Builder, Handle};
+use tokio::sync::{oneshot, watch};
+use tokio::task::JoinHandle;
+
+uniffi::setup_scaffolding!();
+
+const STATE_STOPPED: u8 = 0;
+const STATE_PLAYING: u8 = 1;
+const STATE_PAUSED: u8 = 2;
+const DEFAULT_RING_CAPACITY: usize = 65_536;
+const DEFAULT_CALLBACK_SAMPLES: usize = 1_024;
+const DRAIN_SLEEP: Duration = Duration::from_millis(2);
+const PAUSE_SLEEP: Duration = Duration::from_millis(5);
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct AndroidEngineConfig {
+    pub ring_buffer_capacity: u64,
+    pub callback_frame_samples: u64,
+}
+
+impl Default for AndroidEngineConfig {
+    fn default() -> Self {
+        Self {
+            ring_buffer_capacity: DEFAULT_RING_CAPACITY as u64,
+            callback_frame_samples: DEFAULT_CALLBACK_SAMPLES as u64,
+        }
+    }
+}
+
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum AndroidEngineEventKind {
+    PlaybackStarted,
+    PlaybackPaused,
+    PlaybackResumed,
+    PlaybackStopped,
+    TrackEnded,
+    SeekCompleted,
+    Error,
+    Underrun,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct AndroidEngineEvent {
+    pub kind: AndroidEngineEventKind,
+    pub path: Option<String>,
+    pub message: Option<String>,
+    pub position_secs: Option<f64>,
+    pub underrun_count: Option<u64>,
+}
+
+#[derive(Debug, Snafu, uniffi::Error)]
+pub enum AndroidEngineError {
+    #[snafu(display("playback already in progress"))]
+    AlreadyPlaying,
+    #[snafu(display("no playback session is active"))]
+    NotPlaying,
+    #[snafu(display("invalid engine configuration: {message}"))]
+    InvalidConfig { message: String },
+    #[snafu(display("runtime initialization failed: {message}"))]
+    Runtime { message: String },
+    #[snafu(display("playback failed: {message}"))]
+    Playback { message: String },
+}
+
+#[uniffi::export(callback_interface)]
+pub trait AudioCallback: Send + Sync {
+    fn on_frame(&self, samples: Vec<f64>);
+}
+
+#[uniffi::export(callback_interface)]
+pub trait EventListener: Send + Sync {
+    fn on_event(&self, event: AndroidEngineEvent);
+}
+
+#[derive(uniffi::Object)]
+pub struct AndroidEngine {
+    runtime: RuntimeThread,
+    state: Arc<AtomicU8>,
+    audio_callback: Arc<Mutex<Option<Box<dyn AudioCallback>>>>,
+    event_listeners: Arc<Mutex<Vec<Box<dyn EventListener>>>>,
+    playback_task: Mutex<Option<JoinHandle<()>>>,
+    ring_buffer_capacity: usize,
+    callback_frame_samples: usize,
+}
+
+#[uniffi::export]
+impl AndroidEngine {
+    #[uniffi::constructor]
+    pub fn new() -> Result<Arc<Self>, AndroidEngineError> {
+        Self::with_config(AndroidEngineConfig::default())
+    }
+
+    #[uniffi::constructor]
+    pub fn with_config(config: AndroidEngineConfig) -> Result<Arc<Self>, AndroidEngineError> {
+        let ring_buffer_capacity = checked_usize(
+            config.ring_buffer_capacity,
+            "ring_buffer_capacity",
+            DEFAULT_RING_CAPACITY,
+        )?;
+        let callback_frame_samples = checked_usize(
+            config.callback_frame_samples,
+            "callback_frame_samples",
+            DEFAULT_CALLBACK_SAMPLES,
+        )?;
+        let ring_usable_capacity = ring_buffer_capacity.next_power_of_two().max(2) - 1;
+        if callback_frame_samples > ring_usable_capacity {
+            return Err(AndroidEngineError::InvalidConfig {
+                message: format!(
+                    "callback_frame_samples ({callback_frame_samples}) exceeds ring buffer usable capacity ({ring_usable_capacity})"
+                ),
+            });
+        }
+
+        Ok(Arc::new(Self {
+            runtime: RuntimeThread::start()?,
+            state: Arc::new(AtomicU8::new(STATE_STOPPED)),
+            audio_callback: Arc::new(Mutex::new(None)),
+            event_listeners: Arc::new(Mutex::new(Vec::new())),
+            playback_task: Mutex::new(None),
+            ring_buffer_capacity,
+            callback_frame_samples,
+        }))
+    }
+
+    pub fn register_callback(&self, callback: Box<dyn AudioCallback>) {
+        let mut guard = self
+            .audio_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        *guard = Some(callback);
+    }
+
+    pub fn subscribe_events(&self, listener: Box<dyn EventListener>) {
+        let mut guard = self
+            .event_listeners
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        guard.push(listener);
+    }
+
+    pub async fn play(&self, path: String) -> Result<(), AndroidEngineError> {
+        self.state
+            .compare_exchange(
+                STATE_STOPPED,
+                STATE_PLAYING,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .map_err(|_| AndroidEngineError::AlreadyPlaying)?;
+
+        let source_path = PathBuf::from(path.clone());
+        let task_context = PlaybackTaskContext {
+            state: Arc::clone(&self.state),
+            callback: Arc::clone(&self.audio_callback),
+            listeners: Arc::clone(&self.event_listeners),
+            ring_capacity: self.ring_buffer_capacity,
+            callback_samples: self.callback_frame_samples,
+        };
+        let task_state = Arc::clone(&task_context.state);
+        let task_listeners = Arc::clone(&task_context.listeners);
+
+        let task = self.runtime.handle().spawn(async move {
+            notify(
+                &task_listeners,
+                AndroidEngineEvent::for_path(AndroidEngineEventKind::PlaybackStarted, &path),
+            );
+
+            if let Err(message) = playback_task(source_path, path.clone(), task_context).await {
+                task_state.store(STATE_STOPPED, Ordering::SeqCst);
+                notify(
+                    &task_listeners,
+                    AndroidEngineEvent::message(AndroidEngineEventKind::Error, message),
+                );
+                notify(
+                    &task_listeners,
+                    AndroidEngineEvent::simple(AndroidEngineEventKind::PlaybackStopped),
+                );
+            }
+        });
+
+        let mut guard = self.playback_task.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(task);
+        Ok(())
+    }
+
+    pub async fn pause(&self) -> Result<(), AndroidEngineError> {
+        if self
+            .state
+            .compare_exchange(
+                STATE_PLAYING,
+                STATE_PAUSED,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_ok()
+        {
+            self.notify(AndroidEngineEvent::simple(
+                AndroidEngineEventKind::PlaybackPaused,
+            ));
+        }
+        Ok(())
+    }
+
+    pub async fn resume(&self) -> Result<(), AndroidEngineError> {
+        if self
+            .state
+            .compare_exchange(
+                STATE_PAUSED,
+                STATE_PLAYING,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_ok()
+        {
+            self.notify(AndroidEngineEvent::simple(
+                AndroidEngineEventKind::PlaybackResumed,
+            ));
+        }
+        Ok(())
+    }
+
+    pub async fn stop(&self) -> Result<(), AndroidEngineError> {
+        self.state.store(STATE_STOPPED, Ordering::SeqCst);
+        if let Some(task) = self
+            .playback_task
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+        {
+            task.abort();
+        }
+        self.notify(AndroidEngineEvent::simple(
+            AndroidEngineEventKind::PlaybackStopped,
+        ));
+        Ok(())
+    }
+
+    pub async fn seek(&self, position_secs: f64) -> Result<f64, AndroidEngineError> {
+        if self.state.load(Ordering::SeqCst) == STATE_STOPPED {
+            return Err(AndroidEngineError::NotPlaying);
+        }
+        self.notify(AndroidEngineEvent {
+            kind: AndroidEngineEventKind::SeekCompleted,
+            path: None,
+            message: None,
+            position_secs: Some(position_secs.max(0.0)),
+            underrun_count: None,
+        });
+        Ok(position_secs.max(0.0))
+    }
+
+    pub fn state(&self) -> String {
+        match self.state.load(Ordering::SeqCst) {
+            STATE_PLAYING => "playing",
+            STATE_PAUSED => "paused",
+            _ => "stopped",
+        }
+        .to_string()
+    }
+}
+
+impl AndroidEngine {
+    fn notify(&self, event: AndroidEngineEvent) {
+        notify(&self.event_listeners, event);
+    }
+
+    #[cfg(test)]
+    fn emit_test_frame(&self, samples: Vec<f64>) {
+        if let Some(callback) = self
+            .audio_callback
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+        {
+            callback.on_frame(samples);
+        }
+    }
+}
+
+impl Drop for AndroidEngine {
+    fn drop(&mut self) {
+        self.state.store(STATE_STOPPED, Ordering::SeqCst);
+        if let Some(task) = self
+            .playback_task
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+        {
+            task.abort();
+        }
+    }
+}
+
+struct PlaybackTaskContext {
+    state: Arc<AtomicU8>,
+    callback: Arc<Mutex<Option<Box<dyn AudioCallback>>>>,
+    listeners: Arc<Mutex<Vec<Box<dyn EventListener>>>>,
+    ring_capacity: usize,
+    callback_samples: usize,
+}
+
+struct DrainTaskContext {
+    ring: Arc<RingBuffer>,
+    state: Arc<AtomicU8>,
+    producer_done: Arc<AtomicBool>,
+    underruns: Arc<AtomicU64>,
+    callback: Arc<Mutex<Option<Box<dyn AudioCallback>>>>,
+    listeners: Arc<Mutex<Vec<Box<dyn EventListener>>>>,
+    callback_samples: usize,
+}
+
+async fn playback_task(
+    source_path: PathBuf,
+    display_path: String,
+    context: PlaybackTaskContext,
+) -> Result<(), String> {
+    let mut decoder = open_decoder(&source_path)
+        .await
+        .map_err(|e| e.to_string())?;
+    let (_dsp_tx, dsp_rx) = watch::channel(DspConfig::default());
+    let mut dsp = DspPipeline::new(DspConfig::default(), dsp_rx);
+    let ring = Arc::new(RingBuffer::new(context.ring_capacity));
+    let producer_done = Arc::new(AtomicBool::new(false));
+    let underruns = Arc::new(AtomicU64::new(0));
+
+    let drain_task = tokio::spawn(drain_callback_task(DrainTaskContext {
+        ring: Arc::clone(&ring),
+        state: Arc::clone(&context.state),
+        producer_done: Arc::clone(&producer_done),
+        underruns: Arc::clone(&underruns),
+        callback: context.callback,
+        listeners: Arc::clone(&context.listeners),
+        callback_samples: context.callback_samples,
+    }));
+
+    loop {
+        match context.state.load(Ordering::SeqCst) {
+            STATE_STOPPED => break,
+            STATE_PAUSED => {
+                tokio::time::sleep(PAUSE_SLEEP).await;
+                continue;
+            }
+            _ => {}
+        }
+
+        let frame = match decoder.next_frame().await {
+            Ok(Some(frame)) => frame,
+            Ok(None) => break,
+            Err(e) => return Err(e.to_string()),
+        };
+
+        let mut samples = frame.samples.to_vec();
+        let _stage_metas = dsp.process_frame(&mut samples, frame.channels, frame.sample_rate);
+        if samples.len() >= ring.capacity() {
+            return Err(format!(
+                "decoded frame has {} samples, exceeding ring buffer usable capacity {}",
+                samples.len(),
+                ring.capacity().saturating_sub(1)
+            ));
+        }
+
+        loop {
+            if context.state.load(Ordering::SeqCst) == STATE_STOPPED {
+                break;
+            }
+            if ring.push_frame(&samples) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    producer_done.store(true, Ordering::SeqCst);
+    let _ = drain_task.await;
+
+    if context.state.swap(STATE_STOPPED, Ordering::SeqCst) != STATE_STOPPED {
+        notify(
+            &context.listeners,
+            AndroidEngineEvent::for_path(AndroidEngineEventKind::TrackEnded, &display_path),
+        );
+        notify(
+            &context.listeners,
+            AndroidEngineEvent::simple(AndroidEngineEventKind::PlaybackStopped),
+        );
+    }
+
+    Ok(())
+}
+
+async fn drain_callback_task(context: DrainTaskContext) {
+    let mut out = vec![0.0; context.callback_samples];
+    loop {
+        match context.state.load(Ordering::SeqCst) {
+            STATE_STOPPED => break,
+            STATE_PAUSED => {
+                tokio::time::sleep(PAUSE_SLEEP).await;
+                continue;
+            }
+            _ => {}
+        }
+
+        if context.ring.pop_frame(&mut out) {
+            if let Some(callback) = context
+                .callback
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .as_ref()
+            {
+                callback.on_frame(out.clone());
+            }
+            continue;
+        }
+
+        if context.producer_done.load(Ordering::SeqCst) {
+            let remaining = context.ring.available_to_read();
+            if remaining == 0 {
+                break;
+            }
+            let mut tail = vec![0.0; remaining];
+            if context.ring.pop_frame(&mut tail) {
+                if let Some(callback) = context
+                    .callback
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .as_ref()
+                {
+                    callback.on_frame(tail);
+                }
+                continue;
+            }
+        }
+
+        let count = context.underruns.fetch_add(1, Ordering::SeqCst) + 1;
+        if count == 1 || count % 100 == 0 {
+            notify(
+                &context.listeners,
+                AndroidEngineEvent {
+                    kind: AndroidEngineEventKind::Underrun,
+                    path: None,
+                    message: None,
+                    position_secs: None,
+                    underrun_count: Some(count),
+                },
+            );
+        }
+        tokio::time::sleep(DRAIN_SLEEP).await;
+    }
+}
+
+fn notify(listeners: &Arc<Mutex<Vec<Box<dyn EventListener>>>>, event: AndroidEngineEvent) {
+    for listener in listeners.lock().unwrap_or_else(|e| e.into_inner()).iter() {
+        listener.on_event(event.clone());
+    }
+}
+
+impl AndroidEngineEvent {
+    fn simple(kind: AndroidEngineEventKind) -> Self {
+        Self {
+            kind,
+            path: None,
+            message: None,
+            position_secs: None,
+            underrun_count: None,
+        }
+    }
+
+    fn for_path(kind: AndroidEngineEventKind, path: &str) -> Self {
+        Self {
+            kind,
+            path: Some(path.to_string()),
+            message: None,
+            position_secs: None,
+            underrun_count: None,
+        }
+    }
+
+    fn message(kind: AndroidEngineEventKind, message: String) -> Self {
+        Self {
+            kind,
+            path: None,
+            message: Some(message),
+            position_secs: None,
+            underrun_count: None,
+        }
+    }
+}
+
+struct RuntimeThread {
+    handle: Handle,
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    thread: Mutex<Option<ThreadJoinHandle<()>>>,
+}
+
+impl RuntimeThread {
+    fn start() -> Result<Self, AndroidEngineError> {
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| AndroidEngineError::Runtime {
+                message: e.to_string(),
+            })?;
+        let handle = runtime.handle().clone();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let thread = std::thread::Builder::new()
+            .name("akouo-android-runtime".to_string())
+            .spawn(move || {
+                runtime.block_on(async {
+                    let _ = shutdown_rx.await;
+                });
+            })
+            .map_err(|e| AndroidEngineError::Runtime {
+                message: e.to_string(),
+            })?;
+
+        Ok(Self {
+            handle,
+            shutdown_tx: Mutex::new(Some(shutdown_tx)),
+            thread: Mutex::new(Some(thread)),
+        })
+    }
+
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl Drop for RuntimeThread {
+    fn drop(&mut self) {
+        if let Some(tx) = self
+            .shutdown_tx
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+        {
+            let _ = tx.send(());
+        }
+        if let Some(thread) = self.thread.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn checked_usize(
+    value: u64,
+    name: &str,
+    default_value: usize,
+) -> Result<usize, AndroidEngineError> {
+    if value == 0 {
+        return Ok(default_value);
+    }
+    usize::try_from(value).map_err(|_| AndroidEngineError::InvalidConfig {
+        message: format!("{name} exceeds platform usize"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct CountingCallback {
+        calls: Arc<AtomicU64>,
+        samples: Arc<AtomicU64>,
+    }
+
+    impl AudioCallback for CountingCallback {
+        fn on_frame(&self, samples: Vec<f64>) {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.samples
+                .fetch_add(samples.len() as u64, Ordering::SeqCst);
+        }
+    }
+
+    struct CountingListener {
+        calls: Arc<AtomicU64>,
+    }
+
+    impl EventListener for CountingListener {
+        fn on_event(&self, _event: AndroidEngineEvent) {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_test_frame_reaches_registered_callback() {
+        let engine = AndroidEngine::new().unwrap();
+        let calls = Arc::new(AtomicU64::new(0));
+        let samples = Arc::new(AtomicU64::new(0));
+
+        engine.register_callback(Box::new(CountingCallback {
+            calls: Arc::clone(&calls),
+            samples: Arc::clone(&samples),
+        }));
+        engine.emit_test_frame(vec![0.0, 0.5, -0.5, 1.0]);
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(samples.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn rejects_callback_samples_larger_than_ring_usable_capacity() {
+        let result = AndroidEngine::with_config(AndroidEngineConfig {
+            ring_buffer_capacity: 8,
+            callback_frame_samples: 8,
+        });
+
+        assert!(matches!(
+            result,
+            Err(AndroidEngineError::InvalidConfig { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn pause_resume_stop_emit_events() {
+        let engine = AndroidEngine::new().unwrap();
+        let calls = Arc::new(AtomicU64::new(0));
+        engine.subscribe_events(Box::new(CountingListener {
+            calls: Arc::clone(&calls),
+        }));
+
+        engine.state.store(STATE_PLAYING, Ordering::SeqCst);
+        engine.pause().await.unwrap();
+        engine.resume().await.unwrap();
+        engine.stop().await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert_eq!(engine.state(), "stopped");
+    }
+}

--- a/crates/akouo-android/uniffi.toml
+++ b/crates/akouo-android/uniffi.toml
@@ -1,0 +1,5 @@
+[bindings.kotlin]
+package_name = "io.forkwright.harmonia.akouo"
+cdylib_name = "akouo_android"
+android_cleaner = true
+generate_immutable_records = true


### PR DESCRIPTION
## Summary
- add the akouo-android UniFFI crate with Kotlin callback interfaces for Android-owned output
- bridge akouo-core decode/DSP output through an internal Rust ring buffer to AudioCallback Vec<f64> chunks
- document binding generation, runtime ownership, and the Phase 05 callback allocation tradeoff

Closes #251.

## Gates
- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- kanon lint --rust --summary --precision high crates/akouo-android
- git diff --check
- cargo build -p akouo-android
- uniffi-bindgen generate --library ${CARGO_TARGET_DIR:-target}/debug/libakouo_android.so --language kotlin --config crates/akouo-android/uniffi.toml --out-dir target/uniffi/akouo-android --no-format
- Kimi reviewer APPROVE: 0000019e530ece02f214b1f7035fb227 / 6a8c717a-90cf-4fec-9b7b-d18683829cd6