### PR TITLE
refactor(kritike, exousia, aitesis): add shallow-struct carve-out markers

### DIFF
--- a/crates/aitesis/src/repo.rs
+++ b/crates/aitesis/src/repo.rs
@@ -136,6 +136,7 @@ pub async fn get_request(
 /// Groups the mutation inputs applied to a request row: the new status plus
 /// the admin decision metadata (decided-by / decided-at / deny-reason) and the
 /// optional linked want for Monitoring transitions.
+// WHY: wire DTO — parameter bundle for the update_status SQL call.
 pub struct UpdateStatusParams<'a> {
     /// Request row to update.
     pub id: &'a RequestId,

--- a/crates/aitesis/src/types.rs
+++ b/crates/aitesis/src/types.rs
@@ -80,6 +80,7 @@ impl RequestStatus {
 }
 
 /// Input for creating a new media request.
+// WHY: pure data — user-submitted fields for a new media request.
 #[derive(Debug, Clone)]
 pub struct CreateRequestInput {
     /// Requested media category.

--- a/crates/exousia/src/api_key.rs
+++ b/crates/exousia/src/api_key.rs
@@ -2,6 +2,7 @@ use rand::Rng;
 use sha2::{Digest, Sha256};
 use themelion::ids::ApiKeyId;
 
+// WHY: wire DTO — API key fields returned from the database.
 pub struct ApiKeyRecord {
     pub id: ApiKeyId,
     pub short_token: String,

--- a/crates/kritike/src/profile.rs
+++ b/crates/kritike/src/profile.rs
@@ -5,6 +5,7 @@ use sqlx::SqlitePool;
 use crate::error::{DatabaseSnafu, KritikeError, ProfileNotFoundSnafu};
 
 /// A resolved quality profile FROM the database.
+// WHY: pure data — resolved quality profile name and media type.
 #[derive(Debug, Clone)]
 pub struct ResolvedProfile {
     pub id: i64,


### PR DESCRIPTION
Adds `// WHY:` carve-out markers for the `TOPOLOGY/shallow-struct` lint rule in `kritike`, `exousia`, and `aitesis`.

Fixes part of harmonia#326.