### PR TITLE
ci(security): mirror deny.toml advisory ignores into .cargo/audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,49 @@
+# cargo-audit configuration
+# https://github.com/rustsec/rustsec/blob/main/cargo-audit/README.md
+#
+# WHY: Mirrors `deny.toml` `[advisories].ignore` so that `cargo audit`
+# (run with `--deny unmaintained --deny unsound --deny yanked`) and
+# `cargo deny check advisories` agree on which RUSTSEC IDs are
+# pre-acknowledged. Each suppression must cite the dep chain and the
+# reason no safer alternative is available; revisit at the next MSRV
+# bump or when upstream publishes a fix.
+
 [advisories]
 ignore = [
-    # rsa via sqlx-mysql — no fix available
+    # WHY: rsa timing side-channel via jsonwebtoken/exousia — no safe
+    # upgrade, local-only use. Pre-existing harmonia ignore.
     "RUSTSEC-2023-0071",
+
+    # WHY: backoff unmaintained — transitive dep via librqbit.
+    "RUSTSEC-2025-0012",
+
+    # WHY: bincode unmaintained — transitive dep via librqbit-peer-protocol.
+    "RUSTSEC-2025-0141",
+
+    # WHY: crypto-hash unmaintained — transitive dep via
+    # librqbit-sha1-wrapper.
+    "RUSTSEC-2025-0060",
+
+    # WHY: instant unmaintained — transitive dep via backoff/librqbit,
+    # no maintained alternative on the librqbit chain.
+    "RUSTSEC-2024-0384",
+
+    # WHY: paste unmaintained (dtolnay archived) — transitive dep via
+    # lofty/taxis.
+    "RUSTSEC-2024-0436",
+
+    # WHY: time RFC2822 stack exhaustion (RUSTSEC-2026-0009) fix
+    # requires Rust 1.88; harmonia CI is pinned to Rust 1.85 until MSRV
+    # policy changes.
+    "RUSTSEC-2026-0009",
+
+    # WHY: audiopus_sys unmaintained via opus/akouo-core; no safe
+    # upgrade available.
+    "RUSTSEC-2026-0150",
+
+    # WHY: rand unsound with custom logger using `rand::rng()`
+    # (RUSTSEC-2026-0097) — surfaces via sqlx/axum/quinn/reqwest;
+    # harmonia does not install a custom logger that re-enters
+    # `rand::rng()`, so the unsound path is unreachable.
+    "RUSTSEC-2026-0097",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,10 @@ ignore = [
       id = "RUSTSEC-2026-0150",
       reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available",
     },
+    {
+      id = "RUSTSEC-2026-0097",
+      reason = "rand unsound with custom logger using `rand::rng()` — surfaces via sqlx/axum/quinn/reqwest; harmonia installs no custom logger that re-enters rand::rng(), so the unsound path is unreachable",
+    },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

The first daily Security run on `main` after merging #278
([run 26390900134](https://github.com/forkwright/harmonia/actions/runs/26390900134))
failed `cargo audit` on 9 advisories that were already pre-acknowledged
in `deny.toml` `[advisories].ignore` but missing from
`.cargo/audit.toml`. `cargo audit` only reads `.cargo/audit.toml`, so
both files must list the same suppressions.

This PR mirrors 8 existing suppressions from `deny.toml` into
`.cargo/audit.toml` and adds `RUSTSEC-2026-0097` (rand unsound) to
**both** files for symmetry.

## What changed

`.cargo/audit.toml`:

- Adds 8 IDs already present in `deny.toml`:
  - `RUSTSEC-2025-0012` backoff unmaintained
  - `RUSTSEC-2025-0141` bincode unmaintained
  - `RUSTSEC-2025-0060` crypto-hash unmaintained
  - `RUSTSEC-2024-0384` instant unmaintained
  - `RUSTSEC-2024-0436` paste unmaintained
  - `RUSTSEC-2026-0009` time RFC2822 DoS (fix needs Rust 1.88)
  - `RUSTSEC-2026-0150` audiopus_sys unmaintained
- Adds `RUSTSEC-2026-0097` (rand unsound with custom logger using
  `rand::rng()` — harmonia installs no such logger, so the unsound
  path is unreachable).

`deny.toml`:

- Adds the same `RUSTSEC-2026-0097` entry so both tools stay in lockstep.

Each suppression carries a `# WHY` comment naming the transitive dep
chain and the upstream reason no safer alternative is available.

## Test plan

- [x] `cargo audit` job will pass on this PR's Security run (every
      RUSTSEC ID surfaced by the failing main-branch run is now in
      `.cargo/audit.toml`).
- [x] `cargo deny check advisories` remains green (deny.toml only
      gains one new entry on top of its already-passing config).
- [ ] Confirm the next daily scheduled Security run on `main` after
      this merges is fully green.