### PR TITLE
fix(syntaxis): rename SyntaxisService + suppress Arc<Mutex> + annotate priority

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -23,7 +23,7 @@ use prostheke::providers::Provider;
 use prostheke::{SubtitleManager, SubtitleService};
 use snafu::ResultExt;
 use syndesmos::{ScrobbleClient, ScrobbleClientBuilder};
-use syntaxis::{CompletedDownload, SyntaxisService};
+use syntaxis::{CompletedDownload, DownloadQueue};
 use themelion::{MediaId, MediaType, create_event_bus};
 use tokio::signal::unix::SignalKind;
 use tokio::task::JoinHandle;
@@ -662,7 +662,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         session: Arc::clone(&ergasia_session),
     });
     let syntaxis_svc = Arc::new(
-        SyntaxisService::new(
+        DownloadQueue::new(
             db.write.clone(),
             engine_adapter,
             Arc::new(StubImportService),

--- a/crates/archon/tests/acquisition_integration/pipeline_tests.rs
+++ b/crates/archon/tests/acquisition_integration/pipeline_tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use horismos::SyntaxisConfig;
-use syntaxis::{ImportService, QueueItem, QueueManager, SyntaxisService};
+use syntaxis::{DownloadQueue, ImportService, QueueItem, QueueManager};
 use themelion::ids::{ReleaseId, WantId};
 use themelion::{HarmoniaEvent, create_event_bus};
 use tokio::sync::mpsc;
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use super::{MockEngine, MockImportService, TestError, test_db};
 
-// ── Pipeline integration tests (SyntaxisService + MockEngine) ────────────────
+// ── Pipeline integration tests (DownloadQueue + MockEngine) ────────────────
 
 fn test_syntaxis_config() -> SyntaxisConfig {
     SyntaxisConfig {
@@ -45,7 +45,7 @@ async fn pipeline_enqueue_dispatches_to_engine() -> Result<(), TestError> {
     let import_svc: Arc<dyn ImportService> = Arc::new(MockImportService { imported_tx });
     let config = test_syntaxis_config();
 
-    let svc = Arc::new(SyntaxisService::new(pool, engine, import_svc, config).await?);
+    let svc = Arc::new(DownloadQueue::new(pool, engine, import_svc, config).await?);
 
     let item = make_queue_item(4);
     let pos = svc.enqueue(item).await?;
@@ -70,7 +70,7 @@ async fn pipeline_completion_triggers_import() -> Result<(), TestError> {
     let import_svc: Arc<dyn ImportService> = Arc::new(MockImportService { imported_tx });
     let config = test_syntaxis_config();
 
-    let svc = Arc::new(SyntaxisService::new(pool, engine, import_svc, config).await?);
+    let svc = Arc::new(DownloadQueue::new(pool, engine, import_svc, config).await?);
     let shutdown = tokio_util::sync::CancellationToken::new();
     svc.start(event_tx.subscribe(), shutdown.clone());
 
@@ -111,7 +111,7 @@ async fn pipeline_priority_ordering_in_queue() -> Result<(), TestError> {
         stalled_download_timeout_hours: 24,
     };
 
-    let svc = Arc::new(SyntaxisService::new(pool, engine, import_svc, config).await?);
+    let svc = Arc::new(DownloadQueue::new(pool, engine, import_svc, config).await?);
 
     let low = make_queue_item(1);
     let high = make_queue_item(3);
@@ -144,7 +144,7 @@ async fn pipeline_fifo_within_same_priority_tier() -> Result<(), TestError> {
         stalled_download_timeout_hours: 24,
     };
 
-    let svc = Arc::new(SyntaxisService::new(pool, engine, import_svc, config).await?);
+    let svc = Arc::new(DownloadQueue::new(pool, engine, import_svc, config).await?);
 
     let item_a = make_queue_item(2);
     let item_b = make_queue_item(2);
@@ -178,7 +178,7 @@ async fn pipeline_transient_failure_triggers_retry() -> Result<(), TestError> {
         stalled_download_timeout_hours: 24,
     };
 
-    let svc = Arc::new(SyntaxisService::new(pool.clone(), engine, import_svc, config).await?);
+    let svc = Arc::new(DownloadQueue::new(pool.clone(), engine, import_svc, config).await?);
     let shutdown = tokio_util::sync::CancellationToken::new();
     svc.start(event_tx.subscribe(), shutdown.clone());
 
@@ -226,7 +226,7 @@ async fn pipeline_permanent_failure_marks_failed() -> Result<(), TestError> {
     let import_svc: Arc<dyn ImportService> = Arc::new(MockImportService { imported_tx });
     let config = test_syntaxis_config();
 
-    let svc = Arc::new(SyntaxisService::new(pool.clone(), engine, import_svc, config).await?);
+    let svc = Arc::new(DownloadQueue::new(pool.clone(), engine, import_svc, config).await?);
     let shutdown = tokio_util::sync::CancellationToken::new();
     svc.start(event_tx.subscribe(), shutdown.clone());
 
@@ -259,7 +259,7 @@ async fn pipeline_permanent_failure_marks_failed() -> Result<(), TestError> {
 
 #[tokio::test]
 async fn pipeline_retry_budget_exhaustion_marks_failed() -> Result<(), TestError> {
-    // NOTE: SyntaxisService has a bug where ActiveEntry.retry_count is always
+    // NOTE: DownloadQueue has a bug where ActiveEntry.retry_count is always
     // initialised to 0 regardless of how many retries have occurred in the DB.
     // This means the in-memory retry_count check (`retry_count >= max_retries`)
     // only works when max_retries is 0. We set retry_count=0 in config so
@@ -279,7 +279,7 @@ async fn pipeline_retry_budget_exhaustion_marks_failed() -> Result<(), TestError
         stalled_download_timeout_hours: 24,
     };
 
-    let svc = Arc::new(SyntaxisService::new(pool.clone(), engine, import_svc, config).await?);
+    let svc = Arc::new(DownloadQueue::new(pool.clone(), engine, import_svc, config).await?);
     let shutdown = tokio_util::sync::CancellationToken::new();
     svc.start(event_tx.subscribe(), shutdown.clone());
 

--- a/crates/archon/tests/acquisition_integration/recovery_tests.rs
+++ b/crates/archon/tests/acquisition_integration/recovery_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use horismos::SyntaxisConfig;
-use syntaxis::{ImportService, QueueManager, SyntaxisService};
+use syntaxis::{DownloadQueue, ImportService, QueueManager};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -41,7 +41,7 @@ async fn startup_recovery_loads_queued_items_from_db() -> Result<(), TestError> 
         .await?;
     }
 
-    // Boot SyntaxisService — recovery should load non-terminal items
+    // Boot DownloadQueue — recovery should load non-terminal items
     let (started_tx, _started_rx) = mpsc::unbounded_channel();
     let (imported_tx, _imported_rx) = mpsc::unbounded_channel();
     let engine = Arc::new(MockEngine { started_tx });
@@ -54,7 +54,7 @@ async fn startup_recovery_loads_queued_items_from_db() -> Result<(), TestError> 
         stalled_download_timeout_hours: 24,
     };
 
-    let svc = Arc::new(SyntaxisService::new(pool, engine, import_svc, config).await?);
+    let svc = Arc::new(DownloadQueue::new(pool, engine, import_svc, config).await?);
 
     let snapshot = svc.get_queue_state().await?;
     // 'queued' and 'downloading' are non-terminal and should be recovered

--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -79,16 +79,16 @@ struct Inner {
 
 /// The concrete Syntaxis service, generic over the download engine type.
 ///
-/// Construct via `SyntaxisService::new`, then call `start` to launch the
+/// Construct via `DownloadQueue::new`, then call `start` to launch the
 /// event-listener task that processes Ergasia broadcast events.
-pub struct SyntaxisService<E: DownloadEngine + 'static> {
+pub struct DownloadQueue<E: DownloadEngine + 'static> {
     pool: SqlitePool,
     engine: Arc<E>,
     import_svc: Arc<dyn ImportService>,
     inner: Arc<Mutex<Inner>>,
 }
 
-impl<E: DownloadEngine + 'static> SyntaxisService<E> {
+impl<E: DownloadEngine + 'static> DownloadQueue<E> {
     /// Creates a new service and runs startup reconciliation.
     pub async fn new(
         pool: SqlitePool,
@@ -367,7 +367,7 @@ impl<E: DownloadEngine + 'static> SyntaxisService<E> {
     }
 }
 
-impl<E: DownloadEngine + 'static> QueueManager for Arc<SyntaxisService<E>> {
+impl<E: DownloadEngine + 'static> QueueManager for Arc<DownloadQueue<E>> {
     #[instrument(skip(self))]
     async fn enqueue(&self, item: QueueItem) -> Result<QueuePosition, SyntaxisError> {
         // Persist to DB first for durability.

--- a/crates/syntaxis/src/recovery.rs
+++ b/crates/syntaxis/src/recovery.rs
@@ -40,7 +40,7 @@ fn row_to_queue_item(row: &QueueRow) -> Option<QueueItem> {
         protocol: parse_protocol(&row.protocol),
         // Clamp priority to 1–3 during recovery; interactive (4) items are re-queued
         // at priority 3 so they don't re-bypass on restart.
-        priority: (u8::try_from(row.priority).unwrap_or_default()).clamp(1, 3),
+        priority: (u8::try_from(row.priority).unwrap_or_default()).clamp(1, 3), // WHY: priority is 1-4 by schema CHECK; i64→u8 cannot overflow
         tracker_id: row.tracker_id,
         info_hash: row.info_hash.clone(),
     })


### PR DESCRIPTION
## Summary

- Clears 1 `struct-name-vague-hub` violation: `SyntaxisService` renamed to `DownloadQueue`
- Clears 1 `no-result-unwrap-or-default` violation in `recovery.rs`: priority bounded 1-4 by schema; annotated `// WHY:`
- `.kanon-lint-ignore`: `Arc<Mutex<Inner>>` uses `std::sync::Mutex` correctly; never held across `.await`

## Test plan

- [x] `cargo check` clean
- [x] `kanon gate` PASS (fmt + check + lint + fleet-names)