### PR TITLE
fix(exousia): annotate SystemTime false positives (no-result-unwrap-or-default)

### DIFF
--- a/crates/exousia/src/jwt.rs
+++ b/crates/exousia/src/jwt.rs
@@ -33,7 +33,7 @@ pub struct Claims {
 fn unix_now() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
+        .unwrap_or_default() // WHY: SystemTime cannot be before UNIX_EPOCH on any supported platform
         .as_secs()
 }
 

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -57,7 +57,7 @@ fn generate_refresh_token() -> (String, String) {
 fn now_iso() -> String {
     let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
+        .unwrap_or_default() // WHY: SystemTime cannot be before UNIX_EPOCH on any supported platform
         .as_secs();
     let (y, mo, d, h, mi, s) = seconds_to_datetime(secs);
     format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
@@ -119,7 +119,7 @@ fn is_leap(year: u64) -> bool {
 fn add_days_to_iso_now(days: u64) -> String {
     let now_secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
+        .unwrap_or_default() // WHY: SystemTime cannot be before UNIX_EPOCH on any supported platform
         .as_secs();
     let future_secs = now_secs + days * 86400;
     let (y, mo, d, h, mi, s) = seconds_to_datetime(future_secs);


### PR DESCRIPTION
## Summary

Clears all 3 `no-result-unwrap-or-default` violations in `exousia`.

All 3 are `SystemTime::duration_since(UNIX_EPOCH).unwrap_or_default()` — the error case (time before epoch) cannot occur on any supported platform. Annotated with `// WHY:` inline per kanon false-positive convention (paroche #304 established this pattern).

## Test plan

- [x] `kanon gate` PASS (fmt + check + lint + fleet-names)