### PR TITLE
fix(archon): render reliability and wire metadata/queue/curation traits

### DIFF
--- a/crates/archon/Cargo.toml
+++ b/crates/archon/Cargo.toml
@@ -61,6 +61,11 @@ sd-notify = { version = "0.5", optional = true }
 rstest.workspace = true
 tower.workspace = true
 tempfile = "3"
+tokio = { workspace = true, features = [
+    "rt-multi-thread",
+    "macros",
+    "test-util",
+] }
 
 [package.metadata.kanon]
 maturity = "alpha"

--- a/crates/archon/src/cli.rs
+++ b/crates/archon/src/cli.rs
@@ -65,8 +65,9 @@ pub(crate) struct RenderArgs {
     pub(crate) server: Option<SocketAddr>,
 
     /// Directory for TLS certificates and pairing credentials
-    #[arg(long, default_value = "~/.config/harmonia/renderer")]
-    pub(crate) cert_dir: PathBuf,
+    /// (defaults to $XDG_CONFIG_HOME/harmonia/renderer)
+    #[arg(long)]
+    pub(crate) cert_dir: Option<PathBuf>,
 
     /// Renderer display name (defaults to hostname)
     #[arg(long)]
@@ -172,6 +173,26 @@ mod tests {
             panic!("expected Render command");
         };
         assert!(args.server.is_none());
+    }
+
+    #[test]
+    fn render_cert_dir_defaults_to_unset_for_post_parse_resolution() {
+        // WHY: a literal "~/..." Clap default never expands; the default must
+        // resolve post-parse via paths::default_renderer_cert_dir instead.
+        let cli = Cli::parse_from(["harmonia", "render"]);
+        let Command::Render(args) = cli.command else {
+            panic!("expected Render command");
+        };
+        assert!(args.cert_dir.is_none());
+    }
+
+    #[test]
+    fn render_cert_dir_override_parses() {
+        let cli = Cli::parse_from(["harmonia", "render", "--cert-dir", "/etc/harmonia/certs"]);
+        let Command::Render(args) = cli.command else {
+            panic!("expected Render command");
+        };
+        assert_eq!(args.cert_dir, Some(PathBuf::from("/etc/harmonia/certs")));
     }
 
     #[test]

--- a/crates/archon/src/main.rs
+++ b/crates/archon/src/main.rs
@@ -3,6 +3,7 @@ mod db;
 mod error;
 mod mcp;
 mod migrate;
+mod paths;
 mod play;
 pub mod render;
 mod serve;
