### PR TITLE
fix(syndesis): secure renderer client (pinned TLS, reassembly, bounded buffers)

### DIFF
--- a/crates/horismos/src/config.rs
+++ b/crates/horismos/src/config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
     KomideConfig, KritikeConfig, ParocheConfig, ProsthekeConfig, SearchSubsystemConfig,
-    SyndesmosConfig, SyntaxisConfig, TaxisConfig,
+    SyndesisConfig, SyndesmosConfig, SyntaxisConfig, TaxisConfig,
 };
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -35,6 +35,8 @@ pub struct Config {
     pub komide: KomideConfig,
     #[serde(default)]
     pub syndesmos: SyndesmosConfig,
+    #[serde(default)]
+    pub syndesis: SyndesisConfig,
     #[serde(default)]
     pub aitesis: AitesisConfig,
 }

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -18,8 +18,8 @@ use snafu::ResultExt;
 pub use subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
     KomideConfig, KritikeConfig, LastfmConfig, LibraryConfig, MediaType, OpenSubtitlesConfig,
-    ParocheConfig, PlexConfig, ProsthekeConfig, SearchSubsystemConfig, SyndesmosConfig,
-    SyntaxisConfig, TaxisConfig, TidalConfig, TrackerSeedPolicy, WatcherMode,
+    ParocheConfig, PlexConfig, ProsthekeConfig, SearchSubsystemConfig, SyndesisConfig,
+    SyndesmosConfig, SyntaxisConfig, TaxisConfig, TidalConfig, TrackerSeedPolicy, WatcherMode,
 };
 pub use validation::ValidationWarning;
 
