### PR TITLE
fix(aitesis): atomic approval workflow and request authorization

### DIFF
--- a/crates/aitesis/src/approval.rs
+++ b/crates/aitesis/src/approval.rs
@@ -30,6 +30,14 @@ pub trait IdentityValidator: Send + Sync {
 )]
 pub trait MonitorService: Send + Sync {
     /// Creates a wanted-media entry for an approved request.
+    ///
+    /// INVARIANT: implementations MUST be idempotent per request — a repeat
+    /// call for the same `request.id` returns the already-created want's id
+    /// instead of inserting a duplicate (e.g. an upsert keyed on
+    /// `(source = 'request', source_ref = request id)`). The approval flow
+    /// creates the want before persisting the request-status update and
+    /// relies on this contract to make a retried approval safe after a
+    /// partial failure.
     async fn create_want(&self, request: &MediaRequest) -> Result<WantId, AitesisError>;
 }
 
@@ -46,6 +54,13 @@ pub trait UserRoleProvider: Send + Sync {
 /// Approves a request: validates identity, creates a want, transitions to Monitoring.
 ///
 /// Requires `admin_id` to have the Admin role.
+///
+/// Ordering: the want is created before the request row is updated. The
+/// request table and the want store sit behind different write paths, so no
+/// single transaction can span both; instead the operation is re-runnable — a
+/// failure after `create_want` leaves the row `Submitted`, and a retried
+/// approval resolves to the same want via the [`MonitorService::create_want`]
+/// idempotency contract, then completes the status update.
 #[instrument(skip(pool, identity, monitor), fields(request_id = %request_id, admin_id = %admin_id))]
 pub(crate) async fn approve_request<I, M>(
     pool: &SqlitePool,
@@ -188,6 +203,21 @@ pub(crate) mod tests {
         }
     }
 
+    /// Mirrors the production upsert semantics: one want per request id.
+    #[derive(Default)]
+    struct IdempotentRecordingMonitor {
+        wants: std::sync::Mutex<std::collections::HashMap<RequestId, WantId>>,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl MonitorService for IdempotentRecordingMonitor {
+        async fn create_want(&self, request: &MediaRequest) -> Result<WantId, AitesisError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let mut wants = self.wants.lock().unwrap();
+            Ok(*wants.entry(request.id).or_default())
+        }
+    }
+
     pub(crate) async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
@@ -255,6 +285,73 @@ pub(crate) mod tests {
         .unwrap_err();
 
         assert!(matches!(err, AitesisError::InsufficientPermission { .. }));
+    }
+
+    #[tokio::test]
+    async fn retried_approve_after_update_status_failure_reuses_existing_want() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let admin_id = UserId::new();
+        let req = submitted_request(user_id);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        let monitor = IdempotentRecordingMonitor::default();
+
+        // Inject a persistence failure between create_want and the status update.
+        sqlx::query(
+            "CREATE TRIGGER block_request_update BEFORE UPDATE ON requests
+             BEGIN SELECT RAISE(ABORT, 'injected update failure'); END",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let err = approve_request(
+            &pool,
+            req_id,
+            admin_id,
+            UserRole::Admin,
+            &AlwaysValidIdentity,
+            &monitor,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AitesisError::Database { .. }));
+
+        // The row is untouched — still Submitted, so the approval is retryable.
+        let row = crate::repo::get_request(&pool, &req_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, RequestStatus::Submitted);
+        assert!(row.want_id.is_none());
+
+        sqlx::query("DROP TRIGGER block_request_update")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let updated = approve_request(
+            &pool,
+            req_id,
+            admin_id,
+            UserRole::Admin,
+            &AlwaysValidIdentity,
+            &monitor,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(updated.status, RequestStatus::Monitoring);
+        assert_eq!(
+            monitor.calls.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "create_want runs on both attempts"
+        );
+        let wants = monitor.wants.lock().unwrap();
+        assert_eq!(wants.len(), 1, "the retry must not create a second want");
+        assert_eq!(updated.want_id, wants.get(&req_id).copied());
     }
 
     #[tokio::test]

