### PR TITLE
fix(exousia): harden auth paths (constant-time keys, DB-authoritative bearer, refresh TOCTOU)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "sha2 0.11.0",
  "snafu",
  "sqlx",
+ "subtle",
  "themelion",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ sqlx = { version = "0.8.6", features = [
 jsonwebtoken    = { version = "10", features = ["rust_crypto"] }
 argon2          = "0.5"
 rand            = "0.10"
+subtle          = "2.6.1"
 
 # ── IDs & strings ─────────────────────────────────────────────────────────────
 ulid                    = { version = "1.2", features = ["serde"] }

--- a/crates/apotheke/src/error.rs
+++ b/crates/apotheke/src/error.rs
@@ -26,6 +26,13 @@ pub enum DbError {
         location: snafu::Location,
     },
 
+    #[snafu(display("transaction failed: {source}"))]
+    Transaction {
+        source: sqlx::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("record not found in {table}: {id}"))]
     NotFound {
         table: String,

--- a/crates/apotheke/src/lib.rs
+++ b/crates/apotheke/src/lib.rs
@@ -5,4 +5,4 @@ pub mod repo;
 
 pub use error::DbError;
 pub use migrate::run_migrations;
-pub use pools::{DbPools, init_pools};
+pub use pools::{DbPools, begin_immediate, commit_tx, init_pools};

--- a/crates/apotheke/src/pools.rs
+++ b/crates/apotheke/src/pools.rs
@@ -1,14 +1,30 @@
 use snafu::ResultExt;
-use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
+use sqlx::{Sqlite, SqlitePool, Transaction};
 
-use crate::error::{DbError, PoolInitSnafu};
+use crate::error::{DbError, PoolInitSnafu, TransactionSnafu};
 use crate::migrate::run_migrations;
 
 // WHY: pure data — handles to all SQLite connection pools used by the apotheke repo layer.
 pub struct DbPools {
     pub read: SqlitePool,
     pub write: SqlitePool,
+}
+
+/// Begins a write transaction with `BEGIN IMMEDIATE`.
+///
+/// WHY: SQLite's default deferred `BEGIN` acquires the write lock only at the
+/// first write statement, so a read-check-write sequence can interleave with a
+/// concurrent writer. `BEGIN IMMEDIATE` takes the write lock up front, making
+/// the whole transaction serialize against other writers.
+pub async fn begin_immediate(pool: &SqlitePool) -> Result<Transaction<'static, Sqlite>, DbError> {
+    pool.begin_with("BEGIN IMMEDIATE")
+        .await
+        .context(TransactionSnafu)
+}
+
+pub async fn commit_tx(tx: Transaction<'static, Sqlite>) -> Result<(), DbError> {
+    tx.commit().await.context(TransactionSnafu)
 }
 
 pub async fn init_pools(db_path: &str) -> Result<DbPools, DbError> {

--- a/crates/apotheke/src/repo/user.rs
+++ b/crates/apotheke/src/repo/user.rs
@@ -99,14 +99,19 @@ pub async fn insert_user(pool: &SqlitePool, user: &User) -> Result<(), DbError> 
     Ok(())
 }
 
-pub async fn get_user(pool: &SqlitePool, id: &[u8]) -> Result<Option<User>, DbError> {
+// NOTE: executor-generic so callers can run this inside a transaction
+// (`&mut *tx`) or directly on a pool (`&pool`).
+pub async fn get_user<'e, E>(executor: E, id: &[u8]) -> Result<Option<User>, DbError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     sqlx::query_as::<_, User>(
         "SELECT id, username, display_name, password_hash, role, is_active,
                 created_at, last_login_at
          FROM users WHERE id = ?",
     )
     .bind(id)
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await
     .context(QuerySnafu { table: "users" })
 }
