### PR TITLE
ci(security): strip FLEET_REPO_TOKEN dead code + bump cargo-audit timeout

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,17 +41,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false # PROJECT: security hardening — never expose token to steps
-      - name: Configure git credentials for private fleet deps
-        env:
-          FLEET_REPO_TOKEN: ${{ secrets.FLEET_REPO_TOKEN }}
-        run: |
-          if [ -z "${FLEET_REPO_TOKEN}" ]; then
-            echo "FLEET_REPO_TOKEN is not set; cross-repo private deps will fail to fetch." >&2
-            exit 0
-          fi
-          git config --global credential.helper store
-          printf 'https://forkwright:%s@github.com\n' "${FLEET_REPO_TOKEN}" > ~/.git-credentials
-          chmod 0600 ~/.git-credentials
       - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
         with:
           # WHY: run every check explicitly so a schema regression in one
@@ -60,8 +49,6 @@ jobs:
           # `arguments:` passes post-subcommand flags only.
           command: check advisories licenses bans sources
           arguments: --all-features
-          credentials: https://forkwright:${{ secrets.FLEET_REPO_TOKEN }}@github.com
-          use-git-cli: true
 
   cargo-audit:
     # WHY: cargo-deny's advisories check overlaps but uses a different code
@@ -69,22 +56,15 @@ jobs:
     # config drift disabling one of the two. See standards/CI.md.
     name: cargo audit
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # WHY: bumped from kanon's 15m default because harmonia's 23-crate
+    # workspace + cold-cache `cargo install cargo-audit --locked` exceeded
+    # 15m on the first run (id 26389594858 cancelled at 20m). 30m gives
+    # headroom; subsequent runs hit Swatinem/rust-cache and finish fast.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - name: Configure git credentials for private fleet deps
-        env:
-          FLEET_REPO_TOKEN: ${{ secrets.FLEET_REPO_TOKEN }}
-        run: |
-          if [ -z "${FLEET_REPO_TOKEN}" ]; then
-            echo "FLEET_REPO_TOKEN is not set; cross-repo private deps will fail to fetch." >&2
-            exit 0
-          fi
-          git config --global credential.helper store
-          printf 'https://forkwright:%s@github.com\n' "${FLEET_REPO_TOKEN}" > ~/.git-credentials
-          chmod 0600 ~/.git-credentials
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:


### PR DESCRIPTION
## Summary

Fix-forward for the Security workflow merged in #277. Two issues on the first main-branch run (id 26389594858):

- **cargo-deny job (40s, success but warns)**: inherited kanon's `Configure git credentials for private fleet deps` step + `credentials:` / `use-git-cli: true` args on `EmbarkStudios/cargo-deny-action`. harmonia is a self-contained workspace — every member crate is a `path = \"crates/...\"` dep, no `git =` deps, no sibling private-repo path deps. With `FLEET_REPO_TOKEN` unset on this repo, the action receives an empty `credentials: https://forkwright:@github.com` string. Strip the dead step + arg pair.
- **cargo-audit job (cancelled at 20m, 15m timeout exceeded)**: cold-cache `cargo install cargo-audit --locked` on harmonia's 7,302-line `Cargo.lock` / 23-crate workspace overflowed the kanon-default 15m timeout. Bump to 30m so the cold-cache install fits; subsequent runs hit `Swatinem/rust-cache` and finish in a few minutes.

## Test plan

- [ ] `cargo deny check advisories licenses bans sources --all-features` runs without the empty-credentials warning on the PR run
- [ ] `cargo audit --deny unmaintained --deny unsound --deny yanked` completes within 30m on the PR run (cold cache)
- [ ] Once merged, the next main-branch Security run goes green
- [ ] Subsequent runs (warm cache) finish in <5m

Gate-Passed: kanon 0.1.0