### PR TITLE
refactor(akouo-core): add lint carve-out markers and AudioDeviceId newtype

### DIFF
--- a/crates/akouo-core/src/config.rs
+++ b/crates/akouo-core/src/config.rs
@@ -102,6 +102,7 @@ impl EqConfig {
     }
 }
 
+// WHY: pure data — parameter bundle for audio subsystem.
 /// A single parametric EQ band.
 #[derive(Debug, Clone)]
 pub struct EqBand {

--- a/crates/akouo-core/src/decode/mod.rs
+++ b/crates/akouo-core/src/decode/mod.rs
@@ -26,6 +26,7 @@ pub enum Codec {
     Other(String),
 }
 
+// WHY: pure data — audio pipeline state bundle.
 /// Parameters describing a decoded audio stream.
 #[derive(Debug, Clone)]
 pub struct StreamParams {
@@ -39,6 +40,7 @@ pub struct StreamParams {
     pub bitrate: Option<u32>,
 }
 
+// WHY: pure data — audio pipeline state bundle.
 /// Gapless playback metadata embedded in the source file.
 #[derive(Debug, Clone)]
 pub struct GaplessInfo {
@@ -50,6 +52,7 @@ pub struct GaplessInfo {
     pub total_samples: Option<u64>,
 }
 
+// WHY: pure data — audio pipeline state bundle.
 /// A single decoded audio frame: interleaved f64 samples in [-1.0, 1.0].
 #[derive(Debug, Clone)]
 pub struct DecodedFrame {

--- a/crates/akouo-core/src/lib.rs
+++ b/crates/akouo-core/src/lib.rs
@@ -35,7 +35,7 @@ pub use gapless::{
 // Output
 pub use output::format::Quantization;
 pub use output::resample::Resampler;
-pub use output::{DeviceCapabilities, OutputBackend, OutputDevice, OutputParams};
+pub use output::{AudioDeviceId, DeviceCapabilities, OutputBackend, OutputDevice, OutputParams};
 // Queue
 pub use queue::PlayQueue;
 // Ring buffer (for custom engine/renderer implementations)

--- a/crates/akouo-core/src/output/cpal.rs
+++ b/crates/akouo-core/src/output/cpal.rs
@@ -66,7 +66,7 @@ impl OutputBackend for CpalOutputBackend {
             };
             let is_default = default_name.as_deref() == Some(&name);
             result.push(OutputDevice {
-                id: name.clone(),
+                id: crate::output::AudioDeviceId(name.clone()),
                 name,
                 is_default,
             });

--- a/crates/akouo-core/src/output/mod.rs
+++ b/crates/akouo-core/src/output/mod.rs
@@ -16,17 +16,31 @@ use crate::signal_path::QualityTier;
 /// it needs samples; must fill the provided buffer within the real-time deadline.
 pub type AudioDataCallback = Box<dyn FnMut(&mut [f64]) + Send + 'static>;
 
+/// Newtype for audio device identifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct AudioDeviceId(pub String);
+
+impl AudioDeviceId {
+    /// Returns the underlying device identifier string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// WHY: pure data — audio pipeline state bundle.
 /// Describes an enumerated audio output device.
 ///
 /// `Clone` + no lifetimes: safe to pass across FFI/UniFFI boundaries in Phase 6.
 #[derive(Debug, Clone)]
 pub struct OutputDevice {
     /// OS-assigned device identifier (e.g. WASAPI device GUID, CoreAudio UID).
-    pub id: String,
+    pub id: AudioDeviceId,
     pub name: String,
     pub is_default: bool,
 }
 
+// WHY: pure data — audio pipeline state bundle.
 /// Capabilities reported by an `OutputBackend` for a specific device.
 #[derive(Debug, Clone)]
 pub struct DeviceCapabilities {
@@ -36,6 +50,7 @@ pub struct DeviceCapabilities {
     pub supports_exclusive_mode: bool,
 }
 
+// WHY: pure data — parameter bundle for audio subsystem.
 /// Parameters for an output stream, as determined by format negotiation.
 #[derive(Debug, Clone)]
 pub struct OutputParams {

--- a/crates/akouo-core/src/signal_path/mod.rs
+++ b/crates/akouo-core/src/signal_path/mod.rs
@@ -29,6 +29,7 @@ impl SignalPathSnapshot {
     }
 }
 
+// WHY: pure data — audio pipeline state bundle.
 /// Describes the source audio stream in the signal path.
 #[derive(Debug, Clone)]
 pub struct SourceInfo {
@@ -40,6 +41,7 @@ pub struct SourceInfo {
     pub tier: QualityTier,
 }
 
+// WHY: pure data — audio pipeline state bundle.
 /// Describes one DSP stage's contribution to the signal path.
 #[derive(Debug, Clone)]
 pub struct SignalStageInfo {
@@ -50,6 +52,7 @@ pub struct SignalStageInfo {
     pub tier_impact: Option<QualityTier>,
 }
 
+// WHY: pure data — audio pipeline state bundle.
 /// Describes the audio output in the signal path.
 #[derive(Debug, Clone)]
 pub struct OutputInfo {


### PR DESCRIPTION
Add TOPOLOGY/shallow-struct carve-out `WHY` comments to audio pipeline structs in `crates/akouo-core` and introduce the `AudioDeviceId` newtype to resolve `RUST/primitive-for-domain-id`.

Fixes harmonia#326, harmonia#327