@@ -189,7 +194,12 @@ pub async fn delete_user(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
 
 // --- refresh tokens ---
 
-pub async fn insert_refresh_token(pool: &SqlitePool, token: &RefreshToken) -> Result<(), DbError> {
+// NOTE: executor-generic so token rotation can run check-revoke-insert inside
+// one `BEGIN IMMEDIATE` transaction (`&mut *tx`) instead of racing across pools.
+pub async fn insert_refresh_token<'e, E>(executor: E, token: &RefreshToken) -> Result<(), DbError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     sqlx::query(
         "INSERT INTO refresh_tokens (id, user_id, token_hash, created_at, expires_at, revoked)
          VALUES (?, ?, ?, ?, ?, ?)",
@@ -200,7 +210,7 @@ pub async fn insert_refresh_token(pool: &SqlitePool, token: &RefreshToken) -> Re
     .bind(&token.created_at)
     .bind(&token.expires_at)
     .bind(token.revoked)
-    .execute(pool)
+    .execute(executor)
     .await
     .context(QuerySnafu {
         table: "refresh_tokens",
@@ -208,26 +218,32 @@ pub async fn insert_refresh_token(pool: &SqlitePool, token: &RefreshToken) -> Re
     Ok(())
 }
 
-pub async fn get_refresh_token_by_hash(
-    pool: &SqlitePool,
+pub async fn get_refresh_token_by_hash<'e, E>(
+    executor: E,
     token_hash: &str,
-) -> Result<Option<RefreshToken>, DbError> {
+) -> Result<Option<RefreshToken>, DbError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     sqlx::query_as::<_, RefreshToken>(
         "SELECT id, user_id, token_hash, created_at, expires_at, revoked
          FROM refresh_tokens WHERE token_hash = ?",
     )
     .bind(token_hash)
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await
     .context(QuerySnafu {
         table: "refresh_tokens",
     })
 }
 
-pub async fn revoke_refresh_token(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+pub async fn revoke_refresh_token<'e, E>(executor: E, id: &[u8]) -> Result<(), DbError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     sqlx::query("UPDATE refresh_tokens SET revoked = 1 WHERE id = ?")
         .bind(id)
-        .execute(pool)
+        .execute(executor)
         .await
         .context(QuerySnafu {
             table: "refresh_tokens",

--- a/crates/exousia/Cargo.toml
+++ b/crates/exousia/Cargo.toml
@@ -13,6 +13,7 @@ snafu.workspace = true
 tracing.workspace = true
 jsonwebtoken.workspace = true
 argon2.workspace = true
+subtle.workspace = true
 rand.workspace = true
 uuid.workspace = true
 serde.workspace = true

--- a/crates/exousia/src/api_key.rs
+++ b/crates/exousia/src/api_key.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
 use themelion::ids::ApiKeyId;
 
 // WHY: wire DTO — API key fields returned from the database.
@@ -52,6 +53,10 @@ pub fn generate_renderer_key() -> (String, ApiKeyRecord) {
 }
 
 /// Validates a full API key string against the stored SHA-256 hash of the long token.
+///
+/// WARNING: the hash comparison MUST stay constant-time (`ConstantTimeEq::ct_eq`).
+/// A plain `==` on the hex digests short-circuits on the first differing byte and
+/// leaks a timing side-channel on this authentication path.
 pub fn validate_api_key(key: &str, stored_hash: &str) -> bool {
     let parts: Vec<&str> = key.split('_').collect();
     let long_token = match parts.as_slice() {
@@ -59,7 +64,12 @@ pub fn validate_api_key(key: &str, stored_hash: &str) -> bool {
         ["hmn", "rnd", _short, long] => *long,
         _ => return false,
     };
-    sha256_hex(long_token.as_bytes()) == stored_hash
+    // NOTE: ct_eq on differing-length slices returns false without inspecting
+    // contents; both sides are 64 hex chars by construction, so no length leak.
+    sha256_hex(long_token.as_bytes())
+        .as_bytes()
+        .ct_eq(stored_hash.as_bytes())
+        .into()
 }
 
 #[cfg(test)]
@@ -120,6 +130,22 @@ mod tests {
     fn validate_api_key_fails_with_wrong_hash() {
         let (key, _) = generate_api_key();
         assert!(!validate_api_key(&key, "wronghash"));
+    }
+
+    #[test]
+    fn validate_api_key_fails_with_near_miss_hash() {
+        let (key, record) = generate_api_key();
+        let mut near_miss = record.long_token_hash.clone();
+        let last = near_miss.pop().map(|c| if c == '0' { '1' } else { '0' });
+        near_miss.push(last.unwrap_or('0'));
+        assert_ne!(near_miss, record.long_token_hash);
+        assert!(!validate_api_key(&key, &near_miss));
+    }
+
+    #[test]
+    fn validate_api_key_fails_with_empty_stored_hash() {
+        let (key, _) = generate_api_key();
+        assert!(!validate_api_key(&key, ""));
     }
 
     #[test]

--- a/crates/exousia/src/jwt.rs
+++ b/crates/exousia/src/jwt.rs
@@ -26,6 +26,9 @@ pub struct Claims {
     pub exp: u64,
     pub iat: u64,
     pub jti: String,
+    /// Role snapshot at token-mint time. Informational only, never authoritative:
+    /// authorization decisions read the live user row from the database
+    /// (`validate_bearer` re-fetches role and `is_active` per request).
     pub role: String,
     pub display_name: String,
 }

--- a/crates/exousia/src/lib.rs
+++ b/crates/exousia/src/lib.rs
@@ -124,6 +124,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn refresh_concurrent_double_use_returns_one_success() {
+        // WHY: max_connections(1) mirrors the production write pool and keeps
+        // sqlite::memory: on a single database across both concurrent tasks.
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let pools = Arc::new(DbPools {
+            read: pool.clone(),
+            write: pool.clone(),
+        });
+        let config = ExousiaConfig {
+            access_token_ttl_secs: 900,
+            refresh_token_ttl_days: 30,
+            jwt_secret: "test-secret-that-is-long-enough-for-hs256".to_string(),
+        };
+        let service = Arc::new(ExousiaServiceImpl::new(pools, config));
+        create_test_user(&service).await;
+        let pair = service.login("testuser", "password123").await.unwrap();
+        let (r1, r2) = tokio::join!(
+            service.refresh(&pair.refresh_token),
+            service.refresh(&pair.refresh_token)
+        );
+        let ok_count = usize::from(r1.is_ok()) + usize::from(r2.is_ok());
+        assert_eq!(ok_count, 1, "exactly one concurrent refresh must succeed");
+        let failure = if r1.is_err() { r1.err() } else { r2.err() };
+        assert!(matches!(failure, Some(ExousiaError::TokenInvalid { .. })));
+        let (total,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM refresh_tokens")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let (active,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM refresh_tokens WHERE revoked = 0")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(total, 2, "original token plus exactly one rotation");
+        assert_eq!(active, 1, "only the rotated token remains active");
+    }
+
+    #[tokio::test]
+    async fn refresh_rejects_deactivated_user() {
+        let service = setup().await;
+        let user = create_test_user(&service).await;
+        let pair = service.login("testuser", "password123").await.unwrap();
+        apotheke::repo::user::deactivate_user(
+            &service.pools().write,
+            user.id.as_bytes().as_slice(),
+        )
+        .await
+        .unwrap();
+        let err = service.refresh(&pair.refresh_token).await.unwrap_err();
+        assert!(matches!(err, ExousiaError::UserInactive { .. }));
+    }
+
+    #[tokio::test]
     async fn logout_revokes_refresh_token() {
         let service = setup().await;
         create_test_user(&service).await;
@@ -168,6 +226,71 @@ mod tests {
         .unwrap();
         let err = service.validate_bearer(&expired_token).await.unwrap_err();
         assert!(matches!(err, ExousiaError::TokenExpired { .. }));
+    }
+
+    #[tokio::test]
+    async fn bearer_reflects_role_demotion() {
+        let service = setup().await;
+        let user = service
+            .create_user(CreateUserRequest {
+                username: "admin-user".to_string(),
+                display_name: "Admin User".to_string(),
+                password: "password123".to_string(),
+                role: UserRole::Admin,
+            })
+            .await
+            .unwrap();
+        let pair = service.login("admin-user", "password123").await.unwrap();
+        let before = service.validate_bearer(&pair.access_token).await.unwrap();
+        assert_eq!(before.role, UserRole::Admin);
+        apotheke::repo::user::update_user(
+            &service.pools().write,
+            user.id.as_bytes().as_slice(),
+            "Admin User",
+            "member",
+        )
+        .await
+        .unwrap();
+        let after = service.validate_bearer(&pair.access_token).await.unwrap();
+        assert_eq!(
+            after.role,
+            UserRole::Member,
+            "role must come from the live DB row, not the stale JWT claim"
+        );
+    }
+
+    #[tokio::test]
+    async fn bearer_rejects_deactivated_user() {
+        let service = setup().await;
+        let user = create_test_user(&service).await;
+        let pair = service.login("testuser", "password123").await.unwrap();
+        service.validate_bearer(&pair.access_token).await.unwrap();
+        apotheke::repo::user::deactivate_user(
+            &service.pools().write,
+            user.id.as_bytes().as_slice(),
+        )
+        .await
+        .unwrap();
+        let err = service
+            .validate_bearer(&pair.access_token)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ExousiaError::UserInactive { .. }));
+    }
+
+    #[tokio::test]
+    async fn bearer_rejects_deleted_user() {
+        let service = setup().await;
+        let user = create_test_user(&service).await;
+        let pair = service.login("testuser", "password123").await.unwrap();
+        apotheke::repo::user::delete_user(&service.pools().write, user.id.as_bytes().as_slice())
+            .await
+            .unwrap();
+        let err = service
+            .validate_bearer(&pair.access_token)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ExousiaError::TokenInvalid { .. }));
     }
 
     #[tokio::test]

--- a/crates/exousia/src/middleware.rs
+++ b/crates/exousia/src/middleware.rs
@@ -25,12 +25,14 @@ fn correlation_id() -> String {
     })
 }
 
+// WARNING: no query-parameter credential path. Tokens in URLs leak through
+// access logs, referrer headers, and browser history; only header-delivered
+// credentials (Authorization, X-Api-Key) are accepted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum AuthMethod {
     Bearer,
     ApiKey,
-    QueryParam,
 }
 
 #[derive(Clone)]
@@ -92,13 +94,6 @@ fn extract_api_key_header(parts: &Parts) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-fn extract_query_token(parts: &Parts) -> Option<String> {
-    parts.uri.query().and_then(|q| {
-        q.split('&')
-            .find_map(|pair| pair.strip_prefix("token=").map(|v| v.to_string()))
-    })
-}
-
 impl<S> FromRequestParts<S> for AuthenticatedUser
 where
     S: Send + Sync,
@@ -121,17 +116,6 @@ where
                 .validate_api_key(&key)
                 .await
                 .map_err(|_| unauthorized("invalid or revoked API key"));
-        }
-
-        if let Some(token) = extract_query_token(parts) {
-            return service
-                .validate_bearer(&token)
-                .await
-                .map(|mut u| {
-                    u.auth_method = AuthMethod::QueryParam;
-                    u
-                })
-                .map_err(|_| unauthorized("invalid or expired token"));
         }
 
         Err(unauthorized("authentication required"))
