### PR TITLE
chore(workspace): add kanon maturity metadata to all crates

### DIFF
--- a/crates/aitesis/Cargo.toml
+++ b/crates/aitesis/Cargo.toml
@@ -21,3 +21,8 @@ jiff.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/akouo-android/Cargo.toml
+++ b/crates/akouo-android/Cargo.toml
@@ -17,3 +17,8 @@ uniffi.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/akouo-core/Cargo.toml
+++ b/crates/akouo-core/Cargo.toml
@@ -38,3 +38,8 @@ rand.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 tempfile = "3"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/apotheke/Cargo.toml
+++ b/crates/apotheke/Cargo.toml
@@ -18,3 +18,8 @@ jiff.workspace = true
 rstest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/archon/Cargo.toml
+++ b/crates/archon/Cargo.toml
@@ -59,3 +59,8 @@ sd-notify = { version = "0.5", optional = true }
 rstest.workspace = true
 tower.workspace = true
 tempfile = "3"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/epignosis/Cargo.toml
+++ b/crates/epignosis/Cargo.toml
@@ -20,3 +20,8 @@ tokio-util = { version = "0.7", features = ["rt"] }
 
 [dev-dependencies]
 tokio = { workspace = true }
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/ergasia/Cargo.toml
+++ b/crates/ergasia/Cargo.toml
@@ -26,3 +26,8 @@ rstest.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/exousia/Cargo.toml
+++ b/crates/exousia/Cargo.toml
@@ -26,3 +26,8 @@ tokio = { workspace = true }
 sqlx = { workspace = true }
 tower = { workspace = true }
 http = "1"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/harmonia-convert/Cargo.toml
+++ b/crates/harmonia-convert/Cargo.toml
@@ -12,3 +12,8 @@ tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true }
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/horismos/Cargo.toml
+++ b/crates/horismos/Cargo.toml
@@ -19,3 +19,8 @@ rstest.workspace = true
 tempfile = "3"
 figment = { workspace = true, features = ["toml", "env", "test"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/kathodos/Cargo.toml
+++ b/crates/kathodos/Cargo.toml
@@ -23,3 +23,8 @@ unicode-normalization.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 rstest.workspace = true
 tempfile = "3"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/komide/Cargo.toml
+++ b/crates/komide/Cargo.toml
@@ -22,3 +22,8 @@ jiff            = { workspace = true }
 rstest          = { workspace = true }
 tokio           = { workspace = true, features = ["full"] }
 sqlx            = { workspace = true }
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/kritike/Cargo.toml
+++ b/crates/kritike/Cargo.toml
@@ -19,3 +19,8 @@ sqlx.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 rstest.workspace = true
 uuid.workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -43,3 +43,8 @@ sha1.workspace = true
 sqlx.workspace = true
 apotheke.workspace = true
 http-body-util = "0.1"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/prostheke/Cargo.toml
+++ b/crates/prostheke/Cargo.toml
@@ -24,3 +24,8 @@ jiff.workspace = true
 rstest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/syndesis/Cargo.toml
+++ b/crates/syndesis/Cargo.toml
@@ -35,3 +35,8 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 sqlx.workspace = true
 apotheke = { workspace = true }
 toml.workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/syndesmos/Cargo.toml
+++ b/crates/syndesmos/Cargo.toml
@@ -26,3 +26,8 @@ tokio = { workspace = true, features = [
   "macros",
   "test-util",
 ] }
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/syntaxis/Cargo.toml
+++ b/crates/syntaxis/Cargo.toml
@@ -23,3 +23,8 @@ sqlx.workspace = true
 rstest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/theatron/core/Cargo.toml
+++ b/crates/theatron/core/Cargo.toml
@@ -12,3 +12,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
 tracing = { workspace = true }
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "theatron-desktop"
-version = "0.1.1"
-edition = "2024"
-license = "AGPL-3.0-or-later"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Dioxus desktop UI for the Harmonia media platform"
 publish = false
 
@@ -61,3 +61,8 @@ trait_duplication_in_bounds = "warn"
 unused_self = "warn"
 disallowed_methods = "deny"
 disallowed_types = "deny"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/themelion/Cargo.toml
+++ b/crates/themelion/Cargo.toml
@@ -18,3 +18,8 @@ compact_str = { workspace = true }
 rstest.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"

--- a/crates/zetesis/Cargo.toml
+++ b/crates/zetesis/Cargo.toml
@@ -27,3 +27,8 @@ sqlx.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-26"
+exit-criteria = "issue:forkwright/harmonia#295"


### PR DESCRIPTION
Adds `[package.metadata.kanon]` section to all 22 workspace crates, resolving `MANIFEST/missing-maturity-metadata` (22 violations) and `MANIFEST/package-workspace-inheritance` (2 violations).

All crates are marked `alpha` — workspace is at v0.1.10, pre-1.0.

Also fixes `theatron-desktop/Cargo.toml` workspace inheritance: `version`/`edition`/`license` now use `*.workspace = true`.

Tracking issue for graduation criteria: #295.

Gate-Passed: kanon 0.1.0