### PR TITLE
refactor(syndesmos): add lint carve-out markers and TidalId newtype

### DIFF
--- a/crates/syndesmos/src/lastfm/artist.rs
+++ b/crates/syndesmos/src/lastfm/artist.rs
@@ -6,6 +6,7 @@ use crate::error::SyndesmodError;
 use crate::lastfm::LastfmApi;
 use crate::retry::{CircuitBreaker, with_retry};
 
+// WHY: API schema — Last.fm artist info response.
 /// Artist metadata returned by Last.fm `artist.getinfo`.
 #[derive(Debug, Clone)]
 pub struct ArtistInfo {

--- a/crates/syndesmos/src/lastfm/mod.rs
+++ b/crates/syndesmos/src/lastfm/mod.rs
@@ -16,6 +16,7 @@ use crate::lastfm::artist::ArtistInfo;
 
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+// WHY: wire DTO — Last.fm scrobble submission parameters.
 /// Parameters required to scrobble a single track.
 #[derive(Debug, Clone)]
 pub struct ScrobbleParams {

--- a/crates/syndesmos/src/lib.rs
+++ b/crates/syndesmos/src/lib.rs
@@ -331,7 +331,7 @@ mod tests {
     async fn sync_tidal_returns_new_items_when_configured() {
         let (tx, _rx) = create_event_bus(32);
         let favorites = vec![TidalFavorite {
-            tidal_id: "t1".to_string(),
+            tidal_id: crate::tidal::TidalId("t1".to_string()),
             title: "Track One".to_string(),
             artist: "Artist A".to_string(),
         }];

--- a/crates/syndesmos/src/tidal/mod.rs
+++ b/crates/syndesmos/src/tidal/mod.rs
@@ -13,10 +13,23 @@ use crate::error::{SyndesmodError, TidalApiCallSnafu};
 
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+// WHY: domain newtype — external API identifier, not a semantic struct.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TidalId(pub String);
+
+impl TidalId {
+    /// Returns the raw string identifier.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// WHY: API schema — Tidal favorites endpoint response item.
 /// A Tidal favorite track entry returned by the favorites endpoint.
 #[derive(Debug, Clone)]
 pub struct TidalFavorite {
-    pub tidal_id: String,
+    pub tidal_id: TidalId,
     pub title: String,
     pub artist: String,
 }
@@ -87,7 +100,7 @@ pub(crate) fn parse_favorites(body: &serde_json::Value) -> Vec<TidalFavorite> {
             arr.iter()
                 .filter_map(|item| {
                     let resource = item.get("resource")?;
-                    let tidal_id = resource.get("id")?.as_str()?.to_string();
+                    let tidal_id = TidalId(resource.get("id")?.as_str()?.to_string());
                     let title = resource.get("title")?.as_str()?.to_string();
                     let artist = resource
                         .get("artists")

--- a/crates/syndesmos/src/tidal/wantlist.rs
+++ b/crates/syndesmos/src/tidal/wantlist.rs
@@ -7,7 +7,7 @@ use tracing::instrument;
 
 use crate::error::SyndesmodError;
 use crate::retry::{CircuitBreaker, with_retry};
-use crate::tidal::{TidalApi, TidalFavorite};
+use crate::tidal::{TidalApi, TidalFavorite, TidalId};
 
 /// Syncs Tidal favorites against known want-list entries.
 ///
@@ -20,7 +20,7 @@ use crate::tidal::{TidalApi, TidalFavorite};
 pub(crate) async fn sync_want_list(
     api: &dyn TidalApi,
     event_tx: &EventSender,
-    existing_tidal_ids: &HashSet<String>,
+    existing_tidal_ids: &HashSet<TidalId>,
     circuit: &CircuitBreaker,
 ) -> Result<Vec<MediaId>, SyndesmodError> {
     let favorites: Vec<TidalFavorite> = with_retry(|| api.fetch_favorites(), circuit).await?;
@@ -48,8 +48,8 @@ mod tests {
 
     use super::*;
     use crate::retry::CircuitBreaker;
-    use crate::tidal::TidalFavorite;
     use crate::tidal::tests::MockTidalApi;
+    use crate::tidal::{TidalFavorite, TidalId};
 
     fn breaker() -> CircuitBreaker {
         CircuitBreaker::new("tidal", 5, std::time::Duration::from_secs(300))
@@ -57,7 +57,7 @@ mod tests {
 
     fn make_favorite(id: &str) -> TidalFavorite {
         TidalFavorite {
-            tidal_id: id.to_string(),
+            tidal_id: TidalId(id.to_string()),
             title: format!("Track {}", id),
             artist: "Test Artist".to_string(),
         }
@@ -75,7 +75,7 @@ mod tests {
         let circuit = breaker();
 
         let mut existing = HashSet::new();
-        existing.insert("t1".to_string());
+        existing.insert(TidalId("t1".to_string()));
 
         let added = sync_want_list(&mock, &tx, &existing, &circuit)
             .await
@@ -113,7 +113,7 @@ mod tests {
         let circuit = breaker();
 
         let mut existing = HashSet::new();
-        existing.insert("t1".to_string());
+        existing.insert(TidalId("t1".to_string()));
 
         let added = sync_want_list(&mock, &tx, &existing, &circuit)
             .await
@@ -152,7 +152,7 @@ mod tests {
         });
         let favorites = crate::tidal::parse_favorites(&body);
         assert_eq!(favorites.len(), 1);
-        assert_eq!(favorites[0].tidal_id, "123456");
+        assert_eq!(favorites[0].tidal_id, TidalId("123456".to_string()));
         assert_eq!(favorites[0].title, "Roygbiv");
         assert_eq!(favorites[0].artist, "Boards of Canada");
     }


### PR DESCRIPTION
Fixes two kanon lint rules in `crates/syndesmos`:

- **TOPOLOGY/shallow-struct** — adds `// WHY:` carve-out markers for `ArtistInfo`, `ScrobbleParams`, and `TidalFavorite`.
- **RUST/primitive-for-domain-id** — introduces a `TidalId` newtype to replace the raw `String` used for Tidal track identifiers.

Updates `parse_favorites`, `sync_want_list`, and all call sites/tests to use `TidalId`.

Part of harmonia#326 and harmonia#327.