### PR TITLE
refactor(apotheke): add shallow-struct markers and suppress SQLx row ID lints

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -451,3 +451,15 @@ NAMING/no-fleet-collision:crates/zetesis/Cargo.toml
 # WHY: OAuth2 protocol uses 'client_id' as the field name by spec; this is
 # an external credential identifier, not an internal domain ID.
 RUST/primitive-for-domain-id:crates/horismos/src/subsystems.rs
+
+# =============================================================================
+# crates/apotheke — SQLx row string IDs
+# =============================================================================
+
+# WHY: apotheke repo rows mirror SQLite column types directly. String ID fields
+# in row structs are SQLx-bound to TEXT columns; wrapping in newtypes requires
+# implementing sqlx::Type + sqlx::Encode + sqlx::Decode for each newtype, which
+# is a separate repo-layer refactor tracked in harmonia#327.
+RUST/primitive-for-domain-id:crates/apotheke/src/repo/registry.rs
+RUST/primitive-for-domain-id:crates/apotheke/src/repo/renderer.rs
+RUST/primitive-for-domain-id:crates/apotheke/src/repo/zone.rs

--- a/crates/apotheke/src/pools.rs
+++ b/crates/apotheke/src/pools.rs
@@ -5,6 +5,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, S
 use crate::error::{DbError, PoolInitSnafu};
 use crate::migrate::run_migrations;
 
