### PR TITLE
fix(syntaxis): async mock extract to match ergasia DownloadEngine trait

### DIFF
--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -856,7 +856,7 @@ mod tests {
             })
         }
 
-        fn extract(
+        async fn extract(
             &self,
             _download_path: &std::path::Path,
             _output_dir: &std::path::Path,


### PR DESCRIPTION
Repairs a workspace build break on `main`.

#491 (ergasia) changed `DownloadEngine::extract` to async (`impl Future`) so extraction runs off the executor. #489 (syntaxis) merged a test `MockEngine` whose `extract` was still sync. Each PR was internally consistent and individually green, but #491 was rebased/tested against pre-#489 main, so the stale mock only broke the workspace build once both landed — `cargo clippy/test --workspace` is red at `f8ec16e` (E0277: the sync `extract` result is not a future).

One-line fix: make the mock `extract` `async fn`.

`kanon gate --full` green (full workspace clippy + nextest).