### PR TITLE
refactor(kathodos, komide, zetesis, syntaxis): add shallow-struct carve-out markers

### DIFF
--- a/crates/kathodos/src/event.rs
+++ b/crates/kathodos/src/event.rs
@@ -11,6 +11,7 @@ pub enum WatchEventKind {
     Renamed { from: PathBuf },
 }
 
+// WHY: pure data — filesystem watch event record.
 #[derive(Debug, Clone)]
 pub struct WatchEvent {
     pub path: PathBuf,

--- a/crates/kathodos/src/import/mod.rs
+++ b/crates/kathodos/src/import/mod.rs
@@ -14,6 +14,7 @@ use crate::import::conflict::{ConflictOutcome, DEFAULT_MAX_SUFFIX, resolve_confl
 use crate::import::fileops::{hardlink_or_copy, rename_file};
 use crate::import::template::TemplateEngine;
 
+// WHY: pure data — source descriptor for a media import.
 /// Source of a file entering the import pipeline.
 #[derive(Debug, Clone)]
 pub struct ImportSource {
@@ -37,6 +38,7 @@ pub enum ImportOrigin {
     },
 }
 
+// WHY: pure data — outcome of a media import operation.
 /// Result of a completed import.
 #[derive(Debug, Clone)]
 pub struct ImportResult {
@@ -55,6 +57,7 @@ pub enum ImportOperation {
     Skipped,
 }
 
+// WHY: pure data — import job awaiting processing.
 /// A file waiting for manual metadata matching.
 #[derive(Debug, Clone)]
 pub struct PendingImport {
@@ -63,6 +66,7 @@ pub struct PendingImport {
     pub media_type: MediaType,
 }
 
+// WHY: pure data — completed download ready for import.
 /// A completed download ready for import.
 #[derive(Debug, Clone)]
 pub struct CompletedDownload {
@@ -72,6 +76,7 @@ pub struct CompletedDownload {
     pub media_type: MediaType,
 }
 
+// WHY: pure data — metadata resolved for an import item.
 /// Enriched metadata FROM the metadata resolver.
 #[derive(Debug, Clone)]
 pub struct ResolvedMetadata {

--- a/crates/kathodos/src/scanner/walk.rs
+++ b/crates/kathodos/src/scanner/walk.rs
@@ -8,12 +8,14 @@ use walkdir::WalkDir;
 use crate::error::TaxisError;
 use crate::scanner::filter::{HarmoniaIgnore, is_supported_extension};
 
+// WHY: pure data — result of a directory walk scan.
 #[derive(Debug)]
 pub struct WalkResult {
     pub path: PathBuf,
     pub media_type: MediaType,
 }
 
+// WHY: pure data — statistics from a directory walk.
 #[derive(Debug, Default)]
 pub struct WalkStats {
     pub scanned: usize,

--- a/crates/komide/src/parser.rs
+++ b/crates/komide/src/parser.rs
@@ -2,6 +2,7 @@ use snafu::ResultExt;
 
 use crate::error::{FeedParseSnafu, KomideError};
 
+// WHY: pure data — normalized podcast feed record.
 pub struct NormalizedFeed {
     pub title: String,
     pub description: Option<String>,
@@ -10,6 +11,7 @@ pub struct NormalizedFeed {
     pub entries: Vec<NormalizedEntry>,
 }
 
+// WHY: pure data — normalized podcast episode entry.
 pub struct NormalizedEntry {
     pub guid: String,
     pub title: String,
@@ -20,6 +22,7 @@ pub struct NormalizedEntry {
     pub link: Option<String>,
 }
 
+// WHY: wire DTO — RSS enclosure element from feed XML.
 pub struct Enclosure {
     pub url: String,
     pub content_type: Option<String>,

--- a/crates/komide/src/service/mod.rs
+++ b/crates/komide/src/service/mod.rs
@@ -16,12 +16,14 @@ use crate::news::apply_retention;
 use crate::parser::parse_feed;
 use crate::podcast::extract_audio_enclosure;
 
+// WHY: pure data — result of a feed refresh operation.
 pub struct FeedRefreshResult {
     pub feed_id: FeedId,
     pub new_items: usize,
     pub total_items: usize,
 }
 
+// WHY: pure data — summary of a podcast feed.
 pub struct FeedSummary {
     pub id: FeedId,
     pub title: String,

--- a/crates/syntaxis/src/pipeline.rs
+++ b/crates/syntaxis/src/pipeline.rs
@@ -33,6 +33,7 @@ pub trait ImportService: Send + Sync {
 /// Groups the download-specific context that is known at dispatch time,
 /// keeping `run_pipeline`'s argument list under the Clippy limit.
 #[derive(Debug, Clone)]
+// WHY: pure data — item moving through the download pipeline.
 pub(crate) struct PipelineItem {
     pub queue_id: Uuid,
     pub want_id: WantId,

--- a/crates/syntaxis/src/repo.rs
+++ b/crates/syntaxis/src/repo.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
     dead_code,
     reason = "selected by sqlx::FromRow from all-columns queries; added_at and started_at not yet consumed by current pipeline stages"
 )]
+// WHY: wire DTO — download queue row from the database.
 pub(crate) struct QueueRow {
     pub id: Vec<u8>,
     pub want_id: Vec<u8>,

--- a/crates/syntaxis/src/types.rs
+++ b/crates/syntaxis/src/types.rs
@@ -31,6 +31,7 @@ impl std::fmt::Display for DownloadProtocol {
     }
 }
 
+// WHY: pure data — download queue item for the scheduler.
 /// A single entry waiting to be dispatched or actively downloading.
 #[derive(Debug, Clone)]
 pub struct QueueItem {
@@ -48,6 +49,7 @@ pub struct QueueItem {
     pub info_hash: Option<String>,
 }
 
+// WHY: pure data — record of a completed download.
 /// Passed from Syntaxis to the import service when post-processing is complete.
 #[derive(Debug, Clone)]
 pub struct CompletedDownload {
@@ -63,6 +65,7 @@ pub struct CompletedDownload {
     pub requires_copy: bool,
 }
 
+// WHY: pure data — position of an item in the download queue.
 /// Returned by `QueueManager::enqueue`.
 #[derive(Debug, Clone)]
 pub struct QueuePosition {
@@ -72,6 +75,7 @@ pub struct QueuePosition {
     pub estimated_wait_secs: Option<u64>,
 }
 
+// WHY: pure data — point-in-time snapshot of the download queue.
 /// Current queue state for API responses.
 #[derive(Debug, Clone)]
 pub struct QueueSnapshot {

--- a/crates/zetesis/src/cf_bypass/cookies.rs
+++ b/crates/zetesis/src/cf_bypass/cookies.rs
@@ -9,12 +9,14 @@ pub struct CookieStore {
     jars: DashMap<i64, IndexerCookieJar>,
 }
 
+// WHY: pure data — cookie jar for indexer Cloudflare bypass.
 pub struct IndexerCookieJar {
     pub cookies: Vec<StoredCookie>,
     pub user_agent: String,
     pub last_refreshed: Instant,
 }
 
+// WHY: pure data — persisted cookie entry.
 pub struct StoredCookie {
     pub name: String,
     pub value: String,

--- a/crates/zetesis/src/cf_bypass/mod.rs
+++ b/crates/zetesis/src/cf_bypass/mod.rs
@@ -17,6 +17,7 @@ pub struct ProxyResponse {
     pub user_agent: String,
 }
 
+// WHY: wire DTO — HTTP cookie from Cloudflare bypass response.
 #[derive(Debug, Clone)]
 pub struct Cookie {
     pub name: String,

--- a/crates/zetesis/src/repo.rs
+++ b/crates/zetesis/src/repo.rs
@@ -44,6 +44,7 @@ impl std::fmt::Debug for IndexerRow {
 /// Groups the columns written into the `indexers` row on insert. Columns with
 /// database defaults (`enabled`, `status`, `last_tested`, `caps_json`,
 /// `added_at`) are intentionally omitted.
+// WHY: wire DTO — parameter bundle for the insert_indexer SQL call.
 pub struct InsertIndexerParams<'a> {
     pub name: &'a str,
     pub url: &'a str,


### PR DESCRIPTION
Adds `// WHY:` carve-out markers to 23 shallow-struct definitions across four crates to resolve TOPOLOGY/shallow-struct lint violations.

Closes harmonia#326