### PR TITLE
fix(akouo-core): annotate gapless false positives + suppress Arc<Mutex> + process::Command

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -399,3 +399,18 @@ RUST/no-direct-process-command:crates/ergasia/src/extract/pipeline.rs
 # for this operation; there is no Rust crate wrapping it. All arguments are
 # typed OsStr/constants, not runtime user input.
 RUST/no-direct-process-command:crates/akouo-core/src/output/pipewire.rs
+
+# WHY: akouo-android uses std::sync::Mutex (not tokio::sync::Mutex) for
+# audio_callback and event_listeners. These locks are held for synchronous
+# operations only (setting values, iterating listeners) — never across an
+# .await point. The async context is the wrapping task, not the locked section.
+# Using tokio::sync::Mutex would require async to lock even in non-async drop
+# and from-sync callbacks (UniFFI trait impls cannot be async).
+RUST/no-arc-mutex-anti-pattern:crates/akouo-android/src/lib.rs
+
+# WHY: syntaxis/lib.rs uses std::sync::Mutex<Inner> for the priority queue +
+# slot allocator. The lock is held only for bounded synchronous queue operations;
+# the async event-listener task acquires and releases within a single sync block.
+# tokio::sync::Mutex would require await-to-lock across every queue operation,
+# adding unnecessary yield points in hot scheduler paths.
+RUST/no-arc-mutex-anti-pattern:crates/syntaxis/src/lib.rs

--- a/crates/akouo-core/src/gapless/mod.rs
+++ b/crates/akouo-core/src/gapless/mod.rs
@@ -54,10 +54,11 @@ pub fn trim_codec_delay(
 ) {
     let samples_to_trim = match position {
         TrimPosition::Start => {
-            usize::try_from(gapless_info.encoder_delay).unwrap_or_default() * usize::from(channels)
+            usize::try_from(gapless_info.encoder_delay).unwrap_or_default() // WHY: encoder_delay is a non-negative sample count by codec spec
+                * usize::from(channels)
         }
         TrimPosition::End => {
-            usize::try_from(gapless_info.encoder_padding).unwrap_or_default()
+            usize::try_from(gapless_info.encoder_padding).unwrap_or_default() // WHY: encoder_padding is a non-negative sample count by codec spec
                 * usize::from(channels)
         }
     };


### PR DESCRIPTION
## Summary

- Clears 2 `no-result-unwrap-or-default` violations in `gapless/mod.rs`: encoder delay/padding are non-negative by codec spec; annotated with `// WHY:`
- `.kanon-lint-ignore`: `akouo-android` + `syntaxis` Arc<Mutex> — `std::sync::Mutex` never held across `.await`; `no-arc-mutex-anti-pattern` is a false positive
- `.kanon-lint-ignore`: `akouo-core/output/pipewire.rs` `pw-metadata` calls — no Rust crate wraps this API; all args are typed constants
- `.kanon-lint-ignore`: `ergasia/extract/pipeline.rs` `df` call — POSIX system utility, no injection surface

## Test plan

- [x] `kanon gate` PASS (fmt + check + lint + fleet-names)