### PR TITLE
fix(apotheke): period-scoped stats, checked writes, transactional streaks

### DIFF
--- a/crates/apotheke/src/error.rs
+++ b/crates/apotheke/src/error.rs
@@ -40,4 +40,11 @@ pub enum DbError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    #[snafu(display("unknown media type: {media_type}"))]
+    UnknownMediaType {
+        media_type: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }

--- a/crates/apotheke/src/repo/play_history/mod.rs
+++ b/crates/apotheke/src/repo/play_history/mod.rs
@@ -402,11 +402,18 @@ pub async fn update_daily_stats(
 
 /// Update (or CREATE) the current streak for `user_id`.
 /// `today` must be an ISO date string in "YYYY-MM-DD" format.
+///
+/// INVARIANT: the read-decide-write sequence runs inside one `BEGIN IMMEDIATE`
+/// transaction — concurrent callers serialize on the write lock (no duplicate
+/// or double-extended current streak), and the gap arm's close-then-insert is
+/// atomic (a failed INSERT rolls back the close instead of losing the streak).
 pub async fn update_streak(pool: &SqlitePool, user_id: UserId, today: &str) -> Result<(), DbError> {
+    let mut tx = crate::pools::begin_immediate(pool).await?;
+
     // Compute yesterday using SQLite so we stay free of date-math crates here.
     let (yesterday,): (String,) = sqlx::query_as("SELECT date(?, '-1 day')")
         .bind(today)
-        .fetch_one(pool)
+        .fetch_one(&mut *tx)
         .await
         .context(QuerySnafu {
             table: "play_streaks",
@@ -418,7 +425,7 @@ pub async fn update_streak(pool: &SqlitePool, user_id: UserId, today: &str) -> R
          WHERE user_id = ? AND is_current = 1",
     )
     .bind(user_id.as_bytes().as_ref())
-    .fetch_optional(pool)
+    .fetch_optional(&mut *tx)
     .await
     .context(QuerySnafu {
         table: "play_streaks",
@@ -434,7 +441,7 @@ pub async fn update_streak(pool: &SqlitePool, user_id: UserId, today: &str) -> R
             .bind(user_id.as_bytes().as_ref())
             .bind(today)
             .bind(today)
-            .execute(pool)
+            .execute(&mut *tx)
             .await
             .context(QuerySnafu {
                 table: "play_streaks",
@@ -451,7 +458,7 @@ pub async fn update_streak(pool: &SqlitePool, user_id: UserId, today: &str) -> R
             )
             .bind(today)
             .bind(user_id.as_bytes().as_ref())
-            .execute(pool)
+            .execute(&mut *tx)
             .await
             .context(QuerySnafu {
                 table: "play_streaks",
@@ -462,7 +469,7 @@ pub async fn update_streak(pool: &SqlitePool, user_id: UserId, today: &str) -> R
                 "UPDATE play_streaks SET is_current = 0 WHERE user_id = ? AND is_current = 1",
             )
             .bind(user_id.as_bytes().as_ref())
-            .execute(pool)
+            .execute(&mut *tx)
             .await
             .context(QuerySnafu {
                 table: "play_streaks",
@@ -476,7 +483,7 @@ pub async fn update_streak(pool: &SqlitePool, user_id: UserId, today: &str) -> R
             .bind(user_id.as_bytes().as_ref())
             .bind(today)
             .bind(today)
-            .execute(pool)
+            .execute(&mut *tx)
             .await
             .context(QuerySnafu {
                 table: "play_streaks",
@@ -484,6 +491,7 @@ pub async fn update_streak(pool: &SqlitePool, user_id: UserId, today: &str) -> R
         }
     }
 
+    crate::pools::commit_tx(tx).await?;
     Ok(())
 }
 
@@ -552,23 +560,27 @@ pub async fn top_items(
     period: &DateRange,
     limit: u32,
 ) -> Result<Vec<ItemStats>, DbError> {
+    // WHY: aggregate over play_sessions rows inside the period — play_stats_item
+    // holds lifetime counters, which would leak out-of-range plays into a
+    // date-scoped query and rank by all-time popularity.
+    // NOTE: skip = percent_heard < 50, matching update_item_stats; a NULL
+    // percent_heard falls to ELSE 0, matching the Rust-side unwrap_or(false).
     let rows = sqlx::query_as::<_, ItemStatsRow>(
-        "SELECT psi.media_id, psi.play_count, psi.total_ms,
-                psi.skip_count, psi.last_played_at
-         FROM play_stats_item psi
-         WHERE psi.user_id = ?
-           AND psi.media_id IN (
-               SELECT DISTINCT ps.media_id
-               FROM play_sessions ps
-               WHERE ps.user_id = ?
-                 AND ps.media_type = ?
-                 AND date(ps.started_at) >= ?
-                 AND date(ps.started_at) <= ?
-           )
-         ORDER BY psi.play_count DESC
+        "SELECT ps.media_id,
+                CAST(COUNT(*) AS INTEGER) AS play_count,
+                COALESCE(SUM(ps.duration_ms), 0) AS total_ms,
+                CAST(COALESCE(SUM(CASE WHEN ps.percent_heard < 50 THEN 1 ELSE 0 END), 0)
+                     AS INTEGER) AS skip_count,
+                MAX(ps.started_at) AS last_played_at
+         FROM play_sessions ps
+         WHERE ps.user_id = ?
+           AND ps.media_type = ?
+           AND date(ps.started_at) >= ?
+           AND date(ps.started_at) <= ?
+         GROUP BY ps.media_id
+         ORDER BY play_count DESC
          LIMIT ?",
     )
-    .bind(user_id.as_bytes().as_ref())
     .bind(user_id.as_bytes().as_ref())
     .bind(media_type.to_string())
     .bind(&period.start)
@@ -577,7 +589,7 @@ pub async fn top_items(
     .fetch_all(pool)
     .await
     .context(QuerySnafu {
-        table: "play_stats_item",
+        table: "play_sessions",
     })?;
 
     Ok(rows

--- a/crates/apotheke/src/repo/play_history/tests.rs
+++ b/crates/apotheke/src/repo/play_history/tests.rs
@@ -43,6 +43,28 @@ fn new_session(user_id: UserId, media_id: MediaId, media_type: MediaType) -> New
     }
 }
 
+async fn insert_session_at(
+    pool: &SqlitePool,
+    user_id: UserId,
+    media_id: MediaId,
+    started_at: &str,
+    duration_ms: i64,
+) {
+    sqlx::query(
+        "INSERT INTO play_sessions
+             (id, media_id, user_id, media_type, started_at, duration_ms, source)
+         VALUES (?, ?, ?, 'music', ?, ?, 'local')",
+    )
+    .bind(SessionId::new().as_bytes().as_ref())
+    .bind(media_id.as_bytes().as_ref())
+    .bind(user_id.as_bytes().as_ref())
+    .bind(started_at)
+    .bind(duration_ms)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
 // -----------------------------------------------------------------------
 // Session lifecycle
 // -----------------------------------------------------------------------
@@ -568,6 +590,106 @@ async fn top_items_ordered_by_play_count() {
 }
 
 #[tokio::test]
+async fn top_items_scopes_counts_to_period() {
+    let pool = setup().await;
+    let user_id = make_user_id();
+    insert_user(&pool, user_id).await;
+    let media_id = make_media_id();
+
+    insert_session_at(&pool, user_id, media_id, "2026-03-10T10:00:00Z", 120_000).await;
+    insert_session_at(&pool, user_id, media_id, "2025-01-01T10:00:00Z", 999_000).await;
+
+    let period = DateRange {
+        start: "2026-03-01".to_string(),
+        end: "2026-03-31".to_string(),
+    };
+    let items = top_items(&pool, user_id, MediaType::Music, &period, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].media_id, media_id);
+    assert_eq!(
+        items[0].play_count, 1,
+        "the out-of-range play must not be counted"
+    );
+    assert_eq!(
+        items[0].total_ms, 120_000,
+        "total_ms must cover only in-range sessions"
+    );
+    assert_eq!(
+        items[0].last_played_at.as_deref(),
+        Some("2026-03-10T10:00:00Z")
+    );
+}
+
+#[tokio::test]
+async fn top_items_orders_by_period_count_not_lifetime() {
+    let pool = setup().await;
+    let user_id = make_user_id();
+    insert_user(&pool, user_id).await;
+
+    // Media A: lifetime-heavy (3 plays outside the period), 1 play inside.
+    let media_a = make_media_id();
+    insert_session_at(&pool, user_id, media_a, "2025-06-01T10:00:00Z", 1_000).await;
+    insert_session_at(&pool, user_id, media_a, "2025-06-02T10:00:00Z", 1_000).await;
+    insert_session_at(&pool, user_id, media_a, "2025-06-03T10:00:00Z", 1_000).await;
+    insert_session_at(&pool, user_id, media_a, "2026-03-10T10:00:00Z", 1_000).await;
+
+    // Media B: 2 plays inside the period, none outside.
+    let media_b = make_media_id();
+    insert_session_at(&pool, user_id, media_b, "2026-03-11T10:00:00Z", 1_000).await;
+    insert_session_at(&pool, user_id, media_b, "2026-03-12T10:00:00Z", 1_000).await;
+
+    let period = DateRange {
+        start: "2026-03-01".to_string(),
+        end: "2026-03-31".to_string(),
+    };
+    let items = top_items(&pool, user_id, MediaType::Music, &period, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 2);
+    assert_eq!(
+        items[0].media_id, media_b,
+        "period-heavy media must outrank lifetime-heavy media"
+    );
+    assert_eq!(items[0].play_count, 2);
+    assert_eq!(items[1].media_id, media_a);
+    assert_eq!(items[1].play_count, 1);
+}
+
+#[tokio::test]
+async fn top_items_isolated_by_user() {
+    let pool = setup().await;
+    let user_a = make_user_id();
+    let user_b = make_user_id();
+    insert_user(&pool, user_a).await;
+    insert_user(&pool, user_b).await;
+
+    let media_a = make_media_id();
+    let media_b = make_media_id();
+    insert_session_at(&pool, user_a, media_a, "2026-03-10T10:00:00Z", 1_000).await;
+    insert_session_at(&pool, user_b, media_b, "2026-03-10T11:00:00Z", 1_000).await;
+    insert_session_at(&pool, user_b, media_b, "2026-03-11T11:00:00Z", 1_000).await;
+
+    let period = DateRange {
+        start: "2026-03-01".to_string(),
+        end: "2026-03-31".to_string(),
+    };
+    let items = top_items(&pool, user_a, MediaType::Music, &period, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].media_id, media_a);
+    assert_eq!(
+        items[0].play_count, 1,
+        "user B's plays must not leak into user A's stats"
+    );
+}
+
+#[tokio::test]
 async fn listening_time_aggregates_across_media_types() {
     let pool = setup().await;
     let user_id = make_user_id();
@@ -786,4 +908,163 @@ async fn streak_gap_closes_old_and_starts_new() {
             .await
             .unwrap();
     assert_eq!(closed_count, 1);
+}
+
+#[tokio::test]
+async fn update_streak_concurrent_calls_produce_one_active_row() {
+    // WHY: max_connections(1) mirrors the production write pool and keeps
+    // sqlite::memory: on a single database across both concurrent tasks.
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    MIGRATOR.run(&pool).await.unwrap();
+    let user_id = make_user_id();
+    insert_user(&pool, user_id).await;
+
+    let (r1, r2) = tokio::join!(
+        update_streak(&pool, user_id, "2026-03-12"),
+        update_streak(&pool, user_id, "2026-03-12")
+    );
+    r1.unwrap();
+    r2.unwrap();
+
+    let (active,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM play_streaks WHERE user_id = ? AND is_current = 1")
+            .bind(user_id.as_bytes().as_ref())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        active, 1,
+        "exactly one current streak after concurrent updates"
+    );
+}
+
+#[tokio::test]
+async fn update_streak_gap_arm_atomic_on_injected_failure() {
+    let pool = setup().await;
+    let user_id = make_user_id();
+    insert_user(&pool, user_id).await;
+
+    // Current streak far in the past — the gap arm will close it and INSERT.
+    sqlx::query(
+        "INSERT INTO play_streaks (user_id, streak_start, streak_end, days, is_current)
+         VALUES (?, '2026-01-01', '2026-01-05', 5, 1)",
+    )
+    .bind(user_id.as_bytes().as_ref())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Historical row colliding on PK (user_id, streak_start) with the row the
+    // gap arm will INSERT — injects a failure between the arm's two writes.
+    sqlx::query(
+        "INSERT INTO play_streaks (user_id, streak_start, streak_end, days, is_current)
+         VALUES (?, '2026-03-13', '2026-03-13', 1, 0)",
+    )
+    .bind(user_id.as_bytes().as_ref())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let result = update_streak(&pool, user_id, "2026-03-13").await;
+    assert!(result.is_err());
+
+    // The close-UPDATE must roll back with the failed INSERT — the streak is
+    // not left cleared-but-not-recreated.
+    let streak = current_streak(&pool, user_id).await.unwrap().unwrap();
+    assert_eq!(streak.start, "2026-01-01");
+    assert_eq!(streak.end, "2026-01-05");
+    assert_eq!(streak.days, 5);
+}
+
+// -----------------------------------------------------------------------
+// Per-user isolation
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn recent_sessions_isolated_by_user() {
+    let pool = setup().await;
+    let user_a = make_user_id();
+    let user_b = make_user_id();
+    insert_user(&pool, user_a).await;
+    insert_user(&pool, user_b).await;
+
+    let session_a = start_session(
+        &pool,
+        &new_session(user_a, make_media_id(), MediaType::Music),
+    )
+    .await
+    .unwrap();
+    start_session(
+        &pool,
+        &new_session(user_b, make_media_id(), MediaType::Music),
+    )
+    .await
+    .unwrap();
+
+    let sessions = recent_sessions(&pool, user_a, 10).await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].id, session_a.as_bytes().to_vec());
+    assert!(
+        sessions
+            .iter()
+            .all(|s| s.user_id == user_a.as_bytes().to_vec())
+    );
+}
+
+#[tokio::test]
+async fn get_active_sessions_isolated_by_user() {
+    let pool = setup().await;
+    let user_a = make_user_id();
+    let user_b = make_user_id();
+    insert_user(&pool, user_a).await;
+    insert_user(&pool, user_b).await;
+
+    let session_a = start_session(
+        &pool,
+        &new_session(user_a, make_media_id(), MediaType::Music),
+    )
+    .await
+    .unwrap();
+    start_session(
+        &pool,
+        &new_session(user_b, make_media_id(), MediaType::Music),
+    )
+    .await
+    .unwrap();
+
+    let active = get_active_sessions(&pool, user_a).await.unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].id, session_a.as_bytes().to_vec());
+}
+
+#[tokio::test]
+async fn get_pending_scrobbles_isolated_by_user() {
+    let pool = setup().await;
+    let user_a = make_user_id();
+    let user_b = make_user_id();
+    insert_user(&pool, user_a).await;
+    insert_user(&pool, user_b).await;
+
+    let session_a = start_session(
+        &pool,
+        &new_session(user_a, make_media_id(), MediaType::Music),
+    )
+    .await
+    .unwrap();
+    let session_b = start_session(
+        &pool,
+        &new_session(user_b, make_media_id(), MediaType::Music),
+    )
+    .await
+    .unwrap();
+    mark_scrobble_eligible(&pool, session_a).await.unwrap();
+    mark_scrobble_eligible(&pool, session_b).await.unwrap();
+
+    let pending = get_pending_scrobbles(&pool, user_a).await.unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].id, session_a.as_bytes().to_vec());
 }

--- a/crates/apotheke/src/repo/quality.rs
+++ b/crates/apotheke/src/repo/quality.rs
@@ -1,7 +1,7 @@
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use sqlx::SqlitePool;
 
-use crate::error::{DbError, QuerySnafu};
+use crate::error::{DbError, QuerySnafu, UnknownMediaTypeSnafu};
 
 // WHY: wire DTO — SQLx row from the quality_profiles table.
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -132,12 +132,14 @@ pub async fn delete_profile(pool: &SqlitePool, id: i64) -> Result<(), DbError> {
 }
 
 /// Look up the score for a given format in the appropriate rank table for the media type.
+///
+/// Returns `DbError::UnknownMediaType` when `media_type` has no rank table.
 pub async fn score_for_format(
     pool: &SqlitePool,
     media_type: &str,
     format: &str,
 ) -> Result<Option<i64>, DbError> {
-    let table = rank_table_for(media_type);
+    let table = rank_table_for(media_type).context(UnknownMediaTypeSnafu { media_type })?;
     let sql = format!("SELECT score FROM {table} WHERE format = ?");
     let row: Option<(i64,)> = sqlx::query_as(&sql)
         .bind(format)
@@ -148,11 +150,13 @@ pub async fn score_for_format(
 }
 
 /// List all ranks for a given media type's rank table.
+///
+/// Returns `DbError::UnknownMediaType` when `media_type` has no rank table.
 pub async fn list_ranks(
     pool: &SqlitePool,
     media_type: &str,
 ) -> Result<Vec<QualityRankRow>, DbError> {
-    let table = rank_table_for(media_type);
+    let table = rank_table_for(media_type).context(UnknownMediaTypeSnafu { media_type })?;
     let sql = format!("SELECT rank, format, score FROM {table} ORDER BY rank");
     sqlx::query_as::<_, QualityRankRow>(&sql)
         .fetch_all(pool)
@@ -160,15 +164,18 @@ pub async fn list_ranks(
         .context(QuerySnafu { table })
 }
 
-fn rank_table_for(media_type: &str) -> &'static str {
+// WHY: None (not a music fallback) for unrecognized input — the table name is
+// interpolated into SQL, so an unmatched media_type must fail loud instead of
+// silently answering with music rank data.
+fn rank_table_for(media_type: &str) -> Option<&'static str> {
     match media_type {
-        "music" => "music_quality_ranks",
-        "audiobook" => "audiobook_quality_ranks",
-        "book" => "book_quality_ranks",
-        "comic" => "comic_quality_ranks",
-        "podcast" => "podcast_quality_ranks",
-        "movie" | "tv" => "video_quality_ranks",
-        _ => "music_quality_ranks",
+        "music" => Some("music_quality_ranks"),
+        "audiobook" => Some("audiobook_quality_ranks"),
+        "book" => Some("book_quality_ranks"),
+        "comic" => Some("comic_quality_ranks"),
+        "podcast" => Some("podcast_quality_ranks"),
+        "movie" | "tv" => Some("video_quality_ranks"),
+        _ => None,
     }
 }
 
@@ -252,5 +259,50 @@ mod tests {
         assert_eq!(ranks.len(), 7);
         assert_eq!(ranks[0].format, "FLAC_24BIT");
         assert_eq!(ranks[0].score, 100);
+    }
+
+    #[tokio::test]
+    async fn score_for_format_unknown_media_type_errors() {
+        let pool = setup().await;
+        let err = score_for_format(&pool, "news", "MP3_320_CBR")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DbError::UnknownMediaType { ref media_type, .. } if media_type == "news"
+        ));
+    }
+
+    #[tokio::test]
+    async fn list_ranks_unknown_media_type_errors() {
+        let pool = setup().await;
+        let err = list_ranks(&pool, "comic-book").await.unwrap_err();
+        assert!(matches!(
+            err,
+            DbError::UnknownMediaType { ref media_type, .. } if media_type == "comic-book"
+        ));
+    }
+
+    #[test]
+    fn rank_table_for_known_types_unchanged() {
+        let cases = [
+            ("music", "music_quality_ranks"),
+            ("audiobook", "audiobook_quality_ranks"),
+            ("book", "book_quality_ranks"),
+            ("comic", "comic_quality_ranks"),
+            ("podcast", "podcast_quality_ranks"),
+            ("movie", "video_quality_ranks"),
+            ("tv", "video_quality_ranks"),
+        ];
+        for (media_type, expected) in cases {
+            assert_eq!(rank_table_for(media_type), Some(expected));
+        }
+    }
+
+    #[test]
+    fn rank_table_for_unknown_returns_none() {
+        for media_type in ["news", "", "Music", "music_quality_ranks; DROP TABLE users"] {
+            assert_eq!(rank_table_for(media_type), None);
+        }
     }
 }

--- a/crates/apotheke/src/repo/renderer.rs
+++ b/crates/apotheke/src/repo/renderer.rs
@@ -2,7 +2,7 @@
 use snafu::ResultExt;
 use sqlx::SqlitePool;
 
-use crate::error::{DbError, QuerySnafu};
+use crate::error::{DbError, NotFoundSnafu, QuerySnafu};
 
 #[derive(Clone, sqlx::FromRow)]
 pub struct Renderer {
@@ -85,41 +85,73 @@ pub async fn update_last_seen(pool: &SqlitePool, id: &str) -> Result<(), DbError
     let now = jiff::Zoned::now()
         .strftime("%Y-%m-%dT%H:%M:%SZ")
         .to_string();
-    sqlx::query("UPDATE renderers SET last_seen = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE renderers SET last_seen = ? WHERE id = ?")
         .bind(&now)
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "renderers" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "renderers",
+            id: id.to_string(),
+        }
+        .build());
+    }
     Ok(())
 }
 
 pub async fn set_enabled(pool: &SqlitePool, id: &str, enabled: bool) -> Result<(), DbError> {
-    sqlx::query("UPDATE renderers SET enabled = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE renderers SET enabled = ? WHERE id = ?")
         .bind(if enabled { 1i64 } else { 0i64 })
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "renderers" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "renderers",
+            id: id.to_string(),
+        }
+        .build());
+    }
     Ok(())
 }
 
 pub async fn rename_renderer(pool: &SqlitePool, id: &str, name: &str) -> Result<(), DbError> {
-    sqlx::query("UPDATE renderers SET name = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE renderers SET name = ? WHERE id = ?")
         .bind(name)
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "renderers" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "renderers",
+            id: id.to_string(),
+        }
+        .build());
+    }
     Ok(())
 }
 
 pub async fn delete_renderer(pool: &SqlitePool, id: &str) -> Result<(), DbError> {
-    sqlx::query("DELETE FROM renderers WHERE id = ?")
+    let result = sqlx::query("DELETE FROM renderers WHERE id = ?")
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "renderers" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "renderers",
+            id: id.to_string(),
+        }
+        .build());
+    }
     Ok(())
 }
 
