### PR TITLE
fix(horismos): rename ZetesisConfig + annotate serde false positives

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -927,7 +927,7 @@ mod search_adapter_tests {
             pool.clone(),
             pool,
             Arc::new(zetesis::cf_bypass::noop::NoProxy),
-            horismos::ZetesisConfig::default(),
+            horismos::SearchSubsystemConfig::default(),
             event_tx,
         );
         let adapter = SearchAdapter(Arc::new(service));

--- a/crates/horismos/src/config.rs
+++ b/crates/horismos/src/config.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
-    KomideConfig, KritikeConfig, ParocheConfig, ProsthekeConfig, SyndesmosConfig, SyntaxisConfig,
-    TaxisConfig, ZetesisConfig,
+    KomideConfig, KritikeConfig, ParocheConfig, ProsthekeConfig, SearchSubsystemConfig,
+    SyndesmosConfig, SyntaxisConfig, TaxisConfig,
 };
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -24,7 +24,7 @@ pub struct Config {
     #[serde(default)]
     pub aggelia: AggeliaConfig,
     #[serde(default)]
-    pub zetesis: ZetesisConfig,
+    pub zetesis: SearchSubsystemConfig,
     #[serde(default)]
     pub ergasia: ErgasiaConfig,
     #[serde(default)]

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -9,8 +9,8 @@ const RESTART_REQUIRED: &[&str] = &["database", "exousia"];
 
 /// Compare two configs and return a list of changed top-level sections.
 pub fn diff_config(old: &Config, new: &Config) -> Vec<ConfigChange> {
-    let old_val = serde_json::to_value(old).unwrap_or_default();
-    let new_val = serde_json::to_value(new).unwrap_or_default();
+    let old_val = serde_json::to_value(old).unwrap_or_default(); // WHY: serde_json::to_value on a statically-typed Config struct cannot fail
+    let new_val = serde_json::to_value(new).unwrap_or_default(); // WHY: serde_json::to_value on a statically-typed Config struct cannot fail
 
     let mut changes = Vec::new();
 

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -18,8 +18,8 @@ use snafu::ResultExt;
 pub use subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
     KomideConfig, KritikeConfig, LastfmConfig, LibraryConfig, MediaType, OpenSubtitlesConfig,
-    ParocheConfig, PlexConfig, ProsthekeConfig, SyndesmosConfig, SyntaxisConfig, TaxisConfig,
-    TidalConfig, TrackerSeedPolicy, WatcherMode, ZetesisConfig,
+    ParocheConfig, PlexConfig, ProsthekeConfig, SearchSubsystemConfig, SyndesmosConfig,
+    SyntaxisConfig, TaxisConfig, TidalConfig, TrackerSeedPolicy, WatcherMode,
 };
 pub use validation::ValidationWarning;
 

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -197,7 +197,7 @@ impl Default for AggeliaConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct ZetesisConfig {
+pub struct SearchSubsystemConfig {
     pub request_timeout_secs: u64,
     pub max_results_per_indexer: usize,
     pub cloudflare_bypass_enabled: bool,
@@ -213,7 +213,7 @@ pub struct ZetesisConfig {
     pub cf_health_check_interval_minutes: u64,
 }
 
-impl Default for ZetesisConfig {
+impl Default for SearchSubsystemConfig {
     fn default() -> Self {
         Self {
             request_timeout_secs: 30,

--- a/crates/zetesis/src/lib.rs
+++ b/crates/zetesis/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 pub use cf_bypass::CloudflareProxy;
 pub use client::IndexerClient;
 pub use error::ZetesisError;
-use horismos::ZetesisConfig;
+use horismos::SearchSubsystemConfig;
 pub use search::ZetesisService;
 pub use types::{
     DownloadResponse, IndexerCaps, IndexerStatus, ReleaseProtocol, SearchMediaType, SearchQuery,
@@ -20,7 +20,7 @@ pub use types::{
 
 pub struct CardigannClient {
     #[expect(dead_code)]
-    config: Arc<ZetesisConfig>,
+    config: Arc<SearchSubsystemConfig>,
     #[expect(dead_code)]
     http_client: reqwest::Client,
 }

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
-use horismos::ZetesisConfig;
+use horismos::SearchSubsystemConfig;
 use sqlx::SqlitePool;
 use themelion::{EventSender, HarmoniaEvent, QueryId};
 use tokio_util::sync::CancellationToken;
@@ -24,7 +24,7 @@ pub struct ZetesisService {
     cf_proxy: Arc<dyn CloudflareProxy>,
     rate_limiter: RateLimiter,
     http: reqwest::Client,
-    config: ZetesisConfig,
+    config: SearchSubsystemConfig,
     event_tx: EventSender,
 }
 
@@ -33,7 +33,7 @@ impl ZetesisService {
         read_pool: SqlitePool,
         write_pool: SqlitePool,
         cf_proxy: Arc<dyn CloudflareProxy>,
-        config: ZetesisConfig,
+        config: SearchSubsystemConfig,
         event_tx: EventSender,
     ) -> Self {
         let rate_limiter = RateLimiter::new(


### PR DESCRIPTION
## Summary

- Clears 3 `no-fleet-collision` violations: `ZetesisConfig` (and derived public type refs in `ZetesisError`, `ZetesisService`) use the reserved fleet repo noun; type renamed to `SearchSubsystemConfig`
- Clears 2 `no-result-unwrap-or-default` violations in `diff.rs`: `serde_json::to_value` on a statically-typed struct cannot fail; annotated with `// WHY:`
- All call sites updated: `horismos/{config,lib,subsystems}`, `zetesis/{lib,search}`, `archon/serve`

## Test plan

- [x] `cargo check` clean across all touched crates
- [x] `kanon gate` PASS (fmt + check + lint + fleet-names)