### PR TITLE
fix(epignosis): metadata provider correctness (TVDB cache, TMDB cross-ref, AcoustID)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,6 +1506,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "tempfile",
  "themelion",
  "tokio",
  "tokio-util",

--- a/crates/epignosis/Cargo.toml
+++ b/crates/epignosis/Cargo.toml
@@ -20,6 +20,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 
 [dev-dependencies]
 tokio = { workspace = true }
+tempfile = "3"
 
 [package.metadata.kanon]
 maturity = "alpha"

--- a/crates/epignosis/src/error.rs
+++ b/crates/epignosis/src/error.rs
@@ -57,6 +57,22 @@ pub enum EpignosisError {
         location: snafu::Location,
     },
 
+    #[snafu(display("failed to run fpcalc for {path:?}: {source}"))]
+    FingerprintProcess {
+        path: PathBuf,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("fpcalc output for {path:?} was not valid JSON: {source}"))]
+    FingerprintOutputParse {
+        path: PathBuf,
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("cache error: {message}"))]
     Cache {
         message: String,

--- a/crates/epignosis/src/fingerprint.rs
+++ b/crates/epignosis/src/fingerprint.rs
@@ -1,0 +1,205 @@
+//! Chromaprint fingerprinting via the external fpcalc binary.
+
+use std::path::Path;
+use std::process::Stdio;
+
+use serde::Deserialize;
+use snafu::ResultExt;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::{
+    EpignosisError, FingerprintFailedSnafu, FingerprintOutputParseSnafu, FingerprintProcessSnafu,
+};
+
+/// Name of the chromaprint fingerprinting binary, resolved from `PATH`.
+pub(crate) const FPCALC_BINARY: &str = "fpcalc";
+
+/// Raw fingerprint as reported by `fpcalc -json`.
+// WHY: pure data — chromaprint fingerprint plus track duration in seconds.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawFingerprint {
+    pub fingerprint: String,
+    pub duration: f64,
+}
+
+/// Runs `binary -json <file_path>` and parses the fingerprint output.
+///
+/// The binary is probed at runtime: a missing executable yields a
+/// `FingerprintFailed` error naming the dependency instead of a panic or a
+/// compile-time stub.
+pub(crate) async fn compute(
+    binary: &str,
+    file_path: &Path,
+    ct: &CancellationToken,
+) -> Result<RawFingerprint, EpignosisError> {
+    let mut command = tokio::process::Command::new(binary);
+    command
+        .arg("-json")
+        .arg(file_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // WHY: a cancelled or dropped future must not leave an fpcalc
+        // process running against a possibly large media file.
+        .kill_on_drop(true);
+
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return FingerprintFailedSnafu {
+                path: file_path.to_path_buf(),
+                message: format!(
+                    "{binary} binary not found on PATH; install chromaprint to enable audio fingerprinting"
+                ),
+            }
+            .fail();
+        }
+        Err(e) => {
+            return Err(e).context(FingerprintProcessSnafu {
+                path: file_path.to_path_buf(),
+            });
+        }
+    };
+
+    let output = tokio::select! {
+        output = child.wait_with_output() => output.context(FingerprintProcessSnafu {
+            path: file_path.to_path_buf(),
+        })?,
+        _ = ct.cancelled() => {
+            return FingerprintFailedSnafu {
+                path: file_path.to_path_buf(),
+                message: "fingerprinting cancelled".to_string(),
+            }
+            .fail();
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return FingerprintFailedSnafu {
+            path: file_path.to_path_buf(),
+            message: format!("{binary} exited with {}: {}", output.status, stderr.trim()),
+        }
+        .fail();
+    }
+
+    parse_output(file_path, &output.stdout)
+}
+
+/// Parses `fpcalc -json` stdout into a raw fingerprint.
+pub(crate) fn parse_output(
+    file_path: &Path,
+    stdout: &[u8],
+) -> Result<RawFingerprint, EpignosisError> {
+    serde_json::from_slice(stdout).context(FingerprintOutputParseSnafu {
+        path: file_path.to_path_buf(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_output_reads_fingerprint_and_duration() {
+        let stdout = br#"{"duration": 123.46, "fingerprint": "AQAAA1example"}"#;
+        let raw = parse_output(Path::new("/audio/track.flac"), stdout).unwrap();
+        assert_eq!(raw.fingerprint, "AQAAA1example");
+        assert!((raw.duration - 123.46).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_output_rejects_malformed_json() {
+        let err = parse_output(Path::new("/audio/track.flac"), b"ERROR: boom").unwrap_err();
+        assert!(matches!(err, EpignosisError::FingerprintOutputParse { .. }));
+    }
+
+    #[tokio::test]
+    async fn missing_binary_is_a_clean_runtime_error() {
+        let ct = CancellationToken::new();
+        let err = compute(
+            "fpcalc-test-binary-that-does-not-exist",
+            Path::new("/audio/track.flac"),
+            &ct,
+        )
+        .await
+        .unwrap_err();
+
+        match err {
+            EpignosisError::FingerprintFailed { message, .. } => {
+                assert!(
+                    message.contains("not found on PATH"),
+                    "error must name the missing dependency: {message}"
+                );
+            }
+            other => panic!("expected FingerprintFailed, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stub_binary_output_is_parsed() {
+        let dir = tempfile::tempdir().unwrap();
+        let stub = crate::test_support::write_stub_script(
+            dir.path(),
+            "fpcalc-stub",
+            "#!/bin/sh\nprintf '{\"duration\": 42.5, \"fingerprint\": \"AQFAKE\"}'\n",
+        );
+        let ct = CancellationToken::new();
+
+        let raw = compute(stub.to_str().unwrap(), Path::new("/audio/track.flac"), &ct)
+            .await
+            .unwrap();
+
+        assert_eq!(raw.fingerprint, "AQFAKE");
+        assert!((raw.duration - 42.5).abs() < f64::EPSILON);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn nonzero_exit_is_a_clean_runtime_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let stub = crate::test_support::write_stub_script(
+            dir.path(),
+            "fpcalc-fail",
+            "#!/bin/sh\necho 'ERROR: could not decode' >&2\nexit 3\n",
+        );
+        let ct = CancellationToken::new();
+
+        let err = compute(stub.to_str().unwrap(), Path::new("/audio/track.flac"), &ct)
+            .await
+            .unwrap_err();
+
+        match err {
+            EpignosisError::FingerprintFailed { message, .. } => {
+                assert!(message.contains("exited with"), "{message}");
+                assert!(message.contains("could not decode"), "{message}");
+            }
+            other => panic!("expected FingerprintFailed, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancellation_interrupts_a_running_fpcalc() {
+        let dir = tempfile::tempdir().unwrap();
+        let stub = crate::test_support::write_stub_script(
+            dir.path(),
+            "fpcalc-hang",
+            "#!/bin/sh\nexec sleep 30\n",
+        );
+        let ct = CancellationToken::new();
+        ct.cancel();
+
+        let err = compute(stub.to_str().unwrap(), Path::new("/audio/track.flac"), &ct)
+            .await
+            .unwrap_err();
+
+        match err {
+            EpignosisError::FingerprintFailed { message, .. } => {
+                assert!(message.contains("cancelled"), "{message}");
+            }
+            other => panic!("expected FingerprintFailed, got {other:?}"),
+        }
+    }
+}

--- a/crates/epignosis/src/lib.rs
+++ b/crates/epignosis/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod cache;
 pub mod error;
+mod fingerprint;
 pub mod identity;
 pub mod providers;
 pub mod rate_limit;
 pub mod resolver;
+pub(crate) mod test_support;
 
 use std::path::Path;
 

--- a/crates/epignosis/src/providers/acoustid.rs
+++ b/crates/epignosis/src/providers/acoustid.rs
@@ -11,13 +11,23 @@ const BASE_URL: &str = "https://api.acoustid.org/v2";
 pub struct AcoustIdProvider {
     client: reqwest::Client,
     api_key: String,
+    base_url: String,
 }
 
 impl AcoustIdProvider {
     pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
+        Self::with_base_url(client, api_key, BASE_URL.to_string())
+    }
+
+    pub fn with_base_url(
+        client: reqwest::Client,
+        api_key: impl Into<String>,
+        base_url: String,
+    ) -> Self {
         Self {
             client,
             api_key: api_key.into(),
+            base_url,
         }
     }
 
@@ -27,7 +37,7 @@ impl AcoustIdProvider {
         &self,
         fingerprint: &FingerprintResult,
     ) -> Result<Vec<ProviderResult>, EpignosisError> {
-        let url = format!("{BASE_URL}/lookup");
+        let url = format!("{}/lookup", self.base_url);
         let duration_str = (fingerprint.duration_secs as u64).to_string();
         let response = self
             .client
@@ -128,7 +138,7 @@ impl MetadataProvider for AcoustIdProvider {
 
     #[instrument(skip(self), fields(provider = "acoustid"))]
     async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
-        let url = format!("{BASE_URL}/lookup");
+        let url = format!("{}/lookup", self.base_url);
         let response = self
             .client
             .get(&url)

--- a/crates/epignosis/src/providers/tmdb.rs
+++ b/crates/epignosis/src/providers/tmdb.rs
@@ -10,20 +10,142 @@ const BASE_URL: &str = "https://api.themoviedb.org/3";
 pub struct TmdbProvider {
     client: reqwest::Client,
     api_key: String,
+    base_url: String,
 }
 
 impl TmdbProvider {
     pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
+        Self::with_base_url(client, api_key, BASE_URL.to_string())
+    }
+
+    pub fn with_base_url(
+        client: reqwest::Client,
+        api_key: impl Into<String>,
+        base_url: String,
+    ) -> Self {
         Self {
             client,
             api_key: api_key.into(),
+            base_url,
         }
+    }
+
+    /// Cross-references an external provider ID (e.g. a TVDB series id) to a
+    /// TMDB TV id via `/find/{external_id}`. Returns `None` when TMDB holds
+    /// no mapping for that external id.
+    #[instrument(skip(self), fields(provider = "tmdb"))]
+    pub async fn find_by_external_id(
+        &self,
+        external_id: &str,
+        external_source: &str,
+    ) -> Result<Option<MetadataProviderId>, EpignosisError> {
+        let url = format!("{}/find/{external_id}", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("api_key", self.api_key.as_str()),
+                ("external_source", external_source),
+            ])
+            .send()
+            .await
+            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+
+        let text = response
+            .text()
+            .await
+            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+
+        let parsed: TmdbFindResponse =
+            serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tmdb" })?;
+
+        Ok(parsed
+            .tv_results
+            .into_iter()
+            .next()
+            .map(|tv| MetadataProviderId(tv.id.to_string())))
+    }
+
+    /// Fetches TV-series detail from `/tv/{id}`.
+    ///
+    /// TMDB's TV ids are a separate namespace from the movie ids served by
+    /// `get_metadata`, with a distinct response shape (`name` and
+    /// `first_air_date` instead of `title` and `release_date`).
+    #[instrument(skip(self), fields(provider = "tmdb"))]
+    pub async fn get_tv_metadata(
+        &self,
+        provider_id: &str,
+    ) -> Result<ProviderMetadata, EpignosisError> {
+        let url = format!("{}/tv/{provider_id}", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("api_key", self.api_key.as_str())])
+            .send()
+            .await
+            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+
+        let text = response
+            .text()
+            .await
+            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+
+        let series: TmdbTvDetail =
+            serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tmdb" })?;
+
+        let year = series
+            .first_air_date
+            .as_deref()
+            .and_then(|d| d.split('-').next())
+            .and_then(|y| y.parse().ok());
+
+        let genres: Vec<String> = series
+            .genres
+            .unwrap_or_default()
+            .into_iter()
+            .map(|g| g.name)
+            .collect();
+
+        let extra = serde_json::json!({
+            "overview": series.overview,
+            "seasons": series.number_of_seasons,
+            "genres": genres,
+        });
+
+        Ok(ProviderMetadata {
+            provider_id: MetadataProviderId(series.id.to_string()),
+            title: series.name,
+            artist: None,
+            year,
+            extra,
+        })
     }
 }
 
 #[derive(Debug, Deserialize)]
 struct TmdbSearchResponse {
     results: Vec<TmdbMovie>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TmdbFindResponse {
+    #[serde(default)]
+    tv_results: Vec<TmdbTvResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TmdbTvResult {
+    id: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct TmdbTvDetail {
+    id: u64,
+    name: String,
+    first_air_date: Option<String>,
+    overview: Option<String>,
+    number_of_seasons: Option<u32>,
+    genres: Option<Vec<TmdbGenre>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,7 +179,7 @@ impl MetadataProvider for TmdbProvider {
 
     #[instrument(skip(self), fields(provider = "tmdb"))]
     async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
-        let url = format!("{BASE_URL}/search/movie");
+        let url = format!("{}/search/movie", self.base_url);
         let response = self
             .client
             .get(&url)
@@ -108,7 +230,7 @@ impl MetadataProvider for TmdbProvider {
 
     #[instrument(skip(self), fields(provider = "tmdb"))]
     async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
-        let url = format!("{BASE_URL}/movie/{provider_id}");
+        let url = format!("{}/movie/{provider_id}", self.base_url);
         let response = self
             .client
             .get(&url)
@@ -151,5 +273,93 @@ impl MetadataProvider for TmdbProvider {
             year,
             extra,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::spawn_sequential_http;
+
+    #[tokio::test]
+    async fn find_by_external_id_returns_tv_namespace_id() {
+        let body = serde_json::json!({
+            "movie_results": [],
+            "tv_results": [{ "id": 1396, "name": "Breaking Bad" }],
+        })
+        .to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, body)]).await;
+        let provider = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        let found = provider
+            .find_by_external_id("81189", "tvdb_id")
+            .await
+            .unwrap();
+
+        assert_eq!(found, Some(MetadataProviderId("1396".to_string())));
+        let requests = handle.await.unwrap();
+        assert!(requests[0].starts_with("GET /find/81189"));
+        assert!(
+            requests[0].contains("external_source=tvdb_id"),
+            "cross-reference must name the source namespace"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_by_external_id_no_mapping_returns_none() {
+        let body = serde_json::json!({ "movie_results": [], "tv_results": [] }).to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, body)]).await;
+        let provider = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        let found = provider
+            .find_by_external_id("999999", "tvdb_id")
+            .await
+            .unwrap();
+
+        assert_eq!(found, None);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn find_by_external_id_tolerates_missing_tv_results_field() {
+        let body = serde_json::json!({ "movie_results": [] }).to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, body)]).await;
+        let provider = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        let found = provider
+            .find_by_external_id("81189", "tvdb_id")
+            .await
+            .unwrap();
+
+        assert_eq!(found, None);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_tv_metadata_hits_tv_endpoint_and_parses_tv_shape() {
+        let body = serde_json::json!({
+            "id": 1396,
+            "name": "Breaking Bad",
+            "first_air_date": "2008-01-20",
+            "overview": "A chemistry teacher turns to crime.",
+            "number_of_seasons": 5,
+            "genres": [{ "name": "Drama" }, { "name": "Crime" }],
+        })
+        .to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, body)]).await;
+        let provider = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        let meta = provider.get_tv_metadata("1396").await.unwrap();
+
+        assert_eq!(meta.provider_id, MetadataProviderId("1396".to_string()));
+        assert_eq!(meta.title, "Breaking Bad");
+        assert_eq!(meta.year, Some(2008));
+        assert_eq!(meta.extra["seasons"], 5);
+        assert_eq!(meta.extra["genres"][0], "Drama");
+        let requests = handle.await.unwrap();
+        assert!(
+            requests[0].starts_with("GET /tv/1396"),
+            "TV detail must address the /tv namespace, not /movie"
+        );
     }
 }

--- a/crates/epignosis/src/providers/tvdb.rs
+++ b/crates/epignosis/src/providers/tvdb.rs
@@ -1,5 +1,8 @@
+use std::time::{Duration, Instant};
+
 use serde::Deserialize;
 use snafu::ResultExt;
+use tokio::sync::RwLock;
 use tracing::instrument;
 
 use super::{MetadataProvider, MetadataProviderId, ProviderMetadata, ProviderResult, SearchQuery};
@@ -7,21 +10,56 @@ use crate::error::{EpignosisError, ProviderParseSnafu, ProviderRequestSnafu};
 
 const BASE_URL: &str = "https://api4.thetvdb.com/v4";
 
+// NOTE: TVDB JWTs are valid for roughly a month; one day is a conservative
+// reuse window that keeps a stale token from ever reaching the API.
+const TOKEN_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
 pub struct TvdbProvider {
     client: reqwest::Client,
     api_key: String,
+    base_url: String,
+    // NOTE: interior mutability — MetadataProvider methods take &self.
+    // Holds the bearer token and the instant it stops being valid.
+    token: RwLock<Option<(String, Instant)>>,
 }
 
 impl TvdbProvider {
     pub fn new(client: reqwest::Client, api_key: impl Into<String>) -> Self {
+        Self::with_base_url(client, api_key, BASE_URL.to_string())
+    }
+
+    pub fn with_base_url(
+        client: reqwest::Client,
+        api_key: impl Into<String>,
+        base_url: String,
+    ) -> Self {
         Self {
             client,
             api_key: api_key.into(),
+            base_url,
+            token: RwLock::new(None),
         }
     }
 
+    /// Returns the cached bearer token, logging in only on a cache miss or
+    /// after the reuse window has elapsed.
     async fn bearer_token(&self) -> Result<String, EpignosisError> {
-        let url = format!("{BASE_URL}/login");
+        if let Some((token, valid_until)) = self.token.read().await.as_ref()
+            && Instant::now() < *valid_until
+        {
+            return Ok(token.clone());
+        }
+
+        let mut slot = self.token.write().await;
+        // WHY: double-checked — a concurrent caller may have refreshed the
+        // token while this one waited for the write lock.
+        if let Some((token, valid_until)) = slot.as_ref()
+            && Instant::now() < *valid_until
+        {
+            return Ok(token.clone());
+        }
+
+        let url = format!("{}/login", self.base_url);
         let body = serde_json::json!({ "apikey": self.api_key });
 
         let response = self
@@ -40,7 +78,14 @@ impl TvdbProvider {
         let parsed: TvdbLoginResponse =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tvdb" })?;
 
-        Ok(parsed.data.token)
+        let token = parsed.data.token;
+        *slot = Some((token.clone(), Instant::now() + TOKEN_TTL));
+        Ok(token)
+    }
+
+    #[cfg(test)]
+    async fn seed_token(&self, token: &str, valid_until: Instant) {
+        *self.token.write().await = Some((token.to_string(), valid_until));
     }
 }
 
@@ -95,7 +140,7 @@ impl MetadataProvider for TvdbProvider {
     #[instrument(skip(self), fields(provider = "tvdb"))]
     async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
         let token = self.bearer_token().await?;
-        let url = format!("{BASE_URL}/search");
+        let url = format!("{}/search", self.base_url);
 
         let response = self
             .client
@@ -139,7 +184,7 @@ impl MetadataProvider for TvdbProvider {
     #[instrument(skip(self), fields(provider = "tvdb"))]
     async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
         let token = self.bearer_token().await?;
-        let url = format!("{BASE_URL}/series/{provider_id}");
+        let url = format!("{}/series/{provider_id}", self.base_url);
 
         let response = self
             .client
@@ -178,5 +223,136 @@ impl MetadataProvider for TvdbProvider {
             year,
             extra,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use themelion::MediaType;
+
+    use super::*;
+    use crate::test_support::spawn_sequential_http;
+
+    fn tv_query(title: &str) -> SearchQuery {
+        SearchQuery {
+            media_type: MediaType::Tv,
+            title: title.to_string(),
+            artist: None,
+            year: None,
+            isbn: None,
+            extra: None,
+        }
+    }
+
+    fn login_body(token: &str) -> String {
+        serde_json::json!({ "data": { "token": token } }).to_string()
+    }
+
+    fn empty_search_body() -> String {
+        serde_json::json!({ "data": [] }).to_string()
+    }
+
+    fn series_body(id: u64) -> String {
+        serde_json::json!({ "data": { "id": id, "name": "Show", "year": "2008" } }).to_string()
+    }
+
+    #[tokio::test]
+    async fn token_fetched_once_and_reused_across_calls() {
+        let (base_url, handle) = spawn_sequential_http(vec![
+            (200, login_body("tok-1")),
+            (200, empty_search_body()),
+            (200, empty_search_body()),
+            (200, series_body(42)),
+        ])
+        .await;
+        let provider = TvdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        provider.search(&tv_query("Breaking Bad")).await.unwrap();
+        provider.search(&tv_query("The Wire")).await.unwrap();
+        provider.get_metadata("42").await.unwrap();
+
+        let requests = handle.await.unwrap();
+        assert_eq!(requests.len(), 4, "exactly one login plus three API calls");
+        assert!(requests[0].starts_with("POST /login"));
+        assert!(requests[1].starts_with("GET /search"));
+        assert!(
+            requests[2].starts_with("GET /search"),
+            "second search must reuse the cached token, not re-login: {}",
+            requests[2].lines().next().unwrap_or_default()
+        );
+        assert!(requests[3].starts_with("GET /series/42"));
+        for request in &requests[1..] {
+            assert!(
+                request
+                    .to_ascii_lowercase()
+                    .contains("authorization: bearer tok-1"),
+                "cached token must be sent on every authenticated call"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn expired_token_triggers_fresh_login() {
+        let (base_url, handle) = spawn_sequential_http(vec![
+            (200, login_body("tok-fresh")),
+            (200, empty_search_body()),
+        ])
+        .await;
+        let provider = TvdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+        // NOTE: a deadline of "now" is already past by the time the cache is read.
+        provider.seed_token("tok-stale", Instant::now()).await;
+
+        provider.search(&tv_query("Severance")).await.unwrap();
+
+        let requests = handle.await.unwrap();
+        assert!(requests[0].starts_with("POST /login"));
+        assert!(
+            requests[1]
+                .to_ascii_lowercase()
+                .contains("authorization: bearer tok-fresh"),
+            "stale token must be replaced, not reused"
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_cached_token_skips_login_entirely() {
+        let (base_url, handle) = spawn_sequential_http(vec![(200, empty_search_body())]).await;
+        let provider = TvdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+        provider
+            .seed_token("tok-live", Instant::now() + Duration::from_secs(60))
+            .await;
+
+        provider.search(&tv_query("Dark")).await.unwrap();
+
+        let requests = handle.await.unwrap();
+        assert_eq!(requests.len(), 1, "no login request may be issued");
+        assert!(requests[0].starts_with("GET /search"));
+        assert!(
+            requests[0]
+                .to_ascii_lowercase()
+                .contains("authorization: bearer tok-live")
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_login_caches_nothing() {
+        let (base_url, handle) = spawn_sequential_http(vec![
+            (200, "not json".to_string()),
+            (200, login_body("tok-2")),
+            (200, empty_search_body()),
+        ])
+        .await;
+        let provider = TvdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        assert!(provider.search(&tv_query("Lost")).await.is_err());
+        provider.search(&tv_query("Lost")).await.unwrap();
+
+        let requests = handle.await.unwrap();
+        assert!(requests[0].starts_with("POST /login"));
+        assert!(
+            requests[1].starts_with("POST /login"),
+            "a failed login must not poison the cache"
+        );
+        assert!(requests[2].starts_with("GET /search"));
     }
 }

--- a/crates/epignosis/src/resolver.rs
+++ b/crates/epignosis/src/resolver.rs
@@ -43,7 +43,6 @@ pub struct ProviderBackedResolver {
     #[expect(dead_code)]
     config: EpignosisConfig,
     musicbrainz: MusicBrainzProvider,
-    #[expect(dead_code)]
     acoustid: AcoustIdProvider,
     tmdb: TmdbProvider,
     tvdb: TvdbProvider,
@@ -52,6 +51,9 @@ pub struct ProviderBackedResolver {
     google_books: GoogleBooksProvider,
     itunes: ItunesProvider,
     comicvine: ComicVineProvider,
+    // NOTE: binary name rather than a hardcoded call site so tests can point
+    // fingerprinting at a stub executable.
+    fpcalc_binary: String,
 }
 
 impl ProviderBackedResolver {
@@ -90,6 +92,7 @@ impl ProviderBackedResolver {
             google_books,
             itunes,
             comicvine,
+            fpcalc_binary: crate::fingerprint::FPCALC_BINARY.to_string(),
         }
     }
 
@@ -176,6 +179,32 @@ impl ProviderBackedResolver {
         }
 
         0.2
+    }
+
+    /// Folds AcoustID lookup matches into a computed fingerprint: the
+    /// best-scoring match supplies the AcoustID id and confidence, and every
+    /// match contributes its MusicBrainz recording id.
+    fn merge_lookup_matches(
+        computed: FingerprintResult,
+        matches: &[ProviderResult],
+    ) -> FingerprintResult {
+        let best = matches.iter().max_by(|a, b| {
+            a.score
+                .partial_cmp(&b.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        FingerprintResult {
+            acoustid_id: best.and_then(|m| {
+                m.raw
+                    .get("acoustid")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            }),
+            confidence: best.map_or(0.0, |m| m.score),
+            mb_recording_ids: matches.iter().map(|m| m.provider_id.0.clone()).collect(),
+            ..computed
+        }
     }
 }
 
@@ -303,20 +332,30 @@ impl MetadataResolver for ProviderBackedResolver {
         })
     }
 
-    #[instrument(skip(self, _ct), fields(path = %file_path.display()))]
+    #[instrument(skip(self, ct), fields(path = %file_path.display()))]
     async fn fingerprint_audio(
         &self,
         file_path: &Path,
-        _ct: tokio_util::sync::CancellationToken,
+        ct: tokio_util::sync::CancellationToken,
     ) -> Result<FingerprintResult, EpignosisError> {
-        // Fingerprinting requires a native fpcalc binary (Chromaprint).
-        // This delegates to an external process and returns the result.
-        // The actual chromaprint invocation is deferred to the host process.
-        Err(EpignosisError::FingerprintFailed {
-            path: file_path.to_path_buf(),
-            message: "fpcalc not available in this build".to_string(),
-            location: snafu::location!(),
-        })
+        let raw = crate::fingerprint::compute(&self.fpcalc_binary, file_path, &ct).await?;
+        let computed = FingerprintResult {
+            fingerprint: raw.fingerprint,
+            duration_secs: raw.duration,
+            acoustid_id: None,
+            mb_recording_ids: Vec::new(),
+            confidence: 0.0,
+        };
+
+        self.queues.acoustid.acquire().await;
+        let matches = tokio::select! {
+            matches = self.acoustid.lookup_fingerprint(&computed) => matches?,
+            // WHY: the fingerprint itself is already computed; cancellation
+            // mid-lookup returns it unidentified rather than discarding it.
+            _ = ct.cancelled() => return Ok(computed),
+        };
+
+        Ok(Self::merge_lookup_matches(computed, &matches))
     }
 }
 
@@ -416,8 +455,18 @@ impl ProviderBackedResolver {
     ) -> Option<(String, serde_json::Value)> {
         match identity.media_type {
             MediaType::Tv => {
+                // WHY: identity.provider_id for Tv is a TVDB series id; TMDB
+                // requires its own TV id, so cross-reference via /find first
+                // and skip enrichment when TMDB holds no mapping.
                 self.queues.tmdb.acquire().await;
-                let meta = self.tmdb.get_metadata(&identity.provider_id.0).await.ok()?;
+                let tmdb_tv_id = self
+                    .tmdb
+                    .find_by_external_id(&identity.provider_id.0, "tvdb_id")
+                    .await
+                    .ok()
+                    .flatten()?;
+                self.queues.tmdb.acquire().await;
+                let meta = self.tmdb.get_tv_metadata(&tmdb_tv_id.0).await.ok()?;
                 Some(("tmdb".to_string(), meta.extra))
             }
             MediaType::Audiobook => {
@@ -455,8 +504,226 @@ impl ProviderBackedResolver {
 
 #[cfg(test)]
 mod tests {
+    use themelion::MediaId;
+
     use super::*;
     use crate::identity::MetadataProviderId;
+    use crate::test_support::spawn_sequential_http;
+
+    fn tv_identity(tvdb_id: &str) -> MediaIdentity {
+        MediaIdentity {
+            media_id: MediaId::new(),
+            media_type: MediaType::Tv,
+            provider: "tvdb".to_string(),
+            provider_id: MetadataProviderId(tvdb_id.to_string()),
+            canonical_title: "Breaking Bad".to_string(),
+            canonical_artist: None,
+            year: Some(2008),
+            extra: serde_json::Value::Null,
+        }
+    }
+
+    fn test_resolver() -> ProviderBackedResolver {
+        ProviderBackedResolver::new(
+            horismos::EpignosisConfig::default(),
+            ProviderCredentials::default(),
+        )
+    }
+
+    #[tokio::test]
+    async fn enrich_from_secondary_tv_resolves_via_tmdb_find_cross_reference() {
+        let find_body = serde_json::json!({
+            "movie_results": [],
+            "tv_results": [{ "id": 1396, "name": "Breaking Bad" }],
+        })
+        .to_string();
+        let tv_body = serde_json::json!({
+            "id": 1396,
+            "name": "Breaking Bad",
+            "first_air_date": "2008-01-20",
+            "overview": "A chemistry teacher turns to crime.",
+            "number_of_seasons": 5,
+            "genres": [{ "name": "Drama" }],
+        })
+        .to_string();
+        let (base_url, handle) =
+            spawn_sequential_http(vec![(200, find_body), (200, tv_body)]).await;
+
+        let mut resolver = test_resolver();
+        resolver.tmdb = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        let enrichment = resolver.enrich_from_secondary(&tv_identity("81189")).await;
+
+        let (provider, extra) = enrichment.expect("cross-referenced enrichment must succeed");
+        assert_eq!(provider, "tmdb");
+        assert_eq!(extra["overview"], "A chemistry teacher turns to crime.");
+        assert_eq!(extra["seasons"], 5);
+
+        let requests = handle.await.unwrap();
+        assert!(
+            requests[0].starts_with("GET /find/81189"),
+            "the TVDB id must go through /find, never straight into a TMDB detail endpoint"
+        );
+        assert!(requests[0].contains("external_source=tvdb_id"));
+        assert!(
+            requests[1].starts_with("GET /tv/1396"),
+            "detail fetch must use the cross-referenced TMDB TV id"
+        );
+    }
+
+    #[tokio::test]
+    async fn enrich_from_secondary_tv_without_mapping_returns_none() {
+        let find_body = serde_json::json!({ "movie_results": [], "tv_results": [] }).to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, find_body)]).await;
+
+        let mut resolver = test_resolver();
+        resolver.tmdb = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        let enrichment = resolver.enrich_from_secondary(&tv_identity("999999")).await;
+
+        assert!(
+            enrichment.is_none(),
+            "no cross-reference means no enrichment, not a wrong-namespace fetch"
+        );
+        let requests = handle.await.unwrap();
+        assert_eq!(
+            requests.len(),
+            1,
+            "no detail request may follow a find miss"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn fingerprint_audio_wires_fpcalc_into_acoustid_lookup() {
+        let lookup_body = serde_json::json!({
+            "results": [{
+                "id": "acoustid-123",
+                "score": 0.93,
+                "recordings": [{
+                    "id": "mb-rec-1",
+                    "title": "Song",
+                    "artists": [{ "name": "Artist" }],
+                }],
+            }],
+        })
+        .to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, lookup_body)]).await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let stub = crate::test_support::write_stub_script(
+            dir.path(),
+            "fpcalc-stub",
+            "#!/bin/sh\nprintf '{\"duration\": 42.5, \"fingerprint\": \"AQFAKE\"}'\n",
+        );
+
+        let mut resolver = test_resolver();
+        resolver.acoustid =
+            AcoustIdProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+        resolver.fpcalc_binary = stub.to_str().unwrap().to_string();
+
+        let result = resolver
+            .fingerprint_audio(
+                Path::new("/audio/track.flac"),
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.fingerprint, "AQFAKE");
+        assert!((result.duration_secs - 42.5).abs() < f64::EPSILON);
+        assert_eq!(result.acoustid_id.as_deref(), Some("acoustid-123"));
+        assert_eq!(result.mb_recording_ids, vec!["mb-rec-1".to_string()]);
+        assert!((result.confidence - 0.93).abs() < f64::EPSILON);
+
+        let requests = handle.await.unwrap();
+        assert!(
+            requests[0].contains("fingerprint=AQFAKE"),
+            "the computed fingerprint must reach the lookup call"
+        );
+        assert!(requests[0].contains("duration=42"));
+    }
+
+    #[tokio::test]
+    async fn fingerprint_audio_missing_fpcalc_is_a_clean_error() {
+        let mut resolver = test_resolver();
+        resolver.fpcalc_binary = "fpcalc-test-binary-that-does-not-exist".to_string();
+
+        let err = resolver
+            .fingerprint_audio(
+                Path::new("/audio/track.flac"),
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+            .unwrap_err();
+
+        match err {
+            EpignosisError::FingerprintFailed { message, .. } => {
+                assert!(message.contains("not found on PATH"), "{message}");
+            }
+            other => panic!("expected FingerprintFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_lookup_matches_picks_best_score() {
+        let computed = FingerprintResult {
+            fingerprint: "AQ".to_string(),
+            duration_secs: 10.0,
+            acoustid_id: None,
+            mb_recording_ids: Vec::new(),
+            confidence: 0.0,
+        };
+        let matches = vec![
+            ProviderResult {
+                provider_id: MetadataProviderId("mb-low".to_string()),
+                title: "Low".to_string(),
+                artist: None,
+                year: None,
+                score: 0.4,
+                raw: serde_json::json!({ "acoustid": "acoustid-low" }),
+            },
+            ProviderResult {
+                provider_id: MetadataProviderId("mb-high".to_string()),
+                title: "High".to_string(),
+                artist: None,
+                year: None,
+                score: 0.9,
+                raw: serde_json::json!({ "acoustid": "acoustid-high" }),
+            },
+        ];
+
+        let merged = ProviderBackedResolver::merge_lookup_matches(computed, &matches);
+
+        assert_eq!(merged.acoustid_id.as_deref(), Some("acoustid-high"));
+        assert!((merged.confidence - 0.9).abs() < f64::EPSILON);
+        assert_eq!(
+            merged.mb_recording_ids,
+            vec!["mb-low".to_string(), "mb-high".to_string()]
+        );
+        assert_eq!(merged.fingerprint, "AQ");
+    }
+
+    #[test]
+    fn merge_lookup_matches_empty_is_unidentified() {
+        let computed = FingerprintResult {
+            fingerprint: "AQ".to_string(),
+            duration_secs: 10.0,
+            acoustid_id: None,
+            mb_recording_ids: Vec::new(),
+            confidence: 0.0,
+        };
+
+        let merged = ProviderBackedResolver::merge_lookup_matches(computed, &[]);
+
+        assert_eq!(merged.acoustid_id, None);
+        assert!(merged.mb_recording_ids.is_empty());
+        assert!(merged.confidence.abs() < f64::EPSILON);
+        assert_eq!(
+            merged.fingerprint, "AQ",
+            "the raw fingerprint survives a no-match lookup"
+        );
+    }
 
     #[test]
     fn canonical_provider_music() {

--- a/crates/epignosis/src/test_support.rs
+++ b/crates/epignosis/src/test_support.rs
@@ -1,0 +1,86 @@
+//! Shared test fixtures — sequential one-shot HTTP servers for provider tests.
+#![cfg(test)]
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+/// Spawns a TCP server that answers `responses.len()` sequential HTTP
+/// requests (one connection each) with the given status and body, then
+/// resolves to the raw request bytes it received, in order.
+pub(crate) async fn spawn_sequential_http(
+    responses: Vec<(u16, String)>,
+) -> (String, JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+
+    let handle = tokio::spawn(async move {
+        let mut requests = Vec::new();
+        for (status, body) in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+
+            let header_end = loop {
+                let n = stream.read(&mut chunk).await.unwrap();
+                assert!(n > 0, "client closed before sending full headers");
+                buf.extend_from_slice(&chunk[..n]);
+                if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+
+            let content_length = parse_content_length(&buf[..header_end]);
+            while buf.len() < header_end + content_length {
+                let n = stream.read(&mut chunk).await.unwrap();
+                assert!(n > 0, "client closed before sending full body");
+                buf.extend_from_slice(&chunk[..n]);
+            }
+
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+
+            requests.push(String::from_utf8_lossy(&buf).into_owned());
+        }
+        requests
+    });
+
+    (base_url, handle)
+}
+
+/// Writes an executable stub script into `dir` and returns its path.
+#[cfg(unix)]
+pub(crate) fn write_stub_script(
+    dir: &std::path::Path,
+    name: &str,
+    body: &str,
+) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = dir.join(name);
+    std::fs::write(&path, body).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn parse_content_length(headers: &[u8]) -> usize {
+    String::from_utf8_lossy(headers)
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0)
+}

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -20,8 +20,10 @@ const USER_AGENT: &str = "Harmonia/1.0";
 
 /// Computes the OpenSubtitles-specific file hash.
 ///
-/// The hash is the XOR sum of the file size and the first/last 64 KB of the
-/// file, treating each 8-byte chunk as a little-endian u64.
+/// The hash is the wrapping sum of the file size and the first/last 64 KB of
+/// the file, treating each 8-byte chunk as a little-endian u64. For files
+/// smaller than 128 KB the two windows overlap; bytes between the windows
+/// never affect the hash.
 pub fn compute_file_hash(path: &Path) -> std::io::Result<String> {
     use std::io::{Read, Seek, SeekFrom};
 
@@ -339,6 +341,73 @@ mod tests {
             url: None,
         };
         assert!(score_result(&hash_attr, "en") > score_result(&title_attr, "en"));
+    }
+
+    // NOTE: known-answer vector, hand-computed from the published
+    // OpenSubtitles algorithm. 16 bytes = two u64 words (w1 = 8 bytes of
+    // 0x01, w2 = 8 bytes of 0x02); head and tail windows both start at
+    // offset 0 for a file under 64 KB, so each word is summed twice:
+    // 16 + 2*0x0101010101010101 + 2*0x0202020202020202 = 0x0606060606060616.
+    #[test]
+    fn compute_file_hash_small_file_known_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small.bin");
+        let mut content = vec![0x01u8; 8];
+        content.extend_from_slice(&[0x02u8; 8]);
+        std::fs::write(&path, &content).unwrap();
+
+        assert_eq!(compute_file_hash(&path).unwrap(), "0606060606060616");
+    }
+
+    // NOTE: known-answer vector, hand-computed. 128 KB file: head window is
+    // all zeros (contributes nothing), tail window seeks to offset 65536 and
+    // reads 8192 words of 0xFFFFFFFFFFFFFFFF, contributing
+    // 8192 * (2^64 - 1) = -8192 (mod 2^64). Hash = 0x20000 - 0x2000 = 0x1e000.
+    #[test]
+    fn compute_file_hash_large_file_tail_seek_known_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large.bin");
+        let mut content = vec![0u8; 128 * 1024];
+        content[64 * 1024..].fill(0xFF);
+        std::fs::write(&path, &content).unwrap();
+
+        assert_eq!(compute_file_hash(&path).unwrap(), "000000000001e000");
+    }
+
+    #[test]
+    fn compute_file_hash_ignores_bytes_between_the_windows() {
+        let dir = tempfile::tempdir().unwrap();
+        let plain = dir.path().join("plain.bin");
+        let mutated = dir.path().join("mutated.bin");
+
+        let content = vec![0u8; 192 * 1024];
+        std::fs::write(&plain, &content).unwrap();
+
+        let mut content = content;
+        // WHY: only the region outside both 64 KB windows is changed — the
+        // hash must not see it.
+        content[64 * 1024..128 * 1024].fill(0xAB);
+        std::fs::write(&mutated, &content).unwrap();
+
+        let plain_hash = compute_file_hash(&plain).unwrap();
+        assert_eq!(plain_hash, compute_file_hash(&mutated).unwrap());
+        // NOTE: both windows are zero, so the hash is the file size alone.
+        assert_eq!(plain_hash, "0000000000030000");
+    }
+
+    #[test]
+    fn compute_file_hash_empty_file_is_size_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.bin");
+        std::fs::write(&path, b"").unwrap();
+
+        assert_eq!(compute_file_hash(&path).unwrap(), "0000000000000000");
+    }
+
+    #[test]
+    fn compute_file_hash_missing_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(compute_file_hash(&dir.path().join("absent.bin")).is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #416, #417, #471, #458. TVDB bearer-token caching; TMDB /find external-id cross-reference (fixes ID-namespace bug, fails closed on miss); AcoustID fpcalc fingerprinting (typed failures, no panic); OpenSubtitles hash known-answer tests. kanon gate --full green.