--- a/crates/aitesis/src/lib.rs
+++ b/crates/aitesis/src/lib.rs
@@ -29,6 +29,11 @@ use crate::error::{InsufficientPermissionSnafu, RequestNotFoundSnafu};
 )]
 pub trait RequestService: Send + Sync {
     /// Submits a new request. Admin users auto-approve when `auto_approve_admins` is set.
+    ///
+    /// The request row is always persisted as `Submitted` first; the
+    /// auto-approve handoff (identity validation, want creation, transition to
+    /// `Monitoring`) runs afterwards, so a handoff failure leaves a
+    /// recoverable `Submitted` row that an admin can re-approve.
     async fn submit_request(
         &self,
         user_id: UserId,
@@ -54,8 +59,13 @@ pub trait RequestService: Send + Sync {
     async fn get_request(&self, request_id: RequestId) -> Result<MediaRequest, AitesisError>;
 
     /// Lists requests, optionally filtered by user or status.
+    ///
+    /// Authorization: admins may list any user's requests or all requests;
+    /// members may only list their own (`user_id` must equal
+    /// `Some(caller_id)`).
     async fn list_requests(
         &self,
+        caller_id: UserId,
         user_id: Option<UserId>,
         status: Option<RequestStatus>,
     ) -> Result<Vec<MediaRequest>, AitesisError>;
@@ -131,11 +141,6 @@ where
         .await?;
 
         let auto_approve = role == UserRole::Admin && self.config.auto_approve_admins;
-        let status = if auto_approve {
-            RequestStatus::Approved
-        } else {
-            RequestStatus::Submitted
-        };
 
         let now = jiff::Timestamp::now();
         let request = MediaRequest {
@@ -144,7 +149,7 @@ where
             media_type: input.media_type,
             title: input.title,
             external_id: input.external_id,
-            status,
+            status: RequestStatus::Submitted,
             decided_by: None,
             decided_at: None,
             deny_reason: None,
@@ -154,37 +159,21 @@ where
 
         repo::insert_request(&self.write, &request).await?;
 
-        // Admin auto-approve: immediately validate identity, create the want, and
-        // transition to Monitoring in a single submit call.
+        // WHY: the row is persisted as Submitted BEFORE the identity/monitor
+        // handoff, so a handoff failure leaves a recoverable Submitted row
+        // (re-approvable by an admin) instead of an orphaned terminal state.
+        // The auto-approve path reuses approve_request so the
+        // validate -> create-want -> update-status sequence exists once.
         if auto_approve {
-            self.identity
-                .validate(
-                    request.media_type,
-                    &request.title,
-                    request.external_id.as_deref(),
-                )
-                .await?;
-            let want_id = self.monitor.create_want(&request).await?;
-            repo::update_status(
+            return approval::approve_request(
                 &self.write,
-                repo::UpdateStatusParams {
-                    id: &request.id,
-                    status: RequestStatus::Monitoring,
-                    decided_by: Some(&user_id),
-                    decided_at: Some(jiff::Timestamp::now()),
-                    deny_reason: None,
-                    want_id: Some(&want_id),
-                },
+                request.id,
+                user_id,
+                role,
+                &self.identity,
+                &self.monitor,
             )
-            .await?;
-            return repo::get_request(&self.read, &request.id)
-                .await?
-                .ok_or_else(|| {
-                    RequestNotFoundSnafu {
-                        id: request.id.to_string(),
-                    }
-                    .build()
-                });
+            .await;
         }
 
         Ok(request)
@@ -231,12 +220,18 @@ where
             })
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(caller_id = %caller_id))]
     async fn list_requests(
         &self,
+        caller_id: UserId,
         user_id: Option<UserId>,
         status: Option<RequestStatus>,
     ) -> Result<Vec<MediaRequest>, AitesisError> {
+        let caller_role = self.user_roles.role_of(caller_id).await?;
+        if caller_role != UserRole::Admin && user_id != Some(caller_id) {
+            return InsufficientPermissionSnafu.fail();
+        }
+
         match (user_id, status) {
             (Some(uid), Some(st)) => {
                 let all = repo::list_by_user(&self.read, &uid).await?;
@@ -328,6 +323,31 @@ mod tests {
         }
     }
 
+    struct RejectingIdentity;
+    impl IdentityValidator for RejectingIdentity {
+        async fn validate(
+            &self,
+            _media_type: themelion::MediaType,
+            _title: &str,
+            _external_id: Option<&str>,
+        ) -> Result<(), AitesisError> {
+            crate::error::MediaIdentityInvalidSnafu {
+                detail: "injected validation failure".to_string(),
+            }
+            .fail()
+        }
+    }
+
+    struct FailingMonitor;
+    impl MonitorService for FailingMonitor {
+        async fn create_want(&self, _request: &MediaRequest) -> Result<WantId, AitesisError> {
+            crate::error::MediaIdentityInvalidSnafu {
+                detail: "injected create_want failure".to_string(),
+            }
+            .fail()
+        }
+    }
+
     fn default_config() -> AitesisConfig {
         AitesisConfig::default()
     }
@@ -374,6 +394,102 @@ mod tests {
         let req = svc.submit_request(user_id, music_input()).await.unwrap();
         // auto_approve_admins is true by default — goes straight to Monitoring
         assert_eq!(req.status, RequestStatus::Monitoring);
+        assert_eq!(req.decided_by, Some(user_id));
+        assert!(req.want_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn auto_approve_validation_failure_leaves_row_submitted() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            RejectingIdentity,
+            AlwaysCreateMonitor,
+        );
+        let user_id = UserId::new();
+
+        let err = svc
+            .submit_request(user_id, music_input())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AitesisError::MediaIdentityInvalid { .. }));
+
+        let rows = crate::repo::list_all(&pool).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].status, RequestStatus::Submitted);
+        assert!(rows[0].want_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn auto_approve_create_want_failure_leaves_row_submitted() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            FailingMonitor,
+        );
+        let user_id = UserId::new();
+
+        let err = svc
+            .submit_request(user_id, music_input())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AitesisError::MediaIdentityInvalid { .. }));
+
+        let rows = crate::repo::list_all(&pool).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].status, RequestStatus::Submitted);
+        assert!(rows[0].want_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn admin_can_retry_after_auto_approve_failure() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let failing_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            RejectingIdentity,
+            AlwaysCreateMonitor,
+        );
+        let admin_id = UserId::new();
+
+        failing_svc
+            .submit_request(admin_id, music_input())
+            .await
+            .unwrap_err();
+        let rows = crate::repo::list_all(&pool).await.unwrap();
+        assert_eq!(rows[0].status, RequestStatus::Submitted);
+
+        let working_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let approved = working_svc.approve(rows[0].id, admin_id).await.unwrap();
+        assert_eq!(approved.status, RequestStatus::Monitoring);
+        assert!(approved.want_id.is_some());
     }
 
     // ── Approve tests ─────────────────────────────────────────────────────────
