### PR TITLE
ci(workflows): swap dtolnay/rust-toolchain to actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: 1.85
+          toolchain: "1.85"
           components: rustfmt
+          cache: false
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -37,9 +38,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: 1.85
+          toolchain: "1.85"
+          cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install system dependencies
         run: |
@@ -55,10 +57,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: 1.85
+          toolchain: "1.85"
           components: clippy
+          cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install system dependencies
         run: |
@@ -74,7 +77,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
+          cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-deny
         run: cargo +stable install cargo-deny --locked --version 0.19.6
@@ -90,9 +96,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: 1.85
+          toolchain: "1.85"
+          cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
+          cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Test
         run: cargo test --workspace
@@ -42,9 +45,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          targets: ${{ matrix.target }}
+          toolchain: stable
+          target: ${{ matrix.target }}
+          cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}


### PR DESCRIPTION
## Summary

Replaces `dtolnay/rust-toolchain` (branch-style refs, not dependabot-manageable) with `actions-rust-lang/setup-rust-toolchain` (tag-based) across `.github/workflows/ci.yml` and `.github/workflows/release.yml`.

## Why

`dtolnay/rust-toolchain` publishes via branch refs (`stable`, `nightly`, `1.NN.0`) rather than version tags. Dependabot's github-actions ecosystem cannot reason about update direction for a SHA pin that points at a moving branch, returns `unknown_error`, and fails the daily dependabot updater (issue #273).

`actions-rust-lang/setup-rust-toolchain` is the actively maintained tag-based equivalent.

## Behaviour preserved

- Same toolchain pins: 1.85 for fmt/check/clippy/test; `stable` for audit + release builds.
- Same components (rustfmt, clippy) on the relevant jobs.
- Same matrix targets in `release.yml`.
- `cache: false` on every new step → keeps the existing standalone `Swatinem/rust-cache` step authoritative (the new action bundles caching by default; disabling avoids double caching).
- `dependabot.yml` unchanged — the `github-actions` ecosystem entry now resolves cleanly.

## Test plan

- [ ] CI green on this PR (fmt, check, clippy, audit, test).
- [ ] After merge: watch the next scheduled dependabot run for `github-actions` — `unknown_error` should be gone.

Closes #273.