@@ -201,5 +233,35 @@ mod tests {
 
         let list = list_renderers(&pool).await.unwrap();
         assert_eq!(list.len(), 2);
+    }
+
+    // -- zero-row writes surface NotFound (issue: silent no-op writes) --
+
+    #[tokio::test]
+    async fn update_last_seen_nonexistent_returns_not_found() {
+        let pool = setup().await;
+        let result = update_last_seen(&pool, &renderer_id()).await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn set_enabled_nonexistent_returns_not_found() {
+        let pool = setup().await;
+        let result = set_enabled(&pool, &renderer_id(), false).await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn rename_renderer_nonexistent_returns_not_found() {
+        let pool = setup().await;
+        let result = rename_renderer(&pool, &renderer_id(), "Ghost").await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn delete_renderer_nonexistent_returns_not_found() {
+        let pool = setup().await;
+        let result = delete_renderer(&pool, &renderer_id()).await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
     }
 }

--- a/crates/apotheke/src/repo/user.rs
+++ b/crates/apotheke/src/repo/user.rs
@@ -1,7 +1,18 @@
 use snafu::ResultExt;
 use sqlx::SqlitePool;
 
-use crate::error::{DbError, QuerySnafu};
+use crate::error::{DbError, NotFoundSnafu, QuerySnafu};
+
+// WHY: DbError::NotFound carries a displayable id — raw UUID bytes are not.
+fn id_hex(id: &[u8]) -> String {
+    id.iter()
+        .fold(String::with_capacity(id.len() * 2), |mut s, b| {
+            use std::fmt::Write;
+            // WHY: fmt::Write on String is infallible; ok() avoids unused-result warning
+            write!(s, "{b:02x}").ok();
+            s
+        })
+}
 
 #[derive(Clone, sqlx::FromRow)]
 pub struct User {
@@ -150,22 +161,38 @@ pub async fn update_user(
     display_name: &str,
     role: &str,
 ) -> Result<(), DbError> {
-    sqlx::query("UPDATE users SET display_name = ?, role = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE users SET display_name = ?, role = ? WHERE id = ?")
         .bind(display_name)
         .bind(role)
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "users" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "users",
+            id: id_hex(id),
+        }
+        .build());
+    }
     Ok(())
 }
 
 pub async fn deactivate_user(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
-    sqlx::query("UPDATE users SET is_active = 0 WHERE id = ?")
+    let result = sqlx::query("UPDATE users SET is_active = 0 WHERE id = ?")
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "users" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "users",
+            id: id_hex(id),
+        }
+        .build());
+    }
     Ok(())
 }
 