+// WHY: pure data — handles to all SQLite connection pools used by the apotheke repo layer.
 pub struct DbPools {
     pub read: SqlitePool,
     pub write: SqlitePool,

--- a/crates/apotheke/src/repo/audiobook.rs
+++ b/crates/apotheke/src/repo/audiobook.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the audiobooks table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Audiobook {
     pub id: Vec<u8>,
@@ -26,6 +27,7 @@ pub struct Audiobook {
     pub added_at: String,
 }
 
+// WHY: wire DTO — SQLx row from the audiobook_chapters table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct AudiobookChapter {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/book.rs
+++ b/crates/apotheke/src/repo/book.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the books table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Book {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/comic.rs
+++ b/crates/apotheke/src/repo/comic.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the comics table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Comic {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/kosync.rs
+++ b/crates/apotheke/src/repo/kosync.rs
@@ -21,6 +21,7 @@ impl std::fmt::Debug for KOSyncUser {
     }
 }
 
+// WHY: wire DTO — SQLx row from the kosync_positions table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct KOSyncPosition {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/movie.rs
+++ b/crates/apotheke/src/repo/movie.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the movies table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Movie {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/music.rs
+++ b/crates/apotheke/src/repo/music.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the music_release_groups table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct MusicReleaseGroup {
     pub id: Vec<u8>,
@@ -15,6 +16,7 @@ pub struct MusicReleaseGroup {
     pub added_at: String,
 }
 
+// WHY: wire DTO — SQLx row from the music_releases table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct MusicRelease {
     pub id: Vec<u8>,
@@ -28,6 +30,7 @@ pub struct MusicRelease {
     pub added_at: String,
 }
 
+// WHY: wire DTO — SQLx row from the music_media table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct MusicMedium {
     pub id: Vec<u8>,
@@ -37,6 +40,7 @@ pub struct MusicMedium {
     pub title: Option<String>,
 }
 
+// WHY: wire DTO — SQLx row from the music_tracks table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct MusicTrack {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/news.rs
+++ b/crates/apotheke/src/repo/news.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the news_feeds table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct NewsFeed {
     pub id: Vec<u8>,
@@ -19,6 +20,7 @@ pub struct NewsFeed {
     pub updated_at: String,
 }
 
+// WHY: wire DTO — SQLx row from the news_articles table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct NewsArticle {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/play_history/mod.rs
+++ b/crates/apotheke/src/repo/play_history/mod.rs
@@ -27,6 +27,7 @@ impl PlaySource {
     }
 }
 
+// WHY: pure data — parameter bundle for starting a new play session.
 pub struct NewPlaySession {
     pub media_id: MediaId,
     pub user_id: UserId,
@@ -38,12 +39,14 @@ pub struct NewPlaySession {
     pub total_ms: Option<i64>,
 }
 
+// WHY: pure data — outcome parameters for closing a play session.
 pub struct SessionOutcome {
     pub duration_ms: i64,
     pub completed: bool,
     pub percent_heard: Option<i32>,
 }
 
+// WHY: wire DTO — SQLx row from the play_sessions table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct PlaySession {
     pub id: Vec<u8>,
@@ -65,6 +68,7 @@ pub struct PlaySession {
     pub dsp_active: i64,
 }
 
+// WHY: wire DTO — SQLx aggregate stats for a single media item.
 #[derive(Debug, Clone)]
 pub struct ItemStats {
     pub media_id: MediaId,
@@ -74,6 +78,7 @@ pub struct ItemStats {
     pub last_played_at: Option<String>,
 }
 
+// WHY: wire DTO — SQLx aggregate listening stats for a single day.
 #[derive(Debug, Clone)]
 pub struct DailyStats {
     pub date: String,
@@ -83,6 +88,7 @@ pub struct DailyStats {
     pub unique_items: i32,
 }
 
+// WHY: wire DTO — aggregated listening time summary from the history table.
 #[derive(Debug, Clone)]
 pub struct ListeningTimeSummary {
     pub total_ms: i64,
@@ -90,6 +96,7 @@ pub struct ListeningTimeSummary {
     pub session_count: i32,
 }
 
+// WHY: wire DTO — SQLx aggregate streak record from play history.
 #[derive(Debug, Clone)]
 pub struct Streak {
     pub start: String,
@@ -97,6 +104,7 @@ pub struct Streak {
     pub days: i32,
 }
 
+// WHY: pure data — inclusive date range used in history queries.
 #[derive(Debug, Clone)]
 pub struct DateRange {
     pub start: String,

--- a/crates/apotheke/src/repo/podcast.rs
+++ b/crates/apotheke/src/repo/podcast.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the podcast_subscriptions table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct PodcastSubscription {
     pub id: Vec<u8>,
@@ -18,6 +19,7 @@ pub struct PodcastSubscription {
     pub added_at: String,
 }
 
+// WHY: wire DTO — SQLx row from the podcast_episodes table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct PodcastEpisode {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/quality.rs
+++ b/crates/apotheke/src/repo/quality.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the quality_profiles table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct QualityProfile {
     pub id: i64,
@@ -15,6 +16,7 @@ pub struct QualityProfile {
     pub upgrades_allowed: i64,
 }
 
+// WHY: wire DTO — SQLx row from the quality_ranks table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct QualityRankRow {
     pub rank: i64,

--- a/crates/apotheke/src/repo/registry.rs
+++ b/crates/apotheke/src/repo/registry.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the registry table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct RegistryEntry {
     pub id: Vec<u8>,
@@ -13,6 +14,7 @@ pub struct RegistryEntry {
     pub updated_at: String,
 }
 
+// WHY: wire DTO — SQLx row mapping a media item to an external identifier.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct RegistryExternalId {
     pub registry_id: Vec<u8>,

--- a/crates/apotheke/src/repo/tv.rs
+++ b/crates/apotheke/src/repo/tv.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the tv_series table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct TvSeries {
     pub id: Vec<u8>,
@@ -18,6 +19,7 @@ pub struct TvSeries {
     pub added_at: String,
 }
 
+// WHY: wire DTO — SQLx row from the tv_seasons table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct TvSeason {
     pub id: Vec<u8>,
@@ -29,6 +31,7 @@ pub struct TvSeason {
     pub overview: Option<String>,
 }
 
+// WHY: wire DTO — SQLx row from the tv_episodes table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct TvEpisode {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/want.rs
+++ b/crates/apotheke/src/repo/want.rs
@@ -3,6 +3,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the wants table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Want {
     pub id: Vec<u8>,
@@ -17,6 +18,7 @@ pub struct Want {
     pub fulfilled_at: Option<String>,
 }
 
+// WHY: wire DTO — SQLx row from the releases table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Release {
     pub id: Vec<u8>,
@@ -34,6 +36,7 @@ pub struct Release {
     pub rejected_reason: Option<String>,
 }
 
+// WHY: wire DTO — SQLx row from the haves table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Have {
     pub id: Vec<u8>,

--- a/crates/apotheke/src/repo/zone.rs
+++ b/crates/apotheke/src/repo/zone.rs
@@ -4,6 +4,7 @@ use sqlx::SqlitePool;
 
 use crate::error::{DbError, NotFoundSnafu, QuerySnafu};
 
+// WHY: wire DTO — SQLx row from the zones table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Zone {
     pub id: String,
@@ -11,6 +12,7 @@ pub struct Zone {
     pub created_at: String,
 }
 
+// WHY: wire DTO — SQLx row from the zone_members join table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct ZoneMemberRow {
     pub zone_id: String,
@@ -18,6 +20,7 @@ pub struct ZoneMemberRow {
     pub joined_at: String,
 }
 
+// WHY: wire DTO — SQLx row from the renderers table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Renderer {
     pub id: String,
@@ -26,6 +29,7 @@ pub struct Renderer {
     pub created_at: String,
 }
 
+// WHY: wire DTO — assembled zone with its member renderers from the database.
 #[derive(Debug, Clone)]
 pub struct ZoneWithMembers {
     pub zone: Zone,


### PR DESCRIPTION
Adds `// WHY:` carve-out markers for the `TOPOLOGY/shallow-struct` lint rule to all SQLx repository row types in `apotheke`. Adds `.kanon-lint-ignore` entries for `RUST/primitive-for-domain-id` violations in repo rows where newtypes would require a full SQLx impl refactor.\n\nFixes part of harmonia#326 and harmonia#327.