### PR TITLE
fix(ci): add SLSA attestation, fix high-severity kanon violations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   test:
@@ -66,11 +68,27 @@ jobs:
         run: cp target/${{ matrix.target }}/release/harmonia ${{ matrix.artifact }}
       - name: Generate checksum
         run: sha256sum ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
-      - name: Upload binary and checksum
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          artifact-name: ${{ matrix.artifact }}.sbom.cdx.json
+          output-file: ${{ matrix.artifact }}.sbom.cdx.json
+          format: cyclonedx-json
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: ${{ matrix.artifact }}
+      - name: Attest SBOM
+        uses: actions/attest-sbom@10926c72720ffc3f7b666661c8e55b1344e2a365 # v2
+        with:
+          subject-path: ${{ matrix.artifact }}
+          sbom-path: ${{ matrix.artifact }}.sbom.cdx.json
+      - name: Upload binary, checksum, and SBOM
         run: |
           gh release upload "${GITHUB_REF#refs/tags/}" \
             ${{ matrix.artifact }} \
             ${{ matrix.artifact }}.sha256 \
+            ${{ matrix.artifact }}.sbom.cdx.json \
             --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -312,3 +312,16 @@ SHELL/unpinned-action:crates/paroche/assets/reader/foliate-js-*/**
 YAML/missing-concurrency:crates/paroche/assets/reader/foliate-js-*/**
 YAML/missing-permissions:crates/paroche/assets/reader/foliate-js-*/**
 YAML/persist-credentials:crates/paroche/assets/reader/foliate-js-*/**
+
+# =============================================================================
+# crates/paroche/assets/reader/foliate-js-* — vendored upstream JS
+# =============================================================================
+
+# WHY: foliate-js is a vendored third-party library; the XXX comment is
+# upstream code that must not be modified. The comment predates this repo.
+WORKFLOW/no-hack-xxx-temp:crates/paroche/assets/reader/foliate-js-*/paginator.js
+
+# WHY: release-please.yml is a PR-only workflow; it produces no build
+# artifacts that warrant SLSA attestation. Only release.yml (which uploads
+# binaries) needs the attestation step.
+CI/release-yml-missing-attestation:.github/workflows/release-please.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!--
 scope: harmonia repo cross-tool agent guide (Claude Code, Kimi, Codex, Cursor, Copilot)
-defers_to: README.md for project overview; docs/architecture/binary-modes.md for host-mode boundaries; kanon:projects/harmonia/STATE.md for planning state
+defers_to: README.md for project overview; docs/architecture/binary-modes.md for host-mode boundaries
 tightens: workspace build/test/lint expectations and Harmonia-specific subsystem boundaries
 -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!--
 scope: harmonia repo conventions (archon binary, media-platform crates, Dioxus desktop)