@@ -174,21 +201,37 @@ pub async fn record_login(
     id: &[u8],
     last_login_at: &str,
 ) -> Result<(), DbError> {
-    sqlx::query("UPDATE users SET last_login_at = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE users SET last_login_at = ? WHERE id = ?")
         .bind(last_login_at)
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "users" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "users",
+            id: id_hex(id),
+        }
+        .build());
+    }
     Ok(())
 }
 
 pub async fn delete_user(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
-    sqlx::query("DELETE FROM users WHERE id = ?")
+    let result = sqlx::query("DELETE FROM users WHERE id = ?")
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "users" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "users",
+            id: id_hex(id),
+        }
+        .build());
+    }
     Ok(())
 }
 
@@ -241,13 +284,21 @@ pub async fn revoke_refresh_token<'e, E>(executor: E, id: &[u8]) -> Result<(), D
 where
     E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
 {
-    sqlx::query("UPDATE refresh_tokens SET revoked = 1 WHERE id = ?")
+    let result = sqlx::query("UPDATE refresh_tokens SET revoked = 1 WHERE id = ?")
         .bind(id)
         .execute(executor)
         .await
         .context(QuerySnafu {
             table: "refresh_tokens",
         })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "refresh_tokens",
+            id: id_hex(id),
+        }
+        .build());
+    }
     Ok(())
 }
 
