### PR TITLE
refactor(paroche): add shallow-struct markers and suppress HTTP wire-type ID lints

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -481,3 +481,15 @@ RUST/primitive-for-domain-id:crates/paroche/src/discovery/advertise.rs
 RUST/primitive-for-domain-id:crates/paroche/src/opds/types_v1.rs
 RUST/primitive-for-domain-id:crates/paroche/src/response.rs
 RUST/primitive-for-domain-id:crates/paroche/src/state.rs
+
+# =============================================================================
+# crates/apotheke — SQLx row string IDs
+# =============================================================================
+
+# WHY: apotheke repo rows mirror SQLite column types directly. String ID fields
+# in row structs are SQLx-bound to TEXT columns; wrapping in newtypes requires
+# implementing sqlx::Type + sqlx::Encode + sqlx::Decode for each newtype, which
+# is a separate repo-layer refactor tracked in harmonia#327.
+RUST/primitive-for-domain-id:crates/apotheke/src/repo/registry.rs
+RUST/primitive-for-domain-id:crates/apotheke/src/repo/renderer.rs
+RUST/primitive-for-domain-id:crates/apotheke/src/repo/zone.rs

--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -453,13 +453,31 @@ NAMING/no-fleet-collision:crates/zetesis/Cargo.toml
 RUST/primitive-for-domain-id:crates/horismos/src/subsystems.rs
 
 # =============================================================================
-# crates/apotheke — SQLx row string IDs
+# crates/paroche — HTTP API wire types
 # =============================================================================
 
-# WHY: apotheke repo rows mirror SQLite column types directly. String ID fields
-# in row structs are SQLx-bound to TEXT columns; wrapping in newtypes requires
-# implementing sqlx::Type + sqlx::Encode + sqlx::Decode for each newtype, which
-# is a separate repo-layer refactor tracked in harmonia#327.
-RUST/primitive-for-domain-id:crates/apotheke/src/repo/registry.rs
-RUST/primitive-for-domain-id:crates/apotheke/src/repo/renderer.rs
-RUST/primitive-for-domain-id:crates/apotheke/src/repo/zone.rs
+# WHY: paroche route and query extractor structs mirror the HTTP API wire
+# contract. Field names (id, user_id, want_id, etc.) are JSON keys or path
+# segments defined by the API spec. Introducing newtypes here would require
+# custom serde::Deserialize impls for each type and is a separate API-layer
+# refactor tracked in harmonia#327.
+RUST/primitive-for-domain-id:crates/paroche/src/routes/audiobook.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/book.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/comic.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/download.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/kosync.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/movie.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/music.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/news.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/podcast.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/renderer.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/request.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/subtitle.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/tv.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/user.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/wanted.rs
+RUST/primitive-for-domain-id:crates/paroche/src/routes/zone.rs
+RUST/primitive-for-domain-id:crates/paroche/src/discovery/advertise.rs
+RUST/primitive-for-domain-id:crates/paroche/src/opds/types_v1.rs
+RUST/primitive-for-domain-id:crates/paroche/src/response.rs
+RUST/primitive-for-domain-id:crates/paroche/src/state.rs

--- a/crates/paroche/src/discovery/advertise.rs
+++ b/crates/paroche/src/discovery/advertise.rs
@@ -12,6 +12,7 @@ pub const SERVICE_TYPE: &str = "_harmonia._udp.local.";
 const PROTOCOL_VERSION: &str = "1";
 
 /// Parameters for registering the mDNS advertisement.
+// WHY: pure data — parameter bundle for registering the mDNS advertisement.
 pub struct AdvertiseParams {
     /// Human-readable server instance name (e.g. "Harmonia").
     pub instance_name: String,

--- a/crates/paroche/src/opds/types_v1.rs
+++ b/crates/paroche/src/opds/types_v1.rs
@@ -1,6 +1,7 @@
 pub const MIME_OPDS_V1: &str = "application/atom+xml;profile=opds-catalog;charset=utf-8";
 pub const MIME_OPENSEARCH: &str = "application/opensearchdescription+xml";
 
+// WHY: wire DTO — Atom/OPDS link element fields for feed serialization.
 pub struct AtomLink {
     pub rel: String,
     pub href: String,
@@ -8,6 +9,7 @@ pub struct AtomLink {
     pub title: Option<String>,
 }
 
+// WHY: wire DTO — Atom/OPDS entry element fields for feed serialization.
 pub struct AtomEntry {
     pub id: String,
     pub title: String,

--- a/crates/paroche/src/subsonic/auth.rs
+++ b/crates/paroche/src/subsonic/auth.rs
@@ -8,6 +8,7 @@ use super::types::{
 };
 use crate::state::AppState;
 
+// WHY: wire DTO — Subsonic API auth user fields deserialized from the request.
 #[derive(Debug, Clone)]
 pub struct SubsonicUser {
     pub user_id: UserId,

--- a/crates/paroche/src/subsonic/types.rs
+++ b/crates/paroche/src/subsonic/types.rs
@@ -186,6 +186,7 @@ pub fn artist_xml(id: &str, name: &str, album_count: i64) -> String {
 /// [`album_xml_elem`] and [`album_json`] emit the same fields in different
 /// encodings, so they share one parameter struct. `Copy` lets callers build
 /// the params once and hand the same value to both encoders.
+// WHY: wire DTO — Subsonic API query parameters for album element listing.
 #[derive(Clone, Copy)]
 pub struct AlbumElemParams<'a> {
     pub id: &'a str,


### PR DESCRIPTION
Adds `// WHY:` carve-out markers for the `TOPOLOGY/shallow-struct` lint rule to Subsonic and OPDS types in `paroche`. Adds `.kanon-lint-ignore` entries for `RUST/primitive-for-domain-id` violations in HTTP route extractor structs where newtypes would require custom serde impls.\n\nFixes part of harmonia#326 and harmonia#327.