### PR TITLE
docs(README): note libasound2-dev prerequisite for Linux dev builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ STATE.md tracks that desktop port as the remaining Phase 3.5 scope.
 
 For current planning, blockers, and phase status, see the canonical project state maintained with the internal planning records.
 
+## Prerequisites
+
+Linux (Debian/Ubuntu): the `akouo-core` audio pipeline pulls `cpal` -> `alsa-sys`, which needs the ALSA development headers at build time. Install before the first `cargo check`:
+
+```bash
+sudo apt-get install --no-install-recommends libasound2-dev pkg-config
+```
+
+macOS builds out of the box against CoreAudio.
+
 ## Build
 
 ```bash


### PR DESCRIPTION
## Summary

Add a `## Prerequisites` section to `README.md` (between Architecture and Build) calling out the Linux ALSA dev-header requirement that already ships in CI but was undocumented locally.

```
sudo apt-get install --no-install-recommends libasound2-dev pkg-config
```

macOS uses CoreAudio and needs nothing extra.

## Why

`crates/akouo-core` enables `cpal`, which transitively pulls `alsa-sys`. Without `libasound2-dev` on a Debian/Ubuntu host, `cargo check --workspace` panics out of the alsa-sys build script with an opaque pkg-config error. `.github/workflows/ci.yml` apt-installs the package on every Linux job (lines 48-49, 68-69, 106-107), so CI hides the gap from anyone whose first interaction is a fresh local clone.

Closes #280.

## Test plan

- [x] `git diff` confirms a single 10-line README addition, no other file touched
- [x] markdown renders correctly in GitHub preview
- [ ] CI green