### PR TITLE
chore(ci): cargo-auditable + SLSA L2 + osv-scanner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,15 @@ jobs:
       - name: Install cross
         if: matrix.cross
         run: cargo install cross --locked
+      - name: Install cargo-auditable
+        if: ${{ !matrix.cross }}
+        run: cargo install cargo-auditable --locked --version 0.7.4
       - name: Build (native)
         if: ${{ !matrix.cross }}
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo auditable build --release --target ${{ matrix.target }}
       - name: Build (cross)
         if: ${{ matrix.cross }}
-        run: cross build --release --target ${{ matrix.target }}
+        run: cross auditable build --release --target ${{ matrix.target }}
       - name: Rename binary
         run: cp target/${{ matrix.target }}/release/harmonia ${{ matrix.artifact }}
       - name: Generate checksum
@@ -75,14 +78,26 @@ jobs:
           output-file: ${{ matrix.artifact }}.sbom.cdx.json
           format: cyclonedx-json
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        id: attest-provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: ${{ matrix.artifact }}
-      - name: Attest SBOM
-        uses: actions/attest-sbom@10926c72720ffc3f7b666661c8e55b1344e2a365 # v2
+      - name: Attest CycloneDX SBOM
+        id: attest-cyclonedx-sbom
+        uses: actions/attest-sbom@5026d3663739160db546203eeaffa6aa1c51a4d6 # v1
         with:
           subject-path: ${{ matrix.artifact }}
           sbom-path: ${{ matrix.artifact }}.sbom.cdx.json
+      - name: Upload attestation bundles
+        run: |
+          cp "${{ steps.attest-provenance.outputs.bundle-path }}" "${{ matrix.artifact }}.provenance.intoto.jsonl"
+          cp "${{ steps.attest-cyclonedx-sbom.outputs.bundle-path }}" "${{ matrix.artifact }}.cdx.intoto.jsonl"
+          gh release upload "${GITHUB_REF#refs/tags/}" \
+            "${{ matrix.artifact }}.provenance.intoto.jsonl" \
+            "${{ matrix.artifact }}.cdx.intoto.jsonl" \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload binary, checksum, and SBOM
         run: |
           gh release upload "${GITHUB_REF#refs/tags/}" \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -77,3 +77,14 @@ jobs:
         # .cargo/audit.toml, which mirrors deny.toml's [[advisories.ignore]]
         # entries — no silent --ignore flags here.
         run: cargo audit --deny unmaintained --deny unsound --deny yanked
+
+  osv-scanner:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    with:
+      scan-args: |
+        --config=osv-scanner.toml
+        --lockfile=Cargo.lock

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,38 @@
+# WHY: OSV-Scanner does not read cargo-audit's .cargo/audit.toml or
+# cargo-deny's deny.toml. Keep this ignore list in sync with both files.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0071"
+reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0012"
+reason = "backoff unmaintained — transitive dep via librqbit."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0141"
+reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol. No safe upgrade: bincode 2.x is a breaking-change rewrite and upstream has not migrated."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0060"
+reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0384"
+reason = "instant unmaintained — transitive dep via backoff/librqbit, no maintained alternative on the librqbit chain."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0436"
+reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0009"
+reason = "time RFC2822 stack exhaustion fix requires Rust 1.88; harmonia CI is pinned to Rust 1.85 until MSRV policy changes."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0150"
+reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0097"
+reason = "rand unsound with custom logger using rand::rng() — surfaces via sqlx/axum/quinn/reqwest; harmonia installs no custom logger that re-enters rand::rng(), so the unsound path is unreachable."


### PR DESCRIPTION
Supply-chain hardening pass for the harmonia fleet repo.

Changes:
- **cargo-auditable**: Native builds now use `cargo auditable build --release` and `cross auditable build --release` so release binaries embed a dependency SBOM readable by `cargo-audit`.
- **SLSA Build L2 provenance + CycloneDX SBOM attestation**: Updated action pins to the fleet-standard versions (`actions/attest-build-provenance@e8998f9`, `actions/attest-sbom@5026d36`) and added attestation bundle upload to the release assets.
- **osv-scanner**: Added a new `osv-scanner` job to `security.yml` using the pinned Google reusable workflow, plus `osv-scanner.toml` in the repo root to keep OSV ignore list in sync with `.cargo/audit.toml` and `deny.toml`.