@@ -317,12 +368,28 @@ pub async fn list_api_keys_for_user(
     .context(QuerySnafu { table: "api_keys" })
 }
 
-pub async fn revoke_api_key(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
-    sqlx::query("UPDATE api_keys SET revoked = 1 WHERE id = ?")
+// WHY: the user_id predicate scopes revocation to the key's owner — a caller
+// cannot revoke another user's key by id alone (DB-layer IDOR guard); a
+// cross-user id pair matches zero rows and surfaces as NotFound.
+pub async fn revoke_api_key_for_user(
+    pool: &SqlitePool,
+    user_id: &[u8],
+    id: &[u8],
+) -> Result<(), DbError> {
+    let result = sqlx::query("UPDATE api_keys SET revoked = 1 WHERE id = ? AND user_id = ?")
         .bind(id)
+        .bind(user_id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "api_keys" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "api_keys",
+            id: id_hex(id),
+        }
+        .build());
+    }
     Ok(())
 }
 
@@ -340,21 +407,37 @@ pub async fn update_api_key_last_used(
     id: &[u8],
     last_used_at: &str,
 ) -> Result<(), DbError> {
-    sqlx::query("UPDATE api_keys SET last_used_at = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE api_keys SET last_used_at = ? WHERE id = ?")
         .bind(last_used_at)
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "api_keys" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "api_keys",
+            id: id_hex(id),
+        }
+        .build());
+    }
     Ok(())
 }
 
 pub async fn delete_api_key(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
-    sqlx::query("DELETE FROM api_keys WHERE id = ?")
+    let result = sqlx::query("DELETE FROM api_keys WHERE id = ?")
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "api_keys" })?;
+
+    if result.rows_affected() == 0 {
+        return Err(NotFoundSnafu {
+            table: "api_keys",
+            id: id_hex(id),
+        }
+        .build());
+    }
     Ok(())
 }
 
