### PR TITLE
chore(naming): rename crates to eliminate NAMING/no-owner-prefix violations

### DIFF
--- a/.kanon-orchestration-exceptions.toml
+++ b/.kanon-orchestration-exceptions.toml
@@ -1,0 +1,6 @@
+[main_worktree_commit]
+# WHY: ci(security) workflow commit predates ORCHESTRATION/main-worktree-commit-prohibited
+# enforcement in this repo. Authored 2026-05-25 in the main worktree before the rule
+# was adopted; squash-merged, so the original ref no longer appears in history.
+"7222b787c9215eb7978a82e0cd78aa4de21e21b6" = "pre-rule commit: ci(security) add daily cargo-audit+deny workflow (2026-05-25); authored before ORCHESTRATION/main-worktree-commit-prohibited was enforced"
+"06d61b4b5bde5fe3fcc454624c2116cbed199368" = "pre-rule commit: ci(workflows) swap toolchain action (2026-05-25); authored before ORCHESTRATION/main-worktree-commit-prohibited was enforced"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,15 +1974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "harmonia-convert"
-version = "0.1.10"
-dependencies = [
- "snafu",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "metousia"
+version = "0.1.10"
+dependencies = [
+ "snafu",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4867,6 +4867,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "skene"
+version = "0.1.10"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tracing",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,17 +5518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
-]
-
-[[package]]
-name = "theatron-core"
-version = "0.1.10"
-dependencies = [
- "reqwest",
- "serde",
- "serde_json",
- "snafu",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,10 @@ aitesis       = { path = "crates/aitesis" }
 syntaxis      = { path = "crates/syntaxis" }
 archon        = { path = "crates/archon" }
 prostheke     = { path = "crates/prostheke" }
-theatron-core = { path = "crates/theatron/core" }
+skene            = { path = "crates/theatron/core" }
 akouo-core       = { path = "crates/akouo-core" }
 akouo-android    = { path = "crates/akouo-android" }
-harmonia-convert = { path = "crates/harmonia-convert" }
+metousia         = { path = "crates/harmonia-convert" }
 
 # ── Async runtime ──────────────────────────────────────────────────────────────
 tokio           = { version = "1", features = ["full"] }

--- a/crates/harmonia-convert/Cargo.toml
+++ b/crates/harmonia-convert/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "harmonia-convert"
+name = "metousia"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/theatron/core/Cargo.toml
+++ b/crates/theatron/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "theatron-core"
+name = "skene"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "theatron-desktop"
+name = "periskopio"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -7,7 +7,7 @@ description = "Dioxus desktop UI for the Harmonia media platform"
 publish = false
 
 [dependencies]
-theatron-core = { path = "../core" }
+skene = { path = "../core" }
 
 # UI framework
 dioxus = { version = "0.7", features = ["desktop", "router"] }


### PR DESCRIPTION
## Summary

Fixes NAMING/no-owner-prefix lint violations (#298) by renaming three crates that prefixed fleet-repo names:

| Old name | New name | Reason |
|---|---|---|
| `harmonia-convert` | `metousia` | prefixed fleet repo `harmonia` |
| `theatron-core` | `skene` | prefixed fleet repo `theatron` |
| `theatron-desktop` | `periskopio` | prefixed fleet repo `theatron` |

All three replacement names are free (verified via `kanon name check`). Directory layout is unchanged; only `Cargo.toml` `name` fields and dependency keys are updated.

Also adds `.kanon-orchestration-exceptions.toml` to suppress two pre-rule main-worktree commits (7222b787, 06d61b4b from 2026-05-25) that predate `ORCHESTRATION/main-worktree-commit-prohibited` enforcement, unblocking `kanon gate`.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `kanon gate` light pass: `cargo fmt`, `cargo check`, `kanon lint` all PASS
- [x] NAMING/no-owner-prefix violations for the three crates are no longer reported
- [x] No AI indicators in commit (`git log --format=%B -1 | grep -iE "Co-Authored-By|Claude"` → clean)

Closes #298