@@ -255,7 +239,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn query_param_token_produces_authenticated_user() {
+    async fn query_param_token_is_rejected() {
         let service = setup().await;
         let (_, token) = make_user_and_token(&service, "carol", UserRole::Member).await;
         let response = app(service)
@@ -267,7 +251,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -196,9 +196,15 @@ impl AuthService for ExousiaServiceImpl {
         })
     }
 
+    // INVARIANT: check-revoke-insert runs inside one BEGIN IMMEDIATE transaction
+    // on the write pool. A concurrent refresh of the same token blocks at begin,
+    // then observes revoked = 1 and fails — a refresh token can be used once.
     async fn refresh(&self, refresh_token: &str) -> Result<TokenPair, ExousiaError> {
         let token_hash = sha256_hex(refresh_token.as_bytes());
-        let row = db::get_refresh_token_by_hash(&self.pools.read, &token_hash)
+        let mut tx = apotheke::begin_immediate(&self.pools.write)
+            .await
+            .context(DatabaseSnafu)?;
+        let row = db::get_refresh_token_by_hash(&mut *tx, &token_hash)
             .await
             .context(DatabaseSnafu)?;
         let row = row.ok_or_else(|| ExousiaError::TokenInvalid {
@@ -217,7 +223,7 @@ impl AuthService for ExousiaServiceImpl {
                 location: snafu::location!(),
             });
         }
-        let user_row = db::get_user(&self.pools.read, &row.user_id)
+        let user_row = db::get_user(&mut *tx, &row.user_id)
             .await
             .context(DatabaseSnafu)?
             .ok_or_else(|| ExousiaError::TokenInvalid {
@@ -231,7 +237,7 @@ impl AuthService for ExousiaServiceImpl {
         if !user.is_active {
             return Err(UserInactiveSnafu.build());
         }
-        db::revoke_refresh_token(&self.pools.write, &row.id)
+        db::revoke_refresh_token(&mut *tx, &row.id)
             .await
             .context(DatabaseSnafu)?;
         let access_token = jwt::create_access_token(
@@ -249,9 +255,10 @@ impl AuthService for ExousiaServiceImpl {
             expires_at: add_days_to_iso_now(self.config.refresh_token_ttl_days),
             revoked: 0,
         };
-        db::insert_refresh_token(&self.pools.write, &new_row)
+        db::insert_refresh_token(&mut *tx, &new_row)
             .await
             .context(DatabaseSnafu)?;
+        apotheke::commit_tx(tx).await.context(DatabaseSnafu)?;
         Ok(TokenPair {
             access_token,
             refresh_token: new_refresh_token,
@@ -271,6 +278,9 @@ impl AuthService for ExousiaServiceImpl {
         Ok(())
     }
 
+    // INVARIANT: the JWT is authoritative only for identity (signature + sub);
+    // role and is_active come from the live user row so revocation and role
+    // demotion take effect within the token's lifetime, matching validate_api_key.
     async fn validate_bearer(&self, token: &str) -> Result<AuthenticatedUser, ExousiaError> {
         let claims = jwt::validate_token(token, self.config.jwt_secret.as_bytes())?;
         let uuid = uuid::Uuid::parse_str(&claims.sub).map_err(|_| ExousiaError::TokenInvalid {
@@ -278,13 +288,23 @@ impl AuthService for ExousiaServiceImpl {
             location: snafu::location!(),
         })?;
         let user_id = UserId::from_uuid(uuid);
-        let role = UserRole::parse(&claims.role).ok_or_else(|| ExousiaError::TokenInvalid {
-            error: "invalid role claim".to_string(),
+        let user_row = db::get_user(&self.pools.read, &user_id_to_bytes(user_id))
+            .await
+            .context(DatabaseSnafu)?
+            .ok_or_else(|| ExousiaError::TokenInvalid {
+                error: "user not found for bearer token".to_string(),
+                location: snafu::location!(),
+            })?;
+        let user = db_user_to_domain(user_row).ok_or_else(|| ExousiaError::TokenInvalid {
+            error: "invalid user data".to_string(),
             location: snafu::location!(),
         })?;
+        if !user.is_active {
+            return Err(UserInactiveSnafu.build());
+        }
         Ok(AuthenticatedUser {
-            user_id,
-            role,
+            user_id: user.id,
+            role: user.role,
             auth_method: AuthMethod::Bearer,
         })
     }

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -139,17 +139,16 @@ API keys are long-lived and manually revocable; there is no TTL. Users revoke th
 
 ## Request authentication
 
-Three credential paths, processed in priority order:
+Two credential paths, processed in priority order:
 
-| Priority | Method | Header / Parameter | Use case |
-|----------|--------|--------------------|----------|
+| Priority | Method | Header | Use case |
+|----------|--------|--------|----------|
 | 1 | Bearer token | `Authorization: Bearer <jwt>` | Web UI, Android app |
 | 2 | API key | `X-Api-Key: hmn_{short}_{long}` | External tools, OPDS readers, automation |
-| 3 | Query parameter token | `?token=<jwt>` | Streaming/media routes only |
 
-**Why the query parameter path exists:** Browser elements (`<audio>`, `<img>`, `<video>`) cannot set custom headers. Media routes that serve binary content directly (audio streams, cover art, book files) must accept a JWT via query parameter. This is the same pattern used by the existing C# backend. Query parameter tokens carry the same JWT payload and are subject to the same expiry; they are not weaker credentials, just differently delivered.
+**Why there is no query-parameter path:** credentials in URLs leak through access logs, referrer headers, proxies, and browser history, and a leaked URL token grants a full-duration session. Clients that cannot set headers (browser `<audio>` / `<video>` / `<img>` elements) need a dedicated short-TTL, path-scoped stream-token design before any URL-delivered credential is introduced.
 
-**All three paths produce the same result:** an `AuthenticatedUser` struct passed to downstream handlers. The auth method is recorded but does not affect what the user can do.
+**Both paths produce the same result:** an `AuthenticatedUser` struct passed to downstream handlers. The auth method is recorded but does not affect what the user can do.
 
 ---
 
@@ -198,19 +197,18 @@ The transport is [Syndesis](../serving/streaming.md) (QUIC).
 
 Two extractors in `archon` (or a dedicated auth middleware crate):
 
-**`AuthenticatedUser`:** tries all three credential paths in priority order:
+**`AuthenticatedUser`:** tries both credential paths in priority order:
 
 ```rust
 pub struct AuthenticatedUser {
     pub user_id: UserId,
     pub role: UserRole,
-    pub auth_method: AuthMethod,  // Bearer | ApiKey | QueryParam
+    pub auth_method: AuthMethod,  // Bearer | ApiKey
 }
 
 pub enum AuthMethod {
     Bearer,
     ApiKey,
-    QueryParam,
 }
 ```
 

--- a/docs/serving/streaming.md
+++ b/docs/serving/streaming.md
@@ -143,19 +143,19 @@ Unknown extensions fall back to `application/octet-stream`.
 
 ## Authentication for streaming
 
-Paroche uses the three-path `AuthenticatedUser` extractor established in
-[auth.md](../architecture/auth.md). All three paths produce the same `AuthenticatedUser`
+Paroche uses the two-path `AuthenticatedUser` extractor established in
+[auth.md](../architecture/auth.md). Both paths produce the same `AuthenticatedUser`
 struct; auth method does not affect stream access.
 
 | Priority | Method | Credential | Client |
 |----------|--------|------------|--------|
 | 1 | Bearer JWT | `Authorization: Bearer <token>` | Akouo web UI, Android app |
 | 2 | API Key | `X-Api-Key: hmn_{short}_{long}` | OPDS e-readers, long-lived automation |
-| 3 | Query param | `?token=<jwt>` | Browser `<audio>` / `<video>` elements |
 
-The query parameter path exists because browser media elements cannot set custom headers.
-Query param tokens carry the same JWT payload and expiry as Bearer tokens; they are not weaker
-credentials, just differently delivered.
+No query-parameter credential path exists: tokens in URLs leak through access logs,
+referrer headers, and browser history. Browser media elements that cannot set custom
+headers require a dedicated short-TTL, path-scoped stream-token design before any
+URL-delivered credential is introduced.
 
 **Authorization:** After authentication, Paroche calls `Exousia::authorize(&user,
 Operation::Stream, ct)` before opening any file. 403 Forbidden returned if the user is


### PR DESCRIPTION
Closes #473, #418, #419, #420.

## Changes

- **#473 — constant-time API-key comparison.** `validate_api_key` compared SHA-256 hex digests with `==`, leaking a timing side-channel on an auth path. Now uses `subtle::ConstantTimeEq`. Class-swept the crate for other secret `==` comparisons (none remained). Near-miss + empty-hash tests added.
- **#418 — DB-authoritative bearer.** `validate_bearer` trusted the JWT `role` claim and never re-checked the user, diverging from `validate_api_key`. It now fetches the user row and takes `role` + `is_active` from the DB, so revocation and role demotion take effect within a token's lifetime. The JWT is authoritative for identity only. Tests: role-demotion-reflected, deactivated-user-rejected, deleted-user-rejected.
- **#419 — refresh-token TOCTOU.** `refresh()` ran read-check-revoke-insert as three unsynchronized statements across pools, allowing double-use under concurrency. Now one `BEGIN IMMEDIATE` transaction on the single-writer pool (adds apotheke `begin_immediate`/`commit_tx` and generalizes the refresh-token repo fns over an `Executor`). Concurrent-double-use test asserts exactly one success and no orphaned rows.
- **#420 — query-param token removal.** The `?token=` path minted a full-duration bearer session; a repo-wide grep found no consumer (theatron uses `bearer_auth` only). Removed `extract_query_token`, its call site, and `AuthMethod::QueryParam`. Docs updated to describe the header-only model and the short-TTL stream-token precondition for any future URL-delivered credential.

## Verification

`kanon gate --full` green (fmt, check, advisory-parity, cargo-deny, clippy workspace, nextest 1166 tests, kanon lint). Cross-crate: full-workspace clippy+test confirm archon and callers compile against the generalized apotheke signatures.