### PR TITLE
fix(akouo-core): wrap open_decoder blocking file I/O in spawn_blocking

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -243,6 +243,12 @@ RUST/blocking-in-async:crates/archon/src/**
 # rule cannot see through the spawn_blocking wrap.
 RUST/blocking-in-async:crates/kathodos/src/**
 
+# WHY: akouo-core/decode/probe.rs wraps std::fs::File::open + probe_format in
+# tokio::task::spawn_blocking inside open_decoder. PERFORMANCE/no-blocking-io-in-async
+# fires at the async fn boundary — it cannot see through the spawn_blocking closure.
+# The blocking I/O is intentional and correctly offloaded to a blocking thread.
+PERFORMANCE/no-blocking-io-in-async:crates/akouo-core/src/decode/probe.rs
+
 # WHY: apotheke pools.rs converts NonZero<usize> -> u32 for sqlx pool_size.
 # Capped by a config validator earlier; try_from adds a branch per pool init
 # for a cast that cannot overflow in practice.

--- a/crates/akouo-core/src/decode/probe.rs
+++ b/crates/akouo-core/src/decode/probe.rs
@@ -26,36 +26,47 @@ use crate::error::DecodeError;
 /// - WavPack   → `UnsupportedCodec` error (implement via wavpack-sys when needed)
 /// - All others (FLAC, WAV, ALAC, MP3, AAC, AIFF, Vorbis) → `SymphoniaDecoder` (P1-02)
 pub async fn open_decoder(path: &Path) -> Result<Box<dyn AudioDecoder>, DecodeError> {
-    let probed = probe_format(path)?;
-    let codec = probed
-        .default_track(symphonia::core::formats::TrackType::Audio)
-        .and_then(|t| t.codec_params.as_ref())
-        .and_then(|c| c.audio())
-        .map(|a| a.codec);
+    let path = path.to_path_buf();
+    // WHY: probe_format opens std::fs::File (blocking); spawn_blocking prevents stalling
+    // the async executor thread during disk I/O on the open/probe hot path.
+    tokio::task::spawn_blocking(move || {
+        let probed = probe_format(&path)?;
+        let codec = probed
+            .default_track(symphonia::core::formats::TrackType::Audio)
+            .and_then(|t| t.codec_params.as_ref())
+            .and_then(|c| c.audio())
+            .map(|a| a.codec);
 
-    match codec {
-        Some(CODEC_ID_OPUS) => OpusDecoder::from_probed(probed),
+        match codec {
+            Some(CODEC_ID_OPUS) => OpusDecoder::from_probed(probed),
 
-        Some(CODEC_ID_WAVPACK) => Err(DecodeError::UnsupportedCodec {
-            codec: Codec::Other("WavPack".to_string()),
-            location: snafu::Location::new(file!(), line!(), column!()),
-        }),
+            Some(CODEC_ID_WAVPACK) => Err(DecodeError::UnsupportedCodec {
+                codec: Codec::Other("WavPack".to_string()),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            }),
 
-        _ => {
-            let mss = MediaSourceStream::new(
-                Box::new(
-                    std::fs::File::open(path).map_err(|e| DecodeError::SymphoniaRead {
-                        message: format!("failed to open {}: {e}", path.display()),
-                        location: snafu::Location::new(file!(), line!(), column!()),
-                    })?,
-                ),
-                Default::default(),
-            );
-            let hint = hint_from_path(path);
-            let dec = SymphoniaDecoder::new(mss, &hint)?;
-            Ok(Box::new(dec) as Box<dyn AudioDecoder>)
+            _ => {
+                let mss = MediaSourceStream::new(
+                    Box::new(std::fs::File::open(&path).map_err(|e| {
+                        DecodeError::SymphoniaRead {
+                            message: format!("failed to open {}: {e}", path.display()),
+                            location: snafu::Location::new(file!(), line!(), column!()),
+                        }
+                    })?),
+                    Default::default(),
+                );
+                let hint = hint_from_path(&path);
+                let dec = SymphoniaDecoder::new(mss, &hint)?;
+                Ok(Box::new(dec) as Box<dyn AudioDecoder>)
+            }
         }
-    }
+    })
+    .await
+    .map_err(|e| DecodeError::SymphoniaRead {
+        message: format!("spawn_blocking failed: {e}"),
+        location: snafu::location!(),
+    })
+    .and_then(|r| r)
 }
 
 /// Returns the codec for a file without fully opening a decoder. Useful for UI display.


### PR DESCRIPTION
open_decoder performs std::fs::File::open and Symphonia probe inside an async fn. Wraps the full probe + decoder construction in tokio::task::spawn_blocking (path is owned via to_path_buf; SymphoniaDecoder and OpusDecoder are both Send). Also adds PERFORMANCE/no-blocking-io-in-async suppression to .kanon-lint-ignore for probe.rs since the rule fires at the async fn boundary and cannot see through the spawn_blocking scope. Gate-Passed: light gate 0 errors, 161 warnings (8 suppressed).