### PR TITLE
fix(prostheke): rename ProsthekeService → SubtitleManager; fix opensubtitles Result handling

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -20,7 +20,7 @@ use paroche::state::{
     ServiceError, ServiceFut,
 };
 use prostheke::providers::Provider;
-use prostheke::{ProsthekeService, SubtitleService};
+use prostheke::{SubtitleManager, SubtitleService};
 use snafu::ResultExt;
 use syndesmos::{SyndesmosService, SyndesmosServiceBuilder};
 use syntaxis::{CompletedDownload, SyntaxisService};
@@ -372,7 +372,7 @@ struct ExternalAdapter(#[expect(dead_code)] Arc<SyndesmosService>);
 impl DynExternalIntegration for ExternalAdapter {}
 
 struct SubtitleAdapter {
-    service: Arc<ProsthekeService>,
+    service: Arc<SubtitleManager>,
     read: sqlx::SqlitePool,
 }
 
@@ -685,7 +685,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
 
     // Layer 4: Prostheke (subtitle management)
     let providers = Provider::default_providers(config.prostheke.opensubtitles.clone());
-    let prostheke_svc = Arc::new(ProsthekeService::new(
+    let prostheke_svc = Arc::new(SubtitleManager::new(
         db.read.clone(),
         db.write.clone(),
         config.prostheke.clone(),
@@ -1035,7 +1035,7 @@ mod tests {
         .expect("movie inserted");
 
         let (event_tx, _) = create_event_bus(64);
-        let service = Arc::new(ProsthekeService::new(
+        let service = Arc::new(SubtitleManager::new(
             pool.clone(),
             pool.clone(),
             horismos::ProsthekeConfig::default(),

--- a/crates/prostheke/src/lib.rs
+++ b/crates/prostheke/src/lib.rs
@@ -51,7 +51,7 @@ pub trait SubtitleService: Send + Sync {
 /// Generic over `P` so that tests can inject a `MockProvider` without
 /// needing `dyn SubtitleProvider` (which is not object-safe due to async fn).
 /// Production code uses the default `P = Provider` enum.
-pub struct ProsthekeService<P: SubtitleProvider = Provider> {
+pub struct SubtitleManager<P: SubtitleProvider = Provider> {
     read: sqlx::SqlitePool,
     write: sqlx::SqlitePool,
     config: ProsthekeConfig,
@@ -59,7 +59,7 @@ pub struct ProsthekeService<P: SubtitleProvider = Provider> {
     event_tx: EventSender,
 }
 
-impl<P: SubtitleProvider> ProsthekeService<P> {
+impl<P: SubtitleProvider> SubtitleManager<P> {
     pub fn new(
         read: sqlx::SqlitePool,
         write: sqlx::SqlitePool,
@@ -77,7 +77,7 @@ impl<P: SubtitleProvider> ProsthekeService<P> {
     }
 }
 
-impl<P: SubtitleProvider> SubtitleService for ProsthekeService<P> {
+impl<P: SubtitleProvider> SubtitleService for SubtitleManager<P> {
     #[instrument(skip(self), fields(media_id = %media_id, media_type = ?media_type))]
     async fn acquire_subtitles(
         &self,
@@ -247,14 +247,14 @@ mod tests {
         providers: Vec<MockProvider>,
         config: ProsthekeConfig,
     ) -> (
-        ProsthekeService<MockProvider>,
+        SubtitleManager<MockProvider>,
         SqlitePool,
         themelion::EventReceiver,
     ) {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
         let (tx, rx) = create_event_bus(64);
-        let svc = ProsthekeService::new(pool.clone(), pool.clone(), config, providers, tx);
+        let svc = SubtitleManager::new(pool.clone(), pool.clone(), config, providers, tx);
         (svc, pool, rx)
     }
 

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -45,7 +45,7 @@ pub fn compute_file_hash(path: &Path) -> std::io::Result<String> {
     }
 
     // Read last 64 KB.
-    let tail_offset = file_size.saturating_sub(u64::try_from(CHUNK_SIZE).unwrap_or_default());
+    let tail_offset = file_size.saturating_sub(u64::try_from(CHUNK_SIZE).unwrap_or_default()); // WHY: CHUNK_SIZE is a compile-time constant that fits in u64
     file.seek(SeekFrom::Start(tail_offset))?;
 
     for _ in 0..(CHUNK_SIZE / WORD_SIZE) {
@@ -74,7 +74,7 @@ impl OpenSubtitlesProvider {
             .timeout(Duration::from_secs(30))
             .user_agent(USER_AGENT)
             .build()
-            .unwrap_or_default();
+            .unwrap_or_default(); // WHY: reqwest::Client::default() is a valid fallback; build fails only with invalid TLS config
         Self { config, client }
     }
 
@@ -257,7 +257,10 @@ impl SubtitleProvider for OpenSubtitlesProvider {
         };
 
         // First request the download link FROM the API.
-        let file_id: u64 = subtitle.provider_id.parse().unwrap_or_default();
+        let file_id: u64 = subtitle.provider_id.parse().unwrap_or_else(|e| {
+            tracing::warn!(error = %e, provider_id = %subtitle.provider_id, "opensubtitles: invalid file_id; defaulting to 0");
+            0
+        });
 
         let download_req = serde_json::json!({ "file_id": file_id });
         let dl_resp = self


### PR DESCRIPTION
## Violations fixed

- `NAMING/struct-name-vague-hub` + `NAMING/no-fleet-collision`: `ProsthekeService` → `SubtitleManager` (concrete role name)
- `RUST/no-result-unwrap-or-default` (real error): `subtitle.provider_id.parse().unwrap_or_default()` → `warn+default` pattern
- `RUST/no-result-unwrap-or-default` (false positive, `u64::try_from(CHUNK_SIZE)`): `// WHY: CHUNK_SIZE is compile-time constant that fits in u64`
- `RUST/no-result-unwrap-or-default` (false positive, `reqwest::Client::build()`): `// WHY: reqwest::Client::default() is valid fallback; build fails only with invalid TLS config`

## Notes

`archon/src/serve.rs` updated for `SubtitleManager` rename (forward reference). Gate: PASS.