@@ -27,7 +28,9 @@ async fn main() {
         Command::Render(args) => {
             render::run_render(render::RenderArgs {
                 server: args.server,
-                cert_dir: args.cert_dir,
+                cert_dir: args
+                    .cert_dir
+                    .unwrap_or_else(paths::default_renderer_cert_dir),
                 name: args.name,
                 config_path: args.config,
             })

--- a/crates/archon/src/mcp.rs
+++ b/crates/archon/src/mcp.rs
@@ -195,7 +195,7 @@ fn render_tool() -> Value {
                 "server": { "type": "string", "description": "Optional host:port server address." },
                 "cert_dir": {
                     "type": "string",
-                    "description": "Directory for TLS certificates and pairing credentials. Defaults to ~/.config/harmonia/renderer."
+                    "description": "Directory for TLS certificates and pairing credentials. Defaults to $XDG_CONFIG_HOME/harmonia/renderer."
                 },
                 "name": { "type": "string", "description": "Optional renderer display name." },
                 "config": { "type": "string", "description": "Optional renderer TOML config path." }
@@ -276,7 +276,7 @@ async fn call_play_file(arguments: &Value) -> Result<String, String> {
 async fn call_render(arguments: &Value) -> Result<String, String> {
     let server = optional_socket_addr(arguments, "server")?;
     let cert_dir = optional_path(arguments, "cert_dir")?
-        .unwrap_or_else(|| PathBuf::from("~/.config/harmonia/renderer"));
+        .unwrap_or_else(crate::paths::default_renderer_cert_dir);
     let name = optional_string(arguments, "name")?;
     let config_path = optional_path(arguments, "config")?;
 

--- a/crates/archon/src/migrate.rs
+++ b/crates/archon/src/migrate.rs
@@ -76,16 +76,22 @@ fn migrate_blocking(
     let imported_at = Zoned::now().to_string();
 
     for entry in WalkDir::new(source).follow_links(false).into_iter() {
-        let entry: DirEntry = entry.map_err(|e| {
-            let path = e.path().unwrap_or(source).to_path_buf();
-            HostError::MigrateIo {
-                operation: format!("walk {}", path.display()),
-                source: e.into_io_error().unwrap_or_else(|| {
-                    std::io::Error::other("walkdir error without underlying IO error")
-                }),
-                location: snafu::location!(),
+        // WHY: enumeration errors (unreadable directory, broken symlink) are
+        // per-entry failures — record them and continue so one bad directory
+        // cannot abort the whole migration. File-operation errors further down
+        // (copy/rename/remove/sidecar) stay fatal: they leave an in-flight
+        // move half-applied and must not be silently skipped.
+        let entry: DirEntry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                let path = e.path().unwrap_or(source).to_path_buf();
+                report
+                    .messages
+                    .push(format!("walk error at {}: {e}", path.display()));
+                report.errors += 1;
+                continue;
             }
-        })?;
+        };
 
         if entry.file_type().is_dir() {
             continue;
@@ -927,6 +933,53 @@ mod tests {
             .filter_map(|e| e.ok())
             .any(|e| e.file_name() == "album.toml");
         assert!(sidecar_found, "album.toml sidecar should be written");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn migration_continues_past_unreadable_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let src = TempDir::new().unwrap();
+        let dst = TempDir::new().unwrap();
+
+        let artist_dir = src.path().join("Radiohead");
+        std::fs::create_dir_all(&artist_dir).unwrap();
+        std::fs::write(artist_dir.join("01 - Airbag.flac"), b"FAKE").unwrap();
+
+        let locked_dir = src.path().join("aaa-locked");
+        std::fs::create_dir_all(&locked_dir).unwrap();
+        std::fs::write(locked_dir.join("02 - Hidden.flac"), b"FAKE").unwrap();
+        std::fs::set_permissions(&locked_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // WHY: root bypasses permission checks (common in containers); the
+        // unreadable-directory scenario cannot be constructed, so skip.
+        if std::fs::read_dir(&locked_dir).is_ok() {
+            std::fs::set_permissions(&locked_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+            return;
+        }
+
+        let result = migrate_blocking(src.path(), dst.path(), &CliMediaType::Music, false, true);
+
+        std::fs::set_permissions(&locked_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let report = result.expect("an unreadable directory must not abort the walk");
+        assert!(
+            report.errors >= 1,
+            "the unreadable directory must be counted as an error"
+        );
+        assert!(
+            report
+                .messages
+                .iter()
+                .any(|m| m.contains("aaa-locked") && m.contains("walk error")),
+            "the walk error must name the unreadable path, got: {:?}",
+            report.messages
+        );
+        assert_eq!(
+            report.processed, 1,
+            "readable media files must still be migrated"
+        );
     }
 
     #[test]

--- a/crates/archon/src/paths.rs
+++ b/crates/archon/src/paths.rs
@@ -1,0 +1,61 @@
+// Shared filesystem path resolution for the archon host binary.
+
+use std::path::PathBuf;
+
+/// Harmonia's base configuration directory.
+///
+/// Resolves `$XDG_CONFIG_HOME/harmonia`, falling back to
+/// `$HOME/.config/harmonia`, then `/tmp/harmonia` when neither variable is
+/// set. Never returns a path containing a literal `~` — shells expand tilde,
+/// `PathBuf` does not.
+pub(crate) fn dirs_config_path() -> PathBuf {
+    std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::env::var("HOME")
+                .map(|h| PathBuf::from(h).join(".config"))
+                .unwrap_or_else(|_| PathBuf::from("/tmp"))
+        })
+        .join("harmonia")
+}
+
+/// Default directory for renderer TLS certificates and pairing credentials.
+pub(crate) fn default_renderer_cert_dir() -> PathBuf {
+    dirs_config_path().join("renderer")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dirs_config_path_never_contains_tilde() {
+        let path = dirs_config_path();
+        assert!(
+            path.components()
+                .all(|c| c.as_os_str().to_str() != Some("~")),
+            "config path must never carry an unexpanded tilde: {}",
+            path.display()
+        );
+        assert!(path.ends_with("harmonia"), "got: {}", path.display());
+    }
+
+    #[test]
+    fn dirs_config_path_is_absolute() {
+        // WHY: every fallback branch (XDG, HOME/.config, /tmp) yields an
+        // absolute root, so the joined path must be absolute regardless of CWD.
+        assert!(dirs_config_path().is_absolute());
+    }
+
+    #[test]
+    fn default_renderer_cert_dir_is_under_config_root() {
+        let cert_dir = default_renderer_cert_dir();
+        assert!(cert_dir.starts_with(dirs_config_path()));
+        assert!(cert_dir.ends_with("harmonia/renderer"));
+        assert!(
+            cert_dir
+                .components()
+                .all(|c| c.as_os_str().to_str() != Some("~"))
+        );
+    }
+}

--- a/crates/archon/src/render/pipeline.rs
+++ b/crates/archon/src/render/pipeline.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use akouo_core::output::{AudioDataCallback, OutputBackend, OutputParams};
 use akouo_core::signal_path::QualityTier;
@@ -13,9 +14,17 @@ use super::config::RendererConfig;
 use super::error::RenderError;
 use super::protocol::AudioFrame;
 
+/// Interval between ring-buffer push retries while the buffer is full.
+const PUSH_RETRY_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Lower bound on the push deadline, guarding tiny rings and degenerate
+/// (zero-rate) frame parameters against spurious timeouts.
+const MIN_PUSH_DEADLINE_MS: u64 = 250;
+
 pub struct RenderPipeline {
     dsp: DspPipeline,
     ring: Arc<RingBuffer>,
+    ring_capacity: usize,
     backend: akouo_core::output::cpal::CpalOutputBackend,
     output_opened: bool,
     underrun_count: Arc<AtomicU64>,
@@ -34,7 +43,8 @@ impl RenderPipeline {
         dsp_rx: watch::Receiver<DspConfig>,
     ) -> Result<Self, RenderError> {
         let dsp = DspPipeline::new(config.dsp_config(), dsp_rx);
-        let ring = Arc::new(RingBuffer::new(config.ring_buffer_capacity()));
+        let ring_capacity = config.ring_buffer_capacity();
+        let ring = Arc::new(RingBuffer::new(ring_capacity));
         let backend = akouo_core::output::cpal::CpalOutputBackend::new();
         let device_name = if config.output.device == "default" {
             None
@@ -44,6 +54,7 @@ impl RenderPipeline {
         Ok(Self {
             dsp,
             ring,
+            ring_capacity,
             backend,
             output_opened: false,
             underrun_count: Arc::new(AtomicU64::new(0)),
@@ -66,15 +77,52 @@ impl RenderPipeline {
             .dsp
             .process_frame(&mut samples, frame.channels, frame.sample_rate);
 
-        // Push to ring buffer with yield-based backpressure.
-        loop {
-            if self.ring.push_frame(&samples) {
-                break;
+        // Push to ring buffer with bounded backpressure.
+        //
+        // WHY: a wedged output callback (device unplugged, stream stalled)
+        // leaves the ring full forever; an unbounded retry loop then blocks the
+        // audio receive task silently. A deadline converts the stall into a
+        // loud AudioOutput error so the runner's reconnect path engages.
+        let deadline = self.push_deadline(frame.sample_rate, frame.channels);
+        let ring = Arc::clone(&self.ring);
+        let pushed = tokio::time::timeout(deadline, async move {
+            loop {
+                if ring.push_frame(&samples) {
+                    break;
+                }
+                tokio::time::sleep(PUSH_RETRY_INTERVAL).await;
             }
-            tokio::task::yield_now().await;
+        })
+        .await;
+
+        if pushed.is_err() {
+            let stalled_ms = deadline.as_millis();
+            tracing::error!(
+                stalled_ms,
+                "audio ring buffer stalled; output callback is not draining"
+            );
+            return Err(RenderError::AudioOutput {
+                message: format!("ring buffer full for {stalled_ms} ms; audio output stalled"),
+                location: snafu::location!(),
+            });
         }
 
         Ok(())
+    }
+
+    /// Deadline for a single ring-buffer push.
+    ///
+    /// Twice the ring's real-time duration is the longest a healthy output
+    /// callback can lag before space frees up; anything beyond that is a
+    /// stalled consumer, not backpressure.
+    fn push_deadline(&self, sample_rate: u32, channels: u16) -> Duration {
+        let samples_per_ms = (u64::from(sample_rate) * u64::from(channels)) / 1000;
+        let ring_ms = if samples_per_ms == 0 {
+            0
+        } else {
+            self.ring_capacity as u64 / samples_per_ms
+        };
+        Duration::from_millis((ring_ms * 2).max(MIN_PUSH_DEADLINE_MS))
     }
 
     async fn open_output(&mut self, sample_rate: u32, channels: u16) -> Result<(), RenderError> {
@@ -199,5 +247,75 @@ mod tests {
         let (_tx, rx) = watch::channel(config.dsp_config());
         let pipeline = RenderPipeline::new(&config, rx).unwrap();
         assert_eq!(pipeline.underrun_count(), 0);
+    }
+
+    // ── #410: the push loop is deadline-bounded, not an unbounded retry ────
+
+    fn test_pipeline_with_open_output() -> RenderPipeline {
+        let config = RendererConfig::default();
+        let (_tx, rx) = watch::channel(config.dsp_config());
+        let mut pipeline = RenderPipeline::new(&config, rx).unwrap();
+        // WHY: marking the output opened skips open_output so the test never
+        // touches a real audio device; the ring then has no consumer, which is
+        // exactly the wedged-callback scenario under test.
+        pipeline.output_opened = true;
+        pipeline
+    }
+
+    fn test_frame(samples: usize) -> AudioFrame {
+        AudioFrame {
+            sample_rate: 44100,
+            channels: 2,
+            timestamp: 0,
+            samples: vec![0.25; samples],
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn process_frame_errors_when_ring_stalls() {
+        let mut pipeline = test_pipeline_with_open_output();
+
+        // Fill the ring completely; no consumer ever pops.
+        while pipeline.ring.push_frame(&[0.5; 1024]) {}
+
+        let result = pipeline.process_frame(test_frame(1024)).await;
+
+        assert!(
+            matches!(result, Err(RenderError::AudioOutput { .. })),
+            "a stalled ring must surface as AudioOutput, got: {result:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn process_frame_pushes_when_ring_has_space() {
+        let mut pipeline = test_pipeline_with_open_output();
+
+        pipeline
+            .process_frame(test_frame(1024))
+            .await
+            .expect("a frame that fits must push without timing out");
+        assert_eq!(pipeline.ring.available_to_read(), 1024);
+    }
+
+    #[test]
+    fn push_deadline_scales_with_ring_duration_and_has_floor() {
+        let config = RendererConfig::default();
+        let (_tx, rx) = watch::channel(config.dsp_config());
+        let pipeline = RenderPipeline::new(&config, rx).unwrap();
+
+        // Degenerate parameters fall back to the floor instead of dividing by zero.
+        assert_eq!(
+            pipeline.push_deadline(0, 0),
+            Duration::from_millis(MIN_PUSH_DEADLINE_MS)
+        );
+
+        // At real parameters the deadline is 2x the ring's duration, never
+        // below the floor.
+        let deadline = pipeline.push_deadline(44100, 2);
+        let ring_ms = pipeline.ring_capacity as u64 / ((44100 * 2) / 1000);
+        assert_eq!(
+            deadline,
+            Duration::from_millis((ring_ms * 2).max(MIN_PUSH_DEADLINE_MS))
+        );
     }
 }

--- a/crates/archon/src/render/runner.rs
+++ b/crates/archon/src/render/runner.rs
@@ -230,7 +230,7 @@ async fn connect_and_run(
     let stream_sample_rate = accept.sample_rate;
     let stream_channels = accept.channels;
 
-    let audio_task = tokio::spawn(
+    let mut audio_task = tokio::spawn(
         async move {
             receive_audio(
                 audio_recv,
@@ -248,7 +248,7 @@ async fn connect_and_run(
     let status_report = Arc::clone(&status);
     let shutdown_status = shutdown.child_token();
 
-    let status_task = tokio::spawn(
+    let mut status_task = tokio::spawn(
         async move { send_status_reports(ctrl_send, &status_report, shutdown_status).await }
             .instrument(tracing::info_span!("status_report")),
     );
@@ -258,20 +258,48 @@ async fn connect_and_run(
         _ = shutdown.cancelled() => {
             info!("shutdown requested, draining");
         }
-        result = audio_task => {
-            if let Err(e) = result {
-                warn!(error = %e, "audio task panicked");
+        result = &mut audio_task => {
+            // WHY: the sibling task would otherwise outlive this connection
+            // attempt as a detached leak; the reconnect loop spawns fresh tasks.
+            status_task.abort();
+            if let Err(e) = join_outcome("audio", result) {
+                status.set_device_state(DeviceState::Stopped);
+                return Err(e);
             }
         }
-        result = status_task => {
-            if let Err(e) = result {
-                warn!(error = %e, "status task panicked");
+        result = &mut status_task => {
+            audio_task.abort();
+            if let Err(e) = join_outcome("status", result) {
+                status.set_device_state(DeviceState::Stopped);
+                return Err(e);
             }
         }
     }
 
     status.set_device_state(DeviceState::Stopped);
     Ok(())
+}
+
+/// Classifies a joined renderer task result at the handling site.
+///
+/// A task that returned `Err(RenderError)` propagates so the caller's
+/// backoff-reconnect path engages; a clean exit and a panicked task both
+/// resolve to `Ok(())` (the panic is logged, matching prior behavior).
+fn join_outcome(
+    task: &'static str,
+    result: Result<Result<(), RenderError>, tokio::task::JoinError>,
+) -> Result<(), RenderError> {
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => {
+            warn!(task, error = %e, "renderer task failed");
+            Err(e)
+        }
+        Err(e) => {
+            warn!(task, error = %e, "renderer task panicked");
+            Ok(())
+        }
+    }
 }
 
 async fn receive_audio(
@@ -481,5 +509,163 @@ mod tests {
         backoff.next_delay();
         backoff.reset();
         assert_eq!(backoff.next_delay(), Duration::from_millis(500));
+    }
+
+    // ── #388: inner task Results are handled, not discarded ────────────────
+
+    #[tokio::test]
+    async fn join_outcome_propagates_inner_task_error() {
+        let handle = tokio::spawn(async {
+            Err::<(), RenderError>(RenderError::Protocol {
+                message: "stream corrupted".to_string(),
+                location: snafu::location!(),
+            })
+        });
+        let result = join_outcome("audio", handle.await);
+        assert!(
+            matches!(result, Err(RenderError::Protocol { .. })),
+            "an inner task Err must propagate to trigger reconnect"
+        );
+    }
+
+    #[tokio::test]
+    async fn join_outcome_clean_exit_is_ok() {
+        let handle = tokio::spawn(async { Ok::<(), RenderError>(()) });
+        assert!(join_outcome("audio", handle.await).is_ok());
+    }
+
+    #[tokio::test]
+    async fn join_outcome_panic_is_logged_not_propagated() {
+        let handle = tokio::spawn(async { panic!("injected panic") });
+        // WHY: a panicked JoinHandle yields Err(JoinError); the handler keeps
+        // the pre-fix warn-only behavior for panics.
+        assert!(join_outcome("status", handle.await).is_ok());
+    }
+
+    #[tokio::test]
+    async fn join_outcome_abort_is_not_propagated() {
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok::<(), RenderError>(())
+        });
+        handle.abort();
+        assert!(join_outcome("audio", handle.await).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod connect_and_run_tests {
+    use std::net::SocketAddr;
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::render::protocol::{MSG_AUDIO_FRAME, MSG_SESSION_INIT};
+
+    fn hex_fingerprint(cert_der: &[u8]) -> String {
+        use sha2::{Digest, Sha256};
+        Sha256::digest(cert_der)
+            .iter()
+            .fold(String::with_capacity(64), |mut s, b| {
+                use std::fmt::Write as _;
+                // WHY: fmt::Write on String is infallible; ok() avoids unused-result warning
+                write!(s, "{b:02x}").ok();
+                s
+            })
+    }
+
+    /// Spawns a QUIC server that completes the session handshake, then sends a
+    /// deliberately oversized message header on the audio stream so the
+    /// client's `receive_audio` fails with a protocol error (not a panic).
+    async fn spawn_poisoned_audio_server(api_key: &str) -> (SocketAddr, String, tempfile::TempDir) {
+        let cert_dir = tempfile::TempDir::new().expect("tempdir");
+        let server_config =
+            tls::load_or_generate_server_config(cert_dir.path()).expect("server config");
+        let cert_der = std::fs::read(cert_dir.path().join("server.der")).expect("read cert");
+        let fingerprint = hex_fingerprint(&cert_der);
+
+        let endpoint =
+            quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().expect("loopback addr"))
+                .expect("server endpoint");
+        let addr = endpoint.local_addr().expect("local addr");
+        let expected_key = api_key.to_string();
+
+        tokio::spawn(async move {
+            let Some(incoming) = endpoint.accept().await else {
+                return;
+            };
+            let connection = incoming.await.expect("accept connection");
+            let (mut ctrl_send, mut ctrl_recv) =
+                connection.accept_bi().await.expect("accept control stream");
+
+            let (msg_type, payload) = protocol::recv_message(&mut ctrl_recv)
+                .await
+                .expect("read SessionInit");
+            assert_eq!(msg_type, MSG_SESSION_INIT);
+            let init: SessionInit = serde_json::from_slice(&payload).expect("decode init");
+            assert_eq!(init.api_key, expected_key);
+
+            let accept = SessionAccept {
+                session_id: crate::render::protocol::RendererSessionId("test-session".into()),
+                sample_rate: 44100,
+                channels: 2,
+            };
+            let accept_payload = serde_json::to_vec(&accept).expect("encode accept");
+            protocol::send_message(&mut ctrl_send, MSG_SESSION_ACCEPT, &accept_payload)
+                .await
+                .expect("send accept");
+
+            let mut audio_send = connection.open_uni().await.expect("open audio stream");
+            // A 32 MiB length prefix exceeds recv_message's 16 MiB cap, so the
+            // client's audio task returns Err(RenderError::Protocol).
+            let poison_len = 32u32 * 1024 * 1024;
+            audio_send
+                .write_all(&[MSG_AUDIO_FRAME])
+                .await
+                .expect("write poisoned type");
+            audio_send
+                .write_all(&poison_len.to_le_bytes())
+                .await
+                .expect("write poisoned length");
+
+            // Keep the connection open so the failure is the message error,
+            // not a connection close racing it.
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            drop(connection);
+        });
+
+        (addr, fingerprint, cert_dir)
+    }
+
+    #[tokio::test]
+    async fn connect_and_run_returns_err_when_audio_stream_fails() {
+        let (addr, fingerprint, _cert_dir) = spawn_poisoned_audio_server("key-388").await;
+
+        let args = RunnerArgs {
+            server_addr: addr,
+            name: "test-renderer".to_string(),
+            config_path: None,
+            server_fingerprint: fingerprint.clone(),
+            api_key: "key-388".to_string(),
+        };
+        let client_config = tls::build_client_config(&fingerprint).expect("client config");
+        let config = RendererConfig::default();
+        let (_dsp_tx, dsp_rx) = watch::channel(config.dsp_config());
+        let shutdown = CancellationToken::new();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            connect_and_run(&args, &client_config, &config, dsp_rx, shutdown),
+        )
+        .await
+        .expect("connect_and_run must not hang on a failed audio task");
+
+        // Pre-fix, the Ok(Err(RenderError)) arm was discarded and this
+        // returned Ok(()) — silently ending the renderer loop.
+        assert!(
+            result.is_err(),
+            "a failed audio task must propagate so the reconnect backoff engages"
+        );
     }
 }

--- a/crates/archon/src/render/server.rs
+++ b/crates/archon/src/render/server.rs
@@ -248,11 +248,16 @@ async fn handle_renderer_connection(
         })
         .await;
 
-    // Open unidirectional stream for audio frames.
-    let _audio_send = connection.open_uni().await?;
-
-    // Read status reports from the control stream until disconnection.
-    let result = read_status_loop(&mut ctrl_recv, &registry, &session_id, shutdown).await;
+    // INVARIANT: every fallible operation between add and remove lives inside
+    // run_renderer_session, so no `?` can return past the registry cleanup.
+    let result = run_renderer_session(
+        &connection,
+        &mut ctrl_recv,
+        &registry,
+        &session_id,
+        shutdown,
+    )
+    .await;
 
     registry.remove(&session_id).await;
     info!(
@@ -262,6 +267,22 @@ async fn handle_renderer_connection(
     );
 
     result
+}
+
+/// Session body between registry add and remove: opens the audio stream and
+/// consumes status reports until disconnection.
+async fn run_renderer_session(
+    connection: &quinn::Connection,
+    ctrl_recv: &mut quinn::RecvStream,
+    registry: &RendererRegistry,
+    session_id: &RendererSessionId,
+    shutdown: CancellationToken,
+) -> Result<(), RenderError> {
+    // Open unidirectional stream for audio frames.
+    let _audio_send = connection.open_uni().await?;
+
+    // Read status reports from the control stream until disconnection.
+    read_status_loop(ctrl_recv, registry, session_id, shutdown).await
 }
 
 async fn read_status_loop(
@@ -584,5 +605,34 @@ mod handshake_tests {
 
         assert!(result.is_err(), "wrong pin must fail the TLS handshake");
         assert!(server.registry.list().await.is_empty());
+    }
+
+    // ── #411: registry cleanup covers every post-add exit path ─────────────
+
+    #[tokio::test]
+    async fn registry_entry_removed_when_client_drops_after_accept() {
+        let server = spawn_test_server(Some("key-123")).await;
+
+        // client_handshake drops its endpoint on return, closing the
+        // connection; whatever exit path the handler takes afterwards
+        // (open_uni failure or status-loop termination), the registry entry
+        // must not leak.
+        let (msg_type, _) = client_handshake(&server, &server.fingerprint, "key-123")
+            .await
+            .expect("authenticated handshake succeeds");
+        assert_eq!(msg_type, MSG_SESSION_ACCEPT);
+
+        let mut cleaned = false;
+        for _ in 0..100 {
+            if server.registry.list().await.is_empty() {
+                cleaned = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            cleaned,
+            "a dropped connection must not leave a registry entry behind"
+        );
     }
 }

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -44,11 +44,105 @@ use crate::startup::{ensure_admin_user, init_tracing};
 
 // ── Dyn-trait adapters ──────────────────────────────────────────────────────
 
-struct CurationAdapter(#[expect(dead_code)] Arc<DefaultCurationService>);
-impl DynCurationService for CurationAdapter {}
+struct CurationAdapter(Arc<DefaultCurationService>);
 
-struct MetadataAdapter(#[expect(dead_code)] Arc<ProviderBackedResolver>);
-impl DynMetadataResolver for MetadataAdapter {}
+impl DynCurationService for CurationAdapter {
+    fn assess_quality(
+        &self,
+        media_type: themelion::MediaType,
+        item_metadata: kritike::QualityMetadata,
+    ) -> ServiceFut<kritike::QualityAssessment> {
+        use kritike::CurationService as _;
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .assess_quality(media_type, &item_metadata)
+                .await
+                .map_err(curation_error)
+        })
+    }
+
+    fn check_upgrade_eligibility(
+        &self,
+        have_id: themelion::HaveId,
+        candidate_score: i32,
+    ) -> ServiceFut<kritike::UpgradeDecision> {
+        use kritike::CurationService as _;
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .check_upgrade_eligibility(have_id, candidate_score)
+                .await
+                .map_err(curation_error)
+        })
+    }
+
+    fn health_report(&self) -> ServiceFut<kritike::HealthReport> {
+        use kritike::CurationService as _;
+        let service = Arc::clone(&self.0);
+        Box::pin(async move { service.health_report().await.map_err(curation_error) })
+    }
+}
+
+fn curation_error(error: kritike::KritikeError) -> ServiceError {
+    match error {
+        kritike::KritikeError::ProfileNotFound { .. } => ServiceError::NotFound,
+        other => ServiceError::Internal(other.to_string()),
+    }
+}
+
+struct MetadataAdapter(Arc<ProviderBackedResolver>);
+
+impl DynMetadataResolver for MetadataAdapter {
+    fn resolve_identity(
+        &self,
+        item: epignosis::UnidentifiedItem,
+    ) -> ServiceFut<epignosis::MediaIdentity> {
+        use epignosis::MetadataResolver as _;
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .resolve_identity(&item, CancellationToken::new())
+                .await
+                .map_err(metadata_error)
+        })
+    }
+
+    fn enrich(
+        &self,
+        identity: epignosis::MediaIdentity,
+    ) -> ServiceFut<epignosis::EnrichedMetadata> {
+        use epignosis::MetadataResolver as _;
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .enrich(&identity, CancellationToken::new())
+                .await
+                .map_err(metadata_error)
+        })
+    }
+
+    fn fingerprint_audio(
+        &self,
+        file_path: std::path::PathBuf,
+    ) -> ServiceFut<epignosis::FingerprintResult> {
+        use epignosis::MetadataResolver as _;
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .fingerprint_audio(&file_path, CancellationToken::new())
+                .await
+                .map_err(metadata_error)
+        })
+    }
+}
+
+fn metadata_error(error: epignosis::EpignosisError) -> ServiceError {
+    match error {
+        epignosis::EpignosisError::IdentityNotResolved { .. } => ServiceError::NotFound,
+        other => ServiceError::Internal(other.to_string()),
+    }
+}
 
 struct SearchAdapter(Arc<SearchIndexerService>);
 impl DynSearchService for SearchAdapter {
@@ -163,8 +257,38 @@ fn search_error(error: zetesis::SearchIndexerError) -> ServiceError {
 struct EngineAdapter(#[expect(dead_code)] Arc<TorrentSession>);
 impl DynDownloadEngine for EngineAdapter {}
 
-struct QueueAdapter;
-impl DynQueueManager for QueueAdapter {}
+/// Bridges the running `DownloadQueue` to paroche's queue-manager trait so an
+/// API cancel/reprioritize reaches the live dispatcher and engine.
+struct QueueAdapter<E: ergasia::DownloadEngine + 'static>(Arc<DownloadQueue<E>>);
+
+impl<E: ergasia::DownloadEngine + 'static> DynQueueManager for QueueAdapter<E> {
+    fn cancel(&self, queue_id: uuid::Uuid) -> ServiceFut<()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .cancel_by_queue_id(queue_id)
+                .await
+                .map_err(queue_error)
+        })
+    }
+
+    fn reprioritize(&self, queue_id: uuid::Uuid, priority: u8) -> ServiceFut<()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .reprioritize_by_queue_id(queue_id, priority)
+                .await
+                .map_err(queue_error)
+        })
+    }
+}
+
+fn queue_error(error: syntaxis::SyntaxisError) -> ServiceError {
+    match error {
+        syntaxis::SyntaxisError::ItemNotFound { .. } => ServiceError::NotFound,
+        other => ServiceError::Internal(other.to_string()),
+    }
+}
 
 type LiveRequestService =
     aitesis::AitesisServiceImpl<RequestRoleProvider, RequestIdentityValidator, RequestMonitor>;
@@ -695,7 +819,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         .await
         .context(DownloadQueueSnafu)?,
     );
-    syntaxis_svc.start(event_tx.subscribe(), shutdown_token.child_token());
+    let syntaxis_handle = syntaxis_svc.start(event_tx.subscribe(), shutdown_token.child_token());
     info!("syntaxis (download queue) initialized  -  event listener started");
 
     // Layer 4: Syndesmos (external integrations  -  Plex, Last.fm, Tidal)
@@ -733,7 +857,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
 
     // 12. Start renderer QUIC server
     let renderer_registry = Arc::new(crate::render::RendererRegistry::new());
-    let renderer_cert_dir = dirs_config_path().join("certs");
+    let renderer_cert_dir = crate::paths::dirs_config_path().join("certs");
     let renderer_addr = resolve_listen_addr(
         &config.paroche.listen_addr,
         crate::render::server::DEFAULT_QUIC_PORT,
@@ -777,7 +901,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         curation: Arc::new(CurationAdapter(curation_service)),
         search: Arc::new(SearchAdapter(zetesis)),
         download_engine: Arc::new(EngineAdapter(ergasia_session)),
-        queue: Arc::new(QueueAdapter),
+        queue: Arc::new(QueueAdapter(Arc::clone(&syntaxis_svc))),
         requests: Arc::new(RequestAdapter(request_service)),
         external: Arc::new(ExternalAdapter(syndesmos_svc)),
         subtitles,
@@ -807,6 +931,11 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // Wait for syndesmos event handler to drain
     if let Err(e) = syndesmos_handle.await {
         tracing::warn!(error = %e, "syndesmos event handler panicked during shutdown");
+    }
+
+    // Wait for the syntaxis event listener to drain (layer 2, after layer 4)
+    if let Err(e) = syntaxis_handle.await {
+        tracing::warn!(error = %e, "syntaxis event listener panicked during shutdown");
     }
 
     // Shutdown core subsystems (reverse of startup)
@@ -942,6 +1071,247 @@ fn validate_download_dir(config: &horismos::Config) -> Result<(), HostError> {
 }
 
 #[cfg(test)]
+mod service_adapter_tests {
+    use std::sync::Arc;
+
+    use apotheke::migrate::MIGRATOR;
+    use paroche::state::{DynCurationService, DynMetadataResolver, DynQueueManager, ServiceError};
+    use sqlx::SqlitePool;
+    use syntaxis::QueueManager;
+    use themelion::create_event_bus;
+    use themelion::ids::{DownloadId, ReleaseId, WantId};
+
+    use super::*;
+
+    async fn migrated_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite opens");
+        MIGRATOR.run(&pool).await.expect("migrations run");
+        pool
+    }
+
+    // ── #470: CurationAdapter delegates to the live kritike service ────────
+
+    #[tokio::test]
+    async fn curation_adapter_calls_live_kritike_service() {
+        let pool = migrated_pool().await;
+        let (event_tx, _) = create_event_bus(64);
+        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(pool, event_tx)));
+
+        let report = adapter
+            .health_report()
+            .await
+            .expect("live kritike health report succeeds on an empty library");
+        assert_eq!(report.total_items, 0);
+
+        let decision = adapter
+            .check_upgrade_eligibility(themelion::HaveId::new(), 90)
+            .await
+            .expect("live kritike upgrade check succeeds");
+        assert_eq!(
+            decision,
+            kritike::UpgradeDecision::Skip,
+            "a missing have skips per kritike's real logic"
+        );
+    }
+
+    #[tokio::test]
+    async fn curation_adapter_maps_profile_not_found() {
+        let pool = migrated_pool().await;
+        let (event_tx, _) = create_event_bus(64);
+        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(pool, event_tx)));
+
+        let error = adapter
+            .assess_quality(
+                themelion::MediaType::Music,
+                kritike::QualityMetadata {
+                    format: "FLAC_24BIT".to_string(),
+                    custom_format_score: 0,
+                    profile_id: 999_999,
+                    codec: None,
+                    bit_depth: None,
+                    sample_rate: None,
+                    file_size: None,
+                    channels: None,
+                },
+            )
+            .await
+            .expect_err("a missing profile must not assess");
+        assert!(matches!(error, ServiceError::NotFound));
+    }
+
+    // ── #468: MetadataAdapter delegates to the live epignosis resolver ─────
+
+    #[tokio::test]
+    async fn metadata_adapter_calls_live_epignosis_resolver() {
+        let adapter = MetadataAdapter(Arc::new(ProviderBackedResolver::new(
+            horismos::EpignosisConfig::default(),
+            ProviderCredentials::default(),
+        )));
+
+        // WHY: fingerprint_audio is the resolver's only network-free method;
+        // its distinctive fpcalc error proves the call reaches the real
+        // ProviderBackedResolver, not a stub.
+        let error = adapter
+            .fingerprint_audio(std::path::PathBuf::from("/nonexistent/track.flac"))
+            .await
+            .expect_err("fingerprinting without fpcalc fails in the real resolver");
+        let ServiceError::Internal(message) = error else {
+            panic!("expected the real resolver error to map to Internal");
+        };
+        assert!(
+            message.contains("fpcalc"),
+            "the real epignosis error must surface, got: {message}"
+        );
+    }
+
+    // ── #469: QueueAdapter reaches the live queue and engine ───────────────
+
+    struct RecordingEngine {
+        started: std::sync::Mutex<Vec<DownloadId>>,
+        cancelled: std::sync::Mutex<Vec<DownloadId>>,
+    }
+
+    impl ergasia::DownloadEngine for RecordingEngine {
+        async fn start_download(
+            &self,
+            request: ergasia::DownloadRequest,
+        ) -> Result<DownloadId, ergasia::ErgasiaError> {
+            self.started.lock().expect("lock").push(request.download_id);
+            Ok(request.download_id)
+        }
+
+        async fn cancel_download(
+            &self,
+            download_id: DownloadId,
+        ) -> Result<(), ergasia::ErgasiaError> {
+            self.cancelled.lock().expect("lock").push(download_id);
+            Ok(())
+        }
+
+        async fn get_progress(
+            &self,
+            download_id: DownloadId,
+        ) -> Result<ergasia::DownloadProgress, ergasia::ErgasiaError> {
+            Ok(ergasia::DownloadProgress {
+                download_id,
+                state: ergasia::DownloadState::Downloading,
+                percent_complete: 0,
+                download_speed_bps: 0,
+                upload_speed_bps: 0,
+                peers_connected: 0,
+                seeders: 0,
+                eta_seconds: None,
+            })
+        }
+
+        async fn extract(
+            &self,
+            _download_path: &std::path::Path,
+            _output_dir: &std::path::Path,
+        ) -> Result<Option<ergasia::ExtractionResult>, ergasia::ErgasiaError> {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn queue_adapter_cancel_stops_live_engine_download() {
+        let pool = migrated_pool().await;
+        let engine = Arc::new(RecordingEngine {
+            started: std::sync::Mutex::new(Vec::new()),
+            cancelled: std::sync::Mutex::new(Vec::new()),
+        });
+        let queue = Arc::new(
+            DownloadQueue::new(
+                pool,
+                Arc::clone(&engine),
+                Arc::new(StubImportService),
+                horismos::SyntaxisConfig {
+                    max_concurrent_downloads: 2,
+                    max_per_tracker: 3,
+                    retry_count: 1,
+                    retry_backoff_base_seconds: 0,
+                    stalled_download_timeout_hours: 24,
+                },
+            )
+            .await
+            .expect("queue constructs"),
+        );
+
+        let queue_id = uuid::Uuid::now_v7();
+        queue
+            .enqueue(syntaxis::QueueItem {
+                id: queue_id,
+                want_id: WantId::new(),
+                release_id: ReleaseId::new(),
+                download_url: "magnet:?xt=urn:btih:adapter".to_string(),
+                protocol: syntaxis::DownloadProtocol::Torrent,
+                priority: 4,
+                tracker_id: None,
+                info_hash: None,
+                retry_count: 0,
+            })
+            .await
+            .expect("enqueue succeeds");
+
+        // Wait for the spawned dispatch to reach the engine before cancelling.
+        for _ in 0..500 {
+            if !engine.started.lock().expect("lock").is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let started = engine.started.lock().expect("lock").clone();
+        assert_eq!(started.len(), 1, "precondition: the download is live");
+
+        let adapter = QueueAdapter(Arc::clone(&queue));
+        adapter
+            .cancel(queue_id)
+            .await
+            .expect("adapter cancel succeeds");
+
+        assert_eq!(
+            engine.cancelled.lock().expect("lock").clone(),
+            started,
+            "the API-facing cancel must stop the live engine download"
+        );
+    }
+
+    #[tokio::test]
+    async fn queue_adapter_maps_unknown_item_to_not_found() {
+        let pool = migrated_pool().await;
+        let engine = Arc::new(RecordingEngine {
+            started: std::sync::Mutex::new(Vec::new()),
+            cancelled: std::sync::Mutex::new(Vec::new()),
+        });
+        let queue = Arc::new(
+            DownloadQueue::new(
+                pool,
+                engine,
+                Arc::new(StubImportService),
+                horismos::SyntaxisConfig {
+                    max_concurrent_downloads: 2,
+                    max_per_tracker: 3,
+                    retry_count: 1,
+                    retry_backoff_base_seconds: 0,
+                    stalled_download_timeout_hours: 24,
+                },
+            )
+            .await
+            .expect("queue constructs"),
+        );
+
+        let adapter = QueueAdapter(queue);
+        let error = adapter
+            .cancel(uuid::Uuid::now_v7())
+            .await
+            .expect_err("an unknown id must not succeed");
+        assert!(matches!(error, ServiceError::NotFound));
+    }
+}
+
+#[cfg(test)]
 mod search_adapter_tests {
     use std::sync::Arc;
 
@@ -1012,17 +1382,6 @@ mod search_adapter_tests {
             0
         );
     }
-}
-
-fn dirs_config_path() -> std::path::PathBuf {
-    std::env::var("XDG_CONFIG_HOME")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| {
-            std::env::var("HOME")
-                .map(|h| std::path::PathBuf::from(h).join(".config"))
-                .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"))
-        })
-        .join("harmonia")
 }
 
 #[cfg(test)]

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -16,7 +16,7 @@ use ergasia::{DownloadProgress, DownloadState, ErgasiaError, ExtractionResult};
 use exousia::{AuthService, CreateUserRequest, ExousiaServiceImpl, UserRole};
 use horismos::{AitesisConfig, Config, ExousiaConfig};
 use paroche::state::{
-    AppState, DynRequestService, DynSearchService, RequestServiceFut, ServiceFut,
+    AppState, DynQueueManager, DynRequestService, DynSearchService, RequestServiceFut, ServiceFut,
 };
 use serde_json::{Value, json};
 use snafu::ResultExt;
@@ -95,6 +95,39 @@ impl ergasia::DownloadEngine for MockEngine {
         _output_dir: &std::path::Path,
     ) -> Result<Option<ExtractionResult>, ErgasiaError> {
         Ok(None)
+    }
+}
+
+// ── Queue-manager adapter over the real syntaxis service ────────────────────
+
+struct QueueAdapter(Arc<syntaxis::DownloadQueue<MockEngine>>);
+
+impl DynQueueManager for QueueAdapter {
+    fn cancel(&self, queue_id: Uuid) -> ServiceFut<()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .cancel_by_queue_id(queue_id)
+                .await
+                .map_err(queue_service_error)
+        })
+    }
+
+    fn reprioritize(&self, queue_id: Uuid, priority: u8) -> ServiceFut<()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .reprioritize_by_queue_id(queue_id, priority)
+                .await
+                .map_err(queue_service_error)
+        })
+    }
+}
+
+fn queue_service_error(error: syntaxis::SyntaxisError) -> paroche::state::ServiceError {
+    match error {
+        syntaxis::SyntaxisError::ItemNotFound { .. } => paroche::state::ServiceError::NotFound,
+        other => paroche::state::ServiceError::Internal(other.to_string()),
     }
 }
 
@@ -286,6 +319,26 @@ async fn test_state() -> Result<(AppState, Arc<ExousiaServiceImpl>, SqlitePool),
     let import = paroche::state::make_import_service(|| async { Ok(vec![]) });
     let mut state = AppState::with_stubs(pools, config, event_tx, auth.clone(), import);
     state.search = Arc::new(MockSearchService);
+    // WHY: cancel/reprioritize routes delegate to the live syntaxis service;
+    // wiring the real DownloadQueue keeps these tests end-to-end.
+    let (started_tx, _started_rx) = mpsc::unbounded_channel();
+    let (imported_tx, _imported_rx) = mpsc::unbounded_channel();
+    let queue_svc = Arc::new(
+        syntaxis::DownloadQueue::new(
+            pool.clone(),
+            Arc::new(MockEngine { started_tx }),
+            Arc::new(MockImportService { imported_tx }) as Arc<dyn ImportService>,
+            horismos::SyntaxisConfig {
+                max_concurrent_downloads: 5,
+                max_per_tracker: 3,
+                retry_count: 2,
+                retry_backoff_base_seconds: 0,
+                stalled_download_timeout_hours: 24,
+            },
+        )
+        .await?,
+    );
+    state.queue = Arc::new(QueueAdapter(queue_svc));
     state.requests = Arc::new(MockRequestAdapter(Arc::new(
         aitesis::AitesisServiceImpl::new(
             pool.clone(),

--- a/crates/archon/tests/acquisition_integration/pipeline_tests.rs
+++ b/crates/archon/tests/acquisition_integration/pipeline_tests.rs
@@ -73,7 +73,7 @@ async fn pipeline_completion_triggers_import() -> Result<(), TestError> {
 
     let svc = Arc::new(DownloadQueue::new(pool, engine, import_svc, config).await?);
     let shutdown = tokio_util::sync::CancellationToken::new();
-    svc.start(event_tx.subscribe(), shutdown.clone());
+    let _listener = svc.start(event_tx.subscribe(), shutdown.clone());
 
     svc.enqueue(make_queue_item(4)).await?;
 
@@ -181,7 +181,7 @@ async fn pipeline_transient_failure_triggers_retry() -> Result<(), TestError> {
 
     let svc = Arc::new(DownloadQueue::new(pool.clone(), engine, import_svc, config).await?);
     let shutdown = tokio_util::sync::CancellationToken::new();
-    svc.start(event_tx.subscribe(), shutdown.clone());
+    let _listener = svc.start(event_tx.subscribe(), shutdown.clone());
 
     let item = make_queue_item(4);
     let queue_id = item.id;
@@ -238,7 +238,7 @@ async fn pipeline_permanent_failure_marks_failed() -> Result<(), TestError> {
 
     let svc = Arc::new(DownloadQueue::new(pool.clone(), engine, import_svc, config).await?);
     let shutdown = tokio_util::sync::CancellationToken::new();
-    svc.start(event_tx.subscribe(), shutdown.clone());
+    let _listener = svc.start(event_tx.subscribe(), shutdown.clone());
 
     let item = make_queue_item(4);
     let queue_id = item.id;
@@ -289,7 +289,7 @@ async fn pipeline_retry_budget_exhaustion_marks_failed() -> Result<(), TestError
 
     let svc = Arc::new(DownloadQueue::new(pool.clone(), engine, import_svc, config).await?);
     let shutdown = tokio_util::sync::CancellationToken::new();
-    svc.start(event_tx.subscribe(), shutdown.clone());
+    let _listener = svc.start(event_tx.subscribe(), shutdown.clone());
 
     let item = make_queue_item(4);
     let queue_id = item.id;

--- a/crates/paroche/src/error.rs
+++ b/crates/paroche/src/error.rs
@@ -91,6 +91,21 @@ impl From<apotheke::DbError> for ParocheError {
     }
 }
 
+impl From<crate::state::ServiceError> for ParocheError {
+    fn from(error: crate::state::ServiceError) -> Self {
+        match error {
+            crate::state::ServiceError::NotFound => ParocheError::NotFound,
+            crate::state::ServiceError::NotAvailable => ParocheError::Unavailable,
+            crate::state::ServiceError::Internal(message) => {
+                // WHY: the HTTP body carries only a correlation id; the detail
+                // must land in the log here or it is lost entirely.
+                tracing::error!(%message, "service call failed");
+                ParocheError::Internal
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use axum::body::to_bytes;

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -39,6 +39,8 @@ pub fn build_router(state: AppState) -> Router {
         .nest("/api/system", routes::system::system_routes())
         .nest("/api/v1/indexers", routes::indexer::indexer_routes())
         .nest("/api/v1/search", routes::search::search_routes())
+        .nest("/api/v1/metadata", routes::metadata::metadata_routes())
+        .nest("/api/v1/curation", routes::curation::curation_routes())
         .nest("/api/v1/downloads", routes::download::download_routes())
         .nest("/api/v1/requests", routes::request::request_routes())
         .nest("/api/v1/wanted", routes::wanted::wanted_routes())

--- a/crates/paroche/src/routes/curation.rs
+++ b/crates/paroche/src/routes/curation.rs
@@ -1,0 +1,319 @@
+/// Library curation endpoints — delegates to kritike via DynCurationService.
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use exousia::AuthenticatedUser;
+use serde::Deserialize;
+use themelion::{HaveId, MediaType};
+use uuid::Uuid;
+
+use crate::error::ParocheError;
+use crate::response::ApiResponse;
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct AssessRequest {
+    pub media_type: MediaType,
+    pub metadata: kritike::QualityMetadata,
+}
+
+#[derive(Deserialize)]
+pub struct UpgradeEligibilityQuery {
+    pub candidate_score: i32,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+pub async fn health_report(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let report = state.curation.health_report().await?;
+
+    Ok(ApiResponse::ok(report))
+}
+
+pub async fn assess_quality(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Json(body): Json<AssessRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let assessment = state
+        .curation
+        .assess_quality(body.media_type, body.metadata)
+        .await?;
+
+    Ok(ApiResponse::ok(assessment))
+}
+
+pub async fn check_upgrade_eligibility(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Path(have_id): Path<String>,
+    Query(query): Query<UpgradeEligibilityQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let have_id = Uuid::parse_str(&have_id)
+        .map(HaveId::from_uuid)
+        .map_err(|_| ParocheError::InvalidId)?;
+
+    let decision = state
+        .curation
+        .check_upgrade_eligibility(have_id, query.candidate_score)
+        .await?;
+
+    Ok(ApiResponse::ok(decision))
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn curation_routes() -> axum::Router<AppState> {
+    use axum::routing::{get, post};
+    axum::Router::new()
+        .route("/health", get(health_report))
+        .route("/assess", post(assess_quality))
+        .route(
+            "/upgrade-eligibility/{have_id}",
+            get(check_upgrade_eligibility),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use exousia::AuthService;
+    use exousia::user::{CreateUserRequest, UserRole};
+    use tower::ServiceExt;
+
+    #[expect(
+        unused_imports,
+        reason = "kanon: test-missing-use-super; parent items accessed via explicit super:: prefix in test bodies"
+    )]
+    use super::*;
+    use crate::state::{DynCurationService, ServiceFut};
+    use crate::test_helpers::test_state;
+
+    #[derive(Default)]
+    struct RecordingCuration {
+        health_calls: AtomicUsize,
+        assess_calls: AtomicUsize,
+        upgrade_calls: AtomicUsize,
+    }
+
+    impl DynCurationService for RecordingCuration {
+        fn assess_quality(
+            &self,
+            _media_type: themelion::MediaType,
+            item_metadata: kritike::QualityMetadata,
+        ) -> ServiceFut<kritike::QualityAssessment> {
+            self.assess_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                Ok(kritike::QualityAssessment {
+                    score: 80 + item_metadata.custom_format_score,
+                    format: item_metadata.format,
+                    meets_minimum: true,
+                    meets_ceiling: false,
+                })
+            })
+        }
+
+        fn check_upgrade_eligibility(
+            &self,
+            _have_id: themelion::HaveId,
+            _candidate_score: i32,
+        ) -> ServiceFut<kritike::UpgradeDecision> {
+            self.upgrade_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok(kritike::UpgradeDecision::Upgrade) })
+        }
+
+        fn health_report(&self) -> ServiceFut<kritike::HealthReport> {
+            self.health_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async {
+                Ok(kritike::HealthReport {
+                    total_items: 3,
+                    per_type: HashMap::new(),
+                })
+            })
+        }
+    }
+
+    async fn user_token(auth: &Arc<exousia::ExousiaServiceImpl>) -> String {
+        auth.create_user(CreateUserRequest {
+            username: "member".to_string(),
+            display_name: "member".to_string(),
+            password: "password123".to_string(),
+            role: UserRole::Member,
+        })
+        .await
+        .unwrap();
+        auth.login("member", "password123")
+            .await
+            .unwrap()
+            .access_token
+    }
+
+    #[tokio::test]
+    async fn health_report_invokes_curation_service() {
+        let (mut state, auth) = test_state().await;
+        let curation = Arc::new(RecordingCuration::default());
+        state.curation = curation.clone();
+        let token = user_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/curation/health")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(curation.health_calls.load(Ordering::SeqCst), 1);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["data"]["total_items"], 3);
+    }
+
+    #[tokio::test]
+    async fn assess_quality_invokes_curation_service() {
+        let (mut state, auth) = test_state().await;
+        let curation = Arc::new(RecordingCuration::default());
+        state.curation = curation.clone();
+        let token = user_token(&auth).await;
+
+        let body = serde_json::json!({
+            "media_type": "music",
+            "metadata": {
+                "format": "FLAC_24BIT",
+                "custom_format_score": 5,
+                "profile_id": 1,
+                "codec": null,
+                "bit_depth": 24,
+                "sample_rate": 96000,
+                "file_size": null,
+                "channels": 2,
+            }
+        });
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/curation/assess")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(curation.assess_calls.load(Ordering::SeqCst), 1);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(payload["data"]["score"], 85);
+        assert_eq!(payload["data"]["format"], "FLAC_24BIT");
+    }
+
+    #[tokio::test]
+    async fn upgrade_eligibility_invokes_curation_service() {
+        let (mut state, auth) = test_state().await;
+        let curation = Arc::new(RecordingCuration::default());
+        state.curation = curation.clone();
+        let token = user_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/v1/curation/upgrade-eligibility/{}?candidate_score=90",
+                        uuid::Uuid::now_v7()
+                    ))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(curation.upgrade_calls.load(Ordering::SeqCst), 1);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(payload["data"], "Upgrade");
+    }
+
+    #[tokio::test]
+    async fn upgrade_eligibility_rejects_invalid_have_id() {
+        let (state, auth) = test_state().await;
+        let token = user_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/curation/upgrade-eligibility/not-a-uuid?candidate_score=90")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn health_report_unavailable_when_curation_not_wired() {
+        let (state, auth) = test_state().await;
+        let token = user_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/curation/health")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn health_report_rejects_unauthenticated() {
+        let (state, _auth) = test_state().await;
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/curation/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/paroche/src/routes/download.rs
+++ b/crates/paroche/src/routes/download.rs
@@ -221,56 +221,42 @@ pub async fn enqueue_download(
     Ok(ApiResponse::created(DownloadResponse::from(row)))
 }
 
+// WHY: cancellation goes through the running syntaxis service so a live
+// torrent session is actually stopped — a raw DB DELETE here left the
+// download running in the engine while the API reported success.
 pub async fn cancel_download(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _admin: RequireAdmin,
     Path(id): Path<String>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
-    let id_bytes = uuid.as_bytes().to_vec();
 
-    let affected = sqlx::query("DELETE FROM download_queue WHERE id = ?")
-        .bind(&id_bytes)
-        .execute(&state.db.write)
-        .await
-        .map_err(|_| ParocheError::Internal)?
-        .rows_affected();
-
-    if affected == 0 {
-        return Err(ParocheError::NotFound);
-    }
+    state.queue.cancel(uuid).await?;
 
     Ok(deleted())
 }
 
+// WHY: re-prioritization goes through the running syntaxis service so the
+// live in-memory tier queue re-orders — a raw DB UPDATE here never changed
+// what actually dispatched next.
 pub async fn reprioritize_download(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _admin: RequireAdmin,
     Path(id): Path<String>,
     Json(body): Json<ReprioritizeRequest>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
-    let id_bytes = uuid.as_bytes().to_vec();
-    let priority = body.priority.clamp(1, 4) as i64;
+    let priority = body.priority.clamp(1, 4);
 
-    let affected = sqlx::query("UPDATE download_queue SET priority = ? WHERE id = ?")
-        .bind(priority)
-        .bind(&id_bytes)
-        .execute(&state.db.write)
-        .await
-        .map_err(|_| ParocheError::Internal)?
-        .rows_affected();
-
-    if affected == 0 {
-        return Err(ParocheError::NotFound);
-    }
+    state.queue.reprioritize(uuid, priority).await?;
 
     let q = format!("{SELECT_DOWNLOAD} WHERE id = ?");
     let row = sqlx::query_as::<_, DownloadRow>(&q)
-        .bind(&id_bytes)
-        .fetch_one(&state.db.read)
+        .bind(uuid.as_bytes().as_slice())
+        .fetch_optional(&state.db.read)
         .await
-        .map_err(|_| ParocheError::Internal)?;
+        .map_err(|_| ParocheError::Internal)?
+        .ok_or(ParocheError::NotFound)?;
 
     Ok(ApiResponse::ok(DownloadResponse::from(row)))
 }
@@ -461,5 +447,230 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // ── #469: cancel/reprioritize reach the live queue manager ─────────────
+
+    #[derive(Default)]
+    struct RecordingQueueManager {
+        cancelled: std::sync::Mutex<Vec<uuid::Uuid>>,
+        reprioritized: std::sync::Mutex<Vec<(uuid::Uuid, u8)>>,
+        fail_with: std::sync::Mutex<Option<fn() -> crate::state::ServiceError>>,
+    }
+
+    impl crate::state::DynQueueManager for RecordingQueueManager {
+        fn cancel(&self, queue_id: uuid::Uuid) -> crate::state::ServiceFut<()> {
+            if let Some(make_error) = *self.fail_with.lock().unwrap() {
+                return Box::pin(async move { Err(make_error()) });
+            }
+            self.cancelled.lock().unwrap().push(queue_id);
+            Box::pin(async { Ok(()) })
+        }
+
+        fn reprioritize(&self, queue_id: uuid::Uuid, priority: u8) -> crate::state::ServiceFut<()> {
+            if let Some(make_error) = *self.fail_with.lock().unwrap() {
+                return Box::pin(async move { Err(make_error()) });
+            }
+            self.reprioritized
+                .lock()
+                .unwrap()
+                .push((queue_id, priority));
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    async fn insert_download_row(pool: &sqlx::SqlitePool, id: uuid::Uuid, priority: i64) {
+        sqlx::query(
+            "INSERT INTO download_queue \
+             (id, want_id, release_id, download_url, protocol, priority, \
+              status, added_at, retry_count) \
+             VALUES (?, ?, ?, 'magnet:?xt=urn:btih:row', 'torrent', ?, \
+                     'queued', '2026-01-01T00:00:00Z', 0)",
+        )
+        .bind(id.as_bytes().as_slice())
+        .bind(uuid::Uuid::now_v7().as_bytes().as_slice())
+        .bind(uuid::Uuid::now_v7().as_bytes().as_slice())
+        .bind(priority)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancel_download_reaches_queue_manager_not_raw_db() {
+        let (mut state, auth) = test_state().await;
+        let queue = std::sync::Arc::new(RecordingQueueManager::default());
+        state.queue = queue.clone();
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let pool = app_pool(&auth);
+
+        let id = uuid::Uuid::now_v7();
+        insert_download_row(&pool, id, 2).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/downloads/{id}"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            *queue.cancelled.lock().unwrap(),
+            vec![id],
+            "the cancel must be delegated to the queue manager"
+        );
+        // The queue manager owns the DB write; the route must not raw-DELETE.
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM download_queue WHERE id = ?")
+            .bind(id.as_bytes().as_slice())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "the route must not bypass the service with raw SQL"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_download_maps_service_not_found() {
+        let (mut state, auth) = test_state().await;
+        let queue = std::sync::Arc::new(RecordingQueueManager::default());
+        *queue.fail_with.lock().unwrap() = Some(|| crate::state::ServiceError::NotFound);
+        state.queue = queue;
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/downloads/{}", uuid::Uuid::now_v7()))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cancel_download_unavailable_when_queue_not_wired() {
+        let (state, auth) = test_state().await;
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/downloads/{}", uuid::Uuid::now_v7()))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn cancel_download_rejects_unauthenticated() {
+        let (state, _auth) = test_state().await;
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/downloads/{}", uuid::Uuid::now_v7()))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn cancel_download_rejects_member() {
+        let (state, auth) = test_state().await;
+        let token = token_for(&auth, "member", UserRole::Member).await;
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/downloads/{}", uuid::Uuid::now_v7()))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn reprioritize_download_reaches_queue_manager() {
+        let (mut state, auth) = test_state().await;
+        let queue = std::sync::Arc::new(RecordingQueueManager::default());
+        state.queue = queue.clone();
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let pool = app_pool(&auth);
+
+        let id = uuid::Uuid::now_v7();
+        insert_download_row(&pool, id, 2).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/api/v1/downloads/{id}/priority"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"priority": 4}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            *queue.reprioritized.lock().unwrap(),
+            vec![(id, 4)],
+            "the re-prioritization must be delegated to the queue manager"
+        );
+    }
+
+    #[tokio::test]
+    async fn reprioritize_download_rejects_invalid_id() {
+        let (state, auth) = test_state().await;
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/api/v1/downloads/not-a-uuid/priority")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"priority": 2}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/paroche/src/routes/metadata.rs
+++ b/crates/paroche/src/routes/metadata.rs
@@ -1,0 +1,331 @@
+/// Metadata resolution endpoints — delegates to epignosis via DynMetadataResolver.
+use std::path::PathBuf;
+
+use axum::Json;
+use axum::extract::State;
+use exousia::{AuthenticatedUser, RequireAdmin};
+use serde::Deserialize;
+use themelion::{MediaId, MediaType};
+
+use crate::error::ParocheError;
+use crate::response::ApiResponse;
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct IdentifyRequest {
+    pub media_id: MediaId,
+    pub media_type: MediaType,
+    pub file_path: String,
+    pub filename_hint: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct FingerprintRequest {
+    pub file_path: String,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+pub async fn identify_media(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Json(body): Json<IdentifyRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let file_path = PathBuf::from(&body.file_path);
+    // WHY: without a hint the resolver's provider query is an empty title and
+    // can never match; the file stem is the best available fallback.
+    let filename_hint = body.filename_hint.or_else(|| {
+        file_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(ToOwned::to_owned)
+    });
+
+    let identity = state
+        .metadata
+        .resolve_identity(epignosis::UnidentifiedItem {
+            media_id: body.media_id,
+            media_type: body.media_type,
+            file_path,
+            filename_hint,
+            tags: None,
+        })
+        .await?;
+
+    Ok(ApiResponse::ok(identity))
+}
+
+pub async fn enrich_media(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Json(identity): Json<epignosis::MediaIdentity>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let enriched = state.metadata.enrich(identity).await?;
+
+    Ok(ApiResponse::ok(enriched))
+}
+
+// WHY: admin-only — fingerprinting reads an arbitrary server-side file path.
+pub async fn fingerprint_media(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(body): Json<FingerprintRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let result = state
+        .metadata
+        .fingerprint_audio(PathBuf::from(body.file_path))
+        .await?;
+
+    Ok(ApiResponse::ok(result))
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn metadata_routes() -> axum::Router<AppState> {
+    use axum::routing::post;
+    axum::Router::new()
+        .route("/identify", post(identify_media))
+        .route("/enrich", post(enrich_media))
+        .route("/fingerprint", post(fingerprint_media))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use exousia::AuthService;
+    use exousia::user::{CreateUserRequest, UserRole};
+    use tower::ServiceExt;
+
+    #[expect(
+        unused_imports,
+        reason = "kanon: test-missing-use-super; parent items accessed via explicit super:: prefix in test bodies"
+    )]
+    use super::*;
+    use crate::state::{DynMetadataResolver, ServiceError, ServiceFut};
+    use crate::test_helpers::test_state;
+
+    #[derive(Default)]
+    struct RecordingResolver {
+        identify_calls: AtomicUsize,
+        enrich_calls: AtomicUsize,
+    }
+
+    impl DynMetadataResolver for RecordingResolver {
+        fn resolve_identity(
+            &self,
+            item: epignosis::UnidentifiedItem,
+        ) -> ServiceFut<epignosis::MediaIdentity> {
+            self.identify_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                Ok(epignosis::MediaIdentity {
+                    media_id: item.media_id,
+                    media_type: item.media_type,
+                    provider: "test-provider".to_string(),
+                    provider_id: epignosis::identity::MetadataProviderId("prov-1".to_string()),
+                    canonical_title: item.filename_hint.unwrap_or_default(),
+                    canonical_artist: None,
+                    year: Some(1997),
+                    extra: serde_json::Value::Null,
+                })
+            })
+        }
+
+        fn enrich(
+            &self,
+            identity: epignosis::MediaIdentity,
+        ) -> ServiceFut<epignosis::EnrichedMetadata> {
+            self.enrich_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                Ok(epignosis::EnrichedMetadata {
+                    identity,
+                    enrichments: vec![],
+                })
+            })
+        }
+
+        fn fingerprint_audio(
+            &self,
+            _file_path: std::path::PathBuf,
+        ) -> ServiceFut<epignosis::FingerprintResult> {
+            Box::pin(async { Err(ServiceError::Internal("no fpcalc".to_string())) })
+        }
+    }
+
+    async fn admin_token(auth: &Arc<exousia::ExousiaServiceImpl>) -> String {
+        auth.create_user(CreateUserRequest {
+            username: "admin".to_string(),
+            display_name: "admin".to_string(),
+            password: "password123".to_string(),
+            role: UserRole::Admin,
+        })
+        .await
+        .unwrap();
+        auth.login("admin", "password123")
+            .await
+            .unwrap()
+            .access_token
+    }
+
+    fn identify_body() -> String {
+        serde_json::json!({
+            "media_id": uuid::Uuid::now_v7().to_string(),
+            "media_type": "music",
+            "file_path": "/library/music/Radiohead/OK Computer/01 - Airbag.flac",
+        })
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn identify_invokes_resolver_and_returns_identity() {
+        let (mut state, auth) = test_state().await;
+        let resolver = Arc::new(RecordingResolver::default());
+        state.metadata = resolver.clone();
+        let token = admin_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/metadata/identify")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(identify_body()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resolver.identify_calls.load(Ordering::SeqCst), 1);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["data"]["provider"], "test-provider");
+        assert_eq!(
+            body["data"]["canonical_title"], "01 - Airbag",
+            "a missing filename_hint must default to the file stem"
+        );
+    }
+
+    #[tokio::test]
+    async fn enrich_invokes_resolver() {
+        let (mut state, auth) = test_state().await;
+        let resolver = Arc::new(RecordingResolver::default());
+        state.metadata = resolver.clone();
+        let token = admin_token(&auth).await;
+
+        let identity = serde_json::json!({
+            "media_id": uuid::Uuid::now_v7().to_string(),
+            "media_type": "music",
+            "provider": "musicbrainz",
+            "provider_id": "mbid-1",
+            "canonical_title": "OK Computer",
+            "canonical_artist": "Radiohead",
+            "year": 1997,
+            "extra": null,
+        });
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/metadata/enrich")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(identity.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resolver.enrich_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn identify_unavailable_when_resolver_not_wired() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/metadata/identify")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(identify_body()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn identify_rejects_unauthenticated() {
+        let (state, _auth) = test_state().await;
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/metadata/identify")
+                    .header("content-type", "application/json")
+                    .body(Body::from(identify_body()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn fingerprint_requires_admin() {
+        let (state, auth) = test_state().await;
+        auth.create_user(CreateUserRequest {
+            username: "member".to_string(),
+            display_name: "member".to_string(),
+            password: "password123".to_string(),
+            role: UserRole::Member,
+        })
+        .await
+        .unwrap();
+        let token = auth
+            .login("member", "password123")
+            .await
+            .unwrap()
+            .access_token;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/metadata/fingerprint")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"file_path": "/library/a.flac"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/crates/paroche/src/routes/mod.rs
+++ b/crates/paroche/src/routes/mod.rs
@@ -1,10 +1,12 @@
 pub mod audiobook;
 pub mod book;
 pub mod comic;
+pub mod curation;
 pub mod download;
 pub mod indexer;
 pub mod kosync;
 pub mod library;
+pub mod metadata;
 pub mod movie;
 pub mod music;
 pub mod news;

--- a/crates/paroche/src/routes/search.rs
+++ b/crates/paroche/src/routes/search.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ParocheError;
 use crate::response::ApiResponse;
-use crate::state::{AppState, ServiceError};
+use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -49,11 +49,7 @@ pub async fn search(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let query = serde_json::to_value(&body).map_err(|_| ParocheError::Internal)?;
 
-    let results = state
-        .search
-        .search(query)
-        .await
-        .map_err(search_service_error)?;
+    let results = state.search.search(query).await?;
 
     Ok(ApiResponse::ok(results))
 }
@@ -68,21 +64,9 @@ pub async fn get_search_results(
     // wired this returns 503.
     let query = serde_json::json!({ "query_id": query_id });
 
-    let results = state
-        .search
-        .search(query)
-        .await
-        .map_err(search_service_error)?;
+    let results = state.search.search(query).await?;
 
     Ok(ApiResponse::ok(results))
-}
-
-fn search_service_error(error: ServiceError) -> ParocheError {
-    match error {
-        ServiceError::NotFound => ParocheError::NotFound,
-        ServiceError::NotAvailable => ParocheError::Unavailable,
-        ServiceError::Internal(_) => ParocheError::Internal,
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -21,10 +21,46 @@ pub trait DynImportService: Send + Sync {
     fn get_import_queue_boxed(&self) -> ImportQueueFut;
 }
 
-/// Dyn-compatible interface for services not yet used in route handlers.
-pub trait DynCurationService: Send + Sync {}
+/// Library curation via kritike: quality assessment, upgrade eligibility,
+/// and library health reporting.
+pub trait DynCurationService: Send + Sync {
+    /// Assess the quality score of an item's metadata against its profile.
+    fn assess_quality(
+        &self,
+        media_type: themelion::MediaType,
+        item_metadata: kritike::QualityMetadata,
+    ) -> ServiceFut<kritike::QualityAssessment>;
 
-pub trait DynMetadataResolver: Send + Sync {}
+    /// Decide whether an existing have should be upgraded by a candidate.
+    fn check_upgrade_eligibility(
+        &self,
+        have_id: themelion::HaveId,
+        candidate_score: i32,
+    ) -> ServiceFut<kritike::UpgradeDecision>;
+
+    /// Generate the library-wide health report.
+    fn health_report(&self) -> ServiceFut<kritike::HealthReport>;
+}
+
+/// Metadata identification and enrichment via epignosis' provider-backed
+/// resolver (mirrors `epignosis::MetadataResolver`).
+pub trait DynMetadataResolver: Send + Sync {
+    /// Resolve a media item's canonical identity via the provider fan-out.
+    fn resolve_identity(
+        &self,
+        item: epignosis::UnidentifiedItem,
+    ) -> ServiceFut<epignosis::MediaIdentity>;
+
+    /// Enrich a resolved identity with provider metadata.
+    fn enrich(&self, identity: epignosis::MediaIdentity)
+    -> ServiceFut<epignosis::EnrichedMetadata>;
+
+    /// Compute an audio fingerprint for a file on the server.
+    fn fingerprint_audio(
+        &self,
+        file_path: std::path::PathBuf,
+    ) -> ServiceFut<epignosis::FingerprintResult>;
+}
 
 /// Boxed future type for dyn-safe acquisition service methods.
 pub type ServiceFut<T> = Pin<Box<dyn Future<Output = Result<T, ServiceError>> + Send>>;
@@ -69,7 +105,19 @@ pub trait DynSearchService: Send + Sync {
 }
 
 pub trait DynDownloadEngine: Send + Sync {}
-pub trait DynQueueManager: Send + Sync {}
+
+/// Download queue control via the running syntaxis service.
+///
+/// Items are keyed by their `download_queue` row id — the identifier the
+/// HTTP API exposes.
+pub trait DynQueueManager: Send + Sync {
+    /// Cancels the queue item, stopping the live download when one is active.
+    fn cancel(&self, queue_id: uuid::Uuid) -> ServiceFut<()>;
+
+    /// Changes the dispatch priority (1-4) of the queue item in the live
+    /// queue; priority 4 dispatches immediately when a slot is free.
+    fn reprioritize(&self, queue_id: uuid::Uuid, priority: u8) -> ServiceFut<()>;
+}
 
 /// Media-request lifecycle via Aitesis.
 pub trait DynRequestService: Send + Sync {
@@ -157,10 +205,51 @@ where
 }
 
 struct NullCuration;
-impl DynCurationService for NullCuration {}
+impl DynCurationService for NullCuration {
+    fn assess_quality(
+        &self,
+        _media_type: themelion::MediaType,
+        _item_metadata: kritike::QualityMetadata,
+    ) -> ServiceFut<kritike::QualityAssessment> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
+    fn check_upgrade_eligibility(
+        &self,
+        _have_id: themelion::HaveId,
+        _candidate_score: i32,
+    ) -> ServiceFut<kritike::UpgradeDecision> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
+    fn health_report(&self) -> ServiceFut<kritike::HealthReport> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+}
 
 struct NullMetadata;
-impl DynMetadataResolver for NullMetadata {}
+impl DynMetadataResolver for NullMetadata {
+    fn resolve_identity(
+        &self,
+        _item: epignosis::UnidentifiedItem,
+    ) -> ServiceFut<epignosis::MediaIdentity> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
+    fn enrich(
+        &self,
+        _identity: epignosis::MediaIdentity,
+    ) -> ServiceFut<epignosis::EnrichedMetadata> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
+    fn fingerprint_audio(
+        &self,
+        _file_path: std::path::PathBuf,
+    ) -> ServiceFut<epignosis::FingerprintResult> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+}
 
 struct NullSearch;
 impl DynSearchService for NullSearch {
@@ -179,7 +268,15 @@ struct NullDownloadEngine;
 impl DynDownloadEngine for NullDownloadEngine {}
 
 struct NullQueueManager;
-impl DynQueueManager for NullQueueManager {}
+impl DynQueueManager for NullQueueManager {
+    fn cancel(&self, _queue_id: uuid::Uuid) -> ServiceFut<()> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
+    fn reprioritize(&self, _queue_id: uuid::Uuid, _priority: u8) -> ServiceFut<()> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+}
 
 struct NullRequestService;
 impl DynRequestService for NullRequestService {

--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -148,8 +148,14 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
     /// engine-reported state whenever the broadcast bus lags (dropped events
     /// would otherwise leak slots permanently) and on a periodic interval.
     ///
-    /// The task runs until `shutdown` is cancelled.
-    pub fn start(self: &Arc<Self>, mut event_rx: EventReceiver, shutdown: CancellationToken) {
+    /// The task runs until `shutdown` is cancelled. The returned handle lets
+    /// the host await the listener's drain during graceful shutdown (or abort
+    /// it); dropping the handle detaches the task.
+    pub fn start(
+        self: &Arc<Self>,
+        mut event_rx: EventReceiver,
+        shutdown: CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
         let svc = Arc::clone(self);
         let span = tracing::Span::current();
         tokio::spawn(
@@ -181,7 +187,187 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
                 info!("syntaxis event listener stopped");
             }
             .instrument(span),
-        );
+        )
+    }
+
+    /// Cancels a queue item by its `download_queue` row id, stopping the live
+    /// engine download when one is active.
+    ///
+    /// Resolution order: an active download is claimed (slot released) and
+    /// cancelled on the engine; a queued item is removed from the in-memory
+    /// tier queue; a DB-only row (persisted by the HTTP API before this
+    /// service observed it) is still deleted. The row is deleted in every
+    /// successful branch so a cancelled item can never be re-dispatched by
+    /// startup recovery.
+    pub async fn cancel_by_queue_id(&self, queue_id: uuid::Uuid) -> Result<(), SyntaxisError> {
+        // INVARIANT: claim-and-release is one critical section, so a
+        // concurrent completion/failure event cannot double-release the slot.
+        let active_entry = {
+            let mut inner = self.inner.lock().await;
+            let key = inner
+                .active
+                .iter()
+                .find(|(_, e)| e.queue_id == queue_id)
+                .map(|(k, _)| k.clone());
+            key.and_then(|key| {
+                inner.active.remove(&key).inspect(|e| {
+                    inner.allocator.release(e.protocol, e.tracker_id);
+                })
+            })
+        };
+
+        if let Some(entry) = active_entry {
+            if let Err(e) = self.engine.cancel_download(entry.download_id).await {
+                // WHY: the entry is already claimed; surface the failure loud
+                // and leave the row terminal so recovery cannot re-dispatch a
+                // torrent the engine may still be running.
+                error!(error = %e, %queue_id, "engine cancel failed for active download");
+                repo::mark_failed(
+                    &self.pool,
+                    queue_id,
+                    &format!("cancel requested; engine cancel failed: {e}"),
+                )
+                .await
+                .map_err(|source| SyntaxisError::Database {
+                    source,
+                    location: snafu::location!(),
+                })?;
+                self.try_dispatch_next().await;
+                return Err(SyntaxisError::DispatchFailed {
+                    location: snafu::location!(),
+                });
+            }
+            repo::delete_queue_item(&self.pool, queue_id)
+                .await
+                .map_err(|source| SyntaxisError::Database {
+                    source,
+                    location: snafu::location!(),
+                })?;
+            self.try_dispatch_next().await;
+            return Ok(());
+        }
+
+        let removed_from_queue = {
+            let mut inner = self.inner.lock().await;
+            inner.queue.remove(queue_id).is_some()
+        };
+        let deleted = repo::delete_queue_item(&self.pool, queue_id)
+            .await
+            .map_err(|source| SyntaxisError::Database {
+                source,
+                location: snafu::location!(),
+            })?;
+
+        if removed_from_queue || deleted > 0 {
+            return Ok(());
+        }
+        Err(SyntaxisError::ItemNotFound {
+            id: queue_id.to_string(),
+            location: snafu::location!(),
+        })
+    }
+
+    /// Changes the dispatch priority of a queue item by its `download_queue`
+    /// row id, re-bucketing the live in-memory queue.
+    ///
+    /// Priority 4 (interactive) pulls the item out of the queue and
+    /// dispatches it immediately when a slot is free, demoting to tier 3
+    /// otherwise — mirroring `enqueue`'s interactive path. An active download
+    /// is untouched: priority is a queue-ordering concern with no effect on a
+    /// running transfer. A DB-only row still has its persisted priority
+    /// updated.
+    pub async fn reprioritize_by_queue_id(
+        &self,
+        queue_id: uuid::Uuid,
+        new_priority: u8,
+    ) -> Result<(), SyntaxisError> {
+        let new_priority = new_priority.clamp(1, 4);
+
+        enum Placement {
+            Active,
+            Requeued(u8),
+            Dispatch(QueueItem, DownloadId),
+            NotInMemory,
+        }
+
+        let placement = {
+            let mut inner = self.inner.lock().await;
+            if inner.active.values().any(|e| e.queue_id == queue_id) {
+                Placement::Active
+            } else if new_priority == 4 {
+                match inner.queue.reprioritize_to_interactive(queue_id) {
+                    Some(mut item) => {
+                        // WHY: check-and-acquire under one critical section
+                        // (same TOCTOU guard as the interactive enqueue path).
+                        if inner.allocator.has_slot(&item) {
+                            inner.allocator.acquire(&item);
+                            let download_id = DownloadId::new();
+                            inner.active.insert(
+                                download_id.to_string(),
+                                ActiveEntry::from_item(&item, download_id),
+                            );
+                            Placement::Dispatch(item, download_id)
+                        } else {
+                            // No slot: demote to tier 3 and keep it queued —
+                            // the tier queue only holds priorities 1-3.
+                            item.priority = 3;
+                            inner.queue.insert(item);
+                            Placement::Requeued(3)
+                        }
+                    }
+                    None => Placement::NotInMemory,
+                }
+            } else if inner.queue.reprioritize(queue_id, new_priority) {
+                Placement::Requeued(new_priority)
+            } else {
+                Placement::NotInMemory
+            }
+        };
+
+        match placement {
+            Placement::Active => Ok(()),
+            Placement::Requeued(priority) => {
+                repo::update_priority(&self.pool, queue_id, priority)
+                    .await
+                    .map_err(|source| SyntaxisError::Database {
+                        source,
+                        location: snafu::location!(),
+                    })?;
+                Ok(())
+            }
+            Placement::Dispatch(item, download_id) => {
+                repo::update_priority(&self.pool, queue_id, 4)
+                    .await
+                    .map_err(|source| SyntaxisError::Database {
+                        source,
+                        location: snafu::location!(),
+                    })?;
+                if !Self::dispatch_active(&self.inner, &self.engine, &self.pool, item, download_id)
+                    .await
+                {
+                    // WHY: the failed interactive dispatch released its slot;
+                    // hand the freed capacity to queued work.
+                    Self::dispatch_next_inner(&self.inner, &self.engine, &self.pool).await;
+                }
+                Ok(())
+            }
+            Placement::NotInMemory => {
+                let updated = repo::update_priority(&self.pool, queue_id, new_priority)
+                    .await
+                    .map_err(|source| SyntaxisError::Database {
+                        source,
+                        location: snafu::location!(),
+                    })?;
+                if updated > 0 {
+                    Ok(())
+                } else {
+                    Err(SyntaxisError::ItemNotFound {
+                        id: queue_id.to_string(),
+                        location: snafu::location!(),
+                    })
+                }
+            }
+        }
     }
 
     /// Reconciles in-memory active entries against engine-reported state.
@@ -669,45 +855,19 @@ impl<E: DownloadEngine + 'static> QueueManager for Arc<DownloadQueue<E>> {
         download_id: DownloadId,
         new_priority: u8,
     ) -> Result<(), SyntaxisError> {
-        let id_str = download_id.to_string();
-
         {
             let inner = self.inner.lock().await;
             // If already active, re-prioritization is a no-op.
-            if inner.active.contains_key(&id_str) {
+            if inner.active.contains_key(&download_id.to_string()) {
                 return Ok(());
             }
         }
 
-        // Try to parse as Uuid and find in queue.
-        let uuid = uuid::Uuid::parse_str(&id_str).map_err(|_| SyntaxisError::ItemNotFound {
-            id: id_str.clone(),
-            location: snafu::location!(),
-        })?;
-
-        let found = {
-            let mut inner = self.inner.lock().await;
-            inner.queue.reprioritize(uuid, new_priority)
-        };
-
-        if !found {
-            return Err(SyntaxisError::ItemNotFound {
-                id: id_str,
-                location: snafu::location!(),
-            });
-        }
-
-        repo::update_priority(&self.pool, uuid, new_priority)
+        // WHY: queued items are keyed by their queue row uuid; the prior
+        // Uuid::parse_str on the Display form always failed on the "dl-"
+        // prefix, making this method unreachable for queued items.
+        self.reprioritize_by_queue_id(*download_id.as_uuid(), new_priority)
             .await
-            .map_err(|source| SyntaxisError::Database {
-                source,
-                location: snafu::location!(),
-            })?;
-
-        if new_priority == 4 {
-            self.try_dispatch_next().await;
-        }
-        Ok(())
     }
 
     #[instrument(skip(self))]
@@ -773,6 +933,8 @@ mod tests {
         fail_remaining: AtomicUsize,
         progress_state: StdMutex<DownloadState>,
         progress_unavailable: AtomicBool,
+        cancelled: StdMutex<Vec<DownloadId>>,
+        fail_cancels: AtomicBool,
     }
 
     impl MockEngine {
@@ -785,6 +947,8 @@ mod tests {
                     fail_remaining: AtomicUsize::new(0),
                     progress_state: StdMutex::new(DownloadState::Downloading),
                     progress_unavailable: AtomicBool::new(false),
+                    cancelled: StdMutex::new(Vec::new()),
+                    fail_cancels: AtomicBool::new(false),
                 }),
                 rx,
             )
@@ -804,6 +968,14 @@ mod tests {
 
         fn start_calls(&self) -> usize {
             self.calls.load(Ordering::SeqCst)
+        }
+
+        fn fail_cancels(&self) {
+            self.fail_cancels.store(true, Ordering::SeqCst);
+        }
+
+        fn cancelled_ids(&self) -> Vec<DownloadId> {
+            self.cancelled.lock().unwrap().clone()
         }
     }
 
@@ -830,7 +1002,14 @@ mod tests {
             Ok(request.download_id)
         }
 
-        async fn cancel_download(&self, _download_id: DownloadId) -> Result<(), ErgasiaError> {
+        async fn cancel_download(&self, download_id: DownloadId) -> Result<(), ErgasiaError> {
+            if self.fail_cancels.load(Ordering::SeqCst) {
+                return Err(ErgasiaError::TorrentNotFound {
+                    download_id,
+                    location: snafu::location!(),
+                });
+            }
+            self.cancelled.lock().unwrap().push(download_id);
             Ok(())
         }
 
@@ -1512,7 +1691,7 @@ mod tests {
                 .unwrap();
         }
         let shutdown = CancellationToken::new();
-        svc.start(event_rx, shutdown.clone());
+        let listener = svc.start(event_rx, shutdown.clone());
 
         let (_, reason, _) = wait_for_status(&pool, queue_id, "failed").await;
         assert!(reason.unwrap_or_default().contains("reconciliation"));
@@ -1522,6 +1701,7 @@ mod tests {
             "Lagged must trigger slot reclamation"
         );
         shutdown.cancel();
+        listener.await.unwrap();
     }
 
     #[tokio::test]
@@ -1534,7 +1714,7 @@ mod tests {
         // pass can observe the missed completion.
         let (_event_tx, event_rx) = themelion::create_event_bus(64);
         let shutdown = CancellationToken::new();
-        svc.start(event_rx, shutdown.clone());
+        let listener = svc.start(event_rx, shutdown.clone());
 
         let item = make_item(DownloadProtocol::Torrent, 2);
         let queue_id = item.id;
@@ -1563,5 +1743,376 @@ mod tests {
         );
         assert_eq!(active_total(&svc).await, 0);
         shutdown.cancel();
+        listener.await.unwrap();
+    }
+
+    // ── #412: start returns an awaitable handle for graceful shutdown ──────
+
+    #[tokio::test]
+    async fn start_handle_resolves_on_shutdown_after_draining_event() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 3, 0)).await;
+
+        let (event_tx, event_rx) = themelion::create_event_bus(64);
+        let shutdown = CancellationToken::new();
+        let listener = svc.start(event_rx, shutdown.clone());
+
+        svc.enqueue(make_item(DownloadProtocol::Torrent, 2))
+            .await
+            .unwrap();
+        let (dl_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        event_tx
+            .send(HarmoniaEvent::DownloadCompleted {
+                download_id: dl_id,
+                path: std::path::PathBuf::from("/tmp/none"),
+            })
+            .unwrap();
+
+        // The listener must process the completion (slot released) before the
+        // handle is awaited — proving events are not silently dropped.
+        settle_until(|| {
+            svc.inner
+                .try_lock()
+                .map(|inner| inner.allocator.active_total() == 0)
+                .unwrap_or(false)
+        })
+        .await;
+
+        shutdown.cancel();
+        tokio::time::timeout(RECV_TIMEOUT, listener)
+            .await
+            .expect("the listener handle must resolve on shutdown, not hang")
+            .expect("the listener task must not panic");
+    }
+
+    // ── #469: cancel/reprioritize reach the live queue and engine ──────────
+
+    #[tokio::test]
+    async fn cancel_by_queue_id_stops_live_engine_download() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 3, 0)).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (dl_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        svc.cancel_by_queue_id(queue_id).await.unwrap();
+
+        assert_eq!(
+            engine.cancelled_ids(),
+            vec![dl_id],
+            "the live engine download must be cancelled, not just the DB row"
+        );
+        assert_eq!(active_total(&svc).await, 0, "the slot must be released");
+        assert!(!active_contains(&svc, dl_id).await);
+        assert!(
+            repo::get_queue_item(&pool, queue_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "the cancelled row must be gone so recovery cannot re-dispatch it"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_by_queue_id_frees_slot_for_next_queued_item() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(1, 3, 0)).await;
+
+        let first = make_item(DownloadProtocol::Torrent, 2);
+        let first_queue_id = first.id;
+        let second = make_item(DownloadProtocol::Torrent, 2);
+        let second_url = second.download_url.clone();
+        svc.enqueue(first).await.unwrap();
+        svc.enqueue(second).await.unwrap();
+        tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(queued_len(&svc).await, 1, "precondition: second is queued");
+
+        svc.cancel_by_queue_id(first_queue_id).await.unwrap();
+
+        let (_, url) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(url, second_url, "the freed slot must dispatch queued work");
+    }
+
+    #[tokio::test]
+    async fn cancel_by_queue_id_removes_queued_item_without_engine_call() {
+        let pool = test_pool().await;
+        let (engine, _started_rx) = MockEngine::create();
+        // max_concurrent 0: the item can never dispatch, so it stays queued.
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(0, 3, 0)).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        assert_eq!(queued_len(&svc).await, 1);
+
+        svc.cancel_by_queue_id(queue_id).await.unwrap();
+
+        assert_eq!(queued_len(&svc).await, 0);
+        assert!(
+            engine.cancelled_ids().is_empty(),
+            "a never-dispatched item has nothing to cancel on the engine"
+        );
+        assert!(
+            repo::get_queue_item(&pool, queue_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_by_queue_id_deletes_db_only_row() {
+        let pool = test_pool().await;
+        let (engine, _started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 3, 0)).await;
+
+        // A row persisted by the HTTP API without going through this service.
+        let queue_id = uuid::Uuid::now_v7();
+        repo::insert_queue_item(
+            &pool,
+            queue_id,
+            uuid::Uuid::now_v7().as_bytes().as_ref(),
+            uuid::Uuid::now_v7().as_bytes().as_ref(),
+            "magnet:?xt=urn:btih:dbonly",
+            "torrent",
+            2,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        svc.cancel_by_queue_id(queue_id).await.unwrap();
+
+        assert!(
+            repo::get_queue_item(&pool, queue_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_by_queue_id_unknown_id_errors() {
+        let pool = test_pool().await;
+        let (engine, _started_rx) = MockEngine::create();
+        let svc = make_service(pool, Arc::clone(&engine), test_config(2, 3, 0)).await;
+
+        let result = svc.cancel_by_queue_id(uuid::Uuid::now_v7()).await;
+        assert!(matches!(result, Err(SyntaxisError::ItemNotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn cancel_by_queue_id_engine_failure_surfaces_and_marks_row() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 3, 0)).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        engine.fail_cancels();
+        let result = svc.cancel_by_queue_id(queue_id).await;
+
+        assert!(
+            matches!(result, Err(SyntaxisError::DispatchFailed { .. })),
+            "an engine cancel failure must not report success"
+        );
+        let (status, reason, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "failed", "the row must be terminal, not deleted");
+        assert!(reason.unwrap_or_default().contains("engine cancel failed"));
+        assert_eq!(active_total(&svc).await, 0, "the claimed slot stays freed");
+    }
+
+    #[tokio::test]
+    async fn reprioritize_by_queue_id_moves_queued_item_tier() {
+        let pool = test_pool().await;
+        let (engine, _started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(0, 3, 0)).await;
+
+        let low = make_item(DownloadProtocol::Torrent, 1);
+        let low_id = low.id;
+        let high = make_item(DownloadProtocol::Torrent, 3);
+        svc.enqueue(low).await.unwrap();
+        svc.enqueue(high).await.unwrap();
+
+        svc.reprioritize_by_queue_id(low_id, 3).await.unwrap();
+
+        let snapshot = svc.get_queue_state().await.unwrap();
+        let moved = snapshot
+            .queued_items
+            .iter()
+            .find(|i| i.id == low_id)
+            .expect("the item stays queued");
+        assert_eq!(moved.priority, 3, "the live tier must change");
+        let row = repo::get_queue_item(&pool, low_id).await.unwrap().unwrap();
+        assert_eq!(row.priority, 3, "the persisted priority must match");
+    }
+
+    #[tokio::test]
+    async fn reprioritize_by_queue_id_to_interactive_dispatches_immediately() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(1, 3, 0)).await;
+
+        // Place a queued item directly (slot free, nothing dispatched yet).
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        repo::insert_queue_item(
+            &pool,
+            queue_id,
+            item.want_id.as_uuid().as_bytes(),
+            item.release_id.as_uuid().as_bytes(),
+            &item.download_url,
+            "torrent",
+            2,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        svc.inner.lock().await.queue.insert(item);
+
+        svc.reprioritize_by_queue_id(queue_id, 4).await.unwrap();
+
+        let (dl_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            active_contains(&svc, dl_id).await,
+            "interactive upgrade must dispatch through the live engine"
+        );
+        assert_eq!(queued_len(&svc).await, 0);
+        let row = repo::get_queue_item(&pool, queue_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.priority, 4);
+        assert_eq!(row.status, "downloading");
+    }
+
+    #[tokio::test]
+    async fn reprioritize_to_interactive_without_slot_requeues_at_tier3() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(1, 3, 0)).await;
+
+        // Occupy the single slot.
+        svc.enqueue(make_item(DownloadProtocol::Torrent, 2))
+            .await
+            .unwrap();
+        tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let queued = make_item(DownloadProtocol::Torrent, 2);
+        let queued_id = queued.id;
+        svc.enqueue(queued).await.unwrap();
+        assert_eq!(queued_len(&svc).await, 1);
+
+        svc.reprioritize_by_queue_id(queued_id, 4).await.unwrap();
+
+        // WHY: pre-fix, reprioritize-to-4 dropped the item from memory
+        // entirely (removed but never dispatched or re-inserted).
+        let snapshot = svc.get_queue_state().await.unwrap();
+        let kept = snapshot
+            .queued_items
+            .iter()
+            .find(|i| i.id == queued_id)
+            .expect("without a slot the item must stay queued, not vanish");
+        assert_eq!(kept.priority, 3, "no-slot interactive demotes to tier 3");
+        assert_eq!(engine.start_calls(), 1, "no second dispatch may happen");
+    }
+
+    #[tokio::test]
+    async fn reprioritize_by_queue_id_active_item_is_noop() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 3, 0)).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        svc.reprioritize_by_queue_id(queue_id, 1).await.unwrap();
+
+        let row = repo::get_queue_item(&pool, queue_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.status, "downloading",
+            "an active download must be untouched"
+        );
+        assert_eq!(row.priority, 2, "priority of a running transfer stays put");
+    }
+
+    #[tokio::test]
+    async fn reprioritize_by_queue_id_db_only_row_updates_priority() {
+        let pool = test_pool().await;
+        let (engine, _started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 3, 0)).await;
+
+        let queue_id = uuid::Uuid::now_v7();
+        repo::insert_queue_item(
+            &pool,
+            queue_id,
+            uuid::Uuid::now_v7().as_bytes().as_ref(),
+            uuid::Uuid::now_v7().as_bytes().as_ref(),
+            "magnet:?xt=urn:btih:dbonly",
+            "torrent",
+            1,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        svc.reprioritize_by_queue_id(queue_id, 3).await.unwrap();
+
+        let row = repo::get_queue_item(&pool, queue_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.priority, 3);
+    }
+
+    #[tokio::test]
+    async fn reprioritize_by_queue_id_unknown_id_errors() {
+        let pool = test_pool().await;
+        let (engine, _started_rx) = MockEngine::create();
+        let svc = make_service(pool, Arc::clone(&engine), test_config(2, 3, 0)).await;
+
+        let result = svc.reprioritize_by_queue_id(uuid::Uuid::now_v7(), 3).await;
+        assert!(matches!(result, Err(SyntaxisError::ItemNotFound { .. })));
     }
 }

--- a/crates/syntaxis/src/queue.rs
+++ b/crates/syntaxis/src/queue.rs
@@ -65,6 +65,18 @@ impl PriorityQueue {
         None
     }
 
+    /// Removes and returns the item with `id` FROM whichever tier holds it.
+    ///
+    /// Returns `None` if no queued item has that id.
+    pub(crate) fn remove(&mut self, id: Uuid) -> Option<QueueItem> {
+        for tier in [&mut self.tier3, &mut self.tier2, &mut self.tier1] {
+            if let Some(pos) = tier.iter().position(|item| item.id == id) {
+                return tier.remove(pos);
+            }
+        }
+        None
+    }
+
     /// Upgrades the item with `id` to priority 4 (interactive) and removes it
     /// FROM the queue, returning it to the caller for direct dispatch.
     ///
@@ -239,6 +251,28 @@ mod tests {
         assert_eq!(upgraded.priority, 4);
         assert!(!q.contains(id));
         assert_eq!(q.len(), 0);
+    }
+
+    #[test]
+    fn remove_takes_item_out_of_its_tier() {
+        let mut q = PriorityQueue::new();
+        let item = make_item(2);
+        let id = item.id;
+        q.insert(item);
+        q.insert(make_item(3));
+
+        let removed = q.remove(id).expect("queued item is removable");
+        assert_eq!(removed.id, id);
+        assert!(!q.contains(id));
+        assert_eq!(q.len(), 1);
+    }
+
+    #[test]
+    fn remove_nonexistent_returns_none() {
+        let mut q = PriorityQueue::new();
+        q.insert(make_item(1));
+        assert!(q.remove(Uuid::now_v7()).is_none());
+        assert_eq!(q.len(), 1);
     }
 
     #[test]

--- a/crates/syntaxis/src/repo.rs
+++ b/crates/syntaxis/src/repo.rs
@@ -105,12 +105,14 @@ pub(crate) async fn update_status(
     Ok(())
 }
 
+/// Updates the persisted priority, returning the number of affected rows so
+/// callers can distinguish a missing row from a successful update.
 pub(crate) async fn update_priority(
     pool: &SqlitePool,
     id: Uuid,
     priority: u8,
-) -> Result<(), DbError> {
-    sqlx::query("UPDATE download_queue SET priority = ? WHERE id = ?")
+) -> Result<u64, DbError> {
+    let result = sqlx::query("UPDATE download_queue SET priority = ? WHERE id = ?")
         .bind(i64::from(priority))
         .bind(id.as_bytes().as_slice())
         .execute(pool)
@@ -118,7 +120,20 @@ pub(crate) async fn update_priority(
         .context(QuerySnafu {
             table: "download_queue",
         })?;
-    Ok(())
+    Ok(result.rows_affected())
+}
+
+/// Deletes the row, returning the number of affected rows so callers can
+/// distinguish a missing row from a successful delete.
+pub(crate) async fn delete_queue_item(pool: &SqlitePool, id: Uuid) -> Result<u64, DbError> {
+    let result = sqlx::query("DELETE FROM download_queue WHERE id = ?")
+        .bind(id.as_bytes().as_slice())
+        .execute(pool)
+        .await
+        .context(QuerySnafu {
+            table: "download_queue",
+        })?;
+    Ok(result.rows_affected())
 }
 
 /// Returns all rows with any of the given statuses, ordered by priority DESC, added_at ASC.
@@ -492,6 +507,61 @@ mod tests {
         // First row should be the higher priority item
         assert_eq!(rows[0].priority, 3);
         assert_eq!(rows[1].priority, 1);
+    }
+
+    #[tokio::test]
+    async fn delete_queue_item_reports_affected_rows() {
+        let pool = setup().await;
+        let id = make_uuid();
+        insert_queue_item(
+            &pool,
+            id,
+            &make_id_bytes(),
+            &make_id_bytes(),
+            "magnet:?xt=urn:btih:del",
+            "torrent",
+            2,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(delete_queue_item(&pool, id).await.unwrap(), 1);
+        assert!(get_queue_item(&pool, id).await.unwrap().is_none());
+        assert_eq!(
+            delete_queue_item(&pool, id).await.unwrap(),
+            0,
+            "a second delete must report zero affected rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_priority_reports_affected_rows() {
+        let pool = setup().await;
+        let id = make_uuid();
+        insert_queue_item(
+            &pool,
+            id,
+            &make_id_bytes(),
+            &make_id_bytes(),
+            "magnet:?xt=urn:btih:prio",
+            "torrent",
+            1,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(update_priority(&pool, id, 3).await.unwrap(), 1);
+        let row = get_queue_item(&pool, id).await.unwrap().unwrap();
+        assert_eq!(row.priority, 3);
+        assert_eq!(
+            update_priority(&pool, make_uuid(), 3).await.unwrap(),
+            0,
+            "a missing row must report zero affected rows"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #388, #408, #409, #410, #411, #412, #468, #469, #470.

## Reliability (archon render + migrate)
- **#388** connect_and_run classifies inner task outcomes and propagates an inner error into the reconnect path; **#410** the pipeline push loop has a bounded timeout instead of blocking forever; **#411** renderer session cleanup is structural so no path leaks a registry entry; **#409** migrate continues past a WalkDir enumeration error; **#408** shared `archon::paths` resolves the `~` in the cert_dir default; **#412** `DownloadQueue::start` returns an awaited JoinHandle.

## Wiring the unwired traits (the implemented-but-unreachable surfaces)
- **#468** `DynMetadataResolver` → the real `ProviderBackedResolver`, with `POST /api/v1/metadata/{identify,enrich,fingerprint}` (fingerprint is admin-only — server-side path).
- **#469** `DownloadQueue` gains public `cancel`/`reprioritize` that reach the **live engine**, so an API cancel actually cancels the running download (was a no-op DB delete); the route handlers call the queue manager instead of raw SQL. **cancel/reprioritize are now `RequireAdmin`**, consistent with the admin-only `enqueue_download` (#373) — now that cancel is live, a member could otherwise stop an admin's download.
- **#470** `DynCurationService` → the real `DefaultCurationService`, with `/api/v1/curation` routes.

## Verification
`kanon gate --full` green (full workspace clippy + nextest 1600+ tests, kanon lint).

## Follow-up worth filing
`enqueue_download` still raw-INSERTs, so an API-enqueued item is invisible to the running `DownloadQueue` until restart recovery (same class as #469); cancel/reprioritize handle such DB-only rows explicitly so the API stays consistent, but wiring enqueue through the queue manager is a separate change.