### PR TITLE
chore(deps): patch 3 RustSec advisories + clean kanon gate

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -318,6 +318,12 @@ SHELL/unpinned-action:crates/paroche/assets/reader/foliate-js-*/**
 YAML/missing-concurrency:crates/paroche/assets/reader/foliate-js-*/**
 YAML/missing-permissions:crates/paroche/assets/reader/foliate-js-*/**
 YAML/persist-credentials:crates/paroche/assets/reader/foliate-js-*/**
+# WHY: the vendored pdfjs cmaps (168 *.bcmap files) are binary; the WORKTREE
+# content-scanning rules read files as UTF-8 and error on them. Vendored
+# third-party binary assets are not subject to these text-oriented checks.
+WORKTREE/canonical-clean:crates/paroche/assets/reader/foliate-js-*/**
+WORKTREE/cargo-target-dir-committed:crates/paroche/assets/reader/foliate-js-*/**
+WORKTREE/agent-log-committed:crates/paroche/assets/reader/foliate-js-*/**
 
 # =============================================================================
 # crates/paroche/assets/reader/foliate-js-* — vendored upstream JS

--- a/.kanon-orchestration-exceptions.toml
+++ b/.kanon-orchestration-exceptions.toml
@@ -2,5 +2,5 @@
 # WHY: ci(security) workflow commit predates ORCHESTRATION/main-worktree-commit-prohibited
 # enforcement in this repo. Authored 2026-05-25 in the main worktree before the rule
 # was adopted; squash-merged, so the original ref no longer appears in history.
-"7222b787c9215eb7978a82e0cd78aa4de21e21b6" = "pre-rule commit: ci(security) add daily cargo-audit+deny workflow (2026-05-25); authored before ORCHESTRATION/main-worktree-commit-prohibited was enforced"
-"06d61b4b5bde5fe3fcc454624c2116cbed199368" = "pre-rule commit: ci(workflows) swap toolchain action (2026-05-25); authored before ORCHESTRATION/main-worktree-commit-prohibited was enforced"
+7222b787c9215eb7978a82e0cd78aa4de21e21b6 = "pre-rule commit: ci(security) add daily cargo-audit+deny workflow (2026-05-25); authored before ORCHESTRATION/main-worktree-commit-prohibited was enforced"
+06d61b4b5bde5fe3fcc454624c2116cbed199368 = "pre-rule commit: ci(workflows) swap toolchain action (2026-05-25); authored before ORCHESTRATION/main-worktree-commit-prohibited was enforced"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apotheke"
@@ -3098,9 +3098,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3956,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom",

--- a/deny.toml
+++ b/deny.toml
@@ -6,44 +6,47 @@ targets = []
 all-features = false
 
 [advisories]
-ignore = [
-    {
-      id = "RUSTSEC-2023-0071",
-      reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use",
-    },
-    {
-      id = "RUSTSEC-2025-0012",
-      reason = "backoff unmaintained — transitive dep via librqbit",
-    },
-    {
-      id = "RUSTSEC-2025-0141",
-      reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol",
-    },
-    {
-      id = "RUSTSEC-2025-0060",
-      reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper",
-    },
-    {
-      id = "RUSTSEC-2024-0384",
-      reason = "instant unmaintained — transitive dep via backoff/librqbit, no alternative",
-    },
-    {
-      id = "RUSTSEC-2024-0436",
-      reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis",
-    },
-    {
-      id = "RUSTSEC-2026-0009",
-      reason = "time RFC2822 stack exhaustion fix requires Rust 1.88; Harmonia CI is pinned to Rust 1.85 until MSRV policy changes",
-    },
-    {
-      id = "RUSTSEC-2026-0150",
-      reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available",
-    },
-    {
-      id = "RUSTSEC-2026-0097",
-      reason = "rand unsound with custom logger using `rand::rng()` — surfaces via sqlx/axum/quinn/reqwest; harmonia installs no custom logger that re-enters rand::rng(), so the unsound path is unreachable",
-    },
-]
+# WHY: expanded array-of-tables form. TOML 1.0 forbids newlines inside an
+# inline table (cargo-deny tolerates the multi-line form, strict parsers reject
+# it), and a long single-line inline table trips the TOML/inline-table-too-long
+# lint. [[advisories.ignore]] tables satisfy both. Keep the IDs in sync with
+# .cargo/audit.toml and osv-scanner.toml.
+
+[[advisories.ignore]]
+id = "RUSTSEC-2023-0071"
+reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0012"
+reason = "backoff unmaintained — transitive dep via librqbit"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0141"
+reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0060"
+reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2024-0384"
+reason = "instant unmaintained — transitive dep via backoff/librqbit, no alternative"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2024-0436"
+reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0009"
+reason = "time RFC2822 stack exhaustion fix requires Rust 1.88; Harmonia CI is pinned to Rust 1.85 until MSRV policy changes"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0150"
+reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available"
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0097"
+reason = "rand unsound with custom logger using `rand::rng()` — surfaces via sqlx/axum/quinn/reqwest; harmonia installs no custom logger that re-enters rand::rng(), so the unsound path is unreachable"
 
 [licenses]
 allow = [


### PR DESCRIPTION
Restores a green `Security` workflow and `ci.yml` Audit job on `main`, and brings the repo to a clean `kanon gate --full` (the local gate every PR is expected to pass before push).

## Advisory patches (the actual failures on main)

| Crate | From | To | Advisory | Class |
|-------|------|----|----------|-------|
| quinn-proto | 0.11.14 | 0.11.15 | RUSTSEC-2026-0185 | vuln — remote memory exhaustion via unbounded out-of-order stream reassembly |
| anyhow | 1.0.102 | 1.0.103 | RUSTSEC-2026-0190 | unsound — `Error::downcast_mut()` |
| memmap2 | 0.9.10 | 0.9.11 | RUSTSEC-2026-0186 | unsound — unchecked pointer offset |

Surgical `Cargo.lock` edit (version + checksum only). A full `cargo update -p …` re-resolves `windows-sys` 0.61→0.60 across the tree, introducing an unskipped duplicate pair that fails the `deny.toml` `multiple-versions = deny` bans check. quinn-proto 0.11.15 has byte-identical dependency edges to 0.11.14, so no graph change results.

## Gate hygiene (pre-existing issues surfaced by `kanon gate --full`)

- **deny.toml** — `[advisories].ignore` used multi-line inline tables, which are invalid TOML 1.0 (tolerated by cargo-deny, rejected by the gate's advisory-parity parser). Expanded to `[[advisories.ignore]]` tables (spec-compliant, cargo-deny-accepted, and clear of `TOML/inline-table-too-long`).
- **.kanon-lint-ignore** — the vendored foliate-js pdf.js cmaps (168 binary `*.bcmap` files) crash the content-scanning `WORKTREE/*` rules, which read every file as UTF-8. Added the three affected rules to the existing vendored-asset ignore block. Root cause (basanos should skip binary files) tracked in forkwright/kanon#2359.
- **.kanon-orchestration-exceptions.toml** — unquoted two bare-key commit SHAs (`TOML/quoted-bare-key`).

## Verification (local, CI-exact)

`kanon gate --full` passes all stages: fmt, check, advisory-parity, deterministic-derive, fitness, cargo-deny, clippy (workspace), nextest (workspace, 1159 tests), kanon lint, fleet-names. `cargo audit --deny unmaintained --deny unsound --deny yanked` clean; `cargo deny check advisories licenses bans sources` all ok.