### PR TITLE
dep(akouo-core): migrate symphonia 0.5 → 0.6 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,12 +269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "askama"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4192,6 +4186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,9 +5174,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphonia"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+checksum = "1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-flac",
@@ -5197,44 +5197,44 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-flac"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+checksum = "ee69ad01236a67260b82fd1ff9790dd75ead29f2f46af145e63b7e72273e0e03"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+checksum = "350f1f2f2e19ad4dd315db94304d1eb361b29af070681f94e51b8fdaad769546"
 dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-codec-aac"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+checksum = "f1979c515a76371b186aad2feff5f23e21cbec775bf95de08bf1e3af92a2ad76"
 dependencies = [
  "lazy_static",
  "log",
+ "symphonia-common",
  "symphonia-core",
 ]
 
 [[package]]
 name = "symphonia-codec-adpcm"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+checksum = "4ebbdfd76d6cc5a601c6292a44357c5b7c82f2cd7cdc0f171421f5c5cff0ea1f"
 dependencies = [
  "log",
  "symphonia-core",
@@ -5242,19 +5242,20 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-alac"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+checksum = "3a149cbfc7fb5c405d123a273227d31de17138419552112bf1aa7b73e65827b8"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
 ]
 
 [[package]]
 name = "symphonia-codec-pcm"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+checksum = "50baee168f0e9dcf6ba7fc06e8b57eb62072a4490cc7cf13af77e72baae5d328"
 dependencies = [
  "log",
  "symphonia-core",
@@ -5262,82 +5263,93 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-vorbis"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+checksum = "45b07b4423cd8e0fc472575909a5554b12c2f58e3c190b38c24f042e732fd8de"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-common"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8257891ffa7f05e02b58f4761e2abf7e5278c8744fd59e981559e050f86eef55"
 dependencies = [
  "log",
  "symphonia-core",
- "symphonia-utils-xiph",
+ "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-core"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
 dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "bytemuck",
  "lazy_static",
  "log",
+ "num-complex 0.4.6",
+ "rustfft",
+ "smallvec",
 ]
 
 [[package]]
 name = "symphonia-format-caf"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+checksum = "cde3ca76633d3400ab57195456c09f8a58d775ff5452329f3f212b6efc8622f5"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+checksum = "2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e"
 dependencies = [
- "encoding_rs",
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-mkv"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+checksum = "fb17713e134f5ad316c2690fa3104590ccc85842cdbcf82c3cd1a845cb08aa74"
 dependencies = [
  "lazy_static",
  "log",
+ "symphonia-common",
  "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-ogg"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+checksum = "b05a67e02b1e4fca1a261ba4fe06910a9357489ad8c36aafdd2960e9c6559433"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-riff"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+checksum = "17424452a777666d3eaf09a5c651029b15b6a333812fcc5b5474f2a3f0cff3f0"
 dependencies = [
  "extended",
  "log",
@@ -5347,24 +5359,15 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+checksum = "a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681"
 dependencies = [
- "encoding_rs",
  "lazy_static",
  "log",
+ "regex-lite",
+ "smallvec",
  "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ notify          = "8.2"
 lofty           = "=0.22.4"
 
 # ── Audio decoding ─────────────────────────────────────────────────────────────
-symphonia       = { version = "0.5", features = ["all"] }
+symphonia       = { version = "0.6", features = ["all"] }
 opus            = "0.3"
 rubato          = "3.0"
 ebur128         = "0.1"

--- a/crates/akouo-core/src/decode/metadata.rs
+++ b/crates/akouo-core/src/decode/metadata.rs
@@ -57,11 +57,11 @@ impl TrackMetadata {
 /// - **FLAC / WAV / AIFF**: no encoder delay  -  returns `None`
 #[instrument]
 pub fn read_gapless_info(path: &Path, codec: &Codec) -> Option<GaplessInfo> {
-    use symphonia::core::codecs::CODEC_TYPE_NULL;
+    use symphonia::core::codecs::audio::CODEC_ID_NULL_AUDIO;
     use symphonia::core::formats::FormatOptions;
+    use symphonia::core::formats::probe::Hint;
     use symphonia::core::io::MediaSourceStream;
     use symphonia::core::meta::MetadataOptions;
-    use symphonia::core::probe::Hint;
 
     if matches!(codec, Codec::Vorbis) {
         return Some(GaplessInfo {
@@ -82,30 +82,26 @@ pub fn read_gapless_info(path: &Path, codec: &Codec) -> Option<GaplessInfo> {
         hint.with_extension(ext);
     }
 
-    let probed = symphonia::default::get_probe()
-        .format(
-            &hint,
-            mss,
-            &FormatOptions {
-                enable_gapless: true,
-                ..Default::default()
-            },
-            &MetadataOptions::default(),
-        )
+    let format = symphonia::default::get_probe()
+        .probe(&hint, mss, FormatOptions::default(), MetadataOptions::default())
         .ok()?;
 
-    let track = probed
-        .format
+    let track = format
         .tracks()
         .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)?;
+        .find(|t| {
+            t.codec_params
+                .as_ref()
+                .and_then(|c| c.audio())
+                .map(|a| a.codec != CODEC_ID_NULL_AUDIO)
+                .unwrap_or(false)
+        })?;
 
-    let p = &track.codec_params;
-    if p.delay.is_some() || p.padding.is_some() {
+    if track.delay.is_some() || track.padding.is_some() {
         Some(GaplessInfo {
-            encoder_delay: p.delay.unwrap_or(0),
-            encoder_padding: p.padding.unwrap_or(0),
-            total_samples: p.n_frames,
+            encoder_delay: track.delay.unwrap_or(0),
+            encoder_padding: track.padding.unwrap_or(0),
+            total_samples: track.num_frames,
         })
     } else {
         None

--- a/crates/akouo-core/src/decode/metadata.rs
+++ b/crates/akouo-core/src/decode/metadata.rs
@@ -83,19 +83,21 @@ pub fn read_gapless_info(path: &Path, codec: &Codec) -> Option<GaplessInfo> {
     }
 
     let format = symphonia::default::get_probe()
-        .probe(&hint, mss, FormatOptions::default(), MetadataOptions::default())
+        .probe(
+            &hint,
+            mss,
+            FormatOptions::default(),
+            MetadataOptions::default(),
+        )
         .ok()?;
 
-    let track = format
-        .tracks()
-        .iter()
-        .find(|t| {
-            t.codec_params
-                .as_ref()
-                .and_then(|c| c.audio())
-                .map(|a| a.codec != CODEC_ID_NULL_AUDIO)
-                .unwrap_or(false)
-        })?;
+    let track = format.tracks().iter().find(|t| {
+        t.codec_params
+            .as_ref()
+            .and_then(|c| c.audio())
+            .map(|a| a.codec != CODEC_ID_NULL_AUDIO)
+            .unwrap_or(false)
+    })?;
 
     if track.delay.is_some() || track.padding.is_some() {
         Some(GaplessInfo {

--- a/crates/akouo-core/src/decode/opus.rs
+++ b/crates/akouo-core/src/decode/opus.rs
@@ -253,7 +253,6 @@ fn build_gapless_info(
 
 #[cfg(test)]
 mod tests {
-    use symphonia::core::codecs::audio::AudioCodecParameters;
 
     use super::*;
 

--- a/crates/akouo-core/src/decode/opus.rs
+++ b/crates/akouo-core/src/decode/opus.rs
@@ -8,9 +8,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
-use symphonia::core::codecs::{CODEC_TYPE_OPUS, CodecParameters};
+use symphonia::core::codecs::audio::well_known::CODEC_ID_OPUS;
 use symphonia::core::formats::{FormatReader, SeekMode, SeekTo};
-use symphonia::core::probe::ProbeResult;
+
 use symphonia::core::units::{Time, TimeBase};
 
 use crate::decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams};
@@ -28,7 +28,7 @@ const OPUS_MAX_FRAME_SAMPLES: usize = 5_760;
 /// return `std::future::ready(result)` so the caller can await without blocking.
 pub struct OpusDecoder {
     decoder: opus::Decoder,
-    format_reader: Box<dyn FormatReader>,
+    format_reader: Box<dyn FormatReader + 'static>,
     track_id: u32,
     params: StreamParams,
     gapless: Option<GaplessInfo>,
@@ -44,20 +44,33 @@ impl OpusDecoder {
     ///
     /// The caller (probe.rs) does the format detection; this constructor takes
     /// ownership and sets up the libopus decoder for the OGG/Opus track.
-    pub fn from_probed(probed: ProbeResult) -> Result<Box<dyn AudioDecoder>, DecodeError> {
-        let format = probed.format;
-
+    pub fn from_probed(format: Box<dyn symphonia::core::formats::FormatReader + 'static>) -> Result<Box<dyn AudioDecoder>, DecodeError> {
         let track = format
             .tracks()
             .iter()
-            .find(|t| t.codec_params.codec == CODEC_TYPE_OPUS)
+            .find(|t| {
+                t.codec_params
+                    .as_ref()
+                    .and_then(|c| c.audio())
+                    .map(|a| a.codec == CODEC_ID_OPUS)
+                    .unwrap_or(false)
+            })
             .ok_or_else(|| DecodeError::OpusDecode {
                 message: "no Opus track found in OGG container".to_string(),
                 location: snafu::Location::new(file!(), line!(), column!()),
             })?;
 
         let track_id = track.id;
-        let codec_params = track.codec_params.clone();
+        let num_frames = track.num_frames;
+        let track_time_base = track.time_base;
+        let track_delay = track.delay;
+        let track_padding = track.padding;
+        let codec_params = track
+            .codec_params
+            .as_ref()
+            .and_then(|c| c.audio())
+            .cloned()
+            .unwrap_or_default();
 
         let channels = codec_params.channels.map(|c| c.count() as u16).unwrap_or(2);
 
@@ -74,14 +87,13 @@ impl OpusDecoder {
             }
         })?;
 
-        let time_base = codec_params.time_base.unwrap_or(TimeBase {
-            numer: 1,
-            denom: OPUS_SAMPLE_RATE,
+        let time_base = track_time_base.unwrap_or_else(|| {
+            TimeBase::try_from_recip(OPUS_SAMPLE_RATE)
+                .expect("OPUS_SAMPLE_RATE is non-zero")
         });
 
-        let duration = codec_params.n_frames.map(|n| {
-            let t = time_base.calc_time(n);
-            Duration::from_secs_f64(t.seconds as f64 + t.frac)
+        let duration = num_frames.map(|n| {
+            Duration::from_secs_f64(n as f64 / OPUS_SAMPLE_RATE as f64)
         });
 
         let params = StreamParams {
@@ -93,7 +105,7 @@ impl OpusDecoder {
             bitrate: codec_params.bits_per_coded_sample.map(|b| b / 1000),
         };
 
-        let gapless = build_gapless_info(&codec_params);
+        let gapless = build_gapless_info(track_delay, track_padding, num_frames);
 
         let buf_samples = OPUS_MAX_FRAME_SAMPLES * usize::from(channels);
         let decode_buf = vec![0.0f32; buf_samples].into_boxed_slice();
@@ -114,7 +126,8 @@ impl OpusDecoder {
     fn decode_next_packet(&mut self) -> Result<Option<DecodedFrame>, DecodeError> {
         loop {
             let packet = match self.format_reader.next_packet() {
-                Ok(p) => p,
+                Ok(Some(p)) => p,
+                Ok(None) => return Ok(None),
                 Err(symphonia::core::errors::Error::IoError(e))
                     if e.kind() == std::io::ErrorKind::UnexpectedEof =>
                 {
@@ -128,16 +141,16 @@ impl OpusDecoder {
                 }
             };
 
-            if packet.track_id() != self.track_id {
+            if packet.track_id != self.track_id {
                 continue;
             }
 
-            let timestamp = packet.ts();
+            let timestamp = packet.pts.get().max(0) as u64;
 
             // An empty slice triggers Opus Packet Loss Concealment (PLC).
             let n_samples_per_channel = self
                 .decoder
-                .decode_float(packet.buf(), &mut self.decode_buf, false)
+                .decode_float(packet.data.as_ref(), &mut self.decode_buf, false)
                 .map_err(|e| DecodeError::OpusDecode {
                     message: format!("decode_float failed: {e}"),
                     location: snafu::Location::new(file!(), line!(), column!()),
@@ -161,10 +174,7 @@ impl OpusDecoder {
     }
 
     fn do_seek(&mut self, position: Duration) -> Result<Duration, DecodeError> {
-        let time = Time {
-            seconds: position.as_secs(),
-            frac: position.subsec_nanos() as f64 / 1e9,
-        };
+        let time = Time::try_from_secs_f64(position.as_secs_f64()).unwrap_or(Time::ZERO);
 
         let seeked = self
             .format_reader
@@ -193,10 +203,12 @@ impl OpusDecoder {
             }
         })?;
 
-        let actual_time = self.time_base.calc_time(seeked.actual_ts);
-        Ok(Duration::from_secs_f64(
-            actual_time.seconds as f64 + actual_time.frac,
-        ))
+        let secs = self
+            .time_base
+            .calc_time(seeked.actual_ts)
+            .map(|t| t.as_secs_f64())
+            .unwrap_or(0.0);
+        Ok(Duration::from_secs_f64(secs))
     }
 }
 
@@ -223,12 +235,15 @@ impl AudioDecoder for OpusDecoder {
     }
 }
 
-fn build_gapless_info(params: &CodecParameters) -> Option<GaplessInfo> {
-    let delay = params.delay?;
-    let padding = params.padding.unwrap_or(0);
-    let total_samples = params
-        .n_frames
-        .map(|n| n.saturating_sub(u64::from(delay) + u64::from(padding)));
+fn build_gapless_info(
+    delay: Option<u32>,
+    padding: Option<u32>,
+    n_frames: Option<u64>,
+) -> Option<GaplessInfo> {
+    let delay = delay?;
+    let padding = padding.unwrap_or(0);
+    let total_samples =
+        n_frames.map(|n| n.saturating_sub(u64::from(delay) + u64::from(padding)));
     Some(GaplessInfo {
         encoder_delay: delay,
         encoder_padding: padding,
@@ -238,7 +253,7 @@ fn build_gapless_info(params: &CodecParameters) -> Option<GaplessInfo> {
 
 #[cfg(test)]
 mod tests {
-    use symphonia::core::codecs::CodecParameters;
+    use symphonia::core::codecs::audio::AudioCodecParameters;
 
     use super::*;
 
@@ -254,12 +269,7 @@ mod tests {
 
     #[test]
     fn build_gapless_info_extracts_pre_skip_and_padding() {
-        let mut params = CodecParameters::new();
-        params.delay = Some(3840);
-        params.padding = Some(120);
-        params.n_frames = Some(2_257_920);
-
-        let info = build_gapless_info(&params).unwrap();
+        let info = build_gapless_info(Some(3840), Some(120), Some(2_257_920)).unwrap();
         assert_eq!(info.encoder_delay, 3840);
         assert_eq!(info.encoder_padding, 120);
         assert_eq!(info.total_samples, Some(2_257_920 - 3840 - 120));
@@ -267,17 +277,12 @@ mod tests {
 
     #[test]
     fn build_gapless_info_returns_none_without_delay() {
-        let params = CodecParameters::new();
-        assert!(build_gapless_info(&params).is_none());
+        assert!(build_gapless_info(None, None, None).is_none());
     }
 
     #[test]
     fn build_gapless_info_padding_defaults_to_zero() {
-        let mut params = CodecParameters::new();
-        params.delay = Some(312);
-        // padding intentionally not SET
-
-        let info = build_gapless_info(&params).unwrap();
+        let info = build_gapless_info(Some(312), None, None).unwrap();
         assert_eq!(info.encoder_padding, 0);
         assert_eq!(info.total_samples, None); // n_frames not SET
     }

--- a/crates/akouo-core/src/decode/opus.rs
+++ b/crates/akouo-core/src/decode/opus.rs
@@ -44,7 +44,9 @@ impl OpusDecoder {
     ///
     /// The caller (probe.rs) does the format detection; this constructor takes
     /// ownership and sets up the libopus decoder for the OGG/Opus track.
-    pub fn from_probed(format: Box<dyn symphonia::core::formats::FormatReader + 'static>) -> Result<Box<dyn AudioDecoder>, DecodeError> {
+    pub fn from_probed(
+        format: Box<dyn symphonia::core::formats::FormatReader + 'static>,
+    ) -> Result<Box<dyn AudioDecoder>, DecodeError> {
         let track = format
             .tracks()
             .iter()
@@ -88,13 +90,11 @@ impl OpusDecoder {
         })?;
 
         let time_base = track_time_base.unwrap_or_else(|| {
-            TimeBase::try_from_recip(OPUS_SAMPLE_RATE)
-                .expect("OPUS_SAMPLE_RATE is non-zero")
+            TimeBase::try_from_recip(OPUS_SAMPLE_RATE).expect("OPUS_SAMPLE_RATE is non-zero")
         });
 
-        let duration = num_frames.map(|n| {
-            Duration::from_secs_f64(n as f64 / OPUS_SAMPLE_RATE as f64)
-        });
+        let duration =
+            num_frames.map(|n| Duration::from_secs_f64(n as f64 / OPUS_SAMPLE_RATE as f64));
 
         let params = StreamParams {
             codec: Codec::Opus,
@@ -242,8 +242,7 @@ fn build_gapless_info(
 ) -> Option<GaplessInfo> {
     let delay = delay?;
     let padding = padding.unwrap_or(0);
-    let total_samples =
-        n_frames.map(|n| n.saturating_sub(u64::from(delay) + u64::from(padding)));
+    let total_samples = n_frames.map(|n| n.saturating_sub(u64::from(delay) + u64::from(padding)));
     Some(GaplessInfo {
         encoder_delay: delay,
         encoder_padding: padding,

--- a/crates/akouo-core/src/decode/probe.rs
+++ b/crates/akouo-core/src/decode/probe.rs
@@ -5,11 +5,14 @@
 
 use std::path::Path;
 
-use symphonia::core::codecs::audio::{CODEC_ID_NULL_AUDIO, well_known::{CODEC_ID_OPUS, CODEC_ID_WAVPACK}};
+use symphonia::core::codecs::audio::{
+    CODEC_ID_NULL_AUDIO,
+    well_known::{CODEC_ID_OPUS, CODEC_ID_WAVPACK},
+};
 use symphonia::core::formats::FormatOptions;
+use symphonia::core::formats::probe::Hint;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
-use symphonia::core::formats::probe::Hint;
 
 use crate::decode::opus::OpusDecoder;
 use crate::decode::symphonia::{SymphoniaDecoder, map_codec};
@@ -70,7 +73,9 @@ pub async fn probe_codec(path: &Path) -> Result<Codec, DecodeError> {
 }
 
 /// Opens `path` and runs Symphonia's format probe. Shared by `open_decoder` and `probe_codec`.
-fn probe_format(path: &Path) -> Result<Box<dyn symphonia::core::formats::FormatReader + 'static>, DecodeError> {
+fn probe_format(
+    path: &Path,
+) -> Result<Box<dyn symphonia::core::formats::FormatReader + 'static>, DecodeError> {
     let file = std::fs::File::open(path).map_err(|e| DecodeError::SymphoniaRead {
         message: format!("failed to open {}: {e}", path.display()),
         location: snafu::Location::new(file!(), line!(), column!()),

--- a/crates/akouo-core/src/decode/probe.rs
+++ b/crates/akouo-core/src/decode/probe.rs
@@ -5,11 +5,11 @@
 
 use std::path::Path;
 
-use symphonia::core::codecs::{CODEC_TYPE_NULL, CODEC_TYPE_OPUS, CODEC_TYPE_WAVPACK};
+use symphonia::core::codecs::audio::{CODEC_ID_NULL_AUDIO, well_known::{CODEC_ID_OPUS, CODEC_ID_WAVPACK}};
 use symphonia::core::formats::FormatOptions;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
-use symphonia::core::probe::Hint;
+use symphonia::core::formats::probe::Hint;
 
 use crate::decode::opus::OpusDecoder;
 use crate::decode::symphonia::{SymphoniaDecoder, map_codec};
@@ -24,12 +24,16 @@ use crate::error::DecodeError;
 /// - All others (FLAC, WAV, ALAC, MP3, AAC, AIFF, Vorbis) → `SymphoniaDecoder` (P1-02)
 pub async fn open_decoder(path: &Path) -> Result<Box<dyn AudioDecoder>, DecodeError> {
     let probed = probe_format(path)?;
-    let codec = probed.format.default_track().map(|t| t.codec_params.codec);
+    let codec = probed
+        .default_track(symphonia::core::formats::TrackType::Audio)
+        .and_then(|t| t.codec_params.as_ref())
+        .and_then(|c| c.audio())
+        .map(|a| a.codec);
 
     match codec {
-        Some(CODEC_TYPE_OPUS) => OpusDecoder::from_probed(probed),
+        Some(CODEC_ID_OPUS) => OpusDecoder::from_probed(probed),
 
-        Some(CODEC_TYPE_WAVPACK) => Err(DecodeError::UnsupportedCodec {
+        Some(CODEC_ID_WAVPACK) => Err(DecodeError::UnsupportedCodec {
             codec: Codec::Other("WavPack".to_string()),
             location: snafu::Location::new(file!(), line!(), column!()),
         }),
@@ -56,16 +60,17 @@ pub async fn probe_codec(path: &Path) -> Result<Codec, DecodeError> {
     let probed = probe_format(path)?;
 
     let codec_type = probed
-        .format
-        .default_track()
-        .map(|t| t.codec_params.codec)
-        .unwrap_or(CODEC_TYPE_NULL);
+        .default_track(symphonia::core::formats::TrackType::Audio)
+        .and_then(|t| t.codec_params.as_ref())
+        .and_then(|c| c.audio())
+        .map(|a| a.codec)
+        .unwrap_or(CODEC_ID_NULL_AUDIO);
 
     Ok(map_codec(codec_type))
 }
 
 /// Opens `path` and runs Symphonia's format probe. Shared by `open_decoder` and `probe_codec`.
-fn probe_format(path: &Path) -> Result<symphonia::core::probe::ProbeResult, DecodeError> {
+fn probe_format(path: &Path) -> Result<Box<dyn symphonia::core::formats::FormatReader + 'static>, DecodeError> {
     let file = std::fs::File::open(path).map_err(|e| DecodeError::SymphoniaRead {
         message: format!("failed to open {}: {e}", path.display()),
         location: snafu::Location::new(file!(), line!(), column!()),
@@ -76,11 +81,11 @@ fn probe_format(path: &Path) -> Result<symphonia::core::probe::ProbeResult, Deco
     let hint = hint_from_path(path);
 
     symphonia::default::get_probe()
-        .format(
+        .probe(
             &hint,
             mss,
-            &FormatOptions::default(),
-            &MetadataOptions::default(),
+            FormatOptions::default(),
+            MetadataOptions::default(),
         )
         .map_err(|e| DecodeError::SymphoniaRead {
             message: format!("format probe failed for {}: {e}", path.display()),

--- a/crates/akouo-core/src/decode/symphonia.rs
+++ b/crates/akouo-core/src/decode/symphonia.rs
@@ -29,7 +29,12 @@ impl SymphoniaDecoder {
     #[instrument(skip(mss))]
     pub fn new(mss: MediaSourceStream<'static>, hint: &Hint) -> Result<Self, DecodeError> {
         let format = symphonia::default::get_probe()
-            .probe(hint, mss, FormatOptions::default(), MetadataOptions::default())
+            .probe(
+                hint,
+                mss,
+                FormatOptions::default(),
+                MetadataOptions::default(),
+            )
             .map_err(|e| DecodeError::SymphoniaRead {
                 message: format!("probe failed: {e}"),
                 location: snafu::location!(),
@@ -183,7 +188,10 @@ impl SymphoniaDecoder {
 
     fn seek_to(&mut self, position: Duration) -> Result<Duration, DecodeError> {
         let time = Time::try_from_secs_f64(position.as_secs_f64()).unwrap_or(Time::ZERO);
-        let seek_to = SeekTo::Time { time, track_id: Some(self.track_id) };
+        let seek_to = SeekTo::Time {
+            time,
+            track_id: Some(self.track_id),
+        };
 
         let seeked = self.format.seek(SeekMode::Coarse, seek_to).map_err(|e| {
             DecodeError::SymphoniaRead {
@@ -229,10 +237,7 @@ pub(crate) fn map_codec(ct: AudioCodecId) -> Codec {
     }
 }
 
-fn extract_gapless(
-    track: &symphonia::core::formats::Track,
-    codec: &Codec,
-) -> Option<GaplessInfo> {
+fn extract_gapless(track: &symphonia::core::formats::Track, codec: &Codec) -> Option<GaplessInfo> {
     // WHY: Symphonia issue #418 — Vorbis pre-skip not parsed; hardcode standard value.
     if matches!(codec, Codec::Vorbis) {
         return Some(GaplessInfo {

--- a/crates/akouo-core/src/decode/symphonia.rs
+++ b/crates/akouo-core/src/decode/symphonia.rs
@@ -2,13 +2,13 @@ use std::io::ErrorKind;
 use std::pin::Pin;
 use std::time::Duration;
 
-use symphonia::core::audio::AudioBufferRef;
-use symphonia::core::codecs::{CODEC_TYPE_NULL, DecoderOptions};
+use symphonia::core::audio::GenericAudioBufferRef;
+use symphonia::core::codecs::audio::{AudioCodecId, AudioDecoderOptions, CODEC_ID_NULL_AUDIO};
 use symphonia::core::errors::Error as SymphErr;
+use symphonia::core::formats::probe::Hint;
 use symphonia::core::formats::{FormatOptions, SeekMode, SeekTo};
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
-use symphonia::core::probe::Hint;
 use symphonia::core::units::{Time, TimeBase};
 use tracing::{instrument, warn};
 
@@ -17,7 +17,7 @@ use crate::error::DecodeError;
 
 pub struct SymphoniaDecoder {
     format: Box<dyn symphonia::core::formats::FormatReader>,
-    decoder: Box<dyn symphonia::core::codecs::Decoder>,
+    decoder: Box<dyn symphonia::core::codecs::audio::AudioDecoder>,
     track_id: u32,
     time_base: TimeBase,
     stream_params: StreamParams,
@@ -27,39 +27,46 @@ pub struct SymphoniaDecoder {
 impl SymphoniaDecoder {
     /// Probes `mss` and creates a ready-to-decode instance.
     #[instrument(skip(mss))]
-    pub fn new(mss: MediaSourceStream, hint: &Hint) -> Result<Self, DecodeError> {
-        let format_opts = FormatOptions {
-            enable_gapless: true,
-            ..Default::default()
-        };
-        let probed = symphonia::default::get_probe()
-            .format(hint, mss, &format_opts, &MetadataOptions::default())
+    pub fn new(mss: MediaSourceStream<'static>, hint: &Hint) -> Result<Self, DecodeError> {
+        let format = symphonia::default::get_probe()
+            .probe(hint, mss, FormatOptions::default(), MetadataOptions::default())
             .map_err(|e| DecodeError::SymphoniaRead {
                 message: format!("probe failed: {e}"),
                 location: snafu::location!(),
             })?;
 
-        let format = probed.format;
-
         let track = format
             .tracks()
             .iter()
-            .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+            .find(|t| {
+                t.codec_params
+                    .as_ref()
+                    .and_then(|c| c.audio())
+                    .map(|a| a.codec != CODEC_ID_NULL_AUDIO)
+                    .unwrap_or(false)
+            })
             .ok_or_else(|| DecodeError::SymphoniaRead {
                 message: "no audio track found".to_string(),
                 location: snafu::location!(),
             })?;
 
         let track_id = track.id;
-        let codec = map_codec(track.codec_params.codec);
+        let p = track
+            .codec_params
+            .as_ref()
+            .and_then(|c| c.audio())
+            .ok_or_else(|| DecodeError::SymphoniaRead {
+                message: "track has no audio codec parameters".to_string(),
+                location: snafu::location!(),
+            })?;
 
+        let codec = map_codec(p.codec);
         let gapless_info = extract_gapless(track, &codec);
 
-        let p = &track.codec_params;
         let sample_rate = p.sample_rate.unwrap_or(44100);
-        let channels = p.channels.map(|c| c.count() as u16).unwrap_or(2);
-        let duration = p
-            .n_frames
+        let channels = p.channels.as_ref().map(|c| c.count() as u16).unwrap_or(2);
+        let duration = track
+            .num_frames
             .map(|n| Duration::from_secs_f64(n as f64 / sample_rate as f64));
 
         let stream_params = StreamParams {
@@ -71,13 +78,13 @@ impl SymphoniaDecoder {
             bitrate: None,
         };
 
-        let time_base = p.time_base.unwrap_or(TimeBase {
-            numer: 1,
-            denom: sample_rate,
+        let time_base = track.time_base.unwrap_or_else(|| {
+            TimeBase::try_from_recip(sample_rate)
+                .unwrap_or_else(|| TimeBase::try_new(1, 44100).expect("fallback timebase"))
         });
 
         let decoder = symphonia::default::get_codecs()
-            .make(p, &DecoderOptions::default())
+            .make_audio_decoder(p, &AudioDecoderOptions::default())
             .map_err(|e| DecodeError::SymphoniaRead {
                 message: format!("decoder init failed: {e}"),
                 location: snafu::location!(),
@@ -125,7 +132,8 @@ impl SymphoniaDecoder {
     fn decode_next_frame(&mut self) -> Result<Option<DecodedFrame>, DecodeError> {
         loop {
             let packet = match self.format.next_packet() {
-                Ok(p) => p,
+                Ok(Some(p)) => p,
+                Ok(None) => return Ok(None),
                 Err(SymphErr::IoError(e)) if e.kind() == ErrorKind::UnexpectedEof => {
                     return Ok(None);
                 }
@@ -141,7 +149,7 @@ impl SymphoniaDecoder {
                 }
             };
 
-            if packet.track_id() != self.track_id {
+            if packet.track_id != self.track_id {
                 continue;
             }
 
@@ -159,7 +167,7 @@ impl SymphoniaDecoder {
                 }
             };
 
-            let timestamp = packet.ts;
+            let timestamp = packet.pts.get().max(0) as u64;
             let channels = self.stream_params.channels;
             let sample_rate = self.stream_params.sample_rate;
             let samples = buffer_to_f64_interleaved(&buffer);
@@ -174,10 +182,8 @@ impl SymphoniaDecoder {
     }
 
     fn seek_to(&mut self, position: Duration) -> Result<Duration, DecodeError> {
-        let seek_to = SeekTo::Time {
-            time: Time::from(position.as_secs_f64()),
-            track_id: Some(self.track_id),
-        };
+        let time = Time::try_from_secs_f64(position.as_secs_f64()).unwrap_or(Time::ZERO);
+        let seek_to = SeekTo::Time { time, track_id: Some(self.track_id) };
 
         let seeked = self.format.seek(SeekMode::Coarse, seek_to).map_err(|e| {
             DecodeError::SymphoniaRead {
@@ -188,35 +194,51 @@ impl SymphoniaDecoder {
 
         self.decoder.reset();
 
-        let t = self.time_base.calc_time(seeked.actual_ts);
-        Ok(Duration::from_secs_f64(t.seconds as f64 + t.frac))
+        let t = self
+            .time_base
+            .calc_time(seeked.actual_ts)
+            .unwrap_or(Time::ZERO);
+        Ok(Duration::from_secs_f64(t.as_secs_f64()))
     }
 }
 
-/// Maps a symphonia `CodecType` to the crate's `Codec` enum.
-pub(crate) fn map_codec(ct: symphonia::core::codecs::CodecType) -> Codec {
-    use symphonia::core::codecs::*;
+/// Maps a symphonia `AudioCodecId` to the crate's `Codec` enum.
+pub(crate) fn map_codec(ct: AudioCodecId) -> Codec {
+    use symphonia::core::codecs::audio::well_known::*;
     match ct {
-        CODEC_TYPE_FLAC => Codec::Flac,
-        CODEC_TYPE_MP3 => Codec::Mp3,
-        CODEC_TYPE_AAC => Codec::Aac,
-        CODEC_TYPE_VORBIS => Codec::Vorbis,
-        CODEC_TYPE_OPUS => Codec::Opus,
-        CODEC_TYPE_ALAC => Codec::Alac,
-        CODEC_TYPE_PCM_S16LE | CODEC_TYPE_PCM_S24LE | CODEC_TYPE_PCM_S32LE
-        | CODEC_TYPE_PCM_F32LE | CODEC_TYPE_PCM_S16BE | CODEC_TYPE_PCM_S24BE
-        | CODEC_TYPE_PCM_S32BE => Codec::Wav,
+        CODEC_ID_FLAC => Codec::Flac,
+        CODEC_ID_MP3 => Codec::Mp3,
+        CODEC_ID_AAC => Codec::Aac,
+        CODEC_ID_VORBIS => Codec::Vorbis,
+        CODEC_ID_OPUS => Codec::Opus,
+        CODEC_ID_ALAC => Codec::Alac,
+        c if [
+            CODEC_ID_PCM_S16LE,
+            CODEC_ID_PCM_S24LE,
+            CODEC_ID_PCM_S32LE,
+            CODEC_ID_PCM_F32LE,
+            CODEC_ID_PCM_S16BE,
+            CODEC_ID_PCM_S24BE,
+            CODEC_ID_PCM_S32BE,
+        ]
+        .contains(&c) =>
+        {
+            Codec::Wav
+        }
         _ => Codec::Other(format!("{ct:?}")),
     }
 }
 
-fn extract_gapless(track: &symphonia::core::formats::Track, codec: &Codec) -> Option<GaplessInfo> {
-    // Symphonia issue #418: Vorbis pre-skip is not parsed  -  hardcode the standard value.
+fn extract_gapless(
+    track: &symphonia::core::formats::Track,
+    codec: &Codec,
+) -> Option<GaplessInfo> {
+    // WHY: Symphonia issue #418 — Vorbis pre-skip not parsed; hardcode standard value.
     if matches!(codec, Codec::Vorbis) {
         return Some(GaplessInfo {
             encoder_delay: 3456,
             encoder_padding: 0,
-            total_samples: track.codec_params.n_frames,
+            total_samples: track.num_frames,
         });
     }
 
@@ -225,67 +247,20 @@ fn extract_gapless(track: &symphonia::core::formats::Track, codec: &Codec) -> Op
         return None;
     }
 
-    let p = &track.codec_params;
-    if p.delay.is_some() || p.padding.is_some() {
+    if track.delay.is_some() || track.padding.is_some() {
         Some(GaplessInfo {
-            encoder_delay: p.delay.unwrap_or(0),
-            encoder_padding: p.padding.unwrap_or(0),
-            total_samples: p.n_frames,
+            encoder_delay: track.delay.unwrap_or(0),
+            encoder_padding: track.padding.unwrap_or(0),
+            total_samples: track.num_frames,
         })
     } else {
         None
     }
 }
 
-fn buffer_to_f64_interleaved(buf: &AudioBufferRef<'_>) -> Vec<f64> {
-    let n_channels = buf.spec().channels.count();
-    let n_frames = buf.frames();
-    let mut out = vec![0.0f64; n_frames * n_channels];
-
-    macro_rules! interleave {
-        ($b:expr, $convert:expr) => {{
-            for (ch, plane) in $b.planes().planes().iter().enumerate() {
-                for (frame, &s) in plane.iter().enumerate() {
-                    out[frame * n_channels + ch] = $convert(s);
-                }
-            }
-        }};
-    }
-
-    match buf {
-        AudioBufferRef::U8(b) => {
-            interleave!(b, |s: u8| (f64::from(s) - 128.0) / 128.0)
-        }
-        AudioBufferRef::U16(b) => {
-            interleave!(b, |s: u16| (f64::from(s) - 32768.0) / 32768.0)
-        }
-        AudioBufferRef::U24(b) => {
-            interleave!(b, |s: symphonia::core::sample::u24| {
-                (s.inner() as f64 - 8_388_608.0) / 8_388_608.0
-            })
-        }
-        AudioBufferRef::U32(b) => {
-            interleave!(b, |s: u32| (f64::from(s) - 2_147_483_648.0)
-                / 2_147_483_648.0)
-        }
-        AudioBufferRef::S8(b) => {
-            interleave!(b, |s: i8| f64::from(s) / 128.0)
-        }
-        AudioBufferRef::S16(b) => {
-            interleave!(b, |s: i16| f64::from(s) / 32_768.0)
-        }
-        AudioBufferRef::S24(b) => {
-            interleave!(b, |s: symphonia::core::sample::i24| {
-                s.inner() as f64 / 8_388_608.0
-            })
-        }
-        AudioBufferRef::S32(b) => {
-            interleave!(b, |s: i32| f64::from(s) / 2_147_483_648.0)
-        }
-        AudioBufferRef::F32(b) => interleave!(b, |s: f32| f64::from(s)),
-        AudioBufferRef::F64(b) => interleave!(b, |s: f64| s),
-    }
-
+fn buffer_to_f64_interleaved(buf: &GenericAudioBufferRef<'_>) -> Vec<f64> {
+    let mut out = Vec::with_capacity(buf.frames() * buf.num_planes());
+    buf.copy_to_vec_interleaved(&mut out);
     out
 }
 
@@ -422,8 +397,8 @@ mod tests {
         let frame = dec.next_frame().await.unwrap().unwrap();
         let l = frame.samples.first().copied().unwrap_or_default();
         let r = frame.samples.get(1).copied().unwrap_or_default();
-        assert!(l < -0.999, "LEFT should be ≈ -1.0, got {l}");
-        assert!(r > 0.999, "RIGHT should be ≈ +1.0, got {r}");
+        assert!(l < -0.999, "LEFT should be approx -1.0, got {l}");
+        assert!(r > 0.999, "RIGHT should be approx +1.0, got {r}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
symphonia 0.6 has sweeping breaking API changes. This PR adapts all four affected decode files (`symphonia.rs`, `probe.rs`, `metadata.rs`, `opus.rs`) to the new API.

**Key API changes handled:**

| 0.5 | 0.6 |
|-----|-----|
| `probe()` returns `ProbeResult { format, .. }` | returns `Box<dyn FormatReader>` directly |
| `symphonia::core::probe::Hint` | `symphonia::core::formats::probe::Hint` |
| `CodecType` / `CODEC_TYPE_*` | `AudioCodecId` / `CODEC_ID_*` in `codecs::audio` |
| `Decoder` trait / `DecoderOptions` | `AudioDecoder` / `AudioDecoderOptions` |
| `AudioBufferRef` + manual interleave macro | `GenericAudioBufferRef::copy_to_vec_interleaved::<f64>` |
| `track.codec_params.{sample_rate, channels, ...}` | `track.codec_params.as_ref().and_then(|c| c.audio())` |
| `codec_params.{n_frames, time_base, delay, padding}` | `track.{num_frames, time_base, delay, padding}` |
| `TimeBase { numer: 1, denom: rate }` | `TimeBase::try_from_recip(rate)` |
| `calc_time(u64) -> Time` | `calc_time(Timestamp) -> Option<Time>`; `Time.as_secs_f64()` |
| `packet.ts` (u64) | `packet.pts.get().max(0) as u64` |
| `packet.track_id()` | `packet.track_id` |
| `next_packet() -> Result<Packet>` | `next_packet() -> Result<Option<Packet>>` |
| `FormatOptions::enable_gapless` | removed (gapless handled by decoder) |
| `MediaSourceStream` (no lifetime) | `MediaSourceStream<'s>` (callers use `'static`) |

The `buffer_to_f64_interleaved` macro is replaced by the single `copy_to_vec_interleaved::<f64>` call — the sample conversion semantics are identical (verified against symphonia's `FromSample<T> for f64` impls).

All 182 tests pass; clippy clean under `--deny warnings`.

Closes #291