### PR TITLE
fix(akouo): playback-engine correctness (real seek, decode-failure signaling)

### DIFF
--- a/crates/akouo-android/src/lib.rs
+++ b/crates/akouo-android/src/lib.rs
@@ -5,10 +5,10 @@ use std::thread::JoinHandle as ThreadJoinHandle;
 use std::time::Duration;
 
 use akouo_core::decode::probe::open_decoder;
-use akouo_core::{DspConfig, DspPipeline, RingBuffer};
+use akouo_core::{AudioDecoder, DspConfig, DspPipeline, RingBuffer};
 use snafu::Snafu;
 use tokio::runtime::{Builder, Handle};
-use tokio::sync::{oneshot, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
 uniffi::setup_scaffolding!();
@@ -81,13 +81,24 @@ pub trait EventListener: Send + Sync {
     fn on_event(&self, event: AndroidEngineEvent);
 }
 
+/// A seek request forwarded to the playback task; `reply` carries the decoder's actual
+/// post-seek position in seconds, or an error message.
+struct SeekCommand {
+    target_secs: f64,
+    reply: oneshot::Sender<Result<f64, String>>,
+}
+
+type EventListeners = Arc<Mutex<Vec<(u64, Arc<dyn EventListener>)>>>;
+
 #[derive(uniffi::Object)]
 pub struct AndroidEngine {
     runtime: RuntimeThread,
     state: Arc<AtomicU8>,
     audio_callback: Arc<Mutex<Option<Box<dyn AudioCallback>>>>,
-    event_listeners: Arc<Mutex<Vec<Box<dyn EventListener>>>>,
+    event_listeners: EventListeners,
+    next_listener_id: AtomicU64,
     playback_task: Mutex<Option<JoinHandle<()>>>,
+    seek_tx: Mutex<Option<mpsc::Sender<SeekCommand>>>,
     ring_buffer_capacity: usize,
     callback_frame_samples: usize,
 }
@@ -125,7 +136,9 @@ impl AndroidEngine {
             state: Arc::new(AtomicU8::new(STATE_STOPPED)),
             audio_callback: Arc::new(Mutex::new(None)),
             event_listeners: Arc::new(Mutex::new(Vec::new())),
+            next_listener_id: AtomicU64::new(0),
             playback_task: Mutex::new(None),
+            seek_tx: Mutex::new(None),
             ring_buffer_capacity,
             callback_frame_samples,
         }))
@@ -139,12 +152,28 @@ impl AndroidEngine {
         *guard = Some(callback);
     }
 