@@ -377,16 +460,33 @@ mod tests {
         "2026-01-01T00:00:00Z".to_string()
     }
 
-    fn test_user(id: Vec<u8>) -> User {
+    fn test_user_named(id: Vec<u8>, username: &str) -> User {
         User {
             id,
-            username: "testuser".to_string(),
+            username: username.to_string(),
             display_name: "Test User".to_string(),
             password_hash: "$argon2id$placeholder".to_string(),
             role: "member".to_string(),
             is_active: 1,
             created_at: now(),
             last_login_at: None,
+        }
+    }
+
+    fn test_user(id: Vec<u8>) -> User {
+        test_user_named(id, "testuser")
+    }
+
+    fn test_api_key(id: Vec<u8>, user_id: Vec<u8>, short_token: &str) -> ApiKey {
+        ApiKey {
+            id,
+            user_id,
+            short_token: short_token.to_string(),
+            long_token_hash: format!("hash-{short_token}"),
+            label: "test".to_string(),
+            created_at: now(),
+            last_used_at: None,
+            revoked: 0,
         }
     }
 
@@ -493,7 +593,9 @@ mod tests {
         assert_eq!(fetched.label, "Home NAS");
         assert_eq!(fetched.revoked, 0);
 
-        revoke_api_key(&pool, &key_id).await.unwrap();
+        revoke_api_key_for_user(&pool, &user_id, &key_id)
+            .await
+            .unwrap();
         let revoked = get_api_key_by_short_token(&pool, "abc12345")
             .await
             .unwrap()
@@ -534,5 +636,174 @@ mod tests {
         let keys = list_api_keys_for_user(&pool, &user_id).await.unwrap();
         assert_eq!(keys.len(), 2);
         assert!(keys.iter().all(|k| k.revoked == 1));
+    }
+
+    // -- zero-row writes surface NotFound (issue: silent no-op writes) --
+
+    #[tokio::test]
+    async fn update_user_nonexistent_id_returns_not_found() {
+        let pool = setup().await;
+        let result = update_user(&pool, &make_id(), "Ghost", "member").await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn deactivate_user_nonexistent_id_returns_not_found() {
+        let pool = setup().await;
+        let result = deactivate_user(&pool, &make_id()).await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn record_login_nonexistent_id_returns_not_found() {
+        let pool = setup().await;
+        let result = record_login(&pool, &make_id(), "2026-06-01T12:00:00Z").await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn delete_user_nonexistent_id_returns_not_found() {
+        let pool = setup().await;
+        let result = delete_user(&pool, &make_id()).await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn revoke_refresh_token_nonexistent_id_returns_not_found() {
+        let pool = setup().await;
+        let result = revoke_refresh_token(&pool, &make_id()).await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn revoke_api_key_nonexistent_id_returns_not_found() {
+        let pool = setup().await;
+        let user_id = make_id();
+        insert_user(&pool, &test_user(user_id.clone()))
+            .await
+            .unwrap();
+
+        let result = revoke_api_key_for_user(&pool, &user_id, &make_id()).await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn update_api_key_last_used_nonexistent_id_returns_not_found() {
+        let pool = setup().await;
+        let result = update_api_key_last_used(&pool, &make_id(), "2026-06-01T12:00:00Z").await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn delete_api_key_nonexistent_id_returns_not_found() {
+        let pool = setup().await;
+        let result = delete_api_key(&pool, &make_id()).await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn update_user_existing_id_still_succeeds() {
+        let pool = setup().await;
+        let id = make_id();
+        insert_user(&pool, &test_user(id.clone())).await.unwrap();
+
+        update_user(&pool, &id, "Renamed", "admin").await.unwrap();
+        let updated = get_user(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(updated.display_name, "Renamed");
+    }
+
+    #[tokio::test]
+    async fn deactivate_user_already_inactive_still_succeeds() {
+        let pool = setup().await;
+        let id = make_id();
+        insert_user(&pool, &test_user(id.clone())).await.unwrap();
+
+        // WHY: SQLite counts matched rows even when values are unchanged, so a
+        // repeat deactivation stays idempotent (the DELETE /users/{id} contract).
+        deactivate_user(&pool, &id).await.unwrap();
+        deactivate_user(&pool, &id).await.unwrap();
+        let user = get_user(&pool, &id).await.unwrap().unwrap();
+        assert_eq!(user.is_active, 0);
+    }
+
+    #[tokio::test]
+    async fn revoke_api_key_existing_id_still_succeeds() {
+        let pool = setup().await;
+        let user_id = make_id();
+        insert_user(&pool, &test_user(user_id.clone()))
+            .await
+            .unwrap();
+
+        let key_id = make_id();
+        let key = test_api_key(key_id.clone(), user_id.clone(), "key00001");
+        insert_api_key(&pool, &key).await.unwrap();
+
+        revoke_api_key_for_user(&pool, &user_id, &key_id)
+            .await
+            .unwrap();
+        let keys = list_api_keys_for_user(&pool, &user_id).await.unwrap();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].revoked, 1);
+    }
+
+    // -- per-user scoping (issue: cross-user revocation / untested isolation) --
+
+    #[tokio::test]
+    async fn revoke_api_key_rejects_cross_user() {
+        let pool = setup().await;
+        let user_a = make_id();
+        let user_b = make_id();
+        insert_user(&pool, &test_user_named(user_a.clone(), "usera"))
+            .await
+            .unwrap();
+        insert_user(&pool, &test_user_named(user_b.clone(), "userb"))
+            .await
+            .unwrap();
+
+        let key_a = make_id();
+        insert_api_key(
+            &pool,
+            &test_api_key(key_a.clone(), user_a.clone(), "keyaaaa1"),
+        )
+        .await
+        .unwrap();
+
+        let result = revoke_api_key_for_user(&pool, &user_b, &key_a).await;
+        assert!(matches!(result, Err(DbError::NotFound { .. })));
+
+        let keys = list_api_keys_for_user(&pool, &user_a).await.unwrap();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].revoked, 0, "user A's key must stay unrevoked");
+    }
+
+    #[tokio::test]
+    async fn list_api_keys_for_user_isolated() {
+        let pool = setup().await;
+        let user_a = make_id();
+        let user_b = make_id();
+        insert_user(&pool, &test_user_named(user_a.clone(), "usera"))
+            .await
+            .unwrap();
+        insert_user(&pool, &test_user_named(user_b.clone(), "userb"))
+            .await
+            .unwrap();
+
+        insert_api_key(&pool, &test_api_key(make_id(), user_a.clone(), "keyaaaa1"))
+            .await
+            .unwrap();
+        insert_api_key(&pool, &test_api_key(make_id(), user_a.clone(), "keyaaaa2"))
+            .await
+            .unwrap();
+        insert_api_key(&pool, &test_api_key(make_id(), user_b.clone(), "keybbbb1"))
+            .await
+            .unwrap();
+
+        let keys_a = list_api_keys_for_user(&pool, &user_a).await.unwrap();
+        assert_eq!(keys_a.len(), 2);
+        assert!(keys_a.iter().all(|k| k.user_id == user_a));
+
+        let keys_b = list_api_keys_for_user(&pool, &user_b).await.unwrap();
+        assert_eq!(keys_b.len(), 1);
+        assert!(keys_b.iter().all(|k| k.user_id == user_b));
     }
 }

--- a/crates/exousia/src/lib.rs
+++ b/crates/exousia/src/lib.rs
@@ -38,7 +38,9 @@ pub trait AuthService: Send + Sync {
     async fn validate_api_key(&self, key: &str) -> Result<AuthenticatedUser, ExousiaError>;
     async fn create_user(&self, req: CreateUserRequest) -> Result<User, ExousiaError>;
     async fn create_api_key(&self, user_id: UserId, label: &str) -> Result<String, ExousiaError>;
-    async fn revoke_api_key(&self, key_id: ApiKeyId) -> Result<(), ExousiaError>;
+    /// Revokes `key_id` only when it belongs to `user_id` — a cross-user pair
+    /// matches nothing and errors, so a key cannot be revoked by id alone.
+    async fn revoke_api_key(&self, user_id: UserId, key_id: ApiKeyId) -> Result<(), ExousiaError>;
 }
 
 #[cfg(test)]
@@ -308,9 +310,40 @@ mod tests {
                 .unwrap()
                 .unwrap();
         let key_id = ApiKeyId::from_uuid(uuid::Uuid::from_slice(&db_key.id).unwrap());
-        service.revoke_api_key(key_id).await.unwrap();
+        service.revoke_api_key(user.id, key_id).await.unwrap();
         let err = service.validate_api_key(&full_key).await.unwrap_err();
         assert!(matches!(err, ExousiaError::ApiKeyRevoked { .. }));
+    }
+
+    #[tokio::test]
+    async fn revoke_api_key_rejects_cross_user() {
+        let service = setup().await;
+        let owner = create_test_user(&service).await;
+        let other = service
+            .create_user(CreateUserRequest {
+                username: "otheruser".to_string(),
+                display_name: "Other User".to_string(),
+                password: "password123".to_string(),
+                role: UserRole::Member,
+            })
+            .await
+            .unwrap();
+
+        let full_key = service.create_api_key(owner.id, "owner key").await.unwrap();
+        let parts: Vec<&str> = full_key.split('_').collect();
+        let short_token = parts.get(1).copied().unwrap_or_default();
+        let db_key =
+            apotheke::repo::user::get_api_key_by_short_token(&service.pools().read, short_token)
+                .await
+                .unwrap()
+                .unwrap();
+        let key_id = ApiKeyId::from_uuid(uuid::Uuid::from_slice(&db_key.id).unwrap());
+
+        let err = service.revoke_api_key(other.id, key_id).await.unwrap_err();
+        assert!(matches!(err, ExousiaError::Database { .. }));
+
+        // Owner's key still works — the cross-user attempt revoked nothing.
+        service.validate_api_key(&full_key).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -409,10 +409,14 @@ impl AuthService for ExousiaServiceImpl {
         Ok(full_key)
     }
 
-    async fn revoke_api_key(&self, key_id: ApiKeyId) -> Result<(), ExousiaError> {
-        db::revoke_api_key(&self.pools.write, key_id.as_bytes())
-            .await
-            .context(DatabaseSnafu)?;
+    async fn revoke_api_key(&self, user_id: UserId, key_id: ApiKeyId) -> Result<(), ExousiaError> {
+        db::revoke_api_key_for_user(
+            &self.pools.write,
+            &user_id_to_bytes(user_id),
+            key_id.as_bytes(),
+        )
+        .await
+        .context(DatabaseSnafu)?;
         Ok(())
     }
 }

--- a/crates/kritike/src/health.rs
+++ b/crates/kritike/src/health.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use apotheke::error::QuerySnafu as DbQuerySnafu;
 use apotheke::repo::quality;
 use serde::{Deserialize, Serialize};
-use snafu::ResultExt;
+use snafu::{IntoError, ResultExt};
 use sqlx::{Row, SqlitePool};
 use themelion::MediaType;
 use tracing::instrument;
@@ -100,9 +100,21 @@ pub async fn generate(pool: &SqlitePool) -> Result<HealthReport, KritikeError> {
         });
 
         if !rank_maps.contains_key(&media_type_str) {
-            let ranks = quality::list_ranks(pool, &media_type_str)
-                .await
-                .context(DatabaseSnafu)?;
+            let ranks = match quality::list_ranks(pool, &media_type_str).await {
+                Ok(ranks) => ranks,
+                // WHY: health is a best-effort aggregate — one stale/corrupted
+                // media_type row is skipped (and surfaced in logs) rather than
+                // aborting the whole report or mis-scoring against music ranks.
+                Err(err @ apotheke::DbError::UnknownMediaType { .. }) => {
+                    tracing::warn!(
+                        media_type = %media_type_str,
+                        error = %err,
+                        "skipping unknown media type in health report"
+                    );
+                    continue;
+                }
+                Err(err) => return Err(DatabaseSnafu.into_error(err)),
+            };
             let map: HashMap<i64, String> =
                 ranks.into_iter().map(|r| (r.score, r.format)).collect();
             rank_maps.insert(media_type_str.clone(), map);


### PR DESCRIPTION
Closes #405, #406, #407, #450, #451.

- **#451 (security)** — `revoke_api_key` is now user-scoped (`WHERE id=? AND user_id=?`); the unscoped variant is removed (least privilege), closing a DB-layer cross-user IDOR. (API: `AuthService::revoke_api_key` arity changed; all workspace callers wired.)
- **#450** — user/API-key writes return `NotFound` on a zero-row match instead of silently succeeding. (The same class recurs across the media-entity/quality repos — tracked in #492.)
- **#405** — `top_items` aggregates over `play_sessions` scoped to the query period (was lifetime counters).
- **#406** — `rank_table_for` returns a hard `UnknownMediaType` error instead of silently returning music ranks for unknown types.
- **#407** — `update_streak` runs inside one `BEGIN IMMEDIATE` transaction, closing duplicate-active-streak and streak-loss races.

`kanon gate --full` green.

Follow-up filed: #492 (repo-wide zero-row-write class + a lint to guard it).