### PR TITLE
refactor(horismos): suppress shallow-struct and primitive-id lint violations

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -443,3 +443,11 @@ RUST/indexing-slicing:crates/paroche/src/routes/read.rs
 # Types have been renamed away from ZetesisService/ZetesisError; the crate name
 # collision in Cargo.toml is deferred.
 NAMING/no-fleet-collision:crates/zetesis/Cargo.toml
+
+# =============================================================================
+# crates/horismos — OAuth2 protocol field names
+# =============================================================================
+
+# WHY: OAuth2 protocol uses 'client_id' as the field name by spec; this is
+# an external credential identifier, not an internal domain ID.
+RUST/primitive-for-domain-id:crates/horismos/src/subsystems.rs

--- a/crates/horismos/.kanon-lint-ignore
+++ b/crates/horismos/.kanon-lint-ignore
@@ -1,0 +1,5 @@
+# Kanon lint suppressions for crates/horismos.
+#
+# WHY: OAuth2 protocol uses 'client_id' as the field name by spec; this is
+# an external credential identifier, not an internal domain ID.
+RUST/primitive-for-domain-id:src/subsystems.rs

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -1,5 +1,6 @@
 use crate::Config;
 
+// WHY: pure data — change record for config diff reporting.
 pub struct ConfigChange {
     pub field: String,
     pub requires_restart: bool,

--- a/crates/horismos/src/validation.rs
+++ b/crates/horismos/src/validation.rs
@@ -3,6 +3,7 @@ use tracing::warn;
 use crate::Config;
 use crate::error::{HorismosError, ValidationSnafu};
 
+// WHY: pure data — diagnostic warning from config validation.
 #[derive(Debug)]
 pub struct ValidationWarning {
     pub field: String,


### PR DESCRIPTION
Suppresses two kanon lint rules in `crates/horismos`:

- **TOPOLOGY/shallow-struct**: Adds `WHY` comments to `ConfigChange` and `ValidationWarning`, documenting that they are pure data structs.
- **RUST/primitive-for-domain-id**: Adds ignore-file entries for `TidalConfig.client_id`, which is an OAuth2 protocol field name (external credential identifier, not an internal domain ID).

This fixes part of harmonia#326 and harmonia#327.