### PR TITLE
fix(ergasia): rename ErgasiaSession + suppress no-direct-process-command

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -386,3 +386,16 @@ RUST/box-dyn-error:crates/paroche/src/routes/request.rs
 # validate-returns-unit. Refactoring to a constrained ValidTransition type
 # touches all callers in approval.rs. Tracked in issue #301.
 RUST/validate-returns-unit:crates/aitesis/src/workflow.rs
+
+# WHY: ergasia/pipeline.rs uses std::process::Command("df") to query available
+# disk space before archive extraction. This is a POSIX system utility call with
+# no injection surface (all arguments are typed Path/&str literals, not runtime
+# user input). No project wrapper exists or is warranted for a single-call
+# probe; the call is already gracefully degrading on failure.
+RUST/no-direct-process-command:crates/ergasia/src/extract/pipeline.rs
+
+# WHY: akouo-core/output/pipewire.rs uses std::process::Command("pw-metadata")
+# to force the PipeWire graph clock rate. pw-metadata is the only stable API
+# for this operation; there is no Rust crate wrapping it. All arguments are
+# typed OsStr/constants, not runtime user input.
+RUST/no-direct-process-command:crates/akouo-core/src/output/pipewire.rs

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -7,7 +7,7 @@ use aitesis::{IdentityValidator, MonitorService, RequestService, UserRoleProvide
 use apotheke::init_pools;
 use epignosis::EpignosisService;
 use epignosis::resolver::ProviderCredentials;
-use ergasia::ErgasiaSession;
+use ergasia::TorrentSession;
 use exousia::ExousiaServiceImpl;
 use horismos::ConfigManager;
 use kathodos::ScannerManager;
@@ -158,7 +158,7 @@ fn search_error(error: zetesis::ZetesisError) -> ServiceError {
     }
 }
 
-struct EngineAdapter(#[expect(dead_code)] Arc<ErgasiaSession>);
+struct EngineAdapter(#[expect(dead_code)] Arc<TorrentSession>);
 impl DynDownloadEngine for EngineAdapter {}
 
 struct QueueAdapter;
@@ -431,10 +431,10 @@ async fn subtitle_target(
 
 // ── DownloadEngine adapter ──────────────────────────────────────────────────
 
-/// Bridges `ErgasiaSession` (torrent client) to the `DownloadEngine` trait
+/// Bridges `TorrentSession` (torrent client) to the `DownloadEngine` trait
 /// that Syntaxis expects for dispatching downloads.
 struct SessionEngine {
-    session: Arc<ErgasiaSession>,
+    session: Arc<TorrentSession>,
 }
 
 impl ergasia::DownloadEngine for SessionEngine {
@@ -650,7 +650,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
 
     // Layer 1: Ergasia (download execution)
     let ergasia_session = Arc::new(
-        ErgasiaSession::new(&config.ergasia)
+        TorrentSession::new(&config.ergasia)
             .await
             .context(DownloadEngineSnafu)?,
     );

--- a/crates/ergasia/src/lib.rs
+++ b/crates/ergasia/src/lib.rs
@@ -11,7 +11,7 @@ pub use error::ErgasiaError;
 pub use extract::{ArchiveFormat, ExtractedFile, ExtractionResult, extract_archives};
 pub use progress::DownloadProgress;
 pub use seeding::{SeedingPolicy, TrackerSeedPolicy};
-pub use session::ErgasiaSession;
+pub use session::TorrentSession;
 pub use state::{DownloadEntry, DownloadState};
 use themelion::ids::{DownloadId, WantId};
 

--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -23,14 +23,14 @@ pub struct SeedHandle {
     pub cancel: CancellationToken,
 }
 
-pub struct ErgasiaSession {
+pub struct TorrentSession {
     session: Arc<Session>,
     pub policy: SeedingPolicy,
     pub seed_tracker: Arc<DashMap<DownloadId, SeedHandle>>,
     torrent_map: DashMap<DownloadId, usize>,
 }
 
-impl ErgasiaSession {
+impl TorrentSession {
     #[instrument(skip_all, name = "ergasia_session_init")]
     pub async fn new(config: &ErgasiaConfig) -> Result<Self, ErgasiaError> {
         let peer_opts = librqbit::PeerConnectionOptions {


### PR DESCRIPTION
## Summary

- Clears 1 `struct-name-vague-hub` violation: `ErgasiaSession` repeats crate name and ends in hub word; renamed to `TorrentSession`
- Clears 1 `no-direct-process-command` violation via documented ignore (ergasia/pipeline.rs uses `df` for disk-space pre-flight; POSIX system call, no injection surface, graceful fallback)
- Adds `.kanon-lint-ignore` entry for akouo-core/output/pipewire.rs `pw-metadata` calls (same class; no Rust crate wraps this API)

## Test plan

- [x] `cargo check` clean
- [x] `kanon gate` PASS (fmt + check + lint + fleet-names)