-defers_to: ~/menos-ops/CLAUDE.md for machine topology; ~/.claude/CLAUDE.md for operator principles
+defers_to: README.md for project overview; AGENTS.md for agent conventions
 tightens: per-crate conventions live beside each crate in crates/*/
 -->
 

--- a/_llm/README.md
+++ b/_llm/README.md
@@ -33,4 +33,4 @@ TOML `[[array_of_tables]]` for registry-style data. Machine-parseable, diff-frie
 - `observability.toml`: no standardized metric/span surface yet.
 - `L1-workspace.md` / `L2-crate-summaries/`: deferred - the multi-resolution scheme used by Aletheia lands here in a follow-up pass once per-crate `CLAUDE.md` files exist.
 
-See [`standards/AGENT-DOCS.md`](../standards/AGENT-DOCS.md) (kanon-synced) for the full `_llm/` standard.
+The `_llm/` standard is documented in the kanon repo under `standards/AGENT-DOCS.md`.

--- a/_llm/apis.toml
+++ b/_llm/apis.toml
@@ -1,3 +1,6 @@
+# WHY: archon exposes an MCP command surface but no standalone MCP server; empty array satisfies schema
+mcp_tools = []
+
 [meta]
 name = "harmonia"
 repo = "forkwright/harmonia"

--- a/crates/theatron/desktop/src/state.rs
+++ b/crates/theatron/desktop/src/state.rs
@@ -2,6 +2,10 @@
 
 use theatron_core::types::ConnectionStatus;
 
+// WHY: default dev URL; overridden at runtime via HARMONIA_SERVER_URL env var
+// kanon:ignore SECURITY/hardcoded-loopback-url
+const DEFAULT_SERVER_URL: &str = "http://localhost:3000";
+
 /// Root application state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppState {
@@ -18,7 +22,8 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            server_url: "http://localhost:3000".to_owned(),
+            server_url: std::env::var("HARMONIA_SERVER_URL")
+                .unwrap_or_else(|_| DEFAULT_SERVER_URL.to_owned()),
             auth_token: None,
             connection_status: ConnectionStatus::Disconnected,
             sidebar_visible: true,

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -75,7 +75,7 @@ These services are connected via API; Harmonia uses them, not replaces them.
 
 - **Rust-native:** Rust for the backend, always, unless research proves otherwise for a specific component
 - **Quality over pragmatism:** optimal solution for every domain; no shortcuts that create technical debt
-- **Greek-named subsystems:** gnomon-style naming (see [gnomon.md](gnomon.md)); clean domain boundaries, separate directories
+- **Greek-named subsystems:** gnomon-style naming (see [lexicon.md](lexicon.md)); clean domain boundaries, separate directories
 - **Nothing sacred:** existing tooling, features, and setup are all subject to revision
 - **Single binary:** one process replaces the multi-app coordination overhead of the current setup
 - **All media types:** music and audiobooks are priority, but every media type is in scope

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -157,7 +157,7 @@ Three credential paths, processed in priority order:
 
 Renderers (`harmonia render`) authenticate with a serve instance using a pairing flow.
 Unlike user sessions, renderers are headless devices that need persistent, unattended auth.
-The transport is [Syndesis](../serving/quic-streaming.md) (QUIC).
+The transport is [Syndesis](../serving/streaming.md) (QUIC).
 
 ### Pairing flow
 

--- a/docs/architecture/binary-modes.md
+++ b/docs/architecture/binary-modes.md
@@ -90,7 +90,7 @@ Mode is selected at startup via Clap subcommand:
 
 ## Desktop client
 
-The desktop client is planned as the standalone Dioxus package
+The desktop client is the standalone Dioxus package
 `crates/theatron/desktop/`, sharing API types through `theatron-core`. It
 connects to a `harmonia serve` instance for library and acquisition behavior and
 handles local UI and playback concerns. The package is intentionally excluded
@@ -102,7 +102,7 @@ it directly when working on that track:
 
 ## Cargo features
 
-`archon` does not currently expose per-mode Cargo features. Build the full CLI
+`archon` exposes no per-mode Cargo features. Build the full CLI
 binary with:
 
     cargo build -p archon

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -1,7 +1,7 @@
 # Harmonia: lexicon
 
 *Living registry. Updated as subsystems are added or renamed.*
-*For the naming methodology and construction system, see [gnomon.md](gnomon.md).*
+*For the naming methodology and construction system, see the kanon gnomon standards.*
 
 ---
 

--- a/docs/serving/streaming.md
+++ b/docs/serving/streaming.md
@@ -16,7 +16,7 @@ Paroche serves HTTP media. Use cases:
 - API data endpoints
 
 For native client audio streaming (desktop, Android, renderer endpoints),
-see [QUIC Streaming Protocol](quic-streaming.md) (syndesis subsystem).
+see the syndesis QUIC streaming protocol below.
 
 ---
 
@@ -186,8 +186,7 @@ Default: serve native format. Transcoding is opt-in, never automatic.
 - **OPDS readers:** typically request EPUB/CBZ acquisition links. Audio via OPDS is an
   M4B acquisition link; no format negotiation needed (served as-is).
 
-> Native clients (Android app, desktop) receive audio via the syndesis QUIC protocol,
-> not HTTP. See [quic-streaming.md](quic-streaming.md).
+> Native clients (Android app, desktop) receive audio via the syndesis QUIC protocol, not HTTP. See the syndesis transport section in docs/architecture/communication.md.
 
 ---
 


### PR DESCRIPTION
Clears all fixable high-severity kanon lint violations on harmonia main.

**CI/release-yml-missing-attestation** — `release.yml` now generates a CycloneDX SBOM via `anchore/sbom-action`, attests build provenance via `actions/attest-build-provenance`, and attests the SBOM via `actions/attest-sbom`. All three new actions pinned to SHA. Adds `id-token: write` and `attestations: write` permissions. `release-please.yml` is PR-only (no artifacts) — suppressed in `.kanon-lint-ignore` with WHY.

**SECURITY/hardcoded-loopback-url** — `theatron/desktop/src/state.rs` now reads `HARMONIA_SERVER_URL` env var, falling back to `DEFAULT_SERVER_URL` const.

**WORKFLOW/defers-to** — `AGENTS.md` and `CLAUDE.md` frontmatter updated: removed `kanon:projects/harmonia/STATE.md` (does not exist) and tilde paths that cannot resolve in CI.

**WORKFLOW/no-hack-xxx-temp** — vendored `foliate-js` `XXX` comment suppressed in `.kanon-lint-ignore` with WHY.

**WORKFLOW/llm-schema-valid** — `_llm/apis.toml` now declares `mcp_tools = []` (empty, harmonia exposes no standalone MCP server).

**DOCS/stale-local-link** (6) — `gnomon.md`, `quic-streaming.md`, `../standards/AGENT-DOCS.md` links repaired or removed across `docs/`, `_llm/README.md`.

**WRITING/temporal-staleness** — Two time-sensitive phrases in `docs/architecture/binary-modes.md` rewritten to describe what IS.

Gate-Passed: kanon 0.1.0