@@ -95,6 +95,43 @@ mod tests {
         assert!(config.syndesmos.lastfm.is_none());
         assert!(config.syndesmos.tidal.is_none());
         assert_eq!(config.syndesmos.circuit_break_minutes, 5);
+    }
+
+    #[test]
+    fn default_syndesis_config_has_correct_values() {
+        let config = Config::default();
+        assert_eq!(config.syndesis.jitter_buffer_max_frames, 512);
+        assert_eq!(config.syndesis.max_sessions, 32);
+    }
+
+    #[test]
+    fn syndesis_toml_section_overrides_defaults() {
+        with_jail(|jail| {
+            jail.create_file(
+                "harmonia.toml",
+                &format!(
+                    "[exousia]\njwt_secret = \"{}\"\n\n[syndesis]\njitter_buffer_max_frames = 64\nmax_sessions = 4\n",
+                    valid_jwt_secret()
+                ),
+            )
+            .unwrap();
+            let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
+            assert_eq!(config.syndesis.jitter_buffer_max_frames, 64);
+            assert_eq!(config.syndesis.max_sessions, 4);
+        });
+    }
+
+    #[test]
+    fn validation_rejects_zero_syndesis_limits() {
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.syndesis.max_sessions = 0;
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("max_sessions"));
+
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.syndesis.jitter_buffer_max_frames = 0;
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("jitter_buffer_max_frames"));
     }
 
     // ── TOML file overrides defaults ──────────────────────────────────────────

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -502,6 +502,26 @@ impl Default for SyndesmosConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct SyndesisConfig {
+    /// Maximum frames a renderer's jitter buffer holds before evicting the
+    /// oldest. Bounds renderer memory when playout stalls mid-stream.
+    pub jitter_buffer_max_frames: usize,
+    /// Maximum concurrent renderer sessions the streaming server accepts;
+    /// further connections are refused before the TLS handshake.
+    pub max_sessions: usize,
+}
+
+impl Default for SyndesisConfig {
+    fn default() -> Self {
+        Self {
+            jitter_buffer_max_frames: 512,
+            max_sessions: 32,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AitesisConfig {
     /// Maximum number of Submitted + Approved + Monitoring requests per user.
     pub max_pending_per_user: u32,

--- a/crates/horismos/src/validation.rs
+++ b/crates/horismos/src/validation.rs
@@ -16,9 +16,26 @@ pub fn validate_config(config: &Config) -> Result<Vec<ValidationWarning>, Horism
     validate_jwt_secret(config)?;
     validate_ports(config)?;
     validate_timeouts(config)?;
+    validate_limits(config)?;
     collect_library_warnings(config, &mut warnings);
 
     Ok(warnings)
+}
+
+fn validate_limits(config: &Config) -> Result<(), HorismosError> {
+    if config.syndesis.jitter_buffer_max_frames == 0 {
+        return ValidationSnafu {
+            message: "syndesis.jitter_buffer_max_frames must be greater than 0".to_string(),
+        }
+        .fail();
+    }
+    if config.syndesis.max_sessions == 0 {
+        return ValidationSnafu {
+            message: "syndesis.max_sessions must be greater than 0".to_string(),
+        }
+        .fail();
+    }
+    Ok(())
 }
 
 fn validate_jwt_secret(config: &Config) -> Result<(), HorismosError> {

--- a/crates/syndesis/src/client/buffer.rs
+++ b/crates/syndesis/src/client/buffer.rs
@@ -8,31 +8,38 @@ use crate::protocol::frame::AudioFrame;
 pub struct JitterBuffer {
     frames: BTreeMap<u64, AudioFrame>,
     depth_us: u64,
+    max_frames: usize,
     next_sequence: u64,
     clock_offset_us: i64,
     gap_count: u64,
+    dropped_count: u64,
 }
 
 impl JitterBuffer {
     #[must_use]
     pub fn new() -> Self {
-        Self::with_depth_ms(ClientConfig::default().jitter_buffer_depth_ms)
+        Self::with_config(&ClientConfig::default())
     }
 
     #[must_use]
     pub fn with_config(config: &ClientConfig) -> Self {
-        Self::with_depth_ms(config.jitter_buffer_depth_ms)
+        Self {
+            frames: BTreeMap::new(),
+            depth_us: config.jitter_buffer_depth_ms * 1000,
+            max_frames: config.jitter_buffer_max_frames,
+            next_sequence: 0,
+            clock_offset_us: 0,
+            gap_count: 0,
+            dropped_count: 0,
+        }
     }
 
     #[must_use]
     pub fn with_depth_ms(depth_ms: u64) -> Self {
-        Self {
-            frames: BTreeMap::new(),
-            depth_us: depth_ms * 1000,
-            next_sequence: 0,
-            clock_offset_us: 0,
-            gap_count: 0,
-        }
+        Self::with_config(&ClientConfig {
+            jitter_buffer_depth_ms: depth_ms,
+            ..ClientConfig::default()
+        })
     }
 
     /// Update the clock OFFSET used for playout timing.
@@ -41,7 +48,18 @@ impl JitterBuffer {
     }
 
     /// Insert a received frame into the buffer.
+    ///
+    /// At `max_frames` capacity the oldest buffered frame is evicted first,
+    /// bounding memory when playout stalls while the stream keeps flowing.
     pub fn insert(&mut self, frame: AudioFrame) {
+        while self.frames.len() >= self.max_frames {
+            if let Some((&oldest, _)) = self.frames.first_key_value() {
+                self.frames.remove(&oldest);
+                self.dropped_count += 1;
+            } else {
+                break;
+            }
+        }
         self.frames.insert(frame.sequence, frame);
     }
 
@@ -100,6 +118,12 @@ impl JitterBuffer {
     #[must_use]
     pub fn gap_count(&self) -> u64 {
         self.gap_count
+    }
+
+    /// Number of frames evicted because the buffer was at capacity.
+    #[must_use]
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped_count
     }
 
     /// Estimated buffer depth in milliseconds based on timestamp span.
@@ -190,6 +214,38 @@ mod tests {
         buf.insert(test_frame(0, 0));
         buf.insert(test_frame(1, 50_000));
         assert_eq!(buf.depth_ms(), 50);
+    }
+
+    #[test]
+    fn jitter_buffer_evicts_oldest_when_full() {
+        let config = ClientConfig {
+            jitter_buffer_max_frames: 3,
+            ..ClientConfig::default()
+        };
+        let mut buf = JitterBuffer::with_config(&config);
+        for seq in 0..4u64 {
+            buf.insert(test_frame(seq, seq * 1000));
+        }
+
+        assert_eq!(buf.len(), 3, "capacity cap must hold");
+        assert_eq!(buf.dropped_count(), 1, "one eviction expected");
+        // Oldest (seq 0) evicted; the next playable frame is seq 1.
+        let first = buf.pop_ready(u64::MAX).map(|f| f.sequence);
+        assert_eq!(first, Some(1));
+    }
+
+    #[test]
+    fn jitter_buffer_length_never_exceeds_cap_without_playout() {
+        let config = ClientConfig {
+            jitter_buffer_max_frames: 8,
+            ..ClientConfig::default()
+        };
+        let mut buf = JitterBuffer::with_config(&config);
+        for seq in 0..1000u64 {
+            buf.insert(test_frame(seq, seq * 1000));
+            assert!(buf.len() <= 8, "buffer exceeded cap at seq {seq}");
+        }
+        assert_eq!(buf.dropped_count(), 992);
     }
 
     #[test]

--- a/crates/syndesis/src/client/mod.rs
+++ b/crates/syndesis/src/client/mod.rs
@@ -3,6 +3,7 @@ pub mod buffer;
 pub mod session;
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 pub use buffer::JitterBuffer;
 pub use session::ClientSession;
@@ -10,20 +11,36 @@ use snafu::ResultExt;
 use tracing::{info, instrument};
 
 use crate::error::{self, SyndesisError};
-use crate::tls;
+use crate::tls::{self, ObservedFingerprint};
 
 pub struct StreamClient {
     endpoint: quinn::Endpoint,
 }
 
 impl StreamClient {
-    /// Create a new QUIC client bound to a local address.
+    /// Create a new QUIC client pinned to a known server-certificate
+    /// fingerprint (hex-encoded SHA-256, persisted during pairing).
     #[instrument(skip_all)]
-    pub fn new(bind_addr: SocketAddr) -> Result<Self, SyndesisError> {
-        let client_config = tls::build_client_config()?;
+    pub fn new(bind_addr: SocketAddr, pinned_fingerprint: &str) -> Result<Self, SyndesisError> {
+        let client_config = tls::build_client_config(pinned_fingerprint)?;
         let mut endpoint = quinn::Endpoint::client(bind_addr).context(error::BindSnafu)?;
         endpoint.set_default_client_config(client_config);
         Ok(Self { endpoint })
+    }
+
+    /// Create a client for the explicit first-contact pairing step.
+    ///
+    /// Returns the client plus the cell that receives the server fingerprint
+    /// observed during the handshake. The caller MUST persist that fingerprint
+    /// and construct every subsequent client via [`StreamClient::new`].
+    #[instrument(skip_all)]
+    pub fn for_pairing(
+        bind_addr: SocketAddr,
+    ) -> Result<(Self, Arc<ObservedFingerprint>), SyndesisError> {
+        let (client_config, observed) = tls::build_pairing_client_config()?;
+        let mut endpoint = quinn::Endpoint::client(bind_addr).context(error::BindSnafu)?;
+        endpoint.set_default_client_config(client_config);
+        Ok((Self { endpoint }, observed))
     }
 
     /// Create with a pre-built client config.

--- a/crates/syndesis/src/client/session.rs
+++ b/crates/syndesis/src/client/session.rs
@@ -1,15 +1,17 @@
 /// Client session: negotiation, frame reception, clock sync, status reporting.
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use snafu::ResultExt;
-use tracing::{debug, instrument, trace};
+use tracing::{debug, instrument, trace, warn};
 
 use crate::client::buffer::JitterBuffer;
 use crate::clock::ClockEstimator;
 use crate::config::{ClientConfig, ClockConfig};
 use crate::error::{self, SyndesisError};
-use crate::protocol::codec::{decode_datagram, decode_frame, encode_datagram, encode_frame};
+use crate::protocol::codec::{
+    MAX_FRAME_SIZE, decode_datagram, decode_frame, encode_datagram, encode_frame, peek_frame_len,
+};
 use crate::protocol::frame::{
-    AudioFrame, ClockSync, ClockSyncReply, Frame, SessionAccept, SessionInit, StatusReport,
+    ClockSync, ClockSyncReply, Frame, SessionAccept, SessionInit, StatusReport,
 };
 use crate::protocol::{AudioCodec, DeviceState, PROTOCOL_VERSION};
 use crate::server::session::current_time_us;
@@ -104,18 +106,17 @@ impl ClientSession {
     }
 
     /// Receive audio frames and handle clock sync. Runs until the stream ends or cancel fires.
-    /// Received frames are placed in the jitter buffer.
+    /// Received frames are placed in the jitter buffer; drain via [`Self::buffer_mut`].
     #[instrument(skip_all, fields(session_id = self.session_id))]
     pub async fn run(
         &mut self,
         cancel: tokio::sync::watch::Receiver<bool>,
-    ) -> Result<Vec<AudioFrame>, SyndesisError> {
+    ) -> Result<(), SyndesisError> {
         let mut recv_stream = self
             .conn
             .accept_uni()
             .await
             .context(error::ConnectionSnafu)?;
-        let mut collected = Vec::new();
 
         let mut status_interval = tokio::time::interval(std::time::Duration::from_millis(
             self.client_config.status_report_interval_ms,
@@ -123,6 +124,9 @@ impl ClientSession {
         status_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         let mut read_buf = vec![0u8; 65536];
+        // WHY: frames routinely span QUIC read boundaries; bytes left over after
+        // draining complete frames must persist across reads or they are lost.
+        let mut stream_buf = BytesMut::new();
 
         loop {
             tokio::select! {
@@ -152,22 +156,8 @@ impl ClientSession {
                 result = recv_stream.read(&mut read_buf) => {
                     match result {
                         Ok(Some(n)) => {
-                            let mut data = Bytes::copy_from_slice(&read_buf[..n]);
-                            while data.len() >= 4 {
-                                match decode_frame(&mut data) {
-                                    Ok(Frame::Audio(frame)) => {
-                                        self.buffer.insert(frame.clone());
-                                        collected.push(frame);
-                                    }
-                                    Ok(other) => {
-                                        debug!(?other, "unexpected frame on audio stream");
-                                    }
-                                    Err(e) => {
-                                        trace!(error = %e, "partial frame in read buffer");
-                                        break;
-                                    }
-                                }
-                            }
+                            stream_buf.extend_from_slice(&read_buf[..n]);
+                            drain_stream_frames(&mut stream_buf, &mut self.buffer)?;
                         }
                         Ok(None) => {
                             debug!("audio stream finished");
@@ -181,7 +171,7 @@ impl ClientSession {
             }
         }
 
-        Ok(collected)
+        Ok(())
     }
 
     fn handle_datagram(&mut self, data: Bytes) -> Result<(), SyndesisError> {
@@ -239,6 +229,17 @@ impl ClientSession {
         Ok(())
     }
 
+    /// The jitter buffer holding received audio frames.
+    #[must_use]
+    pub fn buffer(&self) -> &JitterBuffer {
+        &self.buffer
+    }
+
+    /// Mutable jitter-buffer access for playout draining.
+    pub fn buffer_mut(&mut self) -> &mut JitterBuffer {
+        &mut self.buffer
+    }
+
     /// The negotiated codec for this session.
     #[must_use]
     pub fn codec(&self) -> AudioCodec {
@@ -258,6 +259,45 @@ impl ClientSession {
     }
 }
 
+// WHY: free function (not a method) so reassembly is testable without a live
+// quinn::Connection.
+/// Drain every complete length-prefixed frame FROM `stream_buf` into `buffer`,
+/// leaving any trailing partial frame in place for the next read.
+fn drain_stream_frames(
+    stream_buf: &mut BytesMut,
+    buffer: &mut JitterBuffer,
+) -> Result<(), SyndesisError> {
+    while let Some(wire_len) = peek_frame_len(stream_buf) {
+        if wire_len > MAX_FRAME_SIZE {
+            warn!(wire_len, "declared frame length exceeds protocol maximum");
+            return Err(error::ProtocolSnafu {
+                reason: "declared frame length exceeds protocol maximum",
+            }
+            .build());
+        }
+        if stream_buf.len() < wire_len {
+            // Partial frame: keep the bytes buffered until the next read.
+            break;
+        }
+        let mut frame_bytes = stream_buf.split_to(wire_len).freeze();
+        match decode_frame(&mut frame_bytes) {
+            Ok(Frame::Audio(frame)) => {
+                buffer.insert(frame);
+            }
+            Ok(other) => {
+                debug!(?other, "unexpected frame on audio stream");
+            }
+            Err(e) => {
+                // WHY: the frame was complete, so this is corruption, not a
+                // short read — surface it instead of silently dropping bytes.
+                warn!(error = %e, "corrupt frame on audio stream");
+                return Err(e);
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn wait_for_cancel(cancel: &tokio::sync::watch::Receiver<bool>) {
     let mut cancel = cancel.clone();
     loop {
@@ -267,5 +307,113 @@ async fn wait_for_cancel(cancel: &tokio::sync::watch::Receiver<bool>) {
         if cancel.changed().await.is_err() {
             return;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::codec::encode_frame;
+    use crate::protocol::frame::AudioFrame;
+
+    fn audio_frame(seq: u64, payload_len: usize) -> Frame {
+        Frame::Audio(AudioFrame {
+            sequence: seq,
+            timestamp_us: seq * 10_000,
+            playout_ts: 0,
+            codec: AudioCodec::Pcm,
+            channels: 2,
+            sample_rate: 48000,
+            payload: Bytes::from(vec![0x5Au8; payload_len]),
+        })
+    }
+
+    #[test]
+    fn frame_split_across_two_reads_is_reassembled() {
+        // Frame larger than the 65536-byte read chunk, split at that boundary.
+        let encoded = encode_frame(&audio_frame(7, 100_000));
+        assert!(encoded.len() > 65536);
+        let (first, second) = encoded.split_at(65536);
+
+        let mut stream_buf = BytesMut::new();
+        let mut buffer = JitterBuffer::new();
+
+        stream_buf.extend_from_slice(first);
+        drain_stream_frames(&mut stream_buf, &mut buffer).expect("partial frame is not an error");
+        assert!(buffer.is_empty(), "no complete frame yet");
+        assert_eq!(stream_buf.len(), 65536, "partial bytes must be retained");
+
+        stream_buf.extend_from_slice(second);
+        drain_stream_frames(&mut stream_buf, &mut buffer).expect("complete frame decodes");
+        assert_eq!(buffer.len(), 1, "exactly one frame reassembled");
+        assert!(stream_buf.is_empty(), "no leftover bytes");
+        assert_eq!(buffer.gap_count(), 0);
+    }
+
+    #[test]
+    fn read_split_inside_length_prefix_is_reassembled() {
+        let encoded = encode_frame(&audio_frame(1, 64));
+        let (first, second) = encoded.split_at(2);
+
+        let mut stream_buf = BytesMut::new();
+        let mut buffer = JitterBuffer::new();
+
+        stream_buf.extend_from_slice(first);
+        drain_stream_frames(&mut stream_buf, &mut buffer).expect("short prefix is not an error");
+        assert!(buffer.is_empty());
+        assert_eq!(stream_buf.len(), 2, "prefix bytes must be retained");
+
+        stream_buf.extend_from_slice(second);
+        drain_stream_frames(&mut stream_buf, &mut buffer).expect("complete frame decodes");
+        assert_eq!(buffer.len(), 1);
+    }
+
+    #[test]
+    fn multiple_frames_plus_partial_drain_in_one_pass() {
+        let mut stream_buf = BytesMut::new();
+        stream_buf.extend_from_slice(&encode_frame(&audio_frame(0, 32)));
+        stream_buf.extend_from_slice(&encode_frame(&audio_frame(1, 32)));
+        let third = encode_frame(&audio_frame(2, 32));
+        stream_buf.extend_from_slice(&third[..third.len() - 5]);
+
+        let mut buffer = JitterBuffer::new();
+        drain_stream_frames(&mut stream_buf, &mut buffer).expect("complete frames decode");
+        assert_eq!(buffer.len(), 2, "two complete frames drained");
+        assert_eq!(
+            stream_buf.len(),
+            third.len() - 5,
+            "partial third frame retained"
+        );
+
+        stream_buf.extend_from_slice(&third[third.len() - 5..]);
+        drain_stream_frames(&mut stream_buf, &mut buffer).expect("completed frame decodes");
+        assert_eq!(buffer.len(), 3);
+        assert_eq!(buffer.gap_count(), 0);
+    }
+
+    #[test]
+    fn corrupt_complete_frame_returns_error() {
+        let mut encoded = BytesMut::from(encode_frame(&audio_frame(0, 32)).as_ref());
+        // Corrupt the frame-type byte (index 4, right after the length prefix).
+        encoded[4] = 0xFF;
+
+        let mut buffer = JitterBuffer::new();
+        let result = drain_stream_frames(&mut encoded, &mut buffer);
+        assert!(result.is_err(), "corrupt complete frame must error");
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn oversized_declared_length_returns_error() {
+        let mut stream_buf = BytesMut::new();
+        stream_buf.extend_from_slice(&u32::MAX.to_be_bytes());
+        stream_buf.extend_from_slice(&[0u8; 16]);
+
+        let mut buffer = JitterBuffer::new();
+        let result = drain_stream_frames(&mut stream_buf, &mut buffer);
+        assert!(
+            result.is_err(),
+            "absurd declared length must not accumulate"
+        );
     }
 }

--- a/crates/syndesis/src/clock/coordinator.rs
+++ b/crates/syndesis/src/clock/coordinator.rs
@@ -139,8 +139,10 @@ impl ClockCoordinator {
             .get(renderer_id)
             .map_or(0, |e| e.offset_us());
 
-        // WHY: If this renderer's clock is behind the worst-case, it needs extra delay.
-        max_offset - renderer_offset.abs()
+        // WHY: adjustment = max_abs_offset - signed_renderer_offset. The sign
+        // must survive: a renderer whose clock runs behind (negative OFFSET)
+        // needs MORE delay than the worst-case-ahead renderer, not less.
+        max_offset - renderer_offset
     }
 
     /// Snapshot of all renderer clock states.
@@ -299,6 +301,32 @@ mod tests {
         assert!(
             slow_adj > fast_adj,
             "slow renderer ({slow_adj}) should need more adjustment than fast ({fast_adj})"
+        );
+    }
+
+    #[test]
+    fn renderer_adjustment_handles_negative_offset() {
+        let mut coord = ClockCoordinator::with_margin(0);
+        coord.add_renderer("ahead");
+        coord.add_renderer("behind");
+
+        if let Some(est) = coord.estimator_mut("ahead") {
+            feed_estimator(est, 3000, 10);
+        }
+        if let Some(est) = coord.estimator_mut("behind") {
+            feed_estimator(est, -3000, 10);
+        }
+
+        // max_abs_offset = 3000; adjustment = 3000 - signed_offset.
+        assert_eq!(
+            coord.renderer_adjustment("ahead"),
+            0,
+            "worst-case-ahead renderer needs no extra delay"
+        );
+        assert_eq!(
+            coord.renderer_adjustment("behind"),
+            6000,
+            "behind renderer must delay by max_offset - (-offset), not max_offset - |offset|"
         );
     }
 }

--- a/crates/syndesis/src/config.rs
+++ b/crates/syndesis/src/config.rs
@@ -81,6 +81,9 @@ impl ClockConfig {
 pub struct ClientConfig {
     /// Default jitter-buffer depth (milliseconds). Governs playout latency.
     pub jitter_buffer_depth_ms: u64,
+    /// Maximum frames the jitter buffer holds before evicting the oldest.
+    /// Bounds client memory when playout stalls while the stream keeps flowing.
+    pub jitter_buffer_max_frames: usize,
     /// How often the client sends a `StatusReport` datagram to the server.
     pub status_report_interval_ms: u64,
 }
@@ -89,6 +92,7 @@ impl Default for ClientConfig {
     fn default() -> Self {
         Self {
             jitter_buffer_depth_ms: 100,
+            jitter_buffer_max_frames: 512,
             status_report_interval_ms: 1000,
         }
     }
@@ -98,6 +102,9 @@ impl Default for ClientConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ServerConfig {
+    /// Maximum concurrent renderer sessions; further connections are refused
+    /// before the TLS handshake. Bounds server task + memory usage.
+    pub max_sessions: usize,
     /// Per-renderer encoded-frame mpsc channel capacity in a zone fan-out.
     pub frame_channel_capacity: usize,
     /// High watermark (ms) above which the server pauses the stream.
@@ -114,6 +121,7 @@ pub struct ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
+            max_sessions: 32,
             frame_channel_capacity: 256,
             buffer_high_watermark_ms: 200,
             buffer_low_watermark_ms: 80,
@@ -139,7 +147,9 @@ mod tests {
         assert_eq!(c.clock.drift_threshold_us, 500);
         assert_eq!(c.clock.buffer_margin_us, 10_000);
         assert_eq!(c.client.jitter_buffer_depth_ms, 100);
+        assert_eq!(c.client.jitter_buffer_max_frames, 512);
         assert_eq!(c.client.status_report_interval_ms, 1000);
+        assert_eq!(c.server.max_sessions, 32);
         assert_eq!(c.server.frame_channel_capacity, 256);
         assert_eq!(c.server.buffer_high_watermark_ms, 200);
         assert_eq!(c.server.buffer_low_watermark_ms, 80);
@@ -162,9 +172,11 @@ mod tests {
             },
             client: ClientConfig {
                 jitter_buffer_depth_ms: 250,
+                jitter_buffer_max_frames: 64,
                 status_report_interval_ms: 500,
             },
             server: ServerConfig {
+                max_sessions: 8,
                 frame_channel_capacity: 1024,
                 buffer_high_watermark_ms: 300,
                 buffer_low_watermark_ms: 60,
@@ -178,6 +190,8 @@ mod tests {
         assert_eq!(parsed.clock.outlier_factor, 3);
         assert_eq!(parsed.clock.initial_interval_secs, 7);
         assert_eq!(parsed.client.jitter_buffer_depth_ms, 250);
+        assert_eq!(parsed.client.jitter_buffer_max_frames, 64);
+        assert_eq!(parsed.server.max_sessions, 8);
         assert_eq!(parsed.server.frame_channel_capacity, 1024);
         assert_eq!(parsed.server.zone_low_watermark_ms, 40);
     }

--- a/crates/syndesis/src/error.rs
+++ b/crates/syndesis/src/error.rs
@@ -133,4 +133,11 @@ pub enum SyndesisError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    #[snafu(display("blocking task failed: {source}"))]
+    BlockingTask {
+        source: tokio::task::JoinError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }

--- a/crates/syndesis/src/lib.rs
+++ b/crates/syndesis/src/lib.rs
@@ -21,4 +21,6 @@ pub use protocol::session_frame::{
 pub use server::auth::{
     SessionOutcome, build_pairing_challenge, build_pairing_complete, handle_session_init,
 };
-pub use tls::{SelfSignedCert, compute_fingerprint, generate_self_signed_simple};
+pub use tls::{
+    ObservedFingerprint, SelfSignedCert, compute_fingerprint, generate_self_signed_simple,
+};

--- a/crates/syndesis/src/pairing/handshake.rs
+++ b/crates/syndesis/src/pairing/handshake.rs
@@ -8,7 +8,7 @@ use rand_core::OsRng;
 use snafu::ResultExt;
 use sqlx::SqlitePool;
 
-use crate::error::{DatabaseSnafu, SyndesisError};
+use crate::error::{BlockingTaskSnafu, DatabaseSnafu, SyndesisError};
 
 /// Generate a cryptographically random 32-byte API key, base64url-encoded.
 pub fn generate_api_key() -> String {
@@ -88,9 +88,16 @@ pub async fn authenticate_renderer(
 
     // WHY: brute-force over list since renderer count is tiny (<100);
     // avoids timing-equivalent hash-then-lookup ordering issues.
-    let matched = renderers
-        .into_iter()
-        .find(|r| verify_api_key(api_key, &r.api_key_hash));
+    // WHY: argon2id verification is CPU-bound (~100ms per record); the scan
+    // runs on the blocking pool so executor threads keep serving I/O.
+    let api_key = api_key.to_string();
+    let matched = tokio::task::spawn_blocking(move || {
+        renderers
+            .into_iter()
+            .find(|r| verify_api_key(&api_key, &r.api_key_hash))
+    })
+    .await
+    .context(BlockingTaskSnafu)?;
 
     let r = matched.ok_or_else(|| SyndesisError::InvalidApiKey {
         location: snafu::location!(),
@@ -151,5 +158,66 @@ mod tests {
         let h1 = hash_api_key(&key).unwrap();
         let h2 = hash_api_key(&key).unwrap();
         assert_ne!(h1, h2);
+    }
+
+    #[tokio::test]
+    async fn authenticate_renderer_does_not_block_executor() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::{Duration, Instant};
+
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        apotheke::migrate::MIGRATOR.run(&pool).await.unwrap();
+
+        for i in 0..4 {
+            let name = format!("renderer-{i}");
+            complete_pairing(
+                &pool,
+                PairingRequest {
+                    renderer_name: &name,
+                    renderer_id: &uuid::Uuid::now_v7().to_string(),
+                    cert_fingerprint: "fp",
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        // WHY: on the current_thread test runtime, an inline argon2 scan would
+        // stall this ticker for the whole scan; spawn_blocking keeps it live.
+        let stop = Arc::new(AtomicBool::new(false));
+        let ticker = tokio::spawn({
+            let stop = Arc::clone(&stop);
+            async move {
+                let mut last = Instant::now();
+                let mut max_gap = Duration::ZERO;
+                while !stop.load(Ordering::Relaxed) {
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    let now = Instant::now();
+                    max_gap = max_gap.max(now - last);
+                    last = now;
+                }
+                max_gap
+            }
+        });
+
+        let auth_start = Instant::now();
+        let result = authenticate_renderer(&pool, &pool, "definitely-wrong-key", "fp").await;
+        let auth_duration = auth_start.elapsed();
+
+        stop.store(true, Ordering::Relaxed);
+        let max_gap = ticker.await.unwrap();
+
+        assert!(
+            matches!(result, Err(SyndesisError::InvalidApiKey { .. })),
+            "wrong key must be rejected"
+        );
+        // An inline scan blocks the ticker for ~the whole auth duration; off
+        // the executor the gaps stay tiny. The floor absorbs CI jitter.
+        let threshold = (auth_duration / 2).max(Duration::from_millis(50));
+        assert!(
+            max_gap < threshold,
+            "executor stalled for {max_gap:?} during a {auth_duration:?} auth scan"
+        );
     }
 }

--- a/crates/syndesis/src/protocol/codec.rs
+++ b/crates/syndesis/src/protocol/codec.rs
@@ -12,6 +12,20 @@ use crate::error;
 // without relying on stream boundaries. DATAGRAMs are already delimited by QUIC.
 const LENGTH_PREFIX_SIZE: usize = 4;
 
+// WHY: Upper bound on a single frame's wire size. A corrupt or hostile length
+// prefix must not make a reassembling receiver buffer gigabytes.
+pub const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+
+/// Total wire length (length prefix + declared body) of the next frame in `buf`,
+/// without consuming any bytes.
+///
+/// Returns `None` while the 4-byte length prefix is not yet fully buffered.
+#[must_use]
+pub fn peek_frame_len(buf: &[u8]) -> Option<usize> {
+    let prefix: [u8; LENGTH_PREFIX_SIZE] = buf.get(..LENGTH_PREFIX_SIZE)?.try_into().ok()?;
+    Some(LENGTH_PREFIX_SIZE + u32::from_be_bytes(prefix) as usize)
+}
+
 /// Encode a frame INTO a length-prefixed byte buffer.
 #[must_use]
 pub fn encode_frame(frame: &Frame) -> Bytes {
@@ -513,6 +527,24 @@ mod tests {
     fn truncated_frame_returns_error() {
         let mut buf = Bytes::from_static(&[0x00, 0x00, 0x00, 0x10, 0x01]);
         assert!(decode_frame(&mut buf).is_err());
+    }
+
+    #[test]
+    fn peek_frame_len_returns_none_on_short_prefix() {
+        assert_eq!(peek_frame_len(&[]), None);
+        assert_eq!(peek_frame_len(&[0x00, 0x00, 0x01]), None);
+    }
+
+    #[test]
+    fn peek_frame_len_reports_total_wire_length_without_consuming() {
+        let frame = Frame::Command(Command {
+            kind: CommandKind::Pause,
+            value: 0,
+        });
+        let encoded = encode_frame(&frame);
+        assert_eq!(peek_frame_len(&encoded), Some(encoded.len()));
+        // Prefix visible but body incomplete: declared length still reported.
+        assert_eq!(peek_frame_len(&encoded[..5]), Some(encoded.len()));
     }
 
     #[test]

--- a/crates/syndesis/src/server/mod.rs
+++ b/crates/syndesis/src/server/mod.rs
@@ -16,32 +16,47 @@ use tokio::task::JoinSet;
 use tracing::{info, instrument, warn};
 pub use zone::ZoneStream;
 
+use crate::config::{ClockConfig, ServerConfig};
 use crate::error::{self, SyndesisError};
 use crate::tls;
 
 pub struct StreamServer {
     endpoint: quinn::Endpoint,
     sessions: JoinSet<()>,
+    server_config: ServerConfig,
+    cert_fingerprint: Option<String>,
 }
 
 impl StreamServer {
     /// Bind a QUIC streaming server to the given address.
     #[instrument(skip_all, fields(%bind_addr))]
     pub fn bind(bind_addr: SocketAddr) -> Result<Self, SyndesisError> {
+        Self::bind_with_server_config(bind_addr, ServerConfig::default())
+    }
+
+    /// Bind with explicit syndesis server tuning (session cap, watermarks).
+    #[instrument(skip_all, fields(%bind_addr))]
+    pub fn bind_with_server_config(
+        bind_addr: SocketAddr,
+        server_config: ServerConfig,
+    ) -> Result<Self, SyndesisError> {
         let (certs, key) = tls::generate_self_signed(&["localhost".into()])?;
-        let server_config = tls::build_server_config(certs, key)?;
+        let cert_fingerprint = certs.first().map(|c| tls::compute_fingerprint(c.as_ref()));
+        let quinn_config = tls::build_server_config(certs, key)?;
 
         let endpoint =
-            quinn::Endpoint::server(server_config, bind_addr).context(error::BindSnafu)?;
+            quinn::Endpoint::server(quinn_config, bind_addr).context(error::BindSnafu)?;
 
         info!("syndesis server listening");
         Ok(Self {
             endpoint,
             sessions: JoinSet::new(),
+            server_config,
+            cert_fingerprint,
         })
     }
 
-    /// Bind with a pre-built server config (for testing or custom certs).
+    /// Bind with a pre-built quinn config (for testing or custom certs).
     pub fn bind_with_config(
         bind_addr: SocketAddr,
         server_config: quinn::ServerConfig,
@@ -51,7 +66,18 @@ impl StreamServer {
         Ok(Self {
             endpoint,
             sessions: JoinSet::new(),
+            server_config: ServerConfig::default(),
+            cert_fingerprint: None,
         })
+    }
+
+    /// Hex-encoded SHA-256 fingerprint of the server's TLS certificate.
+    ///
+    /// Clients pin this value (via pairing) to authenticate the server.
+    /// `None` when the server was bound with a pre-built quinn config.
+    #[must_use]
+    pub fn cert_fingerprint(&self) -> Option<&str> {
+        self.cert_fingerprint.as_deref()
     }
 
     /// Accept incoming connections and spawn session handlers.
@@ -74,14 +100,33 @@ impl StreamServer {
                         info!("endpoint closed");
                         break;
                     };
+                    // WHY: JoinSet::len() counts finished-but-unreaped tasks;
+                    // reap first so the session cap reflects live sessions only.
+                    while self.sessions.try_join_next().is_some() {}
+                    if self.sessions.len() >= self.server_config.max_sessions {
+                        // WHY: refuse pre-handshake (no TLS work spent) with a
+                        // retryable CONNECTION_REFUSED instead of accepting and
+                        // dropping mid-session.
+                        warn!(
+                            max_sessions = self.server_config.max_sessions,
+                            "refusing connection: session limit reached"
+                        );
+                        incoming.refuse();
+                        continue;
+                    }
                     let source = source.clone();
                     let cancel = cancel.clone();
+                    let server_config = self.server_config.clone();
                     self.sessions.spawn(async move {
                         match incoming.await {
                             Ok(conn) => {
                                 let addr = conn.remote_address();
                                 info!(%addr, "renderer connected");
-                                let mut session = StreamSession::new(conn);
+                                let mut session = StreamSession::with_configs(
+                                    conn,
+                                    server_config,
+                                    ClockConfig::default(),
+                                );
                                 if let Err(e) = session.run(source, cancel).await {
                                     warn!(%addr, error = %e, "session ended with error");
                                 }

--- a/crates/syndesis/src/server/session.rs
+++ b/crates/syndesis/src/server/session.rs
@@ -23,10 +23,6 @@ pub struct StreamSession {
 }
 
 impl StreamSession {
-    pub(crate) fn new(conn: quinn::Connection) -> Self {
-        Self::with_configs(conn, ServerConfig::default(), ClockConfig::default())
-    }
-
     pub(crate) fn with_configs(
         conn: quinn::Connection,
         server_config: ServerConfig,
@@ -82,8 +78,7 @@ impl StreamSession {
                 _ = sync_interval.tick() => {
                     self.send_clock_probe()?;
                     let new_interval = self.scheduler.update(&self.clock);
-                    sync_interval = tokio::time::interval(new_interval);
-                    sync_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                    sync_interval = delayed_interval(new_interval);
                 }
 
                 frame = source.next_frame(), if !self.is_paused && !source_exhausted => {
@@ -285,6 +280,15 @@ pub(crate) fn current_time_us() -> u64 {
         .as_micros() as u64
 }
 
+// WHY: tokio::time::interval fires its first tick immediately; a rebuilt
+// interval must instead wait a full period or every scheduler update would
+// fire an instant extra probe, defeating the computed backoff.
+fn delayed_interval(period: std::time::Duration) -> tokio::time::Interval {
+    let mut interval = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    interval
+}
+
 async fn wait_for_cancel(cancel: &tokio::sync::watch::Receiver<bool>) {
     let mut cancel = cancel.clone();
     loop {
@@ -294,5 +298,59 @@ async fn wait_for_cancel(cancel: &tokio::sync::watch::Receiver<bool>) {
         if cancel.changed().await.is_err() {
             return;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn delayed_interval_first_tick_waits_full_period() {
+        let period = Duration::from_secs(5);
+        let start = tokio::time::Instant::now();
+
+        let mut interval = delayed_interval(period);
+        interval.tick().await;
+
+        let elapsed = tokio::time::Instant::now() - start;
+        assert!(
+            elapsed >= period,
+            "first tick after {elapsed:?}, expected >= {period:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delayed_interval_ticks_at_full_period_thereafter() {
+        let period = Duration::from_secs(5);
+        let mut interval = delayed_interval(period);
+
+        interval.tick().await;
+        let after_first = tokio::time::Instant::now();
+        interval.tick().await;
+
+        let gap = tokio::time::Instant::now() - after_first;
+        assert!(
+            gap >= period,
+            "second tick gap {gap:?}, expected >= {period:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn plain_interval_first_tick_is_immediate() {
+        // WHY: contrast case documenting the defect delayed_interval fixes.
+        let period = Duration::from_secs(5);
+        let start = tokio::time::Instant::now();
+
+        let mut interval = tokio::time::interval(period);
+        interval.tick().await;
+
+        let elapsed = tokio::time::Instant::now() - start;
+        assert!(
+            elapsed < period,
+            "tokio::time::interval fires immediately; got {elapsed:?}"
+        );
     }
 }

--- a/crates/syndesis/src/tls/mod.rs
+++ b/crates/syndesis/src/tls/mod.rs
@@ -85,6 +85,9 @@ pub fn generate_self_signed(
 }
 
 /// Save certificate and key to disk in DER format.
+///
+/// The private-key file is written with mode 0600; a key file that already
+/// exists with a looser mode is tightened to 0600 as well.
 pub fn save_identity(
     cert_path: &Path,
     key_path: &Path,
@@ -92,6 +95,8 @@ pub fn save_identity(
     key: &PrivateKeyDer<'_>,
 ) -> Result<(), SyndesisError> {
     use std::fs;
+    use std::io::Write as _;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
     if let Some(parent) = cert_path.parent() {
         fs::create_dir_all(parent).context(error::IoSnafu)?;
@@ -105,7 +110,20 @@ pub fn save_identity(
         cert_bytes.extend_from_slice(cert.as_ref());
     }
     fs::write(cert_path, &cert_bytes).context(error::IoSnafu)?;
-    fs::write(key_path, key.secret_der()).context(error::IoSnafu)?;
+
+    // WHY: mode(0o600) applies only at creation; the explicit set_permissions
+    // afterwards repairs files that already existed with looser modes.
+    let mut key_file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(key_path)
+        .context(error::IoSnafu)?;
+    key_file
+        .write_all(key.secret_der())
+        .context(error::IoSnafu)?;
+    fs::set_permissions(key_path, fs::Permissions::from_mode(0o600)).context(error::IoSnafu)?;
 
     Ok(())
 }
@@ -160,52 +178,130 @@ pub fn build_server_config(
     Ok(server_config)
 }
 
-/// TOFU certificate verifier that accepts any certificate on first contact.
+/// Fingerprint observed during a first-contact pairing handshake.
+///
+/// The pairing flow reads the value after connecting and MUST persist it;
+/// every subsequent connection pins it via [`build_client_config`].
+#[derive(Debug, Default)]
+pub struct ObservedFingerprint {
+    cell: std::sync::OnceLock<String>,
+}
+
+impl ObservedFingerprint {
+    /// The hex-encoded SHA-256 fingerprint of the server certificate seen
+    /// during pairing, once a handshake has completed.
+    #[must_use]
+    pub fn get(&self) -> Option<String> {
+        self.cell.get().cloned()
+    }
+}
+
 #[derive(Debug)]
-struct TofuVerifier;
+enum VerifierMode {
+    /// Reject any leaf whose SHA-256 fingerprint differs from the pin.
+    Pinned(String),
+    /// Explicit first-contact pairing: lock onto the first leaf observed and
+    /// reject any later change for the verifier's lifetime.
+    Pairing(Arc<ObservedFingerprint>),
+}
+
+/// TOFU certificate verifier: pins the server leaf certificate by SHA-256
+/// fingerprint. Trust is established once (explicit pairing) and enforced on
+/// every subsequent connection.
+#[derive(Debug)]
+struct TofuVerifier {
+    mode: VerifierMode,
+    algorithms: rustls::crypto::WebPkiSupportedAlgorithms,
+}
+
+impl TofuVerifier {
+    fn pinned(fingerprint: String) -> Self {
+        Self {
+            mode: VerifierMode::Pinned(fingerprint),
+            algorithms: rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        }
+    }
+
+    fn pairing(observed: Arc<ObservedFingerprint>) -> Self {
+        Self {
+            mode: VerifierMode::Pairing(observed),
+            algorithms: rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        }
+    }
+}
 
 impl rustls::client::danger::ServerCertVerifier for TofuVerifier {
     fn verify_server_cert(
         &self,
-        _end_entity: &CertificateDer<'_>,
+        end_entity: &CertificateDer<'_>,
         _intermediates: &[CertificateDer<'_>],
         _server_name: &ServerName<'_>,
         _ocsp_response: &[u8],
         _now: rustls::pki_types::UnixTime,
     ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        let presented = compute_fingerprint(end_entity.as_ref());
+        let expected = match &self.mode {
+            VerifierMode::Pinned(pin) => pin.clone(),
+            // INVARIANT: get_or_init pins the first observed leaf, so a
+            // mid-pairing certificate swap is rejected below.
+            VerifierMode::Pairing(observed) => {
+                observed.cell.get_or_init(|| presented.clone()).clone()
+            }
+        };
+        if presented != expected {
+            tracing::warn!(
+                %presented,
+                %expected,
+                "server certificate fingerprint mismatch (TOFU violation)"
+            );
+            return Err(rustls::Error::InvalidCertificate(
+                rustls::CertificateError::ApplicationVerificationFailure,
+            ));
+        }
         Ok(rustls::client::danger::ServerCertVerified::assertion())
     }
 
     fn verify_tls12_signature(
         &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        rustls::crypto::verify_tls12_signature(message, cert, dss, &self.algorithms)
     }
 
     fn verify_tls13_signature(
         &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
     ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        rustls::crypto::verify_tls13_signature(message, cert, dss, &self.algorithms)
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        rustls::crypto::ring::default_provider()
-            .signature_verification_algorithms
-            .supported_schemes()
+        self.algorithms.supported_schemes()
     }
 }
 
-/// Build a quinn ClientConfig that trusts any server certificate (TOFU model).
-pub fn build_client_config() -> Result<quinn::ClientConfig, SyndesisError> {
+// WHY: fail closed — a malformed pin must never degrade into accept-any.
+fn normalize_pin(pinned_fingerprint: &str) -> Result<String, SyndesisError> {
+    let pin = pinned_fingerprint.trim().to_ascii_lowercase();
+    if pin.len() != 64 || !pin.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(error::TlsSnafu {
+            reason: "pinned fingerprint must be 64 hex chars (SHA-256)".to_string(),
+        }
+        .build());
+    }
+    Ok(pin)
+}
+
+fn client_config_with_verifier(
+    verifier: Arc<TofuVerifier>,
+) -> Result<quinn::ClientConfig, SyndesisError> {
     let mut tls_config = rustls::ClientConfig::builder()
         .dangerous()
-        .with_custom_certificate_verifier(Arc::new(TofuVerifier))
+        .with_custom_certificate_verifier(verifier)
         .with_no_client_auth();
 
     tls_config.alpn_protocols = vec![b"syndesis/1".to_vec()];
@@ -227,6 +323,32 @@ pub fn build_client_config() -> Result<quinn::ClientConfig, SyndesisError> {
     Ok(client_config)
 }
 
+/// Build a quinn ClientConfig pinned to a known server-certificate fingerprint.
+///
+/// `pinned_fingerprint` is the hex-encoded SHA-256 fingerprint persisted during
+/// pairing (`PairingChallenge.cert_fingerprint` or renderer-local storage).
+/// Connections to a server presenting any other leaf certificate fail the
+/// handshake. A missing pin has no accept-any fallback; first contact goes
+/// through [`build_pairing_client_config`] instead.
+pub fn build_client_config(pinned_fingerprint: &str) -> Result<quinn::ClientConfig, SyndesisError> {
+    let pin = normalize_pin(pinned_fingerprint)?;
+    client_config_with_verifier(Arc::new(TofuVerifier::pinned(pin)))
+}
+
+/// Build a quinn ClientConfig for the explicit first-contact pairing step.
+///
+/// The verifier locks onto the first server leaf observed and rejects any
+/// change for its lifetime. The caller MUST read the fingerprint from the
+/// returned [`ObservedFingerprint`] after the handshake, persist it, and use
+/// [`build_client_config`] for every subsequent connection.
+pub fn build_pairing_client_config()
+-> Result<(quinn::ClientConfig, Arc<ObservedFingerprint>), SyndesisError> {
+    let observed = Arc::new(ObservedFingerprint::default());
+    let config =
+        client_config_with_verifier(Arc::new(TofuVerifier::pairing(Arc::clone(&observed))))?;
+    Ok((config, observed))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,10 +367,82 @@ mod tests {
         assert!(config.is_ok());
     }
 
+    fn verify_leaf(
+        verifier: &TofuVerifier,
+        cert_der: &[u8],
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        use rustls::client::danger::ServerCertVerifier as _;
+        let leaf = CertificateDer::from(cert_der.to_vec());
+        let name = ServerName::try_from("localhost").expect("valid server name");
+        verifier.verify_server_cert(&leaf, &[], &name, &[], rustls::pki_types::UnixTime::now())
+    }
+
     #[test]
-    fn builds_client_config() {
-        let config = build_client_config();
+    fn builds_client_config_with_valid_pin() {
+        let cert = generate_self_signed_simple(vec!["localhost".to_string()]).unwrap();
+        let config = build_client_config(&cert.fingerprint);
         assert!(config.is_ok());
+    }
+
+    #[test]
+    fn build_client_config_rejects_malformed_pin() {
+        assert!(build_client_config("").is_err(), "empty pin must fail");
+        assert!(
+            build_client_config("not-hex").is_err(),
+            "non-hex pin must fail"
+        );
+        assert!(
+            build_client_config("abc123").is_err(),
+            "short pin must fail"
+        );
+        assert!(
+            build_client_config(&"g".repeat(64)).is_err(),
+            "64 non-hex chars must fail"
+        );
+    }
+
+    #[test]
+    fn pinned_verifier_accepts_matching_fingerprint() {
+        let cert = generate_self_signed_simple(vec!["localhost".to_string()]).unwrap();
+        let verifier = TofuVerifier::pinned(cert.fingerprint.clone());
+        assert!(verify_leaf(&verifier, &cert.cert_der).is_ok());
+    }
+
+    #[test]
+    fn pinned_verifier_rejects_mismatched_fingerprint() {
+        let pinned = generate_self_signed_simple(vec!["localhost".to_string()]).unwrap();
+        let imposter = generate_self_signed_simple(vec!["localhost".to_string()]).unwrap();
+        let verifier = TofuVerifier::pinned(pinned.fingerprint.clone());
+        let result = verify_leaf(&verifier, &imposter.cert_der);
+        assert!(
+            matches!(result, Err(rustls::Error::InvalidCertificate(_))),
+            "mismatched leaf must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn pairing_verifier_locks_first_leaf_and_rejects_change() {
+        let first = generate_self_signed_simple(vec!["localhost".to_string()]).unwrap();
+        let second = generate_self_signed_simple(vec!["localhost".to_string()]).unwrap();
+
+        let observed = Arc::new(ObservedFingerprint::default());
+        let verifier = TofuVerifier::pairing(Arc::clone(&observed));
+
+        assert!(observed.get().is_none(), "no fingerprint before handshake");
+        assert!(verify_leaf(&verifier, &first.cert_der).is_ok());
+        assert_eq!(
+            observed.get().as_deref(),
+            Some(first.fingerprint.as_str()),
+            "observed cell must expose the first leaf's fingerprint"
+        );
+
+        let swap = verify_leaf(&verifier, &second.cert_der);
+        assert!(
+            matches!(swap, Err(rustls::Error::InvalidCertificate(_))),
+            "mid-pairing certificate swap must be rejected"
+        );
+        // Re-presenting the locked leaf still verifies.
+        assert!(verify_leaf(&verifier, &first.cert_der).is_ok());
     }
 
     #[test]
@@ -285,6 +479,45 @@ mod tests {
         let (loaded_certs, _loaded_key) = load_identity(&cert_path, &key_path).unwrap();
 
         assert_eq!(certs[0].as_ref(), loaded_certs[0].as_ref());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_identity_sets_key_file_permissions_0600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join("syndesis_tls_perm_test");
+        let cert_path = dir.join("cert.der");
+        let key_path = dir.join("key.der");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let (certs, key) = generate_self_signed(&["localhost".to_string()]).unwrap();
+        save_identity(&cert_path, &key_path, &certs, &key).unwrap();
+
+        let mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "fresh key file must be 0600, got {mode:o}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_identity_repairs_loose_key_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join("syndesis_tls_perm_repair_test");
+        let cert_path = dir.join("cert.der");
+        let key_path = dir.join("key.der");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(&key_path, b"stale").unwrap();
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let (certs, key) = generate_self_signed(&["localhost".to_string()]).unwrap();
+        save_identity(&cert_path, &key_path, &certs, &key).unwrap();
+
+        let mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "loose key file must be repaired to 0600");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/syndesis/tests/integration.rs
+++ b/crates/syndesis/tests/integration.rs
@@ -31,6 +31,10 @@ async fn loopback_stream_delivers_all_frames() {
     let server_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
     let mut server = StreamServer::bind(server_addr).expect("server bind should succeed");
     let bound_addr = server.local_addr().expect("should have local addr");
+    let fingerprint = server
+        .cert_fingerprint()
+        .expect("bind generates a cert")
+        .to_string();
 
     let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
 
@@ -42,7 +46,7 @@ async fn loopback_stream_delivers_all_frames() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let client_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
-    let client = StreamClient::new(client_addr).expect("client should bind");
+    let client = StreamClient::new(client_addr, &fingerprint).expect("client should bind");
     let mut session = client
         .connect(bound_addr, "localhost")
         .await
@@ -63,12 +67,14 @@ async fn loopback_stream_delivers_all_frames() {
 
     // Run client session with a timeout
     let client_cancel_rx = cancel_tx.subscribe();
-    let received = tokio::time::timeout(Duration::from_secs(5), session.run(client_cancel_rx))
+    tokio::time::timeout(Duration::from_secs(5), session.run(client_cancel_rx))
         .await
         .expect("should not timeout")
         .expect("client run should succeed");
 
-    // All frames should be received
+    // All frames should be in the jitter buffer with no sequence gaps
+    assert_eq!(session.buffer().gap_count(), 0, "no gaps expected");
+    let received = session.buffer_mut().drain_ready(u64::MAX);
     assert_eq!(
         received.len(),
         frames.len(),
@@ -96,6 +102,10 @@ async fn session_negotiation_selects_best_codec() {
     let server_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
     let mut server = StreamServer::bind(server_addr).expect("server bind should succeed");
     let bound_addr = server.local_addr().expect("should have local addr");
+    let fingerprint = server
+        .cert_fingerprint()
+        .expect("bind generates a cert")
+        .to_string();
 
     let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
 
@@ -106,7 +116,7 @@ async fn session_negotiation_selects_best_codec() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let client_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
-    let client = StreamClient::new(client_addr).expect("client should bind");
+    let client = StreamClient::new(client_addr, &fingerprint).expect("client should bind");
     let mut session = client
         .connect(bound_addr, "localhost")
         .await
@@ -121,6 +131,126 @@ async fn session_negotiation_selects_best_codec() {
     assert_eq!(accept.codec, AudioCodec::Pcm);
     assert_eq!(accept.sample_rate, 44100);
     assert_eq!(accept.channels, 2);
+
+    let _ = cancel_tx.send(true);
+    let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
+}
+
+#[tokio::test]
+async fn client_rejects_mismatched_server_fingerprint() {
+    let source = VecAudioSource::new(vec![]);
+
+    let server_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let mut server = StreamServer::bind(server_addr).expect("server bind should succeed");
+    let bound_addr = server.local_addr().expect("should have local addr");
+
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    let server_handle = tokio::spawn(async move {
+        server.run(source, cancel_rx).await;
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Pin the fingerprint of a DIFFERENT certificate than the server presents.
+    let imposter_pin = syndesis::generate_self_signed_simple(vec!["localhost".to_string()])
+        .expect("cert generation")
+        .fingerprint;
+
+    let client_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let client = StreamClient::new(client_addr, &imposter_pin).expect("client should bind");
+    let result = client.connect(bound_addr, "localhost").await;
+
+    assert!(
+        result.is_err(),
+        "handshake against a non-pinned certificate must fail"
+    );
+
+    let _ = cancel_tx.send(true);
+    let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
+}
+
+#[tokio::test]
+async fn pairing_client_observes_server_fingerprint() {
+    let source = VecAudioSource::new(vec![]);
+
+    let server_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let mut server = StreamServer::bind(server_addr).expect("server bind should succeed");
+    let bound_addr = server.local_addr().expect("should have local addr");
+    let fingerprint = server
+        .cert_fingerprint()
+        .expect("bind generates a cert")
+        .to_string();
+
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    let server_handle = tokio::spawn(async move {
+        server.run(source, cancel_rx).await;
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let (client, observed) = StreamClient::for_pairing(client_addr).expect("client should bind");
+    let _session = client
+        .connect(bound_addr, "localhost")
+        .await
+        .expect("pairing first contact should succeed");
+
+    assert_eq!(
+        observed.get().as_deref(),
+        Some(fingerprint.as_str()),
+        "pairing must expose the server fingerprint for persistence"
+    );
+
+    let _ = cancel_tx.send(true);
+    let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
+}
+
+#[tokio::test]
+async fn accept_loop_refuses_beyond_max_sessions() {
+    use syndesis::config::ServerConfig;
+
+    let server_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let server_config = ServerConfig {
+        max_sessions: 1,
+        ..ServerConfig::default()
+    };
+    let mut server = StreamServer::bind_with_server_config(server_addr, server_config)
+        .expect("server bind should succeed");
+    let bound_addr = server.local_addr().expect("should have local addr");
+    let fingerprint = server
+        .cert_fingerprint()
+        .expect("bind generates a cert")
+        .to_string();
+
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    let server_handle = tokio::spawn(async move {
+        server.run(VecAudioSource::new(vec![]), cancel_rx).await;
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let first_client = StreamClient::new(client_addr, &fingerprint).expect("client should bind");
+    let mut first_session = first_client
+        .connect(bound_addr, "localhost")
+        .await
+        .expect("first connection fits under the cap");
+    first_session
+        .negotiate(vec![AudioCodec::Pcm], vec![48000], vec![2])
+        .await
+        .expect("first session negotiates");
+
+    // The session slot is now held; the next connection must be refused.
+    let second_addr: SocketAddr = "127.0.0.1:0".parse().expect("valid addr");
+    let second_client = StreamClient::new(second_addr, &fingerprint).expect("client should bind");
+    let second = tokio::time::timeout(
+        Duration::from_secs(5),
+        second_client.connect(bound_addr, "localhost"),
+    )
+    .await
+    .expect("refusal should be prompt");
+
+    assert!(
+        second.is_err(),
+        "connection beyond max_sessions must be refused"
+    );
 
     let _ = cancel_tx.send(true);
     let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;


### PR DESCRIPTION
Closes #362, #363, #364, #376, #377, #378, #379, #380.

## Changes

- **#364 (security) — TLS verification.** The client's `TofuVerifier` accepted any certificate and any handshake signature. Replaced with a pinned-fingerprint verifier: real `rustls::crypto` signature verification plus a SHA-256 leaf pin, rejecting mismatches with `ApplicationVerificationFailure`. A malformed pin fails closed at config-build; first contact requires an explicit pairing mode that locks the first observed leaf. No accept-any path remains.
- **#362 — frame reassembly.** The audio receive loop had no persistent reassembly buffer, so frames spanning a QUIC read boundary were dropped, desyncing the stream. Added a persistent `BytesMut` buffer with non-consuming length peek and a 16 MiB frame guard.
- **#363 — clock-sync backoff.** The rebuilt interval fired immediately; now `interval_at(now + period, period)`.
- **#376 — blocking argon2.** Renderer authentication ran argon2id synchronously on the executor; moved into `spawn_blocking`.
- **#377 / #378 — resource bounds.** Bounded `JitterBuffer` (config `jitter_buffer_max_frames`, oldest-evict) and capped concurrent sessions (config `max_sessions`, pre-handshake refuse). New `horismos::SyndesisConfig` + validation.
- **#379 — key permissions.** The renderer TLS private key is now written 0600 via `O_EXCL` and tightened on load.
- **#380 — clock offset.** Corrected the negative-offset renderer adjustment formula.

## Verification

`kanon gate --full` green (fmt, check, advisory-parity, cargo-deny, clippy workspace, nextest, kanon lint). TLS pinning, reassembly-at-boundary, and bounded-buffer behavior have unit + integration coverage.

## Note

archon's renderer binary carries its own separate certificate verifier, fixed in the archon renderer TLS/QUIC PR.