### PR TITLE
chore(repo): align harmonia with FLEET-REPO-SETUP (canary)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md whitespace=-trailing-space,-blank-at-eol

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!--
 scope: harmonia repo cross-tool agent guide (Claude Code, Kimi, Codex, Cursor, Copilot)
-defers_to: README.md for project overview; docs/architecture/binary-modes.md for host-mode boundaries; /home/ck/dev/kanon/projects/harmonia/STATE.md for planning state
+defers_to: README.md for project overview; docs/architecture/binary-modes.md for host-mode boundaries; kanon:projects/harmonia/STATE.md for planning state
 tightens: workspace build/test/lint expectations and Harmonia-specific subsystem boundaries
 -->
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ to replace the *arr stack as a full media lifecycle manager.
 
 ## Architecture
 
-Single Tokio/Axum/SQLite server with 20 workspace crates under `crates/`.
+Single Tokio/Axum/SQLite server with 21 workspace crates under `crates/`.
 `crates/theatron/desktop` is an excluded Dioxus desktop package; canonical
 STATE.md tracks that desktop port as the remaining Phase 3.5 scope.
 
@@ -41,8 +41,8 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 ## Documentation
 
-- `<standards-doc>/STANDARDS.md`: Coding standards
-- `<standards-doc>/GNOMON.md`: Greek naming methodology
+- [standards/](standards/): pointer to canonical fleet standards (kanon `crates/basanos/standards/`)
+- [CLAUDE.md](CLAUDE.md): repo conventions and standards links
 - [docs/lexicon.md](docs/lexicon.md): Project name registry
 
 ## License


### PR DESCRIPTION
## Summary

Canary application of the new fleet standard codified in [kanon#524](https://github.com/forkwright/kanon/pull/524) -> `crates/basanos/standards/FLEET-REPO-SETUP.md`. Harmonia is the first Tier U repo to be brought to spec-compliance end-to-end.

## In-tree changes (this PR)

| Item | Before | After |
|------|--------|-------|
| `.gitattributes` | absent | adds `*.md whitespace=-trailing-space,-blank-at-eol` (D-055) |
| `AGENTS.md:3` | `/home/ck/dev/kanon/projects/harmonia/STATE.md` (absolute host path) | `kanon:projects/harmonia/STATE.md` (repo-relative identifier) |
| `README.md` architecture | claims 20 workspace crates | 21 (actual `members` count in `Cargo.toml`; 1 excluded = `crates/theatron/desktop`) |
| `README.md` standards links | literal `<standards-doc>/STANDARDS.md` + `<standards-doc>/GNOMON.md` placeholders | `[standards/](standards/)` pointer + `[CLAUDE.md](CLAUDE.md)` |

## Out-of-tree changes (applied via gh api before opening this PR)

Repo settings — `gh api repos/forkwright/harmonia -X PATCH`:

| Setting | Before | After |
|---------|--------|-------|
| `allow_auto_merge` | false | true |
| `delete_branch_on_merge` | false | true |
| `allow_merge_commit` | true | false |
| `allow_rebase_merge` | true | false |
| `allow_squash_merge` | true | (unchanged) |

## Already spec-compliant (verified, no change)

- release-please workflow + config + manifest (currently v0.1.10, awaiting #253 to bump 0.1.11)
- gate-attestation workflow (pattern from #270)
- CHANGELOG.md (release-please managed)
- llms.txt present at root

## Requires operator manual action

1. **Branch protection on `main`.** Current state has `allow_force_pushes: true` and `gate-attestation` as the only required check. FLEET-REPO-SETUP §2 requires `allow_force_pushes: false`. Not auto-applied — branch-protection mutations can lock automation accounts out, so operator applies via web UI or `gh api -X PUT`. Suggested patch:

   ```bash
   gh api repos/forkwright/harmonia/branches/main/protection -X PUT --input - <<'JSON'
   {
     "required_status_checks": {"strict": false, "contexts": ["gate-attestation"]},
     "enforce_admins": false,
     "required_pull_request_reviews": null,
     "restrictions": null,
     "required_linear_history": false,
     "allow_force_pushes": false,
     "allow_deletions": false
   }
   JSON
   ```

2. **Org-level toggle.** `Settings -> Actions -> General -> Workflow permissions -> "Allow GitHub Actions to create and approve pull requests."` One-time, org-scoped, persists across all repos.

## Deltas the milestone audit missed

- Audit reported 22 workspace members; actual `members = [...]` block contains 21 entries. The 22nd entry the audit counted is the `crates/theatron/desktop` line inside the `exclude = [...]` block (the grep `^\s*"crates` matched both). README now says 21.
- `standards/README.md` is a pointer-only file; the audit's "resolve `<standards-doc>` to either `standards/` or upstream kanon" hint is right but `standards/` doesn't actually carry `STANDARDS.md` / `GNOMON.md`. Resolved by linking the pointer dir instead.

## Related

- [kanon#524](https://github.com/forkwright/kanon/pull/524) — FLEET-REPO-SETUP.md spec PR (merged)

Gate-Passed: kanon 0.1.0