### PR TITLE
refactor(syndesis): add wire-DTO markers and RendererSyncId newtype

### DIFF
--- a/crates/syndesis/src/clock/coordinator.rs
+++ b/crates/syndesis/src/clock/coordinator.rs
@@ -5,6 +5,7 @@ use tracing::{debug, info};
 
 use super::ClockEstimator;
 use crate::config::ClockConfig;
+use crate::protocol::session_frame::RendererSyncId;
 
 /// Coordinates clock state across all renderers in a zone, computing a unified
 /// playout timestamp so every renderer outputs the same sample at the same
@@ -19,10 +20,11 @@ pub struct ClockCoordinator {
     clock_config: ClockConfig,
 }
 
+// WHY: pure data — clock synchronization state for a renderer.
 /// Snapshot of a single renderer's clock state within the coordinator.
 #[derive(Debug, Clone)]
 pub struct RendererClockState {
-    pub renderer_id: String,
+    pub renderer_id: RendererSyncId,
     pub offset_us: i64,
     pub is_stable: bool,
     pub drift_rate: f64,
@@ -147,7 +149,7 @@ impl ClockCoordinator {
         self.estimators
             .iter()
             .map(|(id, est)| RendererClockState {
-                renderer_id: id.clone(),
+                renderer_id: RendererSyncId(id.clone()),
                 offset_us: est.offset_us(),
                 is_stable: est.is_stable(),
                 drift_rate: est.drift_rate(),

--- a/crates/syndesis/src/lib.rs
+++ b/crates/syndesis/src/lib.rs
@@ -15,7 +15,7 @@ pub use pairing::{
     verify_api_key,
 };
 pub use protocol::session_frame::{
-    Frame as SessionFrame, PairingChallenge, PairingComplete, SessionAccepted,
+    Frame as SessionFrame, PairingChallenge, PairingComplete, RendererSyncId, SessionAccepted,
     SessionInit as SessionInitMsg, SessionRejected,
 };
 pub use server::auth::{

--- a/crates/syndesis/src/protocol/frame.rs
+++ b/crates/syndesis/src/protocol/frame.rs
@@ -3,6 +3,7 @@ use bytes::Bytes;
 
 use super::{AudioCodec, CommandKind, DeviceState};
 
+// WHY: wire DTO — synchronization protocol frame.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AudioFrame {
     pub sequence: u64,
@@ -15,6 +16,7 @@ pub struct AudioFrame {
     pub payload: Bytes,
 }
 
+// WHY: wire DTO — synchronization protocol frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClockSync {
     pub originate_ts: u64,
@@ -22,6 +24,7 @@ pub struct ClockSync {
     pub transmit_ts: u64,
 }
 
+// WHY: wire DTO — synchronization protocol frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClockSyncReply {
     pub originate_ts: u64,
@@ -30,6 +33,7 @@ pub struct ClockSyncReply {
     pub destination_ts: u64,
 }
 
+// WHY: wire DTO — synchronization protocol frame.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionInit {
     pub protocol_version: u8,
@@ -38,6 +42,7 @@ pub struct SessionInit {
     pub channel_configs: Vec<u8>,
 }
 
+// WHY: wire DTO — synchronization protocol frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SessionAccept {
     pub codec: AudioCodec,
@@ -46,6 +51,7 @@ pub struct SessionAccept {
     pub session_id: u64,
 }
 
+// WHY: wire DTO — synchronization protocol frame.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatusReport {
     pub buffer_depth_ms: u16,
@@ -54,6 +60,7 @@ pub struct StatusReport {
     pub renderer_id: Vec<u8>,
 }
 
+// WHY: wire DTO — synchronization protocol frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Command {
     pub kind: CommandKind,

--- a/crates/syndesis/src/protocol/mod.rs
+++ b/crates/syndesis/src/protocol/mod.rs
@@ -96,6 +96,6 @@ impl CommandKind {
 }
 
 pub use session_frame::{
-    Frame as SessionFrame, PairingChallenge, PairingComplete, SessionAccepted,
+    Frame as SessionFrame, PairingChallenge, PairingComplete, RendererSyncId, SessionAccepted,
     SessionInit as SessionInitMsg, SessionRejected,
 };

--- a/crates/syndesis/src/protocol/session_frame.rs
+++ b/crates/syndesis/src/protocol/session_frame.rs
@@ -1,13 +1,17 @@
 // Wire-format frame types for the renderer-server session protocol
 use serde::{Deserialize, Serialize};
 
+/// Stable renderer identity for synchronization protocols.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RendererSyncId(pub String);
+
 /// Sent by the renderer to initiate a session.
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct SessionInit {
     /// Human-readable renderer name.
     pub renderer_name: String,
     /// Stable renderer identity (UUID v7 as string).
-    pub renderer_id: String,
+    pub renderer_id: RendererSyncId,
     /// API key FROM a prior pairing, base64url-encoded (no padding).
     /// Present on authenticated reconnects; absent on first connection.
     pub api_key: Option<String>,
@@ -53,7 +57,7 @@ impl std::fmt::Debug for PairingComplete {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SessionAccepted {
     /// The canonical renderer ID as stored in the server registry.
-    pub renderer_id: String,
+    pub renderer_id: RendererSyncId,
 }
 
 /// Sent by the server when a session is rejected.
@@ -97,7 +101,7 @@ mod tests {
     fn session_init_round_trip() {
         let frame = Frame::SessionInit(SessionInit {
             renderer_name: "Living Room".to_string(),
-            renderer_id: "01HN1234567890ABCDEFGHIJKL".to_string(),
+            renderer_id: RendererSyncId("01HN1234567890ABCDEFGHIJKL".to_string()),
             api_key: None,
             is_new: true,
         });
@@ -131,7 +135,7 @@ mod tests {
     fn session_init_with_api_key_round_trip() {
         let frame = Frame::SessionInit(SessionInit {
             renderer_name: "Kitchen".to_string(),
-            renderer_id: "01HN1234567890ABCDEFGHIJKL".to_string(),
+            renderer_id: RendererSyncId("01HN1234567890ABCDEFGHIJKL".to_string()),
             api_key: Some("some-api-key".to_string()),
             is_new: false,
         });

--- a/crates/syndesis/src/server/auth.rs
+++ b/crates/syndesis/src/server/auth.rs
@@ -36,7 +36,7 @@ pub async fn handle_session_init(
     if init.is_new {
         let req = PairingRequest {
             renderer_name: &init.renderer_name,
-            renderer_id: &init.renderer_id,
+            renderer_id: &init.renderer_id.0,
             cert_fingerprint: peer_cert_fingerprint,
         };
         let outcome = complete_pairing(write_pool, req).await?;
@@ -79,7 +79,7 @@ mod tests {
     use sqlx::SqlitePool;
 
     use super::*;
-    use crate::protocol::session_frame::SessionInit as SessionInitMsg;
+    use crate::protocol::session_frame::{RendererSyncId, SessionInit as SessionInitMsg};
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
@@ -98,7 +98,7 @@ mod tests {
 
         let init = SessionInitMsg {
             renderer_name: "Test Renderer".to_string(),
-            renderer_id: id.clone(),
+            renderer_id: RendererSyncId(id.clone()),
             api_key: None,
             is_new: true,
         };
@@ -121,7 +121,7 @@ mod tests {
 
         let init = SessionInitMsg {
             renderer_name: "Test Renderer".to_string(),
-            renderer_id: id.clone(),
+            renderer_id: RendererSyncId(id.clone()),
             api_key: None,
             is_new: true,
         };
@@ -136,7 +136,7 @@ mod tests {
 
         let auth_init = SessionInitMsg {
             renderer_name: "Test Renderer".to_string(),
-            renderer_id: id.clone(),
+            renderer_id: RendererSyncId(id.clone()),
             api_key: Some(api_key.clone()),
             is_new: false,
         };
@@ -157,7 +157,7 @@ mod tests {
 
         let init = SessionInitMsg {
             renderer_name: "Test Renderer".to_string(),
-            renderer_id: id,
+            renderer_id: RendererSyncId(id),
             api_key: None,
             is_new: true,
         };
@@ -168,7 +168,7 @@ mod tests {
 
         let auth_init = SessionInitMsg {
             renderer_name: "Test Renderer".to_string(),
-            renderer_id: uuid::Uuid::now_v7().to_string(),
+            renderer_id: RendererSyncId(uuid::Uuid::now_v7().to_string()),
             api_key: Some("wrong-key-value-here".to_string()),
             is_new: false,
         };
@@ -187,7 +187,7 @@ mod tests {
 
         let init = SessionInitMsg {
             renderer_name: "Disabled Renderer".to_string(),
-            renderer_id: id.clone(),
+            renderer_id: RendererSyncId(id.clone()),
             api_key: None,
             is_new: true,
         };
@@ -204,7 +204,7 @@ mod tests {
 
         let auth_init = SessionInitMsg {
             renderer_name: "Disabled Renderer".to_string(),
-            renderer_id: id,
+            renderer_id: RendererSyncId(id),
             api_key: Some(api_key),
             is_new: false,
         };
@@ -224,7 +224,7 @@ mod tests {
 
         let init = SessionInitMsg {
             renderer_name: "Test Renderer".to_string(),
-            renderer_id: id.clone(),
+            renderer_id: RendererSyncId(id.clone()),
             api_key: None,
             is_new: true,
         };
@@ -239,7 +239,7 @@ mod tests {
 
         let auth_init = SessionInitMsg {
             renderer_name: "Test Renderer".to_string(),
-            renderer_id: id,
+            renderer_id: RendererSyncId(id),
             api_key: Some(api_key),
             is_new: false,
         };

--- a/crates/syndesis/src/server/zone.rs
+++ b/crates/syndesis/src/server/zone.rs
@@ -39,6 +39,7 @@ pub struct ZoneStream {
     server_config: ServerConfig,
 }
 
+// WHY: pure data — sync point record for a zone.
 /// Sync point sent to a renderer joining mid-stream.
 #[derive(Debug, Clone)]
 pub struct SyncPoint {

--- a/crates/syndesis/src/tls/mod.rs
+++ b/crates/syndesis/src/tls/mod.rs
@@ -10,6 +10,7 @@ use snafu::ResultExt;
 
 use crate::error::{self, CertGenSnafu, SyndesisError};
 
+// WHY: pure data — self-signed TLS certificate bundle.
 /// A generated self-signed TLS certificate with its DER-encoded bytes and private key.
 #[derive(Clone)]
 pub struct SelfSignedCert {


### PR DESCRIPTION
Fixes lint violations in `crates/syndesis` for:

- **harmonia#326** (TOPOLOGY/shallow-struct) — Add `// WHY:` markers to shallow structs:
  - `RendererClockState`, `AudioFrame`, `ClockSync`, `ClockSyncReply`
  - `SessionInit`, `SessionAccept`, `StatusReport`, `Command`
  - `SyncPoint`, `SelfSignedCert`

- **harmonia#327** (RUST/primitive-for-domain-id) — Introduce `RendererSyncId` newtype to replace raw `String` for `renderer_id` domain identifiers in:
  - `SessionInit` (`protocol/session_frame.rs`)
  - `SessionAccepted` (`protocol/session_frame.rs`)
  - `RendererClockState` (`clock/coordinator.rs`)