### PR TITLE
fix(epignosis): suppress false-positive no-result-unwrap-or-default on Option chain

### DIFF
--- a/crates/epignosis/src/providers/itunes.rs
+++ b/crates/epignosis/src/providers/itunes.rs
@@ -124,7 +124,7 @@ impl MetadataProvider for ItunesProvider {
             genres: None,
         });
 
-        let title = pod.collection_name.or(pod.track_name).unwrap_or_default();
+        let title = pod.collection_name.or(pod.track_name).unwrap_or_default(); // kanon:ignore RUST/no-result-unwrap-or-default -- Option<String> chain, not a Result; unwrap_or_default on Option is fine
         let year = pod
             .release_date
             .as_deref()


### PR DESCRIPTION
Suppresses RUST/no-result-unwrap-or-default false positive in itunes.rs get_metadata path. The receiver is Option<String>.or(..) -- an Option chain, not a Result. Pattern matches the existing annotation at itunes.rs:72 (search path). Gate-Passed: light gate 0 errors, 161 warnings (8 suppressed).