-    pub fn subscribe_events(&self, listener: Box<dyn EventListener>) {
+    /// Registers an event listener and returns a subscription id for
+    /// `unsubscribe_events`.
+    pub fn subscribe_events(&self, listener: Box<dyn EventListener>) -> u64 {
+        let id = self.next_listener_id.fetch_add(1, Ordering::SeqCst);
         let mut guard = self
             .event_listeners
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        guard.push(listener);
+        guard.push((id, Arc::from(listener)));
+        id
+    }
+
+    /// Removes the listener registered under `id`. Returns `true` if a listener was
+    /// removed, `false` if the id was unknown (already removed or never issued).
+    pub fn unsubscribe_events(&self, id: u64) -> bool {
+        let mut guard = self
+            .event_listeners
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let count_before = guard.len();
+        guard.retain(|(listener_id, _)| *listener_id != id);
+        guard.len() != count_before
     }
 
     pub async fn play(&self, path: String) -> Result<(), AndroidEngineError> {
@@ -157,11 +186,15 @@ impl AndroidEngine {
             )
             .map_err(|_| AndroidEngineError::AlreadyPlaying)?;
 
+        let (seek_tx, seek_rx) = mpsc::channel::<SeekCommand>(4);
+        *self.seek_tx.lock().unwrap_or_else(|e| e.into_inner()) = Some(seek_tx);
+
         let source_path = PathBuf::from(path.clone());
         let task_context = PlaybackTaskContext {
             state: Arc::clone(&self.state),
             callback: Arc::clone(&self.audio_callback),
             listeners: Arc::clone(&self.event_listeners),
+            seek_rx,
             ring_capacity: self.ring_buffer_capacity,
             callback_samples: self.callback_frame_samples,
         };
@@ -230,6 +263,7 @@ impl AndroidEngine {
 
     pub async fn stop(&self) -> Result<(), AndroidEngineError> {
         self.state.store(STATE_STOPPED, Ordering::SeqCst);
+        *self.seek_tx.lock().unwrap_or_else(|e| e.into_inner()) = None;
         if let Some(task) = self
             .playback_task
             .lock()
@@ -244,18 +278,42 @@ impl AndroidEngine {
         Ok(())
     }
 
+    /// Seeks to `position_secs` within the current track. The request is forwarded to
+    /// the playback task, which repositions the decoder, flushes buffered audio, and
+    /// emits `SeekCompleted` with the decoder's actual position — also returned here.
     pub async fn seek(&self, position_secs: f64) -> Result<f64, AndroidEngineError> {
+        if !position_secs.is_finite() {
+            return Err(AndroidEngineError::Playback {
+                message: "seek position must be finite".to_string(),
+            });
+        }
         if self.state.load(Ordering::SeqCst) == STATE_STOPPED {
             return Err(AndroidEngineError::NotPlaying);
         }
-        self.notify(AndroidEngineEvent {
-            kind: AndroidEngineEventKind::SeekCompleted,
-            path: None,
-            message: None,
-            position_secs: Some(position_secs.max(0.0)),
-            underrun_count: None,
-        });
-        Ok(position_secs.max(0.0))
+        let seek_tx = self
+            .seek_tx
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let Some(seek_tx) = seek_tx else {
+            return Err(AndroidEngineError::NotPlaying);
+        };
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        seek_tx
+            .send(SeekCommand {
+                target_secs: position_secs.max(0.0),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| AndroidEngineError::NotPlaying)?;
+
+        match reply_rx.await {
+            Ok(Ok(actual_secs)) => Ok(actual_secs),
+            Ok(Err(message)) => Err(AndroidEngineError::Playback { message }),
+            // WHY: the playback task exited before replying; never fabricate success.
+            Err(_) => Err(AndroidEngineError::NotPlaying),
+        }
     }
 
     pub fn state(&self) -> String {
@@ -303,7 +361,8 @@ impl Drop for AndroidEngine {
 struct PlaybackTaskContext {
     state: Arc<AtomicU8>,
     callback: Arc<Mutex<Option<Box<dyn AudioCallback>>>>,
-    listeners: Arc<Mutex<Vec<Box<dyn EventListener>>>>,
+    listeners: EventListeners,
+    seek_rx: mpsc::Receiver<SeekCommand>,
     ring_capacity: usize,
     callback_samples: usize,
 }
@@ -314,7 +373,7 @@ struct DrainTaskContext {
     producer_done: Arc<AtomicBool>,
     underruns: Arc<AtomicU64>,
     callback: Arc<Mutex<Option<Box<dyn AudioCallback>>>>,
-    listeners: Arc<Mutex<Vec<Box<dyn EventListener>>>>,
+    listeners: EventListeners,
     callback_samples: usize,
 }
 
@@ -323,27 +382,42 @@ async fn playback_task(
     display_path: String,
     context: PlaybackTaskContext,
 ) -> Result<(), String> {
+    let PlaybackTaskContext {
+        state,
+        callback,
+        listeners,
+        mut seek_rx,
+        ring_capacity,
+        callback_samples,
+    } = context;
+
     let mut decoder = open_decoder(&source_path)
         .await
         .map_err(|e| e.to_string())?;
     let (_dsp_tx, dsp_rx) = watch::channel(DspConfig::default());
     let mut dsp = DspPipeline::new(DspConfig::default(), dsp_rx);
-    let ring = Arc::new(RingBuffer::new(context.ring_capacity));
+    let ring = Arc::new(RingBuffer::new(ring_capacity));
     let producer_done = Arc::new(AtomicBool::new(false));
     let underruns = Arc::new(AtomicU64::new(0));
 
     let drain_task = tokio::spawn(drain_callback_task(DrainTaskContext {
         ring: Arc::clone(&ring),
-        state: Arc::clone(&context.state),
+        state: Arc::clone(&state),
         producer_done: Arc::clone(&producer_done),
         underruns: Arc::clone(&underruns),
-        callback: context.callback,
-        listeners: Arc::clone(&context.listeners),
-        callback_samples: context.callback_samples,
+        callback,
+        listeners: Arc::clone(&listeners),
+        callback_samples,
     }));
 
     loop {
-        match context.state.load(Ordering::SeqCst) {
+        // WHY(#398): seeks are serviced before the state check so they also work
+        // while paused.
+        while let Ok(command) = seek_rx.try_recv() {
+            run_seek(decoder.as_mut(), &ring, &listeners, command).await;
+        }
+
+        match state.load(Ordering::SeqCst) {
             STATE_STOPPED => break,
             STATE_PAUSED => {
                 tokio::time::sleep(PAUSE_SLEEP).await;
@@ -369,7 +443,13 @@ async fn playback_task(
         }
 
         loop {
-            if context.state.load(Ordering::SeqCst) == STATE_STOPPED {
+            if state.load(Ordering::SeqCst) == STATE_STOPPED {
+                break;
+            }
+            // WHY(#398): a seek landing mid-backpressure supersedes this frame — it
+            // predates the new position, so it is dropped rather than pushed.
+            if let Ok(command) = seek_rx.try_recv() {
+                run_seek(decoder.as_mut(), &ring, &listeners, command).await;
                 break;
             }
             if ring.push_frame(&samples) {
@@ -382,18 +462,73 @@ async fn playback_task(
     producer_done.store(true, Ordering::SeqCst);
     let _ = drain_task.await;
 
-    if context.state.swap(STATE_STOPPED, Ordering::SeqCst) != STATE_STOPPED {
+    if state.swap(STATE_STOPPED, Ordering::SeqCst) != STATE_STOPPED {
         notify(
-            &context.listeners,
+            &listeners,
             AndroidEngineEvent::for_path(AndroidEngineEventKind::TrackEnded, &display_path),
         );
         notify(
-            &context.listeners,
+            &listeners,
             AndroidEngineEvent::simple(AndroidEngineEventKind::PlaybackStopped),
         );
     }
 
     Ok(())
+}
+
+/// Executes one seek command: repositions the decoder, flushes buffered audio, emits
+/// `SeekCompleted` with the actual position, and replies to the caller. On failure the
+/// caller receives the error and playback continues FROM the old position.
+async fn run_seek(
+    decoder: &mut dyn AudioDecoder,
+    ring: &RingBuffer,
+    listeners: &EventListeners,
+    command: SeekCommand,
+) {
+    let target = match Duration::try_from_secs_f64(command.target_secs) {
+        Ok(target) => target,
+        Err(e) => {
+            let message = format!("invalid seek target {}: {e}", command.target_secs);
+            notify(
+                listeners,
+                AndroidEngineEvent::message(AndroidEngineEventKind::Error, message.clone()),
+            );
+            // WHY: reply send fails only when the caller stopped waiting; intentional
+            command.reply.send(Err(message)).ok();
+            return;
+        }
+    };
+
+    match decoder.seek(target).await {
+        Ok(actual) => {
+            // SAFETY: producer and consumer tasks both run on the engine's dedicated
+            // single-threaded runtime, so no ring access races clear() resetting the
+            // positions.
+            ring.clear();
+            let actual_secs = actual.as_secs_f64();
+            notify(
+                listeners,
+                AndroidEngineEvent {
+                    kind: AndroidEngineEventKind::SeekCompleted,
+                    path: None,
+                    message: None,
+                    position_secs: Some(actual_secs),
+                    underrun_count: None,
+                },
+            );
+            // WHY: reply send fails only when the caller stopped waiting; intentional
+            command.reply.send(Ok(actual_secs)).ok();
+        }
+        Err(e) => {
+            let message = e.to_string();
+            notify(
+                listeners,
+                AndroidEngineEvent::message(AndroidEngineEventKind::Error, message.clone()),
+            );
+            // WHY: reply send fails only when the caller stopped waiting; intentional
+            command.reply.send(Err(message)).ok();
+        }
+    }
 }
 
 async fn drain_callback_task(context: DrainTaskContext) {
@@ -456,8 +591,18 @@ async fn drain_callback_task(context: DrainTaskContext) {
     }
 }
 
-fn notify(listeners: &Arc<Mutex<Vec<Box<dyn EventListener>>>>, event: AndroidEngineEvent) {
-    for listener in listeners.lock().unwrap_or_else(|e| e.into_inner()).iter() {
+fn notify(listeners: &EventListeners, event: AndroidEngineEvent) {
+    // WHY(#400): the lock only covers snapshotting listener handles. Foreign on_event
+    // callbacks run after the guard is released — invoking them under the lock
+    // deadlocks any reentrant subscribe_events/unsubscribe_events call (std::sync::Mutex
+    // is not reentrant).
+    let snapshot: Vec<Arc<dyn EventListener>> = listeners
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .iter()
+        .map(|(_, listener)| Arc::clone(listener))
+        .collect();
+    for listener in snapshot {
         listener.on_event(event.clone());
     }
 }
@@ -633,5 +778,306 @@ mod tests {
 
         assert_eq!(calls.load(Ordering::SeqCst), 3);
         assert_eq!(engine.state(), "stopped");
+    }
+
+    // --- #399: subscription ids and unsubscribe ---
+
+    #[tokio::test]
+    async fn subscribe_events_returns_unique_ids() {
+        let engine = AndroidEngine::new().unwrap();
+        let calls = Arc::new(AtomicU64::new(0));
+        let id_a = engine.subscribe_events(Box::new(CountingListener {
+            calls: Arc::clone(&calls),
+        }));
+        let id_b = engine.subscribe_events(Box::new(CountingListener {
+            calls: Arc::clone(&calls),
+        }));
+        assert_ne!(id_a, id_b, "subscription ids must be unique");
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_removes_listener() {
+        let engine = AndroidEngine::new().unwrap();
+        let calls_a = Arc::new(AtomicU64::new(0));
+        let calls_b = Arc::new(AtomicU64::new(0));
+        let id_a = engine.subscribe_events(Box::new(CountingListener {
+            calls: Arc::clone(&calls_a),
+        }));
+        let id_b = engine.subscribe_events(Box::new(CountingListener {
+            calls: Arc::clone(&calls_b),
+        }));
+
+        engine.state.store(STATE_PLAYING, Ordering::SeqCst);
+        engine.pause().await.unwrap();
+        assert_eq!(calls_a.load(Ordering::SeqCst), 1);
+        assert_eq!(calls_b.load(Ordering::SeqCst), 1);
+
+        assert!(engine.unsubscribe_events(id_a), "id_a must be removed");
+        engine.resume().await.unwrap();
+        assert_eq!(
+            calls_a.load(Ordering::SeqCst),
+            1,
+            "removed listener notified"
+        );
+        assert_eq!(calls_b.load(Ordering::SeqCst), 2);
+
+        assert!(
+            !engine.unsubscribe_events(id_a),
+            "double unsubscribe must report nothing removed"
+        );
+        assert!(engine.unsubscribe_events(id_b));
+        engine.pause().await.unwrap();
+        assert_eq!(calls_a.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            calls_b.load(Ordering::SeqCst),
+            2,
+            "removed listener notified"
+        );
+    }
+
+    // --- #400: notify must not hold the listener lock during callbacks ---
+
+    struct NoopListener;
+
+    impl EventListener for NoopListener {
+        fn on_event(&self, _event: AndroidEngineEvent) {}
+    }
+
+    struct ReentrantSubscribeListener {
+        engine: Arc<AndroidEngine>,
+        reentered: Arc<AtomicU64>,
+    }
+
+    impl EventListener for ReentrantSubscribeListener {
+        fn on_event(&self, _event: AndroidEngineEvent) {
+            if self.reentered.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.engine.subscribe_events(Box::new(NoopListener));
+            }
+        }
+    }
+
+    struct SelfRemovingListener {
+        engine: Arc<AndroidEngine>,
+        own_id: Arc<AtomicU64>,
+        calls: Arc<AtomicU64>,
+    }
+
+    impl EventListener for SelfRemovingListener {
+        fn on_event(&self, _event: AndroidEngineEvent) {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.engine
+                .unsubscribe_events(self.own_id.load(Ordering::SeqCst));
+        }
+    }
+
+    /// Drives one notify (via stop()) on a helper thread so a deadlock regression
+    /// surfaces as a bounded test failure instead of a hang — a thread stuck inside a
+    /// std::sync::Mutex cannot be cancelled by an async timeout.
+    fn stop_with_deadlock_guard(engine: &Arc<AndroidEngine>) {
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let engine_for_thread = Arc::clone(engine);
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("test runtime");
+            runtime
+                .block_on(engine_for_thread.stop())
+                .expect("stop must succeed");
+            done_tx.send(()).ok();
+        });
+        done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("notify() deadlocked while a listener reentered the engine");
+    }
+
+    #[test]
+    fn notify_reentrant_subscribe_does_not_deadlock() {
+        let engine = AndroidEngine::new().unwrap();
+        let reentered = Arc::new(AtomicU64::new(0));
+        engine.subscribe_events(Box::new(ReentrantSubscribeListener {
+            engine: Arc::clone(&engine),
+            reentered: Arc::clone(&reentered),
+        }));
+
+        stop_with_deadlock_guard(&engine);
+        assert_eq!(reentered.load(Ordering::SeqCst), 1);
+
+        // The listener added during notify participates in subsequent notifies.
+        stop_with_deadlock_guard(&engine);
+        assert_eq!(reentered.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn notify_reentrant_unsubscribe_does_not_deadlock() {
+        let engine = AndroidEngine::new().unwrap();
+        let own_id = Arc::new(AtomicU64::new(0));
+        let calls = Arc::new(AtomicU64::new(0));
+        let id = engine.subscribe_events(Box::new(SelfRemovingListener {
+            engine: Arc::clone(&engine),
+            own_id: Arc::clone(&own_id),
+            calls: Arc::clone(&calls),
+        }));
+        own_id.store(id, Ordering::SeqCst);
+
+        stop_with_deadlock_guard(&engine);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        stop_with_deadlock_guard(&engine);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "listener removed itself during the first notify"
+        );
+    }
+
+    // --- #398: seek must reposition playback ---
+
+    #[tokio::test]
+    async fn seek_before_play_errors() {
+        let engine = AndroidEngine::new().unwrap();
+        let result = engine.seek(1.0).await;
+        assert!(matches!(result, Err(AndroidEngineError::NotPlaying)));
+    }
+
+    #[tokio::test]
+    async fn seek_rejects_non_finite_position() {
+        let engine = AndroidEngine::new().unwrap();
+        let result = engine.seek(f64::INFINITY).await;
+        assert!(matches!(result, Err(AndroidEngineError::Playback { .. })));
+    }
+
+    /// Records delivered samples and paces the drain (~5ms per chunk) so the test has a
+    /// stable window to issue the seek before playback finishes.
+    struct PacedRecordingCallback {
+        samples: Arc<Mutex<Vec<f64>>>,
+    }
+
+    impl AudioCallback for PacedRecordingCallback {
+        fn on_frame(&self, samples: Vec<f64>) {
+            self.samples
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .extend_from_slice(&samples);
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    struct RecordingListener {
+        events: Arc<Mutex<Vec<AndroidEngineEvent>>>,
+    }
+
+    impl EventListener for RecordingListener {
+        fn on_event(&self, event: AndroidEngineEvent) {
+            self.events
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(event);
+        }
+    }
+
+    /// Mono 16-bit WAV whose sample amplitude ramps 0 → 1 over the duration, so the
+    /// value of a delivered sample identifies its position in the track.
+    fn ramp_wav_tempfile(seconds: u32) -> tempfile::NamedTempFile {
+        use std::io::Write;
+
+        let sample_rate = 44_100u32;
+        let n_samples = sample_rate * seconds;
+        let data_len = n_samples * 2;
+        let byte_rate = sample_rate * 2;
+
+        let mut v = Vec::with_capacity(44 + data_len as usize);
+        v.extend_from_slice(b"RIFF");
+        v.extend_from_slice(&(36 + data_len).to_le_bytes());
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(b"fmt ");
+        v.extend_from_slice(&16u32.to_le_bytes());
+        v.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        v.extend_from_slice(&1u16.to_le_bytes()); // mono
+        v.extend_from_slice(&sample_rate.to_le_bytes());
+        v.extend_from_slice(&byte_rate.to_le_bytes());
+        v.extend_from_slice(&2u16.to_le_bytes()); // block align
+        v.extend_from_slice(&16u16.to_le_bytes());
+        v.extend_from_slice(b"data");
+        v.extend_from_slice(&data_len.to_le_bytes());
+        for i in 0..n_samples {
+            let value = ((f64::from(i) / f64::from(n_samples)) * 32_767.0) as i16;
+            v.extend_from_slice(&value.to_le_bytes());
+        }
+
+        let mut f = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
+        f.write_all(&v).unwrap();
+        f
+    }
+
+    #[tokio::test]
+    async fn seek_moves_playback_position() {
+        let engine = AndroidEngine::new().unwrap();
+        let samples = Arc::new(Mutex::new(Vec::new()));
+        engine.register_callback(Box::new(PacedRecordingCallback {
+            samples: Arc::clone(&samples),
+        }));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        engine.subscribe_events(Box::new(RecordingListener {
+            events: Arc::clone(&events),
+        }));
+
+        // 10s ramp = 441 000 samples; paced drain gives >2s of wall-clock playback.
+        let wav = ramp_wav_tempfile(10);
+        engine
+            .play(wav.path().to_string_lossy().into_owned())
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let actual = tokio::time::timeout(Duration::from_secs(10), engine.seek(9.0))
+            .await
+            .expect("seek must not hang")
+            .expect("seek must succeed");
+        assert!((actual - 9.0).abs() < 0.5, "actual position {actual}");
+
+        // Await TrackEnded (only ~1s of audio remains after a real seek).
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let ended = events
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .iter()
+                .any(|e| matches!(e.kind, AndroidEngineEventKind::TrackEnded));
+            if ended {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "TrackEnded not observed after seek"
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        let recorded = samples.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        // The full 10s file is 441 000 samples; a real seek skips most of it.
+        assert!(
+            recorded.len() < 300_000,
+            "played {} samples — seek did not skip ahead",
+            recorded.len()
+        );
+        // Ramp values >= 0.85 exist only past the 8.5s mark.
+        let max = recorded.iter().fold(0.0f64, |m, &s| m.max(s));
+        assert!(
+            max >= 0.85,
+            "no post-seek samples delivered (max amplitude {max}) — playback did not jump"
+        );
+
+        // SeekCompleted must carry the decoder's actual position.
+        let seek_positions: Vec<f64> = events
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .filter(|e| matches!(e.kind, AndroidEngineEventKind::SeekCompleted))
+            .filter_map(|e| e.position_secs)
+            .collect();
+        assert!(
+            seek_positions.iter().any(|&p| (p - actual).abs() < 1e-9),
+            "SeekCompleted must carry the actual position, got {seek_positions:?}"
+        );
     }
 }

--- a/crates/akouo-core/src/config.rs
+++ b/crates/akouo-core/src/config.rs
@@ -250,6 +250,10 @@ impl Default for VolumeConfig {
 /// Audio output configuration.
 #[derive(Debug, Clone)]
 pub struct OutputConfig {
+    /// When false the engine decodes and processes without opening an audio device;
+    /// frames flow INTO the ring buffer with no hardware consumer. For headless
+    /// operation (analysis, prebuffering, tests on machines without audio).
+    pub enabled: bool,
     /// Target output device name. `None` = system default.
     pub device_name: Option<String>,
     pub buffer_size: BufferSize,
@@ -262,6 +266,7 @@ pub struct OutputConfig {
 impl Default for OutputConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             device_name: None,
             buffer_size: BufferSize::default(),
             exclusive_mode: false,

--- a/crates/akouo-core/src/decode/blocking.rs
+++ b/crates/akouo-core/src/decode/blocking.rs
@@ -1,0 +1,214 @@
+// Dedicated-thread decoder wrapper: keeps blocking decode I/O off the async executor.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::mpsc as std_mpsc;
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+
+use crate::decode::{AudioDecoder, DecodedFrame, GaplessInfo, StreamParams, SyncAudioDecoder};
+use crate::error::DecodeError;
+
+enum Command {
+    NextFrame(oneshot::Sender<Result<Option<DecodedFrame>, DecodeError>>),
+    Seek(Duration, oneshot::Sender<Result<Duration, DecodeError>>),
+}
+
+/// Runs a `SyncAudioDecoder` on a dedicated OS thread and exposes the async
+/// `AudioDecoder` interface.
+///
+/// Every decode and seek call — including their blocking file reads — executes on the
+/// decode thread; the async side only awaits a `oneshot` reply, so the Tokio executor is
+/// never blocked regardless of runtime flavor (works on `current_thread` runtimes where
+/// `block_in_place` would panic).
+///
+/// Dropping the wrapper closes the command channel; the decode thread drains any queued
+/// command and exits on its own. No join occurs on drop, so dropping from async context
+/// never blocks the runtime.
+pub struct BlockingDecoder {
+    command_tx: std_mpsc::Sender<Command>,
+    stream_params: StreamParams,
+    gapless_info: Option<GaplessInfo>,
+}
+
+impl BlockingDecoder {
+    /// Moves `inner` onto a dedicated decode thread and returns the async wrapper.
+    pub fn spawn(inner: Box<dyn SyncAudioDecoder>) -> Result<Self, DecodeError> {
+        let stream_params = inner.stream_params();
+        let gapless_info = inner.gapless_info();
+        let (command_tx, command_rx) = std_mpsc::channel::<Command>();
+
+        std::thread::Builder::new()
+            .name("akouo-decode".to_string())
+            .spawn(move || decode_thread(inner, command_rx))
+            .map_err(|e| DecodeError::TaskJoin {
+                message: format!("failed to spawn decode thread: {e}"),
+                location: snafu::location!(),
+            })?;
+
+        Ok(Self {
+            command_tx,
+            stream_params,
+            gapless_info,
+        })
+    }
+}
+
+fn decode_thread(mut inner: Box<dyn SyncAudioDecoder>, command_rx: std_mpsc::Receiver<Command>) {
+    while let Ok(command) = command_rx.recv() {
+        match command {
+            // WHY: reply send fails only when the caller dropped its receiver
+            // (request cancelled); the result is discarded intentionally.
+            Command::NextFrame(reply) => {
+                reply.send(inner.next_frame()).ok();
+            }
+            Command::Seek(position, reply) => {
+                reply.send(inner.seek(position)).ok();
+            }
+        }
+    }
+}
+
+fn thread_terminated() -> DecodeError {
+    DecodeError::TaskJoin {
+        message: "decode thread terminated unexpectedly".to_string(),
+        location: snafu::location!(),
+    }
+}
+
+impl AudioDecoder for BlockingDecoder {
+    fn next_frame(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<DecodedFrame>, DecodeError>> + Send + '_>> {
+        Box::pin(async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            self.command_tx
+                .send(Command::NextFrame(reply_tx))
+                .map_err(|_| thread_terminated())?;
+            reply_rx.await.unwrap_or_else(|_| Err(thread_terminated()))
+        })
+    }
+
+    fn seek(
+        &mut self,
+        position: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Duration, DecodeError>> + Send + '_>> {
+        Box::pin(async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            self.command_tx
+                .send(Command::Seek(position, reply_tx))
+                .map_err(|_| thread_terminated())?;
+            reply_rx.await.unwrap_or_else(|_| Err(thread_terminated()))
+        })
+    }
+
+    fn stream_params(&self) -> StreamParams {
+        self.stream_params.clone()
+    }
+
+    fn gapless_info(&self) -> Option<GaplessInfo> {
+        self.gapless_info.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decode::Codec;
+
+    /// Sync decoder stub producing `frames_left` one-sample frames, then EOS.
+    struct StubDecoder {
+        frames_left: u32,
+        fail_next: bool,
+    }
+
+    impl SyncAudioDecoder for StubDecoder {
+        fn next_frame(&mut self) -> Result<Option<DecodedFrame>, DecodeError> {
+            if self.fail_next {
+                return Err(DecodeError::SymphoniaDecode {
+                    message: "stub failure".to_string(),
+                    location: snafu::location!(),
+                });
+            }
+            if self.frames_left == 0 {
+                return Ok(None);
+            }
+            self.frames_left -= 1;
+            Ok(Some(DecodedFrame {
+                samples: vec![0.25].into_boxed_slice(),
+                channels: 1,
+                sample_rate: 44100,
+                timestamp: 0,
+            }))
+        }
+
+        fn seek(&mut self, position: Duration) -> Result<Duration, DecodeError> {
+            Ok(position / 2)
+        }
+
+        fn stream_params(&self) -> StreamParams {
+            StreamParams {
+                codec: Codec::Wav,
+                sample_rate: 44100,
+                channels: 1,
+                bit_depth: Some(16),
+                duration: None,
+                bitrate: None,
+            }
+        }
+
+        fn gapless_info(&self) -> Option<GaplessInfo> {
+            None
+        }
+    }
+
+    #[tokio::test]
+    async fn blocking_decoder_streams_frames_then_eos() {
+        let mut dec = BlockingDecoder::spawn(Box::new(StubDecoder {
+            frames_left: 2,
+            fail_next: false,
+        }))
+        .unwrap();
+
+        assert!(dec.next_frame().await.unwrap().is_some());
+        assert!(dec.next_frame().await.unwrap().is_some());
+        assert!(dec.next_frame().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn blocking_decoder_propagates_decode_errors() {
+        let mut dec = BlockingDecoder::spawn(Box::new(StubDecoder {
+            frames_left: 0,
+            fail_next: true,
+        }))
+        .unwrap();
+
+        let err = dec.next_frame().await.expect_err("stub must fail");
+        assert!(matches!(err, DecodeError::SymphoniaDecode { .. }));
+    }
+
+    #[tokio::test]
+    async fn blocking_decoder_seek_returns_inner_actual_position() {
+        let mut dec = BlockingDecoder::spawn(Box::new(StubDecoder {
+            frames_left: 0,
+            fail_next: false,
+        }))
+        .unwrap();
+
+        let actual = dec.seek(Duration::from_secs(2)).await.unwrap();
+        assert_eq!(actual, Duration::from_secs(1), "stub halves the target");
+    }
+
+    #[tokio::test]
+    async fn blocking_decoder_caches_params_and_gapless() {
+        let dec = BlockingDecoder::spawn(Box::new(StubDecoder {
+            frames_left: 0,
+            fail_next: false,
+        }))
+        .unwrap();
+
+        assert_eq!(dec.stream_params().sample_rate, 44100);
+        assert!(dec.gapless_info().is_none());
+    }
+}

--- a/crates/akouo-core/src/decode/mod.rs
+++ b/crates/akouo-core/src/decode/mod.rs
@@ -1,3 +1,4 @@
+pub mod blocking;
 pub mod metadata;
 pub mod opus;
 pub mod probe;
@@ -84,6 +85,25 @@ pub trait AudioDecoder: Send {
         &mut self,
         position: Duration,
     ) -> Pin<Box<dyn Future<Output = Result<Duration, DecodeError>> + Send + '_>>;
+
+    /// Stream parameters discovered during open/probe.
+    fn stream_params(&self) -> StreamParams;
+
+    /// Gapless metadata if present in the source.
+    fn gapless_info(&self) -> Option<GaplessInfo>;
+}
+
+/// Synchronous decoder contract implemented by the concrete codec bridges.
+///
+/// Implementations perform blocking file I/O directly. They must never be driven on an
+/// async executor thread; `blocking::BlockingDecoder` owns each implementation on a
+/// dedicated decode thread and exposes the async `AudioDecoder` interface on top.
+pub trait SyncAudioDecoder: Send {
+    /// Returns the next decoded frame, or `None` at end of stream. May block on file I/O.
+    fn next_frame(&mut self) -> Result<Option<DecodedFrame>, DecodeError>;
+
+    /// Seeks to the requested position. Returns the actual position reached. May block.
+    fn seek(&mut self, position: Duration) -> Result<Duration, DecodeError>;
 
     /// Stream parameters discovered during open/probe.
     fn stream_params(&self) -> StreamParams;

--- a/crates/akouo-core/src/decode/opus.rs
+++ b/crates/akouo-core/src/decode/opus.rs
@@ -2,10 +2,9 @@
 //
 // Symphonia's OGG demuxer extracts raw Opus packets; `opus::Decoder` decodes them.
 // When Symphonia's native Opus decoder reaches production readiness (PR #398), this
-// bridge can be removed without API change  -  it implements the same AudioDecoder trait.
+// bridge can be removed without API change  -  it implements the same SyncAudioDecoder
+// trait.
 
-use std::future::Future;
-use std::pin::Pin;
 use std::time::Duration;
 
 use symphonia::core::codecs::audio::well_known::CODEC_ID_OPUS;
@@ -13,7 +12,7 @@ use symphonia::core::formats::{FormatReader, SeekMode, SeekTo};
 
 use symphonia::core::units::{Time, TimeBase};
 
-use crate::decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams};
+use crate::decode::{Codec, DecodedFrame, GaplessInfo, StreamParams, SyncAudioDecoder};
 use crate::error::DecodeError;
 
 /// Opus is always 48 kHz internally.
@@ -24,8 +23,8 @@ const OPUS_MAX_FRAME_SAMPLES: usize = 5_760;
 
 /// Opus FFI decoder. Demuxes OGG via Symphonia, decodes packets via libopus.
 ///
-/// All I/O is synchronous (std file reads); the `Pin<Box<dyn Future>>` wrappers
-/// return `std::future::ready(result)` so the caller can await without blocking.
+/// All I/O is synchronous (std file reads); the decoder implements `SyncAudioDecoder`
+/// and is driven on a dedicated decode thread by `blocking::BlockingDecoder`.
 pub struct OpusDecoder {
     decoder: opus::Decoder,
     format_reader: Box<dyn FormatReader + 'static>,
@@ -46,7 +45,7 @@ impl OpusDecoder {
     /// ownership and sets up the libopus decoder for the OGG/Opus track.
     pub fn from_probed(
         format: Box<dyn symphonia::core::formats::FormatReader + 'static>,
-    ) -> Result<Box<dyn AudioDecoder>, DecodeError> {
+    ) -> Result<Box<dyn SyncAudioDecoder>, DecodeError> {
         let track = format
             .tracks()
             .iter()
@@ -215,18 +214,15 @@ impl OpusDecoder {
     }
 }
 
-impl AudioDecoder for OpusDecoder {
-    fn next_frame(
-        &mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<DecodedFrame>, DecodeError>> + Send + '_>> {
-        Box::pin(std::future::ready(self.decode_next_packet()))
+// WHY(#403): OpusDecoder performs blocking OGG file reads, so it implements only the
+// synchronous trait; `blocking::BlockingDecoder` hosts it on a dedicated decode thread.
+impl SyncAudioDecoder for OpusDecoder {
+    fn next_frame(&mut self) -> Result<Option<DecodedFrame>, DecodeError> {
+        self.decode_next_packet()
     }
 
-    fn seek(
-        &mut self,
-        position: Duration,
-    ) -> Pin<Box<dyn Future<Output = Result<Duration, DecodeError>> + Send + '_>> {
-        Box::pin(std::future::ready(self.do_seek(position)))
+    fn seek(&mut self, position: Duration) -> Result<Duration, DecodeError> {
+        self.do_seek(position)
     }
 
     fn stream_params(&self) -> StreamParams {

--- a/crates/akouo-core/src/decode/probe.rs
+++ b/crates/akouo-core/src/decode/probe.rs
@@ -14,9 +14,10 @@ use symphonia::core::formats::probe::Hint;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 
+use crate::decode::blocking::BlockingDecoder;
 use crate::decode::opus::OpusDecoder;
 use crate::decode::symphonia::{SymphoniaDecoder, map_codec};
-use crate::decode::{AudioDecoder, Codec};
+use crate::decode::{AudioDecoder, Codec, SyncAudioDecoder};
 use crate::error::DecodeError;
 
 /// Probes `path` and returns a boxed decoder appropriate for the detected format.
@@ -25,11 +26,14 @@ use crate::error::DecodeError;
 /// - OGG/Opus  → `OpusDecoder` (Symphonia OGG demux + libopus FFI)
 /// - WavPack   → `UnsupportedCodec` error (implement via wavpack-sys when needed)
 /// - All others (FLAC, WAV, ALAC, MP3, AAC, AIFF, Vorbis) → `SymphoniaDecoder` (P1-02)
+///
+/// The returned decoder is a `BlockingDecoder` wrapper: all subsequent decode and seek
+/// I/O runs on a dedicated decode thread, never on the async executor.
 pub async fn open_decoder(path: &Path) -> Result<Box<dyn AudioDecoder>, DecodeError> {
     let path = path.to_path_buf();
     // WHY: probe_format opens std::fs::File (blocking); spawn_blocking prevents stalling
     // the async executor thread during disk I/O on the open/probe hot path.
-    tokio::task::spawn_blocking(move || {
+    let sync_decoder = tokio::task::spawn_blocking(move || {
         let probed = probe_format(&path)?;
         let codec = probed
             .default_track(symphonia::core::formats::TrackType::Audio)
@@ -57,30 +61,43 @@ pub async fn open_decoder(path: &Path) -> Result<Box<dyn AudioDecoder>, DecodeEr
                 );
                 let hint = hint_from_path(&path);
                 let dec = SymphoniaDecoder::new(mss, &hint)?;
-                Ok(Box::new(dec) as Box<dyn AudioDecoder>)
+                Ok(Box::new(dec) as Box<dyn SyncAudioDecoder>)
             }
         }
     })
     .await
-    .map_err(|e| DecodeError::SymphoniaRead {
-        message: format!("spawn_blocking failed: {e}"),
+    .map_err(|e| DecodeError::TaskJoin {
+        message: format!("decoder probe task failed to join: {e}"),
         location: snafu::location!(),
     })
-    .and_then(|r| r)
+    .and_then(|r| r)?;
+
+    Ok(Box::new(BlockingDecoder::spawn(sync_decoder)?) as Box<dyn AudioDecoder>)
 }
 
 /// Returns the codec for a file without fully opening a decoder. Useful for UI display.
 pub async fn probe_codec(path: &Path) -> Result<Codec, DecodeError> {
-    let probed = probe_format(path)?;
+    let path = path.to_path_buf();
+    // WHY(#403): probe_format opens std::fs::File (blocking); spawn_blocking keeps the
+    // probe I/O off the async executor, mirroring open_decoder.
+    tokio::task::spawn_blocking(move || {
+        let probed = probe_format(&path)?;
 
-    let codec_type = probed
-        .default_track(symphonia::core::formats::TrackType::Audio)
-        .and_then(|t| t.codec_params.as_ref())
-        .and_then(|c| c.audio())
-        .map(|a| a.codec)
-        .unwrap_or(CODEC_ID_NULL_AUDIO);
+        let codec_type = probed
+            .default_track(symphonia::core::formats::TrackType::Audio)
+            .and_then(|t| t.codec_params.as_ref())
+            .and_then(|c| c.audio())
+            .map(|a| a.codec)
+            .unwrap_or(CODEC_ID_NULL_AUDIO);
 
-    Ok(map_codec(codec_type))
+        Ok(map_codec(codec_type))
+    })
+    .await
+    .map_err(|e| DecodeError::TaskJoin {
+        message: format!("codec probe task failed to join: {e}"),
+        location: snafu::location!(),
+    })
+    .and_then(|r| r)
 }
 
 /// Opens `path` and runs Symphonia's format probe. Shared by `open_decoder` and `probe_codec`.
@@ -184,5 +201,66 @@ mod tests {
     async fn missing_file_returns_err() {
         let result = open_decoder(Path::new("/nonexistent/file.wav")).await;
         assert!(result.is_err());
+    }
+
+    // --- #403: blocking I/O must never run on the async executor ---
+
+    /// On a current_thread runtime a task spawned before an await only runs if that
+    /// await actually yields. The old probe_codec ran its blocking I/O inline in the
+    /// async fn body (ready on first poll — no yield), starving other tasks.
+    #[tokio::test]
+    async fn probe_codec_yields_to_executor() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let f = wav_tempfile(2, 44100, &[0i16; 64]);
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_task = Arc::clone(&flag);
+        tokio::spawn(async move {
+            flag_task.store(true, Ordering::SeqCst);
+        });
+
+        let codec = probe_codec(f.path()).await.unwrap();
+        assert!(matches!(codec, Codec::Wav));
+        assert!(
+            flag.load(Ordering::SeqCst),
+            "executor was starved during probe I/O — blocking work ran inline"
+        );
+    }
+
+    /// The old decoder next_frame wrappers returned already-ready futures whose blocking
+    /// work ran inline, so a full decode loop never yielded to the scheduler. With the
+    /// dedicated decode thread, every next_frame awaits a cross-thread reply and yields.
+    #[tokio::test]
+    async fn next_frame_yields_to_executor() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        // 5s stereo — several hundred packets, far more than the loop bound needs.
+        let samples: Vec<i16> = vec![0i16; 44100 * 2 * 5];
+        let f = wav_tempfile(2, 44100, &samples);
+        let mut dec = open_decoder(f.path()).await.unwrap();
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_task = Arc::clone(&flag);
+        tokio::spawn(async move {
+            flag_task.store(true, Ordering::SeqCst);
+        });
+
+        let mut yielded = false;
+        for _ in 0..1000 {
+            let frame = dec.next_frame().await.unwrap();
+            if flag.load(Ordering::SeqCst) {
+                yielded = true;
+                break;
+            }
+            if frame.is_none() {
+                break;
+            }
+        }
+        assert!(
+            yielded,
+            "decode loop never yielded to the executor — blocking work ran inline"
+        );
     }
 }

--- a/crates/akouo-core/src/decode/symphonia.rs
+++ b/crates/akouo-core/src/decode/symphonia.rs
@@ -1,5 +1,4 @@
 use std::io::ErrorKind;
-use std::pin::Pin;
 use std::time::Duration;
 
 use symphonia::core::audio::GenericAudioBufferRef;
@@ -12,7 +11,7 @@ use symphonia::core::meta::MetadataOptions;
 use symphonia::core::units::{Time, TimeBase};
 use tracing::{instrument, warn};
 
-use crate::decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams};
+use crate::decode::{Codec, DecodedFrame, GaplessInfo, StreamParams, SyncAudioDecoder};
 use crate::error::DecodeError;
 
 pub struct SymphoniaDecoder {
@@ -110,22 +109,15 @@ impl SymphoniaDecoder {
     }
 }
 
-impl AudioDecoder for SymphoniaDecoder {
-    fn next_frame(
-        &mut self,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<Output = Result<Option<DecodedFrame>, DecodeError>> + Send + '_,
-        >,
-    > {
-        Box::pin(async move { self.decode_next_frame() })
+// WHY(#403): SymphoniaDecoder performs blocking file reads, so it implements only the
+// synchronous trait; `blocking::BlockingDecoder` hosts it on a dedicated decode thread.
+impl SyncAudioDecoder for SymphoniaDecoder {
+    fn next_frame(&mut self) -> Result<Option<DecodedFrame>, DecodeError> {
+        self.decode_next_frame()
     }
 
-    fn seek(
-        &mut self,
-        position: Duration,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<Duration, DecodeError>> + Send + '_>> {
-        Box::pin(async move { self.seek_to(position) })
+    fn seek(&mut self, position: Duration) -> Result<Duration, DecodeError> {
+        self.seek_to(position)
     }
 
     fn stream_params(&self) -> StreamParams {
@@ -361,16 +353,16 @@ mod tests {
 
     // --- Decode loop tests ---
 
-    #[tokio::test]
-    async fn empty_wav_returns_ok_none() {
+    #[test]
+    fn empty_wav_returns_ok_none() {
         let wav = wav_bytes(2, 44100, &[]);
         let mut dec = decoder_from_wav(wav);
-        let result = dec.next_frame().await.unwrap_or_default();
+        let result = dec.next_frame().unwrap_or_default();
         assert!(result.is_none(), "expected Ok(None) for empty stream");
     }
 
-    #[tokio::test]
-    async fn wav_stream_params_populated() {
+    #[test]
+    fn wav_stream_params_populated() {
         let wav = wav_bytes(2, 44100, &[0i16; 4]);
         let dec = decoder_from_wav(wav);
         let p = dec.stream_params();
@@ -380,13 +372,13 @@ mod tests {
         assert!(matches!(p.codec, Codec::Wav));
     }
 
-    #[tokio::test]
-    async fn wav_decodes_first_frame() {
+    #[test]
+    fn wav_decodes_first_frame() {
         // 4 interleaved stereo samples: [0x7FFF, 0x7FFF, 0, 0]
         let samples: &[i16] = &[i16::MAX, i16::MAX, 0, 0];
         let wav = wav_bytes(2, 44100, samples);
         let mut dec = decoder_from_wav(wav);
-        let frame = dec.next_frame().await.unwrap().unwrap();
+        let frame = dec.next_frame().unwrap().unwrap();
         assert_eq!(frame.channels, 2);
         assert_eq!(frame.sample_rate, 44100);
         assert!(!frame.samples.is_empty());
@@ -397,32 +389,32 @@ mod tests {
         assert!(r > 0.999, "RIGHT channel = {r}");
     }
 
-    #[tokio::test]
-    async fn interleave_ordering_l_then_r() {
+    #[test]
+    fn interleave_ordering_l_then_r() {
         // Left = i16::MIN (-1.0), Right = i16::MAX (~1.0)
         let samples: &[i16] = &[i16::MIN, i16::MAX];
         let wav = wav_bytes(2, 44100, samples);
         let mut dec = decoder_from_wav(wav);
-        let frame = dec.next_frame().await.unwrap().unwrap();
+        let frame = dec.next_frame().unwrap().unwrap();
         let l = frame.samples.first().copied().unwrap_or_default();
         let r = frame.samples.get(1).copied().unwrap_or_default();
         assert!(l < -0.999, "LEFT should be approx -1.0, got {l}");
         assert!(r > 0.999, "RIGHT should be approx +1.0, got {r}");
     }
 
-    #[tokio::test]
-    async fn seek_returns_duration() {
+    #[test]
+    fn seek_returns_duration() {
         let samples: Vec<i16> = vec![0i16; 44100 * 2 * 2]; // 1s stereo
         let wav = wav_bytes(2, 44100, &samples);
         let mut dec = decoder_from_wav(wav);
         let target = Duration::from_millis(500);
-        let actual = dec.seek(target).await.unwrap_or_default();
+        let actual = dec.seek(target).unwrap_or_default();
         // Coarse seek  -  should be within 500ms of requested
         assert!(actual.as_millis() < 600, "seek overshot: {actual:?}");
     }
 
-    #[tokio::test]
-    async fn gapless_none_for_wav() {
+    #[test]
+    fn gapless_none_for_wav() {
         let wav = wav_bytes(2, 44100, &[]);
         let dec = decoder_from_wav(wav);
         assert!(dec.gapless_info().is_none());

--- a/crates/akouo-core/src/engine.rs
+++ b/crates/akouo-core/src/engine.rs
@@ -3,7 +3,8 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use tokio::sync::{broadcast, mpsc, watch};
+use snafu::ResultExt;
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{Instrument, instrument, warn};
 
@@ -11,7 +12,7 @@ use crate::config::{DspConfig, EngineConfig};
 use crate::decode::DecodedFrame;
 use crate::decode::probe::open_decoder;
 use crate::dsp::DspPipeline;
-use crate::error::EngineError;
+use crate::error::{DecodeError, EngineError, OutputError, SeekFailedSnafu};
 use crate::output::OutputDevice;
 use crate::ring_buffer::RingBuffer;
 use crate::signal_path::{QualityTier, SignalPathSnapshot, SignalStageInfo, SourceInfo};
@@ -56,9 +57,44 @@ pub enum EngineEvent {
     Underrun { count: u64 },
 }
 
+/// Outcome of one decode step, sent decode task → DSP task.
+///
+/// Distinguishes clean end-of-stream (`Eos`) so a failed decode is never
+/// reported as a completed track.
+enum DecodeOutcome {
+    /// A decoded frame tagged with the seek generation it was produced under.
+    Frame {
+        frame: DecodedFrame,
+        generation: u64,
+    },
+    /// Clean end of stream: the track played to completion.
+    Eos,
+    /// Decoding failed; an `EngineEvent::Error` was already emitted by the decode task.
+    Failed,
+}
+
+/// A seek request sent to the decode task; `reply` carries the decoder's actual
+/// post-seek position.
+struct SeekCommand {
+    target: Duration,
+    reply: oneshot::Sender<Result<Duration, DecodeError>>,
+}
+
 struct PlaybackSession {
     decode_task: JoinHandle<()>,
     dsp_task: JoinHandle<()>,
+    seek_tx: mpsc::Sender<SeekCommand>,
+    // WHY: keeps the output-error channel open for the session's lifetime and provides
+    // the injection seam for stream-error tests; production sends originate in the
+    // output backend.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "held to keep the output-error channel open; read via the test-only inject_output_error seam"
+        )
+    )]
+    output_error_tx: mpsc::Sender<OutputError>,
 }
 
 /// The audio engine: owns the decode → DSP → output pipeline.
@@ -119,8 +155,21 @@ impl Engine {
             )
             .map_err(|_| EngineError::AlreadyPlaying)?;
 
-        // Build fresh decode→DSP channel and output ring buffer.
-        let (frame_tx, frame_rx) = mpsc::channel::<Option<DecodedFrame>>(256);
+        // WHY(#401): PlaybackStarted must be observable before any event the spawned
+        // tasks can emit (Error, TrackEnded, PlaybackStopped). broadcast::Sender::send
+        // is synchronous, so emitting before tokio::spawn guarantees the ordering.
+        // WHY: send fails only when no receivers exist; dropping is intentional
+        self.event_tx
+            .send(EngineEvent::PlaybackStarted {
+                source: source.clone(),
+            })
+            .ok();
+
+        // Build fresh decode→DSP channel, seek channels, and output ring buffer.
+        let (frame_tx, frame_rx) = mpsc::channel::<DecodeOutcome>(256);
+        let (seek_tx, seek_rx) = mpsc::channel::<SeekCommand>(4);
+        let (seek_generation_tx, seek_generation_rx) = watch::channel(0u64);
+        let (output_error_tx, output_error_rx) = mpsc::channel::<OutputError>(16);
         let ring = Arc::new(RingBuffer::new(self.config.ring_buffer_capacity));
 
         // Clone shared handles for the tasks.
@@ -132,39 +181,43 @@ impl Engine {
         let initial_dsp_config = self.config.dsp.clone();
         let source_for_dsp = source.clone();
         let ring_for_dsp = Arc::clone(&ring);
+        let output_error_tx_for_dsp = output_error_tx.clone();
 
         let AudioSource::File(ref path) = source;
         let path = path.clone();
 
-        // Decode task: read file, send DecodedFrame to DSP channel.
+        // Decode task: read file, send DecodeOutcome to DSP channel, service seeks.
         let state_dec = Arc::clone(&state);
         let event_dec = event_tx.clone();
         let decode_task = tokio::spawn(
-            async move {
-                decode_task_fn(path, frame_tx, state_dec, event_dec).await;
-            }
+            decode_task_fn(
+                path,
+                frame_tx,
+                seek_rx,
+                seek_generation_tx,
+                state_dec,
+                event_dec,
+            )
             .instrument(tracing::info_span!("decode_task")),
         );
 
         // DSP+output task: receive frames, run DSP pipeline, push to ring buffer,
         // open cpal stream and feed audio hardware (when native-output feature is enabled).
-        let state_dsp = Arc::clone(&state);
-        let event_dsp = event_tx.clone();
         let dsp_task = tokio::spawn(
-            async move {
-                dsp_task_fn(
-                    source_for_dsp,
-                    frame_rx,
-                    dsp_config_rx,
-                    initial_dsp_config,
-                    engine_config,
-                    ring_for_dsp,
-                    signal_path_tx,
-                    state_dsp,
-                    event_dsp,
-                )
-                .await;
-            }
+            dsp_task_fn(DspTaskParams {
+                source: source_for_dsp,
+                frame_rx,
+                dsp_config_rx,
+                initial_dsp_config,
+                engine_config,
+                ring: ring_for_dsp,
+                signal_path_tx,
+                state,
+                event_tx,
+                seek_generation_rx,
+                output_error_rx,
+                output_error_tx: output_error_tx_for_dsp,
+            })
             .instrument(tracing::info_span!("dsp_task")),
         );
 
@@ -173,13 +226,11 @@ impl Engine {
         *guard = Some(PlaybackSession {
             decode_task,
             dsp_task,
+            seek_tx,
+            output_error_tx,
         });
         drop(guard);
 
-        // WHY: send fails only when no receivers exist; dropping is intentional
-        self.event_tx
-            .send(EngineEvent::PlaybackStarted { source })
-            .ok();
         Ok(())
     }
 
@@ -234,27 +285,42 @@ impl Engine {
 
     /// Seeks to `position` within the current track. Returns the actual position reached.
     ///
-    /// The seek flushes DSP state and signals the decode task to reposition. In this
-    /// implementation the position is accepted as-is and a `SeekCompleted` event is emitted.
-    /// Full inter-task seek coordination is completed in a subsequent pass.
+    /// The request is forwarded to the decode task, which repositions the decoder,
+    /// bumps the seek generation (so the DSP task discards stale pre-seek frames and
+    /// flushes buffered output), and replies with the decoder's actual post-seek
+    /// position. A `SeekCompleted` event carrying that actual position is emitted by
+    /// the decode task once the decoder has repositioned.
     #[instrument(skip(self))]
-    pub fn seek(&self, position: Duration) -> Result<Duration, EngineError> {
-        if self
-            .session
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .is_none()
-        {
-            return Err(EngineError::SeekOutOfBounds {
-                position_secs: position.as_secs_f64(),
-                duration_secs: 0.0,
-            });
+    pub async fn seek(&self, position: Duration) -> Result<Duration, EngineError> {
+        let seek_tx = {
+            let guard = self.session.lock().unwrap_or_else(|e| e.into_inner());
+            match guard.as_ref() {
+                Some(session) => session.seek_tx.clone(),
+                None => {
+                    return Err(EngineError::SeekOutOfBounds {
+                        position_secs: position.as_secs_f64(),
+                        duration_secs: 0.0,
+                    });
+                }
+            }
+        };
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        seek_tx
+            .send(SeekCommand {
+                target: position,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| decode_task_gone())
+            .context(SeekFailedSnafu)?;
+
+        match reply_rx.await {
+            Ok(result) => result.context(SeekFailedSnafu),
+            // WHY: the decode task exited (stop/abort/track end) before replying;
+            // never fabricate success.
+            Err(_) => Err(decode_task_gone()).context(SeekFailedSnafu),
         }
-        // WHY: send fails only when no receivers exist; dropping is intentional
-        self.event_tx
-            .send(EngineEvent::SeekCompleted { position })
-            .ok();
-        Ok(position)
     }
 
     /// Applies a new DSP configuration to the running pipeline without interrupting playback.
@@ -281,6 +347,22 @@ impl Engine {
     pub fn subscribe_events(&self) -> broadcast::Receiver<EngineEvent> {
         self.event_tx.subscribe()
     }
+
+    /// Test seam: injects an output-stream error as if the audio backend reported it.
+    #[cfg(test)]
+    fn inject_output_error(&self, error: OutputError) -> bool {
+        let guard = self.session.lock().unwrap_or_else(|e| e.into_inner());
+        guard
+            .as_ref()
+            .is_some_and(|session| session.output_error_tx.try_send(error).is_ok())
+    }
+}
+
+fn decode_task_gone() -> DecodeError {
+    DecodeError::TaskJoin {
+        message: "decode task is not running".to_string(),
+        location: snafu::location!(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -289,7 +371,9 @@ impl Engine {
 
 async fn decode_task_fn(
     path: PathBuf,
-    frame_tx: mpsc::Sender<Option<DecodedFrame>>,
+    frame_tx: mpsc::Sender<DecodeOutcome>,
+    mut seek_rx: mpsc::Receiver<SeekCommand>,
+    seek_generation_tx: watch::Sender<u64>,
     state: Arc<AtomicU8>,
     event_tx: broadcast::Sender<EngineEvent>,
 ) {
@@ -302,15 +386,36 @@ async fn decode_task_fn(
                     message: e.to_string(),
                 })
                 .ok();
+            // WHY(#402): open failure is a Failed outcome, never Eos — the DSP task
+            // must not report TrackEnded for a track that never decoded.
             // WHY: send fails only when no receivers exist; dropping is intentional
-            frame_tx.send(None).await.ok();
+            frame_tx.send(DecodeOutcome::Failed).await.ok();
             return;
         }
     };
 
+    let mut generation: u64 = 0;
+    // INVARIANT: once seek_rx yields None the sender is gone (session replaced or
+    // dropped); the branch is disabled to keep the select FROM spinning on a closed
+    // channel.
+    let mut seek_channel_open = true;
+
     loop {
         if state.load(Ordering::Relaxed) == STATE_STOPPED {
             break;
+        }
+
+        // Service pending seeks first so they work while paused and take priority
+        // over decoding the next frame.
+        while let Ok(command) = seek_rx.try_recv() {
+            generation = run_seek(
+                decoder.as_mut(),
+                command,
+                generation,
+                &seek_generation_tx,
+                &event_tx,
+            )
+            .await;
         }
 
         // Pause: yield until resumed or stopped.
@@ -321,13 +426,36 @@ async fn decode_task_fn(
 
         match decoder.next_frame().await {
             Ok(Some(frame)) => {
-                if frame_tx.send(Some(frame)).await.is_err() {
-                    break; // DSP task dropped receiver
+                let outcome = DecodeOutcome::Frame { frame, generation };
+                // WHY(#386): select keeps seeks responsive even while the frame
+                // channel is full; a seek that wins drops the pending frame, which is
+                // correct — it predates the new position.
+                tokio::select! {
+                    sent = frame_tx.send(outcome) => {
+                        if sent.is_err() {
+                            break; // DSP task dropped receiver
+                        }
+                    }
+                    command = seek_rx.recv(), if seek_channel_open => {
+                        match command {
+                            Some(command) => {
+                                generation = run_seek(
+                                    decoder.as_mut(),
+                                    command,
+                                    generation,
+                                    &seek_generation_tx,
+                                    &event_tx,
+                                )
+                                .await;
+                            }
+                            None => seek_channel_open = false,
+                        }
+                    }
                 }
             }
             Ok(None) => {
                 // WHY: send fails only when no receivers exist; dropping is intentional
-                frame_tx.send(None).await.ok();
+                frame_tx.send(DecodeOutcome::Eos).await.ok();
                 break;
             }
             Err(e) => {
@@ -337,10 +465,50 @@ async fn decode_task_fn(
                         message: e.to_string(),
                     })
                     .ok();
+                // WHY(#402): decode failure is signalled distinctly FROM end-of-stream
+                // so the DSP task never emits TrackEnded for a failed track.
                 // WHY: send fails only when no receivers exist; dropping is intentional
-                frame_tx.send(None).await.ok();
+                frame_tx.send(DecodeOutcome::Failed).await.ok();
                 break;
             }
+        }
+    }
+}
+
+/// Executes one seek command against the decoder. On success bumps the seek generation
+/// (visible to the DSP task before any post-seek frame is sent), emits `SeekCompleted`
+/// with the decoder's actual position, and replies to the caller. Returns the
+/// generation in effect afterwards.
+async fn run_seek(
+    decoder: &mut dyn crate::decode::AudioDecoder,
+    command: SeekCommand,
+    generation: u64,
+    seek_generation_tx: &watch::Sender<u64>,
+    event_tx: &broadcast::Sender<EngineEvent>,
+) -> u64 {
+    match decoder.seek(command.target).await {
+        Ok(actual) => {
+            let next_generation = generation + 1;
+            // WHY: send fails only when no receivers exist; dropping is intentional
+            seek_generation_tx.send(next_generation).ok();
+            // WHY: send fails only when no receivers exist; dropping is intentional
+            event_tx
+                .send(EngineEvent::SeekCompleted { position: actual })
+                .ok();
+            // WHY: reply send fails only when the caller stopped waiting; intentional
+            command.reply.send(Ok(actual)).ok();
+            next_generation
+        }
+        Err(e) => {
+            // WHY: send fails only when no receivers exist; dropping is intentional
+            event_tx
+                .send(EngineEvent::Error {
+                    message: e.to_string(),
+                })
+                .ok();
+            // WHY: reply send fails only when the caller stopped waiting; intentional
+            command.reply.send(Err(e)).ok();
+            generation
         }
     }
 }
@@ -349,20 +517,11 @@ async fn decode_task_fn(
 // DSP + output task
 // ---------------------------------------------------------------------------
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "DSP task receives all pipeline components; splitting further would require wrapper structs"
-)]
-#[cfg_attr(
-    not(feature = "native-output"),
-    expect(
-        unused_variables,
-        reason = "several parameters are used only when native-output feature is enabled"
-    )
-)]
-async fn dsp_task_fn(
+/// Everything the DSP+output task needs; bundled so the task has a single owner-struct
+/// instead of a dozen positional parameters.
+struct DspTaskParams {
     source: AudioSource,
-    mut frame_rx: mpsc::Receiver<Option<DecodedFrame>>,
+    frame_rx: mpsc::Receiver<DecodeOutcome>,
     dsp_config_rx: watch::Receiver<DspConfig>,
     initial_dsp_config: DspConfig,
     engine_config: EngineConfig,
@@ -370,10 +529,35 @@ async fn dsp_task_fn(
     signal_path_tx: Arc<watch::Sender<SignalPathSnapshot>>,
     state: Arc<AtomicU8>,
     event_tx: broadcast::Sender<EngineEvent>,
-) {
+    seek_generation_rx: watch::Receiver<u64>,
+    output_error_rx: mpsc::Receiver<OutputError>,
+    output_error_tx: mpsc::Sender<OutputError>,
+}
+
+async fn dsp_task_fn(params: DspTaskParams) {
+    let DspTaskParams {
+        source,
+        mut frame_rx,
+        dsp_config_rx,
+        initial_dsp_config,
+        engine_config,
+        ring,
+        signal_path_tx,
+        state,
+        event_tx,
+        seek_generation_rx,
+        mut output_error_rx,
+        output_error_tx,
+    } = params;
+    #[cfg(not(feature = "native-output"))]
+    let _ = (&engine_config, &output_error_tx);
+
     let mut dsp = DspPipeline::new(initial_dsp_config, dsp_config_rx);
     let mut output_opened = false;
     let mut last_snapshot_update = Instant::now();
+    // Seek generation currently being played; frames tagged with an older generation
+    // predate the most recent seek and are discarded.
+    let mut current_generation: u64 = 0;
 
     #[cfg(feature = "native-output")]
     let mut backend: Option<crate::output::cpal::CpalOutputBackend> = None;
@@ -388,34 +572,79 @@ async fn dsp_task_fn(
             continue;
         }
 
-        let opt_frame = match frame_rx.recv().await {
-            Some(v) => v,
-            None => break, // decode task dropped sender
+        // WHY(#404): the select surfaces asynchronous output-stream errors while
+        // waiting for frames, so a dead stream stops playback instead of leaving
+        // STATE_PLAYING forever.
+        let outcome = tokio::select! {
+            received = frame_rx.recv() => match received {
+                Some(outcome) => outcome,
+                None => break, // decode task dropped sender
+            },
+            stream_error = output_error_rx.recv() => {
+                let Some(e) = stream_error else {
+                    // INVARIANT: unreachable while the session holds a sender clone;
+                    // defensive break avoids spinning on a closed channel.
+                    break;
+                };
+                report_output_error(&e, &state, &event_tx);
+                break;
+            }
         };
 
-        let Some(frame) = opt_frame else {
-            // End of stream: allow ring buffer to drain before stopping.
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            let prev = state.swap(STATE_STOPPED, Ordering::SeqCst);
-            if prev != STATE_STOPPED {
-                // WHY: send fails only when no receivers exist; dropping is intentional
-                event_tx
-                    .send(EngineEvent::TrackEnded {
-                        source: source.clone(),
-                    })
-                    .ok();
-                // WHY: send fails only when no receivers exist; dropping is intentional
-                event_tx.send(EngineEvent::PlaybackStopped).ok();
+        let (frame, frame_generation) = match outcome {
+            DecodeOutcome::Frame { frame, generation } => (frame, generation),
+            DecodeOutcome::Eos => {
+                // End of stream: allow ring buffer to drain before stopping.
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                let prev = state.swap(STATE_STOPPED, Ordering::SeqCst);
+                if prev != STATE_STOPPED {
+                    // WHY: send fails only when no receivers exist; dropping is intentional
+                    event_tx
+                        .send(EngineEvent::TrackEnded {
+                            source: source.clone(),
+                        })
+                        .ok();
+                    // WHY: send fails only when no receivers exist; dropping is intentional
+                    event_tx.send(EngineEvent::PlaybackStopped).ok();
+                }
+                break;
             }
-            break;
+            DecodeOutcome::Failed => {
+                // WHY(#402): decode failure — the decode task already emitted Error;
+                // stop playback WITHOUT TrackEnded (the track did not complete).
+                let prev = state.swap(STATE_STOPPED, Ordering::SeqCst);
+                if prev != STATE_STOPPED {
+                    // WHY: send fails only when no receivers exist; dropping is intentional
+                    event_tx.send(EngineEvent::PlaybackStopped).ok();
+                }
+                break;
+            }
         };
+
+        // WHY(#386): frames FROM before the latest seek are stale — drop them without
+        // processing so the seek takes effect immediately instead of after the stale
+        // backlog drains at real-time rate.
+        let latest_generation = *seek_generation_rx.borrow();
+        if frame_generation < latest_generation {
+            continue;
+        }
+        if frame_generation > current_generation {
+            current_generation = frame_generation;
+            // First frame after a seek: discard buffered pre-seek audio.
+            #[cfg(feature = "native-output")]
+            flush_ring_after_seek(&ring, backend.as_mut()).await;
+            #[cfg(not(feature = "native-output"))]
+            // SAFETY: without native output no consumer thread exists for this ring;
+            // clear() is not racing a concurrent pop_frame.
+            ring.clear();
+        }
 
         // Open output on first frame (now that we know sample rate and channels).
         if !output_opened {
             output_opened = true;
 
             #[cfg(feature = "native-output")]
-            {
+            if engine_config.output.enabled {
                 use crate::output::{AudioDataCallback, OutputBackend, OutputParams};
                 let ring_cb = Arc::clone(&ring);
                 let callback: AudioDataCallback = Box::new(move |buf: &mut [f64]| {
@@ -438,6 +667,7 @@ async fn dsp_task_fn(
                         engine_config.output.device_name.as_deref(),
                         params,
                         callback,
+                        output_error_tx.clone(),
                     )
                     .await
                 {
@@ -492,9 +722,41 @@ async fn dsp_task_fn(
         let mut samples = frame.samples.to_vec();
         let stage_metas = dsp.process_frame(&mut samples, frame.channels, frame.sample_rate);
 
+        // WHY(#387): a frame that can never fit the ring would spin the retry loop
+        // forever (push_frame requires used + n < capacity); fail fast instead.
+        if samples.len() >= ring.capacity() {
+            // WHY: send fails only when no receivers exist; dropping is intentional
+            event_tx
+                .send(EngineEvent::Error {
+                    message: format!(
+                        "decoded frame has {} samples, exceeding ring buffer usable capacity {}; increase ring_buffer_capacity",
+                        samples.len(),
+                        ring.capacity().saturating_sub(1)
+                    ),
+                })
+                .ok();
+            state.store(STATE_STOPPED, Ordering::SeqCst);
+            // WHY: send fails only when no receivers exist; dropping is intentional
+            event_tx.send(EngineEvent::PlaybackStopped).ok();
+            break;
+        }
+
         // Push processed samples to ring buffer with yield-based backpressure.
         loop {
             if state.load(Ordering::Relaxed) == STATE_STOPPED {
+                break;
+            }
+            // WHY(#386): abandon the push when a seek lands mid-backpressure — this
+            // frame is stale and blocking here would delay the seek by a full ring
+            // drain.
+            if *seek_generation_rx.borrow() != current_generation {
+                break;
+            }
+            // WHY(#404): a dead output stream stops the consumer, so backpressure
+            // never resolves — the error must be polled here or a stream failure
+            // under full ring would spin forever unnoticed.
+            if let Ok(e) = output_error_rx.try_recv() {
+                report_output_error(&e, &state, &event_tx);
                 break;
             }
             if ring.push_frame(&samples) {
@@ -526,6 +788,49 @@ async fn dsp_task_fn(
         use crate::output::OutputBackend;
         // WHY: close error on shutdown is non-fatal; device already stopping
         b.close().await.ok();
+    }
+}
+
+/// Surfaces an asynchronous output-stream error: emits `EngineEvent::Error`, stops
+/// playback state, and emits `PlaybackStopped`.
+fn report_output_error(
+    error: &OutputError,
+    state: &AtomicU8,
+    event_tx: &broadcast::Sender<EngineEvent>,
+) {
+    // WHY: send fails only when no receivers exist; dropping is intentional
+    event_tx
+        .send(EngineEvent::Error {
+            message: error.to_string(),
+        })
+        .ok();
+    state.store(STATE_STOPPED, Ordering::SeqCst);
+    // WHY: send fails only when no receivers exist; dropping is intentional
+    event_tx.send(EngineEvent::PlaybackStopped).ok();
+}
+
+/// Discards buffered pre-seek audio. With an open backend the stream is paused first so
+/// the output callback is not concurrently popping while positions reset, then resumed.
+#[cfg(feature = "native-output")]
+async fn flush_ring_after_seek(
+    ring: &RingBuffer,
+    backend: Option<&mut crate::output::cpal::CpalOutputBackend>,
+) {
+    use crate::output::OutputBackend;
+    match backend {
+        Some(b) => {
+            // WHY: pause/start failures are non-fatal here — worst case a fragment of
+            // pre-seek audio plays; stream errors surface via the error channel.
+            b.pause().await.ok();
+            // WARNING: cpal pause is best-effort; an in-flight callback may still be
+            // reading. clear() only resets positions, so the residual risk is one
+            // callback buffer of mixed samples, not memory unsafety beyond the ring's
+            // documented SPSC contract.
+            ring.clear();
+            b.start().await.ok();
+        }
+        // SAFETY: no backend open yet — no consumer thread exists; clear() is safe.
+        None => ring.clear(),
     }
 }
 
@@ -604,6 +909,15 @@ mod tests {
         let mut f = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
         f.write_all(&v).unwrap();
         f
+    }
+
+    /// Config with hardware output disabled: behavioral tests must not depend on an
+    /// audio device existing (CI is headless and feature unification with archon
+    /// enables native-output for this crate's tests).
+    fn headless_config() -> EngineConfig {
+        let mut config = EngineConfig::default();
+        config.output.enabled = false;
+        config
     }
 
     #[test]
@@ -773,5 +1087,378 @@ mod tests {
         // Receiver should hold the initial idle snapshot.
         let snap = rx.borrow().clone();
         assert!(snap.source.is_none());
+    }
+
+    // --- #386: seek must reposition the decoder, not fabricate completion ---
+
+    #[tokio::test]
+    async fn engine_seek_before_play_errors() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let result = engine.seek(Duration::from_millis(500)).await;
+        assert!(
+            matches!(result, Err(EngineError::SeekOutOfBounds { .. })),
+            "seek without a session must error"
+        );
+    }
+
+    /// Behavioral proof the decoder repositions: a 5s stereo WAV (882 000 samples) can
+    /// never reach EOS in the test build — nothing drains the 65 536-sample ring, so
+    /// decode stalls on backpressure well before the end. Only a real seek close to EOF
+    /// leaves few enough samples for decode to finish and TrackEnded to fire.
+    #[tokio::test]
+    async fn engine_seek_moves_playback_position() {
+        let engine = Engine::new(headless_config()).unwrap();
+        let mut events = engine.subscribe_events();
+        let wav = make_wav(2, 44100, 5.0);
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+
+        loop {
+            let evt = timeout(Duration::from_secs(5), events.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            if matches!(evt, EngineEvent::PlaybackStarted { .. }) {
+                break;
+            }
+        }
+
+        let actual = timeout(
+            Duration::from_secs(5),
+            engine.seek(Duration::from_millis(4900)),
+        )
+        .await
+        .expect("seek must not hang")
+        .expect("seek must succeed");
+        assert!(
+            actual >= Duration::from_secs(4) && actual <= Duration::from_secs(5),
+            "seek landed at {actual:?}"
+        );
+
+        let mut saw_seek_completed = false;
+        let mut saw_track_ended = false;
+        for _ in 0..50 {
+            match timeout(Duration::from_secs(10), events.recv()).await {
+                Ok(Ok(EngineEvent::SeekCompleted { position })) => {
+                    saw_seek_completed = true;
+                    assert_eq!(position, actual, "event and return value must agree");
+                }
+                Ok(Ok(EngineEvent::TrackEnded { .. })) => {
+                    saw_track_ended = true;
+                    break;
+                }
+                Ok(Ok(_)) => continue,
+                _ => break,
+            }
+        }
+        assert!(saw_seek_completed, "SeekCompleted event missing");
+        assert!(
+            saw_track_ended,
+            "TrackEnded missing — the decoder did not actually reposition near EOF"
+        );
+    }
+
+    #[tokio::test]
+    async fn engine_seek_past_eof_does_not_fabricate_position() {
+        let engine = Engine::new(headless_config()).unwrap();
+        let mut events = engine.subscribe_events();
+        let wav = make_wav(2, 44100, 1.0);
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+        loop {
+            let evt = timeout(Duration::from_secs(5), events.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            if matches!(evt, EngineEvent::PlaybackStarted { .. }) {
+                break;
+            }
+        }
+
+        let requested = Duration::from_secs(30);
+        match timeout(Duration::from_secs(5), engine.seek(requested))
+            .await
+            .expect("seek must not hang")
+        {
+            // A clamping decoder must report where it actually landed, never echo the
+            // out-of-range request.
+            Ok(actual) => assert!(
+                actual < requested,
+                "seek fabricated the requested position: {actual:?}"
+            ),
+            Err(e) => assert!(
+                matches!(e, EngineError::SeekFailed { .. }),
+                "unexpected error kind: {e}"
+            ),
+        }
+
+        engine.stop().unwrap();
+    }
+
+    #[tokio::test]
+    async fn engine_seek_works_while_paused() {
+        let engine = Engine::new(headless_config()).unwrap();
+        let mut events = engine.subscribe_events();
+        let wav = make_wav(2, 44100, 5.0);
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+        loop {
+            let evt = timeout(Duration::from_secs(5), events.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            if matches!(evt, EngineEvent::PlaybackStarted { .. }) {
+                break;
+            }
+        }
+        engine.pause().unwrap();
+
+        let actual = timeout(Duration::from_secs(5), engine.seek(Duration::from_secs(3)))
+            .await
+            .expect("seek while paused must not hang")
+            .expect("seek while paused must succeed");
+        assert!(actual <= Duration::from_secs(5), "landed at {actual:?}");
+
+        engine.stop().unwrap();
+    }
+
+    // --- #387: oversized frame must error, not livelock ---
+
+    #[tokio::test]
+    async fn engine_oversized_frame_errors_instead_of_livelocking() {
+        let config = EngineConfig {
+            ring_buffer_capacity: 64,
+            ..headless_config()
+        };
+        let engine = Engine::new(config).unwrap();
+        let mut events = engine.subscribe_events();
+        let wav = make_wav(2, 44100, 1.0);
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+
+        let mut saw_error = false;
+        let mut saw_stopped = false;
+        for _ in 0..20 {
+            // WHY: the bounded timeout turns a regression to the old spin INTO a test
+            // failure instead of a hang.
+            match timeout(Duration::from_secs(5), events.recv()).await {
+                Ok(Ok(EngineEvent::Error { message })) => {
+                    assert!(
+                        message.contains("exceeding"),
+                        "unexpected error message: {message}"
+                    );
+                    saw_error = true;
+                }
+                Ok(Ok(EngineEvent::PlaybackStopped)) => {
+                    saw_stopped = true;
+                    break;
+                }
+                Ok(Ok(_)) => continue,
+                _ => break,
+            }
+        }
+        assert!(saw_error, "oversized frame must emit EngineEvent::Error");
+        assert!(saw_stopped, "oversized frame must stop playback");
+    }
+
+    // --- #401: PlaybackStarted must precede any task-emitted event ---
+
+    #[tokio::test]
+    async fn playback_started_precedes_error_on_bad_file() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let mut events = engine.subscribe_events();
+        engine
+            .play(AudioSource::File(PathBuf::from(
+                "/nonexistent/akouo-test-file.wav",
+            )))
+            .unwrap();
+
+        let mut received = Vec::new();
+        for _ in 0..10 {
+            match timeout(Duration::from_secs(2), events.recv()).await {
+                Ok(Ok(evt)) => {
+                    let is_stopped = matches!(evt, EngineEvent::PlaybackStopped);
+                    received.push(evt);
+                    if is_stopped {
+                        break;
+                    }
+                }
+                _ => break,
+            }
+        }
+
+        assert!(
+            matches!(received.first(), Some(EngineEvent::PlaybackStarted { .. })),
+            "first event must be PlaybackStarted, got {received:?}"
+        );
+        assert!(
+            received
+                .iter()
+                .any(|e| matches!(e, EngineEvent::Error { .. })),
+            "open failure must surface as Error: {received:?}"
+        );
+        assert!(
+            received
+                .iter()
+                .any(|e| matches!(e, EngineEvent::PlaybackStopped)),
+            "open failure must stop playback: {received:?}"
+        );
+        // #402: a track that never decoded must not report TrackEnded.
+        assert!(
+            !received
+                .iter()
+                .any(|e| matches!(e, EngineEvent::TrackEnded { .. })),
+            "no TrackEnded for a failed open: {received:?}"
+        );
+    }
+
+    // --- #402: decode failure vs clean EOS ---
+
+    #[tokio::test]
+    async fn clean_eos_still_emits_track_ended() {
+        let engine = Engine::new(headless_config()).unwrap();
+        let mut events = engine.subscribe_events();
+        // 0.2s stereo = 17 640 samples: fits the ring, so decode reaches EOS.
+        let wav = make_wav(2, 44100, 0.2);
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+
+        let mut saw_track_ended = false;
+        for _ in 0..20 {
+            match timeout(Duration::from_secs(10), events.recv()).await {
+                Ok(Ok(EngineEvent::TrackEnded { .. })) => {
+                    saw_track_ended = true;
+                    break;
+                }
+                Ok(Ok(_)) => continue,
+                _ => break,
+            }
+        }
+        assert!(saw_track_ended, "clean EOS must still emit TrackEnded");
+    }
+
+    /// Direct DSP-task unit test: a mid-stream decode failure (frames, then Failed)
+    /// must stop playback WITHOUT TrackEnded.
+    #[tokio::test]
+    async fn dsp_failed_after_frames_stops_without_track_ended() {
+        let (frame_tx, frame_rx) = mpsc::channel::<DecodeOutcome>(8);
+        let (_dsp_cfg_tx, dsp_cfg_rx) = watch::channel(DspConfig::default());
+        let (_generation_tx, seek_generation_rx) = watch::channel(0u64);
+        let (output_error_tx, output_error_rx) = mpsc::channel::<OutputError>(4);
+        let (event_tx, mut events) = broadcast::channel::<EngineEvent>(64);
+        let (signal_path_tx, _signal_path_rx) = watch::channel(SignalPathSnapshot::idle());
+        let state = Arc::new(AtomicU8::new(STATE_PLAYING));
+
+        let task = tokio::spawn(dsp_task_fn(DspTaskParams {
+            source: AudioSource::File(PathBuf::from("test.wav")),
+            frame_rx,
+            dsp_config_rx: dsp_cfg_rx,
+            initial_dsp_config: DspConfig::default(),
+            engine_config: headless_config(),
+            ring: Arc::new(RingBuffer::new(1024)),
+            signal_path_tx: Arc::new(signal_path_tx),
+            state: Arc::clone(&state),
+            event_tx: event_tx.clone(),
+            seek_generation_rx,
+            output_error_rx,
+            output_error_tx,
+        }));
+
+        frame_tx
+            .send(DecodeOutcome::Frame {
+                frame: DecodedFrame {
+                    samples: vec![0.0; 8].into_boxed_slice(),
+                    channels: 2,
+                    sample_rate: 44100,
+                    timestamp: 0,
+                },
+                generation: 0,
+            })
+            .await
+            .unwrap();
+        frame_tx.send(DecodeOutcome::Failed).await.unwrap();
+
+        timeout(Duration::from_secs(5), task)
+            .await
+            .expect("dsp task must terminate on Failed")
+            .unwrap();
+        assert_eq!(state.load(Ordering::SeqCst), STATE_STOPPED);
+
+        let mut saw_track_ended = false;
+        let mut saw_stopped = false;
+        while let Ok(evt) = events.try_recv() {
+            match evt {
+                EngineEvent::TrackEnded { .. } => saw_track_ended = true,
+                EngineEvent::PlaybackStopped => saw_stopped = true,
+                _ => {}
+            }
+        }
+        assert!(
+            !saw_track_ended,
+            "decode failure must not be reported as TrackEnded"
+        );
+        assert!(saw_stopped, "decode failure must emit PlaybackStopped");
+    }
+
+    // --- #404: output stream errors must stop playback ---
+
+    #[tokio::test]
+    async fn output_stream_error_emits_error_and_stops() {
+        let engine = Engine::new(headless_config()).unwrap();
+        let mut events = engine.subscribe_events();
+        // 2s stereo ≫ ring capacity keeps the DSP task alive (in backpressure) so the
+        // injected error is observed FROM the push loop poll.
+        let wav = make_wav(2, 44100, 2.0);
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+        loop {
+            let evt = timeout(Duration::from_secs(5), events.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            if matches!(evt, EngineEvent::PlaybackStarted { .. }) {
+                break;
+            }
+        }
+
+        assert!(
+            engine.inject_output_error(OutputError::StreamError {
+                message: "device unplugged".to_string(),
+            }),
+            "injection requires a live session"
+        );
+
+        let mut saw_error = false;
+        let mut saw_stopped = false;
+        for _ in 0..20 {
+            match timeout(Duration::from_secs(5), events.recv()).await {
+                Ok(Ok(EngineEvent::Error { message })) => {
+                    if message.contains("device unplugged") {
+                        saw_error = true;
+                    }
+                }
+                Ok(Ok(EngineEvent::PlaybackStopped)) => {
+                    saw_stopped = true;
+                    break;
+                }
+                Ok(Ok(_)) => continue,
+                _ => break,
+            }
+        }
+        assert!(saw_error, "stream error must surface as EngineEvent::Error");
+        assert!(saw_stopped, "stream error must stop playback");
+
+        // Engine must be reusable after the failure.
+        let wav2 = make_wav(2, 44100, 0.2);
+        engine
+            .play(AudioSource::File(wav2.path().to_path_buf()))
+            .expect("engine must accept a new play() after a stream error");
+        engine.stop().unwrap();
     }
 }

--- a/crates/akouo-core/src/error.rs
+++ b/crates/akouo-core/src/error.rs
@@ -3,6 +3,7 @@
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
 #[non_exhaustive]
 pub enum EngineError {
     #[snafu(display("decode error"))]
@@ -24,6 +25,9 @@ pub enum EngineError {
         position_secs: f64,
         duration_secs: f64,
     },
+
+    #[snafu(display("seek failed"))]
+    SeekFailed { source: DecodeError },
 }
 
 #[derive(Debug, Snafu)]
@@ -59,6 +63,13 @@ pub enum DecodeError {
 
     #[snafu(display("metadata error: {message}"))]
     Metadata {
+        message: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("decode worker terminated: {message}"))]
+    TaskJoin {
         message: String,
         #[snafu(implicit)]
         location: snafu::Location,

--- a/crates/akouo-core/src/lib.rs
+++ b/crates/akouo-core/src/lib.rs
@@ -18,8 +18,9 @@ pub use config::{
     VolumeConfig,
 };
 // Decode types
+pub use decode::blocking::BlockingDecoder;
 pub use decode::metadata::TrackMetadata;
-pub use decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams};
+pub use decode::{AudioDecoder, Codec, DecodedFrame, GaplessInfo, StreamParams, SyncAudioDecoder};
 // DSP pipeline (for embedding in custom engine implementations)
 pub use dsp::{DspPipeline, DspStage, StageResult};
 // Engine

--- a/crates/akouo-core/src/output/cpal.rs
+++ b/crates/akouo-core/src/output/cpal.rs
@@ -151,6 +151,7 @@ impl OutputBackend for CpalOutputBackend {
         device_id: Option<&str>,
         params: OutputParams,
         data_callback: AudioDataCallback,
+        error_tx: tokio::sync::mpsc::Sender<OutputError>,
     ) -> Result<(), OutputError> {
         let device = resolve_device(&self.host, device_id)?;
         let device_name = device.name().unwrap_or_else(|_| "<unknown>".into());
@@ -172,12 +173,7 @@ impl OutputBackend for CpalOutputBackend {
         let underruns = Arc::new(AtomicU64::new(0));
         let underruns_rt = Arc::clone(&underruns);
 
-        let error_cb = {
-            let device_name = device_name.clone();
-            move |err: cpal::StreamError| {
-                warn!("audio stream error on '{device_name}': {err}");
-            }
-        };
+        let error_cb = make_stream_error_callback(device_name.clone(), error_tx);
 
         let stream = match device.build_output_stream_raw(
             &stream_config,
@@ -293,6 +289,25 @@ impl CpalOutputBackend {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Builds the cpal stream-error callback: logs the error and forwards it to the engine.
+///
+/// Runs on the audio backend's callback thread; `try_send` never blocks. A full channel
+/// drops the report — the first error already triggers engine shutdown, so later ones
+/// carry no additional signal.
+fn make_stream_error_callback(
+    device_name: String,
+    error_tx: tokio::sync::mpsc::Sender<OutputError>,
+) -> impl FnMut(cpal::StreamError) {
+    move |err: cpal::StreamError| {
+        warn!("audio stream error on '{device_name}': {err}");
+        error_tx
+            .try_send(OutputError::StreamError {
+                message: format!("audio stream error on '{device_name}': {err}"),
+            })
+            .ok();
+    }
+}
 
 fn resolve_device(host: &cpal::Host, device_id: Option<&str>) -> Result<cpal::Device, OutputError> {
     match device_id {
@@ -478,6 +493,38 @@ mod tests {
         let caps = backend.device_capabilities(None).unwrap();
         assert!(!caps.supported_sample_rates.is_empty());
         assert!(caps.max_channels >= 2);
+    }
+
+    #[test]
+    fn stream_error_callback_forwards_error_to_channel() {
+        let (error_tx, mut error_rx) = tokio::sync::mpsc::channel::<OutputError>(1);
+        let mut cb = make_stream_error_callback("test-device".to_string(), error_tx);
+
+        cb(cpal::StreamError::DeviceNotAvailable);
+
+        let err = error_rx.try_recv().expect("error must reach the channel");
+        match err {
+            OutputError::StreamError { message } => {
+                assert!(message.contains("test-device"), "message: {message}");
+            }
+            other => panic!("expected StreamError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_error_callback_full_channel_drops_report_without_panic() {
+        let (error_tx, mut error_rx) = tokio::sync::mpsc::channel::<OutputError>(1);
+        let mut cb = make_stream_error_callback("test-device".to_string(), error_tx);
+
+        // Second send hits a full channel; must be dropped silently, not panic.
+        cb(cpal::StreamError::DeviceNotAvailable);
+        cb(cpal::StreamError::DeviceNotAvailable);
+
+        assert!(error_rx.try_recv().is_ok(), "first error must be delivered");
+        assert!(
+            error_rx.try_recv().is_err(),
+            "second error must have been dropped by the full channel"
+        );
     }
 
     #[test]

--- a/crates/akouo-core/src/output/mod.rs
+++ b/crates/akouo-core/src/output/mod.rs
@@ -87,11 +87,16 @@ pub trait OutputBackend: Send + Sync {
     /// Opens an output stream with the given parameters. The backend calls `data_callback`
     /// whenever it needs audio samples. `data_callback` receives a mutable interleaved f64
     /// buffer; it must fill it within the real-time deadline.
+    ///
+    /// Asynchronous stream failures (device unplugged, backend died) are reported through
+    /// `error_tx` so the engine can surface them as events and stop playback; `open()`
+    /// itself only reports failures to establish the stream.
     fn open(
         &mut self,
         device_id: Option<&str>,
         params: OutputParams,
         data_callback: AudioDataCallback,
+        error_tx: tokio::sync::mpsc::Sender<OutputError>,
     ) -> impl std::future::Future<Output = Result<(), OutputError>> + Send;
 
     /// Starts the audio stream (begins calling `data_callback`).

--- a/crates/archon/src/render/pipeline.rs
+++ b/crates/archon/src/render/pipeline.rs
@@ -108,8 +108,21 @@ impl RenderPipeline {
             }
         }
 
+        let (stream_error_tx, mut stream_error_rx) =
+            tokio::sync::mpsc::channel::<akouo_core::OutputError>(16);
+        tokio::spawn(async move {
+            while let Some(e) = stream_error_rx.recv().await {
+                warn!("audio output stream error: {e}");
+            }
+        });
+
         self.backend
-            .open(self.device_name.as_deref(), params, callback)
+            .open(
+                self.device_name.as_deref(),
+                params,
+                callback,
+                stream_error_tx,
+            )
             .await
             .map_err(|e| RenderError::AudioOutput {
                 message: e.to_string(),


### PR DESCRIPTION
Closes #386, #387, #398, #399, #400, #401, #402, #403, #404.

## Changes

- **#386 / #398 — real seek.** `Engine::seek` (and the Android `seek`) were stubs that fabricated `SeekCompleted` and echoed the requested position. Both now forward a command to the decode task, call the decoder's real seek, and return the decoder's actual post-seek position; a generation counter drops stale pre-seek frames.
- **#402 — decode failure vs EOS.** The decode→DSP channel now carries `DecodeOutcome{Frame,Eos,Failed}`, so a decode error (or open failure) is distinct from end-of-stream and never emits `TrackEnded`.
- **#403 — blocking I/O off the executor (full restructure).** All blocking decode/probe file I/O moved off the async runtime: a new `decode/blocking.rs` runs each decoder on a dedicated thread (works on the current-thread runtime, where `block_in_place` would panic), and `probe_codec` is wrapped in `spawn_blocking`. Regression-proven with yields-to-executor tests.
- **#400 — reentrant-notify deadlock.** `notify()` snapshots listener handles under the lock and invokes the foreign callbacks after releasing it (the std mutex is not reentrant).
- **#387 — DSP livelock.** An oversized frame now emits `Error` + stops instead of spinning.
- **#399 — unsubscribe.** Android `subscribe_events` returns an id and gains `unsubscribe_events` (bounded listeners).
- **#401 — event ordering.** `PlaybackStarted` is emitted before the decode/dsp tasks spawn.
- **#404 — output errors.** cpal stream errors surface as `EngineEvent::Error` via an error channel.

## Verification

`kanon gate --full` green; `cargo test --workspace` passes (23 binaries). akouo-android compiles + tests host-side (UniFFI scaffolding); Android NDK cross-compile is not exercised on this host.

## Notes

Adds an `OutputConfig.enabled` flag (default true) so headless decode/analysis works without an audio device — a small design addition beyond the nine issues. The f64 DSP hot path allocation profile is unchanged.