### PR TITLE
refactor(aitesis): return validated transition

### DIFF
--- a/crates/aitesis/src/approval.rs
+++ b/crates/aitesis/src/approval.rs
@@ -72,7 +72,7 @@ where
             .build()
         })?;
 
-    validate_transition(request.status, RequestStatus::Approved)?;
+    let approved = validate_transition(request.status, RequestStatus::Approved)?;
 
     identity
         .validate(
@@ -83,13 +83,14 @@ where
         .await?;
 
     let want_id = monitor.create_want(&request).await?;
+    let monitoring = validate_transition(approved.to(), RequestStatus::Monitoring)?;
 
     let now = jiff::Timestamp::now();
     crate::repo::update_status(
         pool,
         crate::repo::UpdateStatusParams {
             id: &request_id,
-            status: RequestStatus::Monitoring,
+            status: monitoring.to(),
             decided_by: Some(&admin_id),
             decided_at: Some(now),
             deny_reason: None,
@@ -132,14 +133,14 @@ pub(crate) async fn deny_request(
             .build()
         })?;
 
-    validate_transition(request.status, RequestStatus::Denied)?;
+    let denied = validate_transition(request.status, RequestStatus::Denied)?;
 
     let now = jiff::Timestamp::now();
     crate::repo::update_status(
         pool,
         crate::repo::UpdateStatusParams {
             id: &request_id,
-            status: RequestStatus::Denied,
+            status: denied.to(),
             decided_by: Some(&admin_id),
             decided_at: Some(now),
             deny_reason: reason.as_deref(),

--- a/crates/aitesis/src/workflow.rs
+++ b/crates/aitesis/src/workflow.rs
@@ -3,6 +3,23 @@
 use crate::error::{AitesisError, InvalidTransitionSnafu};
 use crate::types::RequestStatus;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ValidTransition {
+    from: RequestStatus,
+    to: RequestStatus,
+}
+
+impl ValidTransition {
+    #[cfg(test)]
+    pub(crate) fn from(self) -> RequestStatus {
+        self.from
+    }
+
+    pub(crate) fn to(self) -> RequestStatus {
+        self.to
+    }
+}
+
 /// Valid transitions:
 /// ```text
 /// Submitted → Approved
@@ -14,7 +31,7 @@ use crate::types::RequestStatus;
 pub(crate) fn validate_transition(
     from: RequestStatus,
     to: RequestStatus,
-) -> Result<(), AitesisError> {
+) -> Result<ValidTransition, AitesisError> {
     let allowed = matches!(
         (from, to),
         (RequestStatus::Submitted, RequestStatus::Approved)
@@ -25,7 +42,7 @@ pub(crate) fn validate_transition(
     );
 
     if allowed {
-        Ok(())
+        Ok(ValidTransition { from, to })
     } else {
         InvalidTransitionSnafu {
             from: from.as_str().to_string(),
@@ -42,53 +59,97 @@ mod tests {
 
     #[test]
     fn submitted_to_approved_is_valid() {
-        assert!(validate_transition(RequestStatus::Submitted, RequestStatus::Approved).is_ok());
+        assert!(matches!(
+            validate_transition(RequestStatus::Submitted, RequestStatus::Approved),
+            Ok(valid)
+                if valid.from() == RequestStatus::Submitted
+                    && valid.to() == RequestStatus::Approved
+        ));
     }
 
     #[test]
     fn submitted_to_denied_is_valid() {
-        assert!(validate_transition(RequestStatus::Submitted, RequestStatus::Denied).is_ok());
+        assert!(matches!(
+            validate_transition(RequestStatus::Submitted, RequestStatus::Denied),
+            Ok(valid)
+                if valid.from() == RequestStatus::Submitted
+                    && valid.to() == RequestStatus::Denied
+        ));
     }
 
     #[test]
     fn approved_to_monitoring_is_valid() {
-        assert!(validate_transition(RequestStatus::Approved, RequestStatus::Monitoring).is_ok());
+        assert!(matches!(
+            validate_transition(RequestStatus::Approved, RequestStatus::Monitoring),
+            Ok(valid)
+                if valid.from() == RequestStatus::Approved
+                    && valid.to() == RequestStatus::Monitoring
+        ));
     }
 
     #[test]
     fn monitoring_to_fulfilled_is_valid() {
-        assert!(validate_transition(RequestStatus::Monitoring, RequestStatus::Fulfilled).is_ok());
+        assert!(matches!(
+            validate_transition(RequestStatus::Monitoring, RequestStatus::Fulfilled),
+            Ok(valid)
+                if valid.from() == RequestStatus::Monitoring
+                    && valid.to() == RequestStatus::Fulfilled
+        ));
     }
 
     #[test]
     fn monitoring_to_failed_is_valid() {
-        assert!(validate_transition(RequestStatus::Monitoring, RequestStatus::Failed).is_ok());
+        assert!(matches!(
+            validate_transition(RequestStatus::Monitoring, RequestStatus::Failed),
+            Ok(valid)
+                if valid.from() == RequestStatus::Monitoring
+                    && valid.to() == RequestStatus::Failed
+        ));
     }
 
     #[test]
     fn denied_to_approved_is_invalid() {
-        let err = validate_transition(RequestStatus::Denied, RequestStatus::Approved).unwrap_err();
-        assert!(matches!(err, AitesisError::InvalidTransition { .. }));
+        assert!(matches!(
+            validate_transition(RequestStatus::Denied, RequestStatus::Approved),
+            Err(AitesisError::InvalidTransition { .. })
+        ));
     }
 
     #[test]
     fn fulfilled_to_monitoring_is_invalid() {
-        let err =
-            validate_transition(RequestStatus::Fulfilled, RequestStatus::Monitoring).unwrap_err();
-        assert!(matches!(err, AitesisError::InvalidTransition { .. }));
+        assert!(matches!(
+            validate_transition(RequestStatus::Fulfilled, RequestStatus::Monitoring),
+            Err(AitesisError::InvalidTransition { .. })
+        ));
     }
 
     #[test]
     fn submitted_to_monitoring_is_invalid() {
-        let err =
-            validate_transition(RequestStatus::Submitted, RequestStatus::Monitoring).unwrap_err();
-        assert!(matches!(err, AitesisError::InvalidTransition { .. }));
+        assert!(matches!(
+            validate_transition(RequestStatus::Submitted, RequestStatus::Monitoring),
+            Err(AitesisError::InvalidTransition { .. })
+        ));
     }
 
     #[test]
     fn full_lifecycle_transitions_are_valid() {
-        validate_transition(RequestStatus::Submitted, RequestStatus::Approved).unwrap();
-        validate_transition(RequestStatus::Approved, RequestStatus::Monitoring).unwrap();
-        validate_transition(RequestStatus::Monitoring, RequestStatus::Fulfilled).unwrap();
+        assert!(matches!(
+            validate_transition(RequestStatus::Submitted, RequestStatus::Approved),
+            Ok(valid)
+                if valid.from() == RequestStatus::Submitted
+                    && valid.to() == RequestStatus::Approved
+        ));
+        assert!(matches!(
+            validate_transition(RequestStatus::Approved, RequestStatus::Monitoring),
+            Ok(valid)
+                if valid.from() == RequestStatus::Approved
+                    && valid.to() == RequestStatus::Monitoring
+        ));
+        assert!(matches!(
+            validate_transition(RequestStatus::Monitoring, RequestStatus::Fulfilled),
+            Ok(valid)
+                if valid.from() == RequestStatus::Monitoring
+                    && valid.to() == RequestStatus::Fulfilled
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- make transition validation return an internal `ValidTransition` value instead of unit
- bind validated transitions in approval and denial flows before using destination statuses
- update workflow tests to assert the constrained transition contents directly

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p aitesis`
- `cargo clippy -p aitesis --all-targets -- -D warnings`
- `kanon lint crates/aitesis/src/workflow.rs --summary`

Closes #301

Gate-Passed: cargo fmt --all -- --check; cargo test -p aitesis; cargo clippy -p aitesis --all-targets -- -D warnings; kanon lint crates/aitesis/src/workflow.rs --summary