### PR TITLE
refactor(epignosis): add shallow-struct markers and MetadataProviderId newtype

### DIFF
--- a/crates/epignosis/src/identity.rs
+++ b/crates/epignosis/src/identity.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use themelion::{MediaId, MediaType};
 
+// WHY: pure data — unresolved media item pending identification.
 #[derive(Debug, Clone)]
 pub struct UnidentifiedItem {
     pub media_id: MediaId,
@@ -12,6 +13,7 @@ pub struct UnidentifiedItem {
     pub tags: Option<EmbeddedTags>,
 }
 
+// WHY: pure data — embedded metadata tags read from media file.
 #[derive(Debug, Clone, Default)]
 pub struct EmbeddedTags {
     pub title: Option<String>,
@@ -27,12 +29,16 @@ pub struct EmbeddedTags {
     pub isbn: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MetadataProviderId(pub String);
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MediaIdentity {
     pub media_id: MediaId,
     pub media_type: MediaType,
     pub provider: String,
-    pub provider_id: String,
+    pub provider_id: MetadataProviderId,
     pub canonical_title: String,
     pub canonical_artist: Option<String>,
     pub year: Option<u32>,
@@ -128,6 +134,7 @@ pub fn parse_filename(path: &std::path::Path) -> ParsedFilename {
     }
 }
 
+// WHY: pure data — structured fields parsed from a media filename.
 #[derive(Debug, Clone, Default)]
 pub struct ParsedFilename {
     pub artist: Option<String>,

--- a/crates/epignosis/src/providers/acoustid.rs
+++ b/crates/epignosis/src/providers/acoustid.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 use crate::identity::FingerprintResult;
 
@@ -74,7 +74,7 @@ impl AcoustIdProvider {
                             "mb_recording_id": rec.id,
                         });
                         ProviderResult {
-                            provider_id: rec.id,
+                            provider_id: MetadataProviderId(rec.id),
                             title: rec.title.unwrap_or_default(),
                             artist,
                             year: None,
@@ -166,7 +166,7 @@ impl MetadataProvider for AcoustIdProvider {
                     .and_then(|a| a.first())
                     .map(|a| a.name.clone());
                 Ok(ProviderMetadata {
-                    provider_id: rec.id,
+                    provider_id: MetadataProviderId(rec.id),
                     title: rec.title.unwrap_or_default(),
                     artist,
                     year: None,
@@ -174,7 +174,7 @@ impl MetadataProvider for AcoustIdProvider {
                 })
             }
             None => Ok(ProviderMetadata {
-                provider_id: provider_id.to_string(),
+                provider_id: MetadataProviderId(provider_id.to_string()),
                 title: String::new(),
                 artist: None,
                 year: None,

--- a/crates/epignosis/src/providers/audnexus.rs
+++ b/crates/epignosis/src/providers/audnexus.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://api.audnex.us";
@@ -174,7 +174,7 @@ impl MetadataProvider for AudnexusProvider {
                     .map(|a| a.name.clone());
                 let raw = serde_json::json!({ "asin": book.asin });
                 ProviderResult {
-                    provider_id: book.asin,
+                    provider_id: MetadataProviderId(book.asin),
                     title: book.title,
                     artist,
                     year: None,
@@ -280,7 +280,7 @@ impl MetadataProvider for AudnexusProvider {
         });
 
         Ok(ProviderMetadata {
-            provider_id: book.asin,
+            provider_id: MetadataProviderId(book.asin),
             title: book.title,
             artist,
             year,

--- a/crates/epignosis/src/providers/comicvine.rs
+++ b/crates/epignosis/src/providers/comicvine.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://comicvine.gamespot.com/api";
@@ -94,7 +94,7 @@ impl MetadataProvider for ComicVineProvider {
                     "image": vol.image.and_then(|i| i.medium_url),
                 });
                 ProviderResult {
-                    provider_id: format!("4050-{}", vol.id),
+                    provider_id: MetadataProviderId(format!("4050-{}", vol.id)),
                     title: vol.name,
                     artist,
                     year,
@@ -138,7 +138,7 @@ impl MetadataProvider for ComicVineProvider {
         });
 
         Ok(ProviderMetadata {
-            provider_id: format!("4050-{}", vol.id),
+            provider_id: MetadataProviderId(format!("4050-{}", vol.id)),
             title: vol.name,
             artist,
             year,

--- a/crates/epignosis/src/providers/googlebooks.rs
+++ b/crates/epignosis/src/providers/googlebooks.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://www.googleapis.com/books/v1";
@@ -154,7 +154,7 @@ impl MetadataProvider for GoogleBooksProvider {
                 });
 
                 ProviderResult {
-                    provider_id: item.id,
+                    provider_id: MetadataProviderId(item.id),
                     title: item.volume_info.title,
                     artist,
                     year,
@@ -238,7 +238,7 @@ impl MetadataProvider for GoogleBooksProvider {
         });
 
         Ok(ProviderMetadata {
-            provider_id: volume.id,
+            provider_id: MetadataProviderId(volume.id),
             title: info.title,
             artist,
             year,

--- a/crates/epignosis/src/providers/itunes.rs
+++ b/crates/epignosis/src/providers/itunes.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://itunes.apple.com";
@@ -81,7 +81,7 @@ impl MetadataProvider for ItunesProvider {
                     "genres": pod.genres.unwrap_or_default(),
                 });
                 Some(ProviderResult {
-                    provider_id: id,
+                    provider_id: MetadataProviderId(id),
                     title,
                     artist: pod.artist_name,
                     year,
@@ -138,7 +138,7 @@ impl MetadataProvider for ItunesProvider {
         });
 
         Ok(ProviderMetadata {
-            provider_id: provider_id.to_string(),
+            provider_id: MetadataProviderId(provider_id.to_string()),
             title,
             artist: pod.artist_name,
             year,

--- a/crates/epignosis/src/providers/mod.rs
+++ b/crates/epignosis/src/providers/mod.rs
@@ -13,6 +13,9 @@ pub mod openlibrary;
 pub mod tmdb;
 pub mod tvdb;
 
+pub use crate::identity::MetadataProviderId;
+
+// WHY: pure data — query parameters for a metadata provider search.
 #[derive(Debug, Clone)]
 pub struct SearchQuery {
     pub media_type: MediaType,
@@ -25,7 +28,7 @@ pub struct SearchQuery {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderResult {
-    pub provider_id: String,
+    pub provider_id: MetadataProviderId,
     pub title: String,
     pub artist: Option<String>,
     pub year: Option<u32>,
@@ -35,7 +38,7 @@ pub struct ProviderResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderMetadata {
-    pub provider_id: String,
+    pub provider_id: MetadataProviderId,
     pub title: String,
     pub artist: Option<String>,
     pub year: Option<u32>,

--- a/crates/epignosis/src/providers/musicbrainz.rs
+++ b/crates/epignosis/src/providers/musicbrainz.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://musicbrainz.org/ws/2";
@@ -106,7 +106,7 @@ impl MetadataProvider for MusicBrainzProvider {
                 let score = rec.score.unwrap_or(0) as f64 / 100.0;
                 let raw = serde_json::json!({ "mb_recording_id": rec.id });
                 ProviderResult {
-                    provider_id: rec.id,
+                    provider_id: MetadataProviderId(rec.id),
                     title: rec.title,
                     artist,
                     year,
@@ -153,7 +153,7 @@ impl MetadataProvider for MusicBrainzProvider {
             .and_then(|y| y.parse().ok());
 
         Ok(ProviderMetadata {
-            provider_id: release.id,
+            provider_id: MetadataProviderId(release.id),
             title: release.title,
             artist,
             year,

--- a/crates/epignosis/src/providers/openlibrary.rs
+++ b/crates/epignosis/src/providers/openlibrary.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://openlibrary.org";
@@ -206,7 +206,7 @@ impl MetadataProvider for OpenLibraryProvider {
                     "edition_count": doc.edition_count,
                 });
                 ProviderResult {
-                    provider_id: doc.key,
+                    provider_id: MetadataProviderId(doc.key),
                     title: doc.title,
                     artist,
                     year: doc.first_publish_year,
@@ -321,7 +321,7 @@ impl MetadataProvider for OpenLibraryProvider {
         });
 
         Ok(ProviderMetadata {
-            provider_id: provider_id.to_string(),
+            provider_id: MetadataProviderId(provider_id.to_string()),
             title,
             artist: None,
             year,

--- a/crates/epignosis/src/providers/tmdb.rs
+++ b/crates/epignosis/src/providers/tmdb.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://api.themoviedb.org/3";
@@ -93,7 +93,7 @@ impl MetadataProvider for TmdbProvider {
                     "tmdb_id": movie.id,
                 });
                 ProviderResult {
-                    provider_id: movie.id.to_string(),
+                    provider_id: MetadataProviderId(movie.id.to_string()),
                     title: movie.title,
                     artist: None,
                     year,
@@ -145,7 +145,7 @@ impl MetadataProvider for TmdbProvider {
         });
 
         Ok(ProviderMetadata {
-            provider_id: movie.id.to_string(),
+            provider_id: MetadataProviderId(movie.id.to_string()),
             title: movie.title,
             artist: None,
             year,

--- a/crates/epignosis/src/providers/tvdb.rs
+++ b/crates/epignosis/src/providers/tvdb.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::ResultExt;
 use tracing::instrument;
 
-use super::{MetadataProvider, ProviderMetadata, ProviderResult, SearchQuery};
+use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
 use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://api4.thetvdb.com/v4";
@@ -123,7 +123,7 @@ impl MetadataProvider for TvdbProvider {
                 let id = series.tvdb_id.unwrap_or_default();
                 let raw = serde_json::json!({ "overview": series.overview, "tvdb_id": id });
                 ProviderResult {
-                    provider_id: id,
+                    provider_id: MetadataProviderId(id),
                     title: series.name,
                     artist: None,
                     year,
@@ -172,7 +172,7 @@ impl MetadataProvider for TvdbProvider {
         });
 
         Ok(ProviderMetadata {
-            provider_id: detail.data.id.to_string(),
+            provider_id: MetadataProviderId(detail.data.id.to_string()),
             title: detail.data.name,
             artist: None,
             year,

--- a/crates/epignosis/src/resolver.rs
+++ b/crates/epignosis/src/resolver.rs
@@ -25,6 +25,7 @@ use crate::providers::{MetadataProvider, ProviderResult, SearchQuery};
 use crate::rate_limit::ProviderQueues;
 
 /// Provider credentials supplied at construction time.
+// WHY: pure data — authentication credentials for a metadata provider.
 #[derive(Debug, Clone, Default)]
 pub struct ProviderCredentials {
     pub acoustid_key: String,
@@ -373,31 +374,35 @@ impl ProviderBackedResolver {
         let metadata = match identity.media_type {
             MediaType::Music => {
                 self.queues.musicbrainz.acquire().await;
-                self.musicbrainz.get_metadata(&identity.provider_id).await?
+                self.musicbrainz
+                    .get_metadata(&identity.provider_id.0)
+                    .await?
             }
             MediaType::Movie => {
                 self.queues.tmdb.acquire().await;
-                self.tmdb.get_metadata(&identity.provider_id).await?
+                self.tmdb.get_metadata(&identity.provider_id.0).await?
             }
             MediaType::Tv => {
                 self.queues.tvdb.acquire().await;
-                self.tvdb.get_metadata(&identity.provider_id).await?
+                self.tvdb.get_metadata(&identity.provider_id.0).await?
             }
             MediaType::Audiobook => {
                 self.queues.audnexus.acquire().await;
-                self.audnexus.get_metadata(&identity.provider_id).await?
+                self.audnexus.get_metadata(&identity.provider_id.0).await?
             }
             MediaType::Book => {
                 self.queues.openlibrary.acquire().await;
-                self.openlibrary.get_metadata(&identity.provider_id).await?
+                self.openlibrary
+                    .get_metadata(&identity.provider_id.0)
+                    .await?
             }
             MediaType::Comic => {
                 self.queues.comicvine.acquire().await;
-                self.comicvine.get_metadata(&identity.provider_id).await?
+                self.comicvine.get_metadata(&identity.provider_id.0).await?
             }
             MediaType::Podcast | MediaType::News => {
                 self.queues.itunes.acquire().await;
-                self.itunes.get_metadata(&identity.provider_id).await?
+                self.itunes.get_metadata(&identity.provider_id.0).await?
             }
             _ => return Ok(serde_json::Value::Null),
         };
@@ -412,7 +417,7 @@ impl ProviderBackedResolver {
         match identity.media_type {
             MediaType::Tv => {
                 self.queues.tmdb.acquire().await;
-                let meta = self.tmdb.get_metadata(&identity.provider_id).await.ok()?;
+                let meta = self.tmdb.get_metadata(&identity.provider_id.0).await.ok()?;
                 Some(("tmdb".to_string(), meta.extra))
             }
             MediaType::Audiobook => {
@@ -429,7 +434,7 @@ impl ProviderBackedResolver {
                 let best = results.into_iter().next()?;
                 let meta = self
                     .openlibrary
-                    .get_metadata(&best.provider_id)
+                    .get_metadata(&best.provider_id.0)
                     .await
                     .ok()?;
                 Some(("openlibrary".to_string(), meta.extra))
@@ -438,7 +443,7 @@ impl ProviderBackedResolver {
                 self.queues.google_books.acquire().await;
                 let meta = self
                     .google_books
-                    .get_metadata(&identity.provider_id)
+                    .get_metadata(&identity.provider_id.0)
                     .await
                     .ok()?;
                 Some(("google_books".to_string(), meta.extra))
@@ -451,6 +456,7 @@ impl ProviderBackedResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::identity::MetadataProviderId;
 
     #[test]
     fn canonical_provider_music() {
@@ -528,7 +534,7 @@ mod tests {
         };
 
         let result = ProviderResult {
-            provider_id: "/works/OL123W".to_string(),
+            provider_id: MetadataProviderId("/works/OL123W".to_string()),
             title: "Dune".to_string(),
             artist: Some("Frank Herbert".to_string()),
             year: Some(1965),
@@ -555,7 +561,7 @@ mod tests {
         };
 
         let result = ProviderResult {
-            provider_id: "abc123".to_string(),
+            provider_id: MetadataProviderId("abc123".to_string()),
             title: "Dune".to_string(),
             artist: Some("Frank Herbert".to_string()),
             year: Some(1965),
@@ -582,7 +588,7 @@ mod tests {
         };
 
         let result = ProviderResult {
-            provider_id: "/works/OL123W".to_string(),
+            provider_id: MetadataProviderId("/works/OL123W".to_string()),
             title: "Dune".to_string(),
             artist: Some("Frank Herbert".to_string()),
             year: Some(1965),
@@ -607,7 +613,7 @@ mod tests {
         };
 
         let result = ProviderResult {
-            provider_id: "/works/OL123W".to_string(),
+            provider_id: MetadataProviderId("/works/OL123W".to_string()),
             title: "Dune".to_string(),
             artist: Some("Different Author".to_string()),
             year: Some(2000),
@@ -632,7 +638,7 @@ mod tests {
         };
 
         let result = ProviderResult {
-            provider_id: "/works/OL123W".to_string(),
+            provider_id: MetadataProviderId("/works/OL123W".to_string()),
             title: "Foundation".to_string(),
             artist: Some("Isaac Asimov".to_string()),
             year: Some(1951),
@@ -657,7 +663,7 @@ mod tests {
         };
 
         let result = ProviderResult {
-            provider_id: "/works/OL123W".to_string(),
+            provider_id: MetadataProviderId("/works/OL123W".to_string()),
             title: "".to_string(),
             artist: None,
             year: None,


### PR DESCRIPTION
Fixes TOPOLOGY/shallow-struct and RUST/primitive-for-domain-id violations in `crates/epignosis`.

- Adds `MetadataProviderId` newtype and replaces `provider_id: String` in `MediaIdentity`, `ProviderResult`, and `ProviderMetadata`.
- Adds `// WHY: pure data` markers to `UnidentifiedItem`, `EmbeddedTags`, `ParsedFilename`, `SearchQuery`, and `ProviderCredentials`.

Closes harmonia#326
Closes harmonia#327