### PR TITLE
fix(workspace): satisfy rust 1.95 clippy

### DIFF
--- a/crates/akouo-android/src/lib.rs
+++ b/crates/akouo-android/src/lib.rs
@@ -440,7 +440,7 @@ async fn drain_callback_task(context: DrainTaskContext) {
         }
 
         let count = context.underruns.fetch_add(1, Ordering::SeqCst) + 1;
-        if count == 1 || count % 100 == 0 {
+        if count == 1 || count.checked_rem(100) == Some(0) {
             notify(
                 &context.listeners,
                 AndroidEngineEvent {

--- a/crates/akouo-core/src/output/format.rs
+++ b/crates/akouo-core/src/output/format.rs
@@ -113,13 +113,17 @@ enum ClockFamily {
 }
 
 fn clock_family(rate: u32) -> Option<ClockFamily> {
-    if rate != 0 && (rate % 44_100 == 0 || 44_100 % rate == 0) {
+    if rate != 0 && (is_multiple_of(rate, 44_100) || is_multiple_of(44_100, rate)) {
         Some(ClockFamily::Family441)
-    } else if rate != 0 && (rate % 48_000 == 0 || 48_000 % rate == 0) {
+    } else if rate != 0 && (is_multiple_of(rate, 48_000) || is_multiple_of(48_000, rate)) {
         Some(ClockFamily::Family48)
     } else {
         None
     }
+}
+
+fn is_multiple_of(value: u32, divisor: u32) -> bool {
+    value.checked_rem(divisor) == Some(0)
 }
 
 fn same_family_fallback(

--- a/crates/archon/src/render/protocol.rs
+++ b/crates/archon/src/render/protocol.rs
@@ -89,7 +89,7 @@ impl AudioFrame {
         let channels = u16::from_le_bytes(payload[4..6].try_into().unwrap_or_default()); // WHY: payload[4..6] is exactly 2 bytes; try_into::<[u8;2]> cannot fail
         let timestamp = u64::from_le_bytes(payload[6..14].try_into().unwrap_or_default()); // WHY: payload[6..14] is exactly 8 bytes; try_into::<[u8;8]> cannot fail
         let sample_data = &payload[14..];
-        if sample_data.len() % 8 != 0 {
+        if sample_data.len().checked_rem(8) != Some(0) {
             return ProtocolSnafu {
                 message: format!(
                     "sample data length {} not a multiple of 8",

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -113,7 +113,8 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
 }
 
 fn is_leap(year: u64) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+    (year.checked_rem(4) == Some(0) && year.checked_rem(100) != Some(0))
+        || year.checked_rem(400) == Some(0)
 }
 
 fn add_days_to_iso_now(days: u64) -> String {

--- a/crates/horismos/src/handle.rs
+++ b/crates/horismos/src/handle.rs
@@ -96,6 +96,17 @@ mod tests {
         format!("[exousia]\njwt_secret = \"{VALID_JWT}\"\n\n[paroche]\nport = {port}\n")
     }
 
+    #[allow(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with requires figment::Result; this lint is version-dependent"
+    )]
+    fn with_jail(run: impl FnOnce(&mut Jail)) {
+        Jail::expect_with(|jail| {
+            run(jail);
+            Ok(())
+        });
+    }
+
     // ── ConfigManager::new ────────────────────────────────────────────────────
 
     #[test]
@@ -135,41 +146,43 @@ mod tests {
 
     #[test]
     fn reload_with_unchanged_file_returns_no_warnings() {
-        Jail::expect_with(|jail| {
-            jail.create_file("harmonia.toml", &toml_with_port(8096))?;
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port(8096))
+                .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             let (manager, _) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
 
             let warnings = manager.reload().unwrap();
             assert!(warnings.is_empty());
-            Ok(())
         });
     }
 
     #[test]
     fn reload_with_changed_paroche_updates_config() {
-        Jail::expect_with(|jail| {
-            jail.create_file("harmonia.toml", &toml_with_port(8096))?;
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port(8096))
+                .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
 
-            jail.create_file("harmonia.toml", &toml_with_port(9090))?;
+            jail.create_file("harmonia.toml", &toml_with_port(9090))
+                .unwrap();
             manager.reload().unwrap();
 
             assert_eq!(handle.current().paroche.port, 9090);
-            Ok(())
         });
     }
 
     #[test]
     fn reload_with_changed_database_path_updates_config() {
-        Jail::expect_with(|jail| {
+        with_jail(|jail| {
             jail.create_file(
                 "harmonia.toml",
                 &format!(
                     "[exousia]\njwt_secret = \"{VALID_JWT}\"\n\n[database]\ndb_path = \"/tmp/harmonia.db\"\n"
                 ),
-            )?;
+            )
+            .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
 
@@ -178,52 +191,54 @@ mod tests {
                 &format!(
                     "[exousia]\njwt_secret = \"{VALID_JWT}\"\n\n[database]\ndb_path = \"/tmp/harmonia2.db\"\n"
                 ),
-            )?;
+            )
+            .unwrap();
             manager.reload().unwrap();
 
             assert_eq!(
                 handle.current().database.db_path,
                 PathBuf::from("/tmp/harmonia2.db")
             );
-            Ok(())
         });
     }
 
     #[test]
     fn reload_with_invalid_config_returns_error_and_keeps_current() {
-        Jail::expect_with(|jail| {
-            jail.create_file("harmonia.toml", &toml_with_port(8096))?;
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port(8096))
+                .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
 
             // Remove jwt_secret — validation will reject it
-            jail.create_file("harmonia.toml", "[paroche]\nport = 9090\n")?;
+            jail.create_file("harmonia.toml", "[paroche]\nport = 9090\n")
+                .unwrap();
             let result = manager.reload();
 
             assert!(result.is_err());
             assert_eq!(handle.current().paroche.port, 8096);
-            Ok(())
         });
     }
 
     #[test]
     fn reload_broadcasts_to_all_subscribers() {
-        Jail::expect_with(|jail| {
-            jail.create_file("harmonia.toml", &toml_with_port(8096))?;
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port(8096))
+                .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
 
             let mut rx1 = handle.subscribe();
             let mut rx2 = handle.subscribe();
 
-            jail.create_file("harmonia.toml", &toml_with_port(9090))?;
+            jail.create_file("harmonia.toml", &toml_with_port(9090))
+                .unwrap();
             manager.reload().unwrap();
 
             assert!(rx1.has_changed().unwrap());
             assert!(rx2.has_changed().unwrap());
             assert_eq!(rx1.borrow_and_update().paroche.port, 9090);
             assert_eq!(rx2.borrow_and_update().paroche.port, 9090);
-            Ok(())
         });
     }
 
@@ -231,25 +246,27 @@ mod tests {
 
     #[test]
     fn subscribe_yields_on_change() {
-        Jail::expect_with(|jail| {
-            jail.create_file("harmonia.toml", &toml_with_port(8096))?;
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port(8096))
+                .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
             let mut rx = handle.subscribe();
 
-            jail.create_file("harmonia.toml", &toml_with_port(9090))?;
+            jail.create_file("harmonia.toml", &toml_with_port(9090))
+                .unwrap();
             manager.reload().unwrap();
 
             assert!(rx.has_changed().unwrap());
             assert_eq!(rx.borrow_and_update().paroche.port, 9090);
-            Ok(())
         });
     }
 
     #[test]
     fn subscribe_does_not_yield_when_config_unchanged() {
-        Jail::expect_with(|jail| {
-            jail.create_file("harmonia.toml", &toml_with_port(8096))?;
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port(8096))
+                .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
             let rx = handle.subscribe();
@@ -258,7 +275,6 @@ mod tests {
             manager.reload().unwrap();
 
             assert!(!rx.has_changed().unwrap());
-            Ok(())
         });
     }
 }

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -62,6 +62,17 @@ mod tests {
         "a-very-long-secret-key-that-is-at-least-32-bytes-long"
     }
 
+    #[allow(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with requires figment::Result; this lint is version-dependent"
+    )]
+    fn with_jail(run: impl FnOnce(&mut Jail)) {
+        Jail::expect_with(|jail| {
+            run(jail);
+            Ok(())
+        });
+    }
+
     // ── Default config ────────────────────────────────────────────────────────
 
     #[test]
@@ -90,18 +101,18 @@ mod tests {
 
     #[test]
     fn toml_overrides_defaults() {
-        Jail::expect_with(|jail: &mut Jail| {
+        with_jail(|jail| {
             jail.create_file(
                 "harmonia.toml",
                 &format!(
                     "[exousia]\naccess_token_ttl_secs = 1800\njwt_secret = \"{}\"\n\n[paroche]\nport = 9090\n",
                     valid_jwt_secret()
                 ),
-            )?;
+            )
+            .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             assert_eq!(config.exousia.access_token_ttl_secs, 1800);
             assert_eq!(config.paroche.port, 9090);
-            Ok(())
         });
     }
 
@@ -109,18 +120,18 @@ mod tests {
 
     #[test]
     fn env_vars_override_toml() {
-        Jail::expect_with(|jail: &mut Jail| {
+        with_jail(|jail| {
             jail.create_file(
                 "harmonia.toml",
                 &format!(
                     "[exousia]\naccess_token_ttl_secs = 900\njwt_secret = \"{}\"\n\n[paroche]\nport = 8096\n",
                     valid_jwt_secret()
                 ),
-            )?;
+            )
+            .unwrap();
             jail.set_env("HARMONIA__PAROCHE__PORT", "7777");
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             assert_eq!(config.paroche.port, 7777);
-            Ok(())
         });
     }
 
@@ -128,16 +139,17 @@ mod tests {
 
     #[test]
     fn secrets_toml_is_loaded() {
-        Jail::expect_with(|jail: &mut Jail| {
+        with_jail(|jail| {
             let secrets_secret = "secrets-toml-jwt-secret-long-enough-for-validation";
-            jail.create_file("harmonia.toml", "[exousia]\naccess_token_ttl_secs = 900\n")?;
+            jail.create_file("harmonia.toml", "[exousia]\naccess_token_ttl_secs = 900\n")
+                .unwrap();
             jail.create_file(
                 "secrets.toml",
                 &format!("[exousia]\njwt_secret = \"{secrets_secret}\"\n"),
-            )?;
+            )
+            .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
             assert_eq!(config.exousia.jwt_secret, secrets_secret);
-            Ok(())
         });
     }
 
@@ -145,12 +157,11 @@ mod tests {
 
     #[test]
     fn missing_config_file_uses_defaults() {
-        Jail::expect_with(|jail: &mut Jail| {
+        with_jail(|jail| {
             jail.set_env("HARMONIA__EXOUSIA__JWT_SECRET", valid_jwt_secret());
             let (config, _) = load_config(Some(Path::new("nonexistent.toml"))).unwrap();
             assert_eq!(config.exousia.access_token_ttl_secs, 900);
             assert_eq!(config.paroche.port, 8096);
-            Ok(())
         });
     }
 


### PR DESCRIPTION
## Summary
- replace manual divisibility checks now denied by Rust 1.95 clippy without requiring newer std APIs
- keep figment jail test helpers compatible across local Rust 1.95 clippy and CI Rust 1.89

## Verification
- `kanon gate --full`

Gate-Passed: kanon gate --full

Notes: kanon-lint architectural warnings remain non-blocking and are tracked separately (#326, #327, #298).