### PR TITLE
fix(kathodos): fix indexing-slicing violations with safe boundary annotations

### DIFF
--- a/crates/kathodos/src/import/template.rs
+++ b/crates/kathodos/src/import/template.rs
@@ -156,8 +156,8 @@ fn parse_template(
                 continue;
             }
             let (name, padding) = if let Some(colon_pos) = token_str.find(':') {
-                let name = token_str[..colon_pos].trim().to_string();
-                let pad_str = &token_str[colon_pos + 1..];
+                let name = token_str[..colon_pos].trim().to_string(); // WHY: colon_pos from str::find is a valid byte boundary
+                let pad_str = &token_str[colon_pos + 1..]; // WHY: ASCII colon is one byte; colon_pos+1 is a valid boundary
                 let padding = if pad_str.chars().all(|c| c == '0') && !pad_str.is_empty() {
                     Some(pad_str.len())
                 } else {

--- a/crates/kathodos/src/sanitize.rs
+++ b/crates/kathodos/src/sanitize.rs
@@ -103,7 +103,7 @@ fn truncate_to_bytes(s: &str, max_bytes: usize) -> &str {
     while !s.is_char_boundary(end) {
         end -= 1;
     }
-    &s[..end]
+    &s[..end] // WHY: end is walked back to is_char_boundary; index is safe // WHY: end is walked to is_char_boundary; slice is safe
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/kathodos/src/scanner/filter.rs
+++ b/crates/kathodos/src/scanner/filter.rs
@@ -80,7 +80,7 @@ enum IgnorePattern {
 impl HarmoniaIgnore {
     /// Load .harmoniaignore from root directory only.
     pub fn load(root: &Path) -> Self {
-        let rules = Self::load_file(&root.join(".harmoniaignore")).unwrap_or_default();
+        let rules = Self::load_file(&root.join(".harmoniaignore")).unwrap_or_default(); // WHY: load_file returns Option<_>, not Result; lint heuristic false positive // WHY: load_file returns Option<_>, not Result; lint heuristic false positive
         Self {
             rules,
             root: root.to_path_buf(),


### PR DESCRIPTION
## Violations fixed

- `RUST/indexing-slicing` (false positive, `template.rs`): byte-slice after `str::find` — `// WHY: colon_pos from str::find is a valid UTF-8 boundary; colon_pos+1 is valid because ASCII colon is one byte`
- `RUST/indexing-slicing` (false positive, `sanitize.rs`): `&s[..end]` after explicit char boundary walk — `// WHY: end is walked back to is_char_boundary`
- `RUST/no-result-unwrap-or-default` (false positive, `scanner/filter.rs`): `load_file` returns `Option`, not `Result` — `// WHY: load_file returns Option<_>, not Result; lint heuristic false positive`

Gate: PASS.