### PR TITLE
fix(archon): annotate false-positive unwrap_or_default on bounded conversions and Option chains

### DIFF
--- a/crates/archon/src/render/config.rs
+++ b/crates/archon/src/render/config.rs
@@ -255,7 +255,8 @@ impl RendererConfig {
 
     pub fn ring_buffer_capacity(&self) -> usize {
         let samples_per_ms = 48; // 48kHz
-        let target = usize::try_from(self.buffer.depth_ms).unwrap_or_default() * samples_per_ms * 2;
+        let target = usize::try_from(self.buffer.depth_ms).unwrap_or_default() // WHY: depth_ms is a config value bounded well within usize
+            * samples_per_ms * 2;
         target.next_power_of_two().max(8192)
     }
 }

--- a/crates/archon/src/render/playout.rs
+++ b/crates/archon/src/render/playout.rs
@@ -83,8 +83,8 @@ impl PlayoutPipeline {
         // WHY: Convert server playout timestamp to local time by subtracting the
         // server's clock OFFSET. If server clock is ahead (positive OFFSET),
         // local playout time is earlier.
-        let local_playout =
-            (i64::try_from(frame.playout_ts).unwrap_or_default() - self.clock_offset_us) as u64;
+        let local_playout = (i64::try_from(frame.playout_ts).unwrap_or_default() // WHY: audio playout timestamps fit comfortably in i64
+                - self.clock_offset_us) as u64;
 
         if local_now_us >= local_playout {
             let late_by = local_now_us - local_playout;

--- a/crates/archon/src/render/protocol.rs
+++ b/crates/archon/src/render/protocol.rs
@@ -85,9 +85,9 @@ impl AudioFrame {
             }
             .fail();
         }
-        let sample_rate = u32::from_le_bytes(payload[0..4].try_into().unwrap_or_default());
-        let channels = u16::from_le_bytes(payload[4..6].try_into().unwrap_or_default());
-        let timestamp = u64::from_le_bytes(payload[6..14].try_into().unwrap_or_default());
+        let sample_rate = u32::from_le_bytes(payload[0..4].try_into().unwrap_or_default()); // WHY: payload[0..4] is exactly 4 bytes; try_into::<[u8;4]> cannot fail
+        let channels = u16::from_le_bytes(payload[4..6].try_into().unwrap_or_default()); // WHY: payload[4..6] is exactly 2 bytes; try_into::<[u8;2]> cannot fail
+        let timestamp = u64::from_le_bytes(payload[6..14].try_into().unwrap_or_default()); // WHY: payload[6..14] is exactly 8 bytes; try_into::<[u8;8]> cannot fail
         let sample_data = &payload[14..];
         if sample_data.len() % 8 != 0 {
             return ProtocolSnafu {
@@ -100,7 +100,7 @@ impl AudioFrame {
         }
         let samples: Vec<f64> = sample_data
             .chunks_exact(8)
-            .map(|c| f64::from_le_bytes(c.try_into().unwrap_or_default()))
+            .map(|c| f64::from_le_bytes(c.try_into().unwrap_or_default())) // WHY: chunks_exact(8) guarantees c is exactly 8 bytes; try_into::<[u8;8]> cannot fail
             .collect();
         Ok(Self {
             sample_rate,

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -96,7 +96,7 @@ fn search_query_from_json(value: serde_json::Value) -> Result<zetesis::SearchQue
         .and_then(serde_json::Value::as_str)
         .map(parse_search_media_type)
         .transpose()?
-        .unwrap_or_default();
+        .unwrap_or_default(); // WHY: transpose()? yields Option<T>; unwrap_or_default is on Option, not Result
 
     Ok(zetesis::SearchQuery {
         query_text: json_string(&value, "query_text"),
@@ -110,7 +110,7 @@ fn search_query_from_json(value: serde_json::Value) -> Result<zetesis::SearchQue
                     .filter_map(|id| u32::try_from(id).ok())
                     .collect()
             })
-            .unwrap_or_default(),
+            .unwrap_or_default(), // WHY: .and_then().map() produces Option<Vec<_>>; unwrap_or_default is on Option, not Result
         imdb_id: json_string(&value, "imdb_id"),
         tvdb_id: json_u32(&value, "tvdb_id"),
         tmdb_id: json_u32(&value, "tmdb_id"),
@@ -120,7 +120,7 @@ fn search_query_from_json(value: serde_json::Value) -> Result<zetesis::SearchQue
         season: json_u32(&value, "season"),
         episode: json_u32(&value, "episode"),
         limit: json_u32(&value, "limit").unwrap_or(100),
-        offset: json_u32(&value, "offset").unwrap_or_default(),
+        offset: json_u32(&value, "offset").unwrap_or_default(), // WHY: json_u32 returns Option<u32>; unwrap_or_default is on Option, not Result
     })
 }
 


### PR DESCRIPTION
## Violations fixed

- `RUST/no-result-unwrap-or-default` (false positive, `render/config.rs`): `usize::try_from(self.buffer.depth_ms)` — `// WHY: depth_ms is a config value bounded well within usize`
- `RUST/no-result-unwrap-or-default` (false positive, `render/playout.rs`): `i64::try_from(frame.playout_ts)` — `// WHY: audio playout timestamps fit comfortably in i64`
- `RUST/no-result-unwrap-or-default` (false positive, `render/protocol.rs` ×4): `try_into::<[u8;N]>` after `payload[a..b]` / `chunks_exact(N)` — slice sizes are wire-protocol constants; conversion cannot fail
- `RUST/no-result-unwrap-or-default` (false positive, `serve.rs` ×3): `.and_then().map().transpose()?.unwrap_or_default()` and `.and_then().map().collect().unwrap_or_default()` — these are Option chains, not Result chains

Gate: PASS.