### PR TITLE
refactor(prostheke): fix #327 and #326 lint violations

### DIFF
--- a/crates/prostheke/src/lib.rs
+++ b/crates/prostheke/src/lib.rs
@@ -19,7 +19,9 @@ pub use error::ProsthekeError;
 use horismos::ProsthekeConfig;
 use themelion::{EventSender, HarmoniaEvent, MediaId, MediaType};
 use tracing::instrument;
-pub use types::{LanguagePreference, SubtitleFormat, SubtitleMatch, SubtitleTrack};
+pub use types::{
+    LanguagePreference, SubtitleFormat, SubtitleMatch, SubtitleProviderId, SubtitleTrack,
+};
 use uuid::Uuid;
 
 use crate::download::{detect_format_from_name, subtitle_path, write_subtitle_file};
@@ -234,7 +236,7 @@ mod tests {
     fn make_match(provider: &str, lang: &str, score: f64) -> SubtitleMatch {
         SubtitleMatch {
             provider: provider.to_string(),
-            provider_id: "42".to_string(),
+            provider_id: SubtitleProviderId("42".to_string()),
             language: lang.to_string(),
             hearing_impaired: false,
             forced: false,

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -13,7 +13,7 @@ use crate::error::{
     AcquisitionFailedSnafu, DownloadFailedSnafu, ProsthekeError, ProviderDownSnafu,
 };
 use crate::providers::SubtitleProvider;
-use crate::types::SubtitleMatch;
+use crate::types::{SubtitleMatch, SubtitleProviderId};
 
 const BASE_URL: &str = "https://api.opensubtitles.com/api/v1";
 const USER_AGENT: &str = "Harmonia/1.0";
@@ -235,7 +235,7 @@ impl SubtitleProvider for OpenSubtitlesProvider {
 
             matches.push(SubtitleMatch {
                 provider: self.name().to_string(),
-                provider_id: item.id,
+                provider_id: SubtitleProviderId(item.id),
                 language: item.attributes.language,
                 hearing_impaired: item.attributes.hearing_impaired,
                 forced: item.attributes.foreign_parts_only,
@@ -247,7 +247,7 @@ impl SubtitleProvider for OpenSubtitlesProvider {
         Ok(matches)
     }
 
-    #[instrument(skip(self, subtitle), fields(provider = "opensubtitles", provider_id = %subtitle.provider_id))]
+    #[instrument(skip(self, subtitle), fields(provider = "opensubtitles", provider_id = %subtitle.provider_id.0))]
     async fn download(&self, subtitle: &SubtitleMatch) -> Result<Vec<u8>, ProsthekeError> {
         let Some(api_key) = self.api_key() else {
             return DownloadFailedSnafu {
@@ -257,8 +257,8 @@ impl SubtitleProvider for OpenSubtitlesProvider {
         };
 
         // First request the download link FROM the API.
-        let file_id: u64 = subtitle.provider_id.parse().unwrap_or_else(|e| {
-            tracing::warn!(error = %e, provider_id = %subtitle.provider_id, "opensubtitles: invalid file_id; defaulting to 0");
+        let file_id: u64 = subtitle.provider_id.0.parse().unwrap_or_else(|e| {
+            tracing::warn!(error = %e, provider_id = %subtitle.provider_id.0, "opensubtitles: invalid file_id; defaulting to 0");
             0
         });
 

--- a/crates/prostheke/src/repo.rs
+++ b/crates/prostheke/src/repo.rs
@@ -7,7 +7,7 @@ use themelion::MediaId;
 use uuid::Uuid;
 
 use crate::error::{DatabaseSnafu, ProsthekeError};
-use crate::types::{SubtitleFormat, SubtitleTrack};
+use crate::types::{SubtitleFormat, SubtitleProviderId, SubtitleTrack};
 
 // ── Row type ─────────────────────────────────────────────────────────────────
 
@@ -40,7 +40,7 @@ impl SubtitleRow {
             format,
             file_path: self.file_path.into(),
             provider: self.provider,
-            provider_id: self.provider_id,
+            provider_id: SubtitleProviderId(self.provider_id),
             hearing_impaired: self.hearing_impaired,
             forced: self.forced,
             score: self.score,
@@ -81,7 +81,7 @@ pub async fn insert_subtitle(
     .bind(track.format.as_str())
     .bind(track.file_path.to_string_lossy().as_ref())
     .bind(&track.provider)
-    .bind(&track.provider_id)
+    .bind(&track.provider_id.0)
     .bind(track.hearing_impaired)
     .bind(track.forced)
     .bind(track.score)
@@ -199,7 +199,7 @@ mod tests {
             format: SubtitleFormat::Srt,
             file_path: format!("/library/movie.{language}.srt").into(),
             provider: "opensubtitles".to_string(),
-            provider_id: "12345".to_string(),
+            provider_id: SubtitleProviderId("12345".to_string()),
             hearing_impaired: false,
             forced,
             score: 0.95,
@@ -255,7 +255,7 @@ mod tests {
         // Same (media_id, language, forced) triplet — different id.
         let track2 = SubtitleTrack {
             id: Uuid::now_v7(),
-            provider_id: "99999".to_string(),
+            provider_id: SubtitleProviderId("99999".to_string()),
             ..make_track(media_id, "en", false)
         };
         let result = insert_subtitle(&pool, &track2).await;

--- a/crates/prostheke/src/search.rs
+++ b/crates/prostheke/src/search.rs
@@ -127,7 +127,7 @@ mod tests {
     fn make_match(lang: &str, score: f64, _hash_match: bool) -> SubtitleMatch {
         SubtitleMatch {
             provider: "opensubtitles".to_string(),
-            provider_id: format!("id-{lang}-{score}"),
+            provider_id: crate::types::SubtitleProviderId(format!("id-{lang}-{score}")),
             language: lang.to_string(),
             hearing_impaired: false,
             forced: false,

--- a/crates/prostheke/src/types.rs
+++ b/crates/prostheke/src/types.rs
@@ -7,6 +7,11 @@ use serde::{Deserialize, Serialize};
 use themelion::MediaId;
 use uuid::Uuid;
 
+/// External subtitle provider identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct SubtitleProviderId(pub String);
+
+// WHY: API schema
 /// A subtitle track acquired and stored for a media item.
 pub struct SubtitleTrack {
     pub id: Uuid,
@@ -19,7 +24,7 @@ pub struct SubtitleTrack {
     /// Provider name, e.g. "opensubtitles", "addic7ed".
     pub provider: String,
     /// Provider-specific subtitle identifier.
-    pub provider_id: String,
+    pub provider_id: SubtitleProviderId,
     pub hearing_impaired: bool,
     /// True for forced subtitles (e.g. foreign language signs).
     pub forced: bool,
@@ -61,11 +66,12 @@ impl SubtitleFormat {
     }
 }
 
+// WHY: API schema
 /// A candidate subtitle match returned by a provider search.
 #[derive(Clone)]
 pub struct SubtitleMatch {
     pub provider: String,
-    pub provider_id: String,
+    pub provider_id: SubtitleProviderId,
     /// BCP 47 language tag.
     pub language: String,
     pub hearing_impaired: bool,
@@ -75,6 +81,7 @@ pub struct SubtitleMatch {
     pub download_url: String,
 }
 
+// WHY: pure data
 /// User language preferences for subtitle acquisition.
 pub struct LanguagePreference {
     /// BCP 47 tags in preference order: ["en", "fr", "ja"].


### PR DESCRIPTION
Fixes RUST/primitive-for-domain-id (#327) and TOPOLOGY/shallow-struct (#326) violations in `crates/prostheke`.

## Changes

- **#327**: Introduced `SubtitleProviderId` newtype for external subtitle provider identifiers and updated all construction and access sites within the crate.
- **#326**: Added `// WHY: API schema` markers to `SubtitleTrack` and `SubtitleMatch`, and `// WHY: pure data` to `LanguagePreference`.

## Verification

- `kanon lint crates/prostheke` returns zero violations for both rules.
- `cargo clippy -p prostheke --all-targets -- -D warnings` is clean.
- `cargo test -p prostheke` passes (46 tests).
- `kanon gate --full --stamp` passes.

Refs: #327, #326