@@ -624,30 +740,164 @@ mod tests {
             .unwrap();
         bob_svc.submit_request(bob, music_input()).await.unwrap();
 
-        let alice_requests = alice_svc.list_requests(Some(alice), None).await.unwrap();
+        let alice_requests = alice_svc
+            .list_requests(alice, Some(alice), None)
+            .await
+            .unwrap();
         assert_eq!(alice_requests.len(), 2);
         assert!(alice_requests.iter().all(|r| r.user_id == alice));
     }
 
     #[tokio::test]
     async fn list_requests_filter_by_status() {
-        let (svc, _pool) = make_service(UserRole::Member).await;
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let member_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Member,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let admin_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
         let user_id = UserId::new();
+        let admin_id = UserId::new();
 
-        svc.submit_request(user_id, music_input()).await.unwrap();
-        svc.submit_request(user_id, music_input()).await.unwrap();
+        member_svc
+            .submit_request(user_id, music_input())
+            .await
+            .unwrap();
+        member_svc
+            .submit_request(user_id, music_input())
+            .await
+            .unwrap();
 
-        let submitted = svc
-            .list_requests(None, Some(RequestStatus::Submitted))
+        let submitted = admin_svc
+            .list_requests(admin_id, None, Some(RequestStatus::Submitted))
             .await
             .unwrap();
         assert_eq!(submitted.len(), 2);
 
-        let monitoring = svc
-            .list_requests(None, Some(RequestStatus::Monitoring))
+        let monitoring = admin_svc
+            .list_requests(admin_id, None, Some(RequestStatus::Monitoring))
             .await
             .unwrap();
         assert!(monitoring.is_empty());
+    }
+
+    #[tokio::test]
+    async fn member_list_requests_with_no_filter_is_denied() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let member_id = UserId::new();
+
+        let err = svc.list_requests(member_id, None, None).await.unwrap_err();
+        assert!(matches!(err, AitesisError::InsufficientPermission { .. }));
+    }
+
+    #[tokio::test]
+    async fn member_list_requests_for_other_user_is_denied() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let member_id = UserId::new();
+        let other_id = UserId::new();
+        svc.submit_request(other_id, music_input()).await.unwrap();
+
+        let err = svc
+            .list_requests(member_id, Some(other_id), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AitesisError::InsufficientPermission { .. }));
+
+        let err = svc
+            .list_requests(member_id, Some(other_id), Some(RequestStatus::Submitted))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AitesisError::InsufficientPermission { .. }));
+    }
+
+    #[tokio::test]
+    async fn member_list_requests_status_only_is_denied() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let member_id = UserId::new();
+
+        let err = svc
+            .list_requests(member_id, None, Some(RequestStatus::Submitted))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AitesisError::InsufficientPermission { .. }));
+    }
+
+    #[tokio::test]
+    async fn member_list_requests_for_self_succeeds() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let member_id = UserId::new();
+        let other_id = UserId::new();
+
+        svc.submit_request(member_id, music_input()).await.unwrap();
+        svc.submit_request(other_id, music_input()).await.unwrap();
+
+        let own = svc
+            .list_requests(member_id, Some(member_id), None)
+            .await
+            .unwrap();
+        assert_eq!(own.len(), 1);
+        assert!(own.iter().all(|r| r.user_id == member_id));
+    }
+
+    #[tokio::test]
+    async fn admin_list_requests_with_no_filter_returns_all() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let member_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Member,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let admin_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let alice = UserId::new();
+        let bob = UserId::new();
+        let admin_id = UserId::new();
+
+        member_svc
+            .submit_request(alice, music_input())
+            .await
+            .unwrap();
+        member_svc.submit_request(bob, music_input()).await.unwrap();
+
+        let all = admin_svc.list_requests(admin_id, None, None).await.unwrap();
+        assert_eq!(all.len(), 2);
+
+        let bobs = admin_svc
+            .list_requests(admin_id, Some(bob), None)
+            .await
+            .unwrap();
+        assert_eq!(bobs.len(), 1);
+        assert_eq!(bobs[0].user_id, bob);
     }
 
     // ── Full lifecycle ────────────────────────────────────────────────────────

--- a/crates/apotheke/src/repo/want.rs
+++ b/crates/apotheke/src/repo/want.rs
@@ -2,6 +2,7 @@ use snafu::ResultExt;
 use sqlx::SqlitePool;
 
 use crate::error::{DbError, QuerySnafu};
+use crate::pools::{begin_immediate, commit_tx};
 
 // WHY: wire DTO — SQLx row from the wants table.
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -75,6 +76,63 @@ pub async fn insert_want(pool: &SqlitePool, want: &Want) -> Result<(), DbError> 
     .await
     .context(QuerySnafu { table: "wants" })?;
     Ok(())
+}
+
+/// Idempotently inserts a want keyed on `(source, source_ref)`.
+///
+/// Returns the id of the surviving row: the existing want's id when a row
+/// already matches the key, otherwise the freshly inserted `want.id`. The
+/// explicit key parameters are bound into the inserted row (overriding
+/// `want.source` / `want.source_ref`), so the idempotency key can never be
+/// absent. The check-then-insert runs inside a `BEGIN IMMEDIATE` transaction
+/// and therefore cannot interleave with a concurrent writer.
+///
+/// This is the storage-level guarantee behind the request-approval handoff:
+/// a retried approval for the same request resolves to the same want instead
+/// of inserting a duplicate.
+pub async fn upsert_want_by_source_ref(
+    pool: &SqlitePool,
+    source: &str,
+    source_ref: &str,
+    want: &Want,
+) -> Result<Vec<u8>, DbError> {
+    let mut tx = begin_immediate(pool).await?;
+
+    let existing: Option<Vec<u8>> =
+        sqlx::query_scalar("SELECT id FROM wants WHERE source = ? AND source_ref = ?")
+            .bind(source)
+            .bind(source_ref)
+            .fetch_optional(&mut *tx)
+            .await
+            .context(QuerySnafu { table: "wants" })?;
+
+    if let Some(id) = existing {
+        commit_tx(tx).await?;
+        return Ok(id);
+    }
+
+    sqlx::query(
+        "INSERT INTO wants
+         (id, media_type, title, registry_id, quality_profile_id, status,
+          source, source_ref, added_at, fulfilled_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&want.id)
+    .bind(&want.media_type)
+    .bind(&want.title)
+    .bind(&want.registry_id)
+    .bind(want.quality_profile_id)
+    .bind(&want.status)
+    .bind(source)
+    .bind(source_ref)
+    .bind(&want.added_at)
+    .bind(&want.fulfilled_at)
+    .execute(&mut *tx)
+    .await
+    .context(QuerySnafu { table: "wants" })?;
+
+    commit_tx(tx).await?;
+    Ok(want.id.clone())
 }
 
 pub async fn get_want(pool: &SqlitePool, id: &[u8]) -> Result<Option<Want>, DbError> {
@@ -452,6 +510,73 @@ mod tests {
         let mut refs = list_want_source_refs(&pool, "tidal_sync").await.unwrap();
         refs.sort();
         assert_eq!(refs, vec!["t1".to_string(), "t2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn upsert_want_by_source_ref_returns_existing_want_for_same_request() {
+        let pool = setup().await;
+        let profile_id = insert_test_profile(&pool).await;
+
+        let first = make_sourced_want(profile_id, Some("request"), Some("req-1"));
+        let first_id = upsert_want_by_source_ref(&pool, "request", "req-1", &first)
+            .await
+            .unwrap();
+        assert_eq!(first_id, first.id);
+
+        // Same key, different want payload and id — must resolve to the first row.
+        let second = make_sourced_want(profile_id, Some("request"), Some("req-1"));
+        let second_id = upsert_want_by_source_ref(&pool, "request", "req-1", &second)
+            .await
+            .unwrap();
+        assert_eq!(second_id, first.id);
+
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM wants WHERE source = 'request' AND source_ref = 'req-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count.0, 1);
+    }
+
+    #[tokio::test]
+    async fn upsert_want_by_source_ref_inserts_distinct_keys() {
+        let pool = setup().await;
+        let profile_id = insert_test_profile(&pool).await;
+
+        let a = make_sourced_want(profile_id, Some("request"), Some("req-a"));
+        let b = make_sourced_want(profile_id, Some("request"), Some("req-b"));
+        let a_id = upsert_want_by_source_ref(&pool, "request", "req-a", &a)
+            .await
+            .unwrap();
+        let b_id = upsert_want_by_source_ref(&pool, "request", "req-b", &b)
+            .await
+            .unwrap();
+        assert_eq!(a_id, a.id);
+        assert_eq!(b_id, b.id);
+        assert_ne!(a_id, b_id);
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM wants WHERE source = 'request'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 2);
+    }
+
+    #[tokio::test]
+    async fn upsert_want_by_source_ref_key_overrides_want_fields() {
+        let pool = setup().await;
+        let profile_id = insert_test_profile(&pool).await;
+
+        // Want payload carries a stale/absent key — the explicit key wins.
+        let want = make_sourced_want(profile_id, None, None);
+        let id = upsert_want_by_source_ref(&pool, "request", "req-k", &want)
+            .await
+            .unwrap();
+
+        let stored = get_want(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(stored.source.as_deref(), Some("request"));
+        assert_eq!(stored.source_ref.as_deref(), Some("req-k"));
     }
 
     #[tokio::test]

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -222,13 +222,14 @@ impl DynRequestService for RequestAdapter {
 
     fn list_requests(
         &self,
+        caller_id: themelion::UserId,
         user_id: Option<themelion::UserId>,
         status: Option<aitesis::RequestStatus>,
     ) -> RequestServiceFut<'_, Vec<aitesis::MediaRequest>> {
         let service = Arc::clone(&self.0);
         Box::pin(async move {
             service
-                .list_requests(user_id, status)
+                .list_requests(caller_id, user_id, status)
                 .await
                 .map_err(Into::into)
         })
@@ -332,9 +333,16 @@ impl MonitorService for RequestMonitor {
                     .build()
                 })?;
 
+        // WHY: upsert keyed on (source='request', source_ref=request id) —
+        // MonitorService::create_want must be idempotent per request so a
+        // retried approval resolves to the existing want instead of
+        // double-inserting one.
         let want_id = themelion::WantId::new();
-        apotheke::repo::want::insert_want(
+        let source_ref = request.id.as_uuid().to_string();
+        let stored_id = apotheke::repo::want::upsert_want_by_source_ref(
             &self.db.write,
+            "request",
+            &source_ref,
             &apotheke::repo::want::Want {
                 id: want_id.as_bytes().to_vec(),
                 media_type: want_media_type.to_string(),
@@ -343,14 +351,23 @@ impl MonitorService for RequestMonitor {
                 quality_profile_id: profile.id,
                 status: "searching".to_string(),
                 source: Some("request".to_string()),
-                source_ref: Some(request.id.as_uuid().to_string()),
+                source_ref: Some(source_ref.clone()),
                 added_at: jiff::Timestamp::now().to_string(),
                 fulfilled_at: None,
             },
         )
         .await
         .context(aitesis::error::DatabaseSnafu)?;
-        Ok(want_id)
+        let stored_uuid = uuid::Uuid::from_slice(&stored_id).map_err(|_| {
+            aitesis::error::MediaIdentityInvalidSnafu {
+                detail: format!(
+                    "stored want id for request {} is not a valid uuid",
+                    request.id
+                ),
+            }
+            .build()
+        })?;
+        Ok(themelion::WantId::from_uuid(stored_uuid))
     }
 }
 

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -178,13 +178,14 @@ impl DynRequestService for MockRequestAdapter {
 
     fn list_requests(
         &self,
+        caller_id: themelion::UserId,
         user_id: Option<themelion::UserId>,
         status: Option<aitesis::RequestStatus>,
     ) -> RequestServiceFut<'_, Vec<aitesis::MediaRequest>> {
         let service = Arc::clone(&self.0);
         Box::pin(async move {
             service
-                .list_requests(user_id, status)
+                .list_requests(caller_id, user_id, status)
                 .await
                 .map_err(Into::into)
         })
@@ -705,6 +706,84 @@ async fn deny_request_requires_admin() -> Result<(), TestError> {
     assert_eq!(resp.status(), StatusCode::OK);
     let json = body_json(resp).await?;
     assert_eq!(json["data"]["status"], "denied");
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_requests_scopes_members_to_own_requests() -> Result<(), TestError> {
+    let (state, auth, _pool) = test_state().await?;
+    let admin = admin_token(&auth).await?;
+    let member = member_token(&auth).await?;
+    let app = build_app(state);
+
+    // One request from each user.
+    let submit = |token: String, title: &str| {
+        let app = app.clone();
+        let body = json!({"media_type": "music_album", "title": title});
+        async move {
+            let resp = app
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/v1/requests")
+                        .header("Content-Type", "application/json")
+                        .header("Authorization", auth_header(&token))
+                        .body(Body::from(serde_json::to_vec(&body)?))?,
+                )
+                .await?;
+            assert_eq!(resp.status(), StatusCode::CREATED);
+            body_json(resp).await
+        }
+    };
+    let admin_req = submit(admin.clone(), "Admin Album").await?;
+    let member_req = submit(member.clone(), "Member Album").await?;
+    let admin_user_id = admin_req["data"]["user_id"].as_str().unwrap().to_string();
+    let member_user_id = member_req["data"]["user_id"].as_str().unwrap().to_string();
+
+    // Member with no filter sees only their own requests.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/requests")
+                .header("Authorization", auth_header(&member))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await?;
+    let data = json["data"].as_array().unwrap();
+    assert_eq!(data.len(), 1);
+    assert_eq!(data[0]["user_id"], Value::String(member_user_id));
+
+    // Member naming another user's requests is rejected.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/v1/requests?user_id={admin_user_id}"))
+                .header("Authorization", auth_header(&member))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    // Admin with no filter sees everything.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/requests")
+                .header("Authorization", auth_header(&admin))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await?;
+    assert_eq!(json["data"].as_array().unwrap().len(), 2);
     Ok(())
 }
 

--- a/crates/paroche/src/routes/request.rs
+++ b/crates/paroche/src/routes/request.rs
@@ -138,7 +138,7 @@ pub struct DenyRequestBody {
 
 pub async fn list_requests(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    auth: AuthenticatedUser,
     Query(filter): Query<RequestFilterQuery>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let per_page = filter.per_page.clamp(1, 100);
@@ -146,6 +146,15 @@ pub async fn list_requests(
     let offset = (page - 1) * per_page;
 
     let user_id = filter.user_id.as_deref().map(parse_user_id).transpose()?;
+    // WHY: a member with no explicit filter is scoped to their own requests;
+    // the query parameter is never trusted for authorization — aitesis
+    // re-checks against the authenticated caller and rejects a member naming
+    // anyone else.
+    let user_id = if auth.role == exousia::UserRole::Admin {
+        user_id
+    } else {
+        user_id.or(Some(auth.user_id))
+    };
     let status = filter
         .status
         .as_deref()
@@ -153,7 +162,7 @@ pub async fn list_requests(
         .transpose()?;
     let requests = state
         .requests
-        .list_requests(user_id, status)
+        .list_requests(auth.user_id, user_id, status)
         .await
         .map_err(map_request_service_error)?;
 
@@ -359,13 +368,14 @@ mod tests {
 
         fn list_requests(
             &self,
+            caller_id: UserId,
             user_id: Option<UserId>,
             status: Option<aitesis::RequestStatus>,
         ) -> crate::state::RequestServiceFut<'_, Vec<aitesis::MediaRequest>> {
             let service = Arc::clone(&self.0);
             Box::pin(async move {
                 service
-                    .list_requests(user_id, status)
+                    .list_requests(caller_id, user_id, status)
                     .await
                     .map_err(Into::into)
             })

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -99,6 +99,7 @@ pub trait DynRequestService: Send + Sync {
 
     fn list_requests(
         &self,
+        caller_id: themelion::UserId,
         user_id: Option<themelion::UserId>,
         status: Option<aitesis::RequestStatus>,
     ) -> RequestServiceFut<'_, Vec<aitesis::MediaRequest>>;
@@ -216,6 +217,7 @@ impl DynRequestService for NullRequestService {
 
     fn list_requests(
         &self,
+        _caller_id: themelion::UserId,
         _user_id: Option<themelion::UserId>,
         _status: Option<aitesis::RequestStatus>,
     ) -> RequestServiceFut<'_, Vec<aitesis::MediaRequest>> {


### PR DESCRIPTION
Closes #395, #396, #397.

## Changes

- **#395 — orphaned Approved row.** `submit_request`/`auto_approve` persisted an `Approved` request before identity validation, leaving an orphaned non-terminal row on failure. `submit_request` now always inserts a `Submitted` row and the auto-approve path delegates to the same validated approve sequence, so a validation or create-want failure leaves a recoverable `Submitted` row an admin can retry.
- **#396 — orphaned want / duplicate acquisition.** `approve_request` created the want before persisting the status, so a DB failure orphaned the want and allowed duplicate acquisition. Now idempotent: a new `apotheke::upsert_want_by_source_ref` keyed on `(source='request', source_ref=request id)` runs inside `BEGIN IMMEDIATE`, so a retried approve reuses the same want instead of double-inserting.
- **#397 (security) — request enumeration.** `list_requests` enumerated all users' requests with no caller check. It now takes the caller's `UserId` and denies unless the caller is an admin or querying their own requests; the HTTP layer passes the JWT-derived caller id, never the query parameter.

## Verification

`kanon gate --full` green (fmt, check, advisory-parity, cargo-deny, clippy workspace, nextest, kanon lint). Authorization, idempotency (real DB-failure injection via a trigger), and retry-convergence paths tested.

## Follow-ups noted

A unique index on `(source, source_ref)` was deliberately not added (it could fail startup on deployments that already have duplicate wants from this bug); a guarded dedup migration is the right place for it. A separate lingering-want-on-cancel-after-approve-failure path is pre-existing and worth its own issue.