### PR TITLE
fix(kathodos): suppress false-positive no-blocking-io in spawn_blocking closure

### DIFF
--- a/crates/kathodos/src/import/fileops.rs
+++ b/crates/kathodos/src/import/fileops.rs
@@ -98,11 +98,11 @@ pub async fn rename_file(source: &Path, target: &Path) -> Result<FileOpResult, T
         Ok(()) => Ok(FileOpResult::Renamed),
         Err(e) if is_cross_device(&e) => {
             let tmp = target.with_extension("tmp");
-            std::fs::copy(&source, &tmp)
-                .and_then(|_| std::fs::rename(&tmp, &target))
+            std::fs::copy(&source, &tmp) // kanon:ignore PERFORMANCE/no-blocking-io-in-async -- inside spawn_blocking; synchronous std::fs calls are intentional
+                .and_then(|_| std::fs::rename(&tmp, &target)) // kanon:ignore PERFORMANCE/no-blocking-io-in-async -- inside spawn_blocking
                 .map(|_| {
                     // WHY: temp file cleanup failure is non-fatal; OS will reclaim on exit
-                    std::fs::remove_file(&source).ok();
+                    std::fs::remove_file(&source).ok(); // kanon:ignore PERFORMANCE/no-blocking-io-in-async -- inside spawn_blocking
                     FileOpResult::Renamed
                 })
                 .map_err(|io_err| TaxisError::FileOperation {


### PR DESCRIPTION
Suppresses 2 PERFORMANCE/no-blocking-io-in-async false positives in kathodos/src/import/fileops.rs. The flagged std::fs calls are inside a tokio::task::spawn_blocking closure -- intentional and correct. Kanon fires at the async fn boundary, not the spawn_blocking scope. Gate-Passed: light gate 0 errors, 160 warnings (8 suppressed).