### PR TITLE
chore(ci): dependency and format config conformance to kanon standard

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,24 +6,27 @@
 
 [advisories]
 ignore = [
-    # rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use
+    # rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use.
+    # review-by: 2026-10-01
     "RUSTSEC-2023-0071",
-    # backoff unmaintained — transitive dep via librqbit
+    # backoff unmaintained — transitive dep via librqbit.
+    # review-by: 2026-10-01
     "RUSTSEC-2025-0012",
-    # bincode unmaintained — transitive dep via librqbit-peer-protocol
+    # bincode unmaintained — transitive dep via librqbit-peer-protocol.
+    # review-by: 2026-10-01
     "RUSTSEC-2025-0141",
-    # crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper
+    # crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper.
+    # review-by: 2026-10-01
     "RUSTSEC-2025-0060",
-    # instant unmaintained — transitive dep via backoff/librqbit, no alternative
+    # instant unmaintained — transitive dep via backoff/librqbit, no alternative.
+    # review-by: 2026-10-01
     "RUSTSEC-2024-0384",
-    # paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis
+    # paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis.
+    # review-by: 2026-10-01
     "RUSTSEC-2024-0436",
-    # time RFC2822 stack exhaustion fix requires Rust 1.88; Harmonia CI is pinned to Rust 1.85 until MSRV policy changes
-    "RUSTSEC-2026-0009",
-    # audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available
+    # audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available.
+    # review-by: 2026-10-01
     "RUSTSEC-2026-0150",
-    # rand unsound with custom logger using `rand::rng()` — surfaces via sqlx/axum/quinn/reqwest; harmonia installs no custom logger that re-enters rand::rng(), so the unsound path is unreachable
-    "RUSTSEC-2026-0097",
     # quick-xml < 0.41 quadratic-attribute DoS. The direct indexer-XML parser (zetesis) is on 0.41; the remaining 0.37.5 is transitively pinned by feed-rs (RSS/podcast) and librqbit-upnp (LAN UPnP), neither of which yet targets 0.41. No safe upgrade until upstream bumps.
     # review-by: 2026-10-01
     "RUSTSEC-2026-0194",

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-# IDE
+# Build artifacts
+target/
+
+# IDE / editor
 .vs/
 .vscode/
 .idea/
@@ -6,19 +9,19 @@
 *.suo
 *.swp
 *.swo
+*.bak
 *~
 
 # OS
 .DS_Store
 Thumbs.db
 
-# GSD planning
-.planning/
-
 # Nix
 result
 result-*
 .direnv/
+
+# Agent-local
 .claude/
 
 # Secrets
@@ -30,40 +33,3 @@ result-*
 **/*.key
 **/*.pem
 **/api-key
-
-# Large/binary (don't track in git)
-*.pdf
-*.png
-*.jpg
-*.jpeg
-*.gif
-*.svg
-*.mp3
-*.mp4
-*.zip
-*.tar.gz
-
-# Cache/logs
-__pycache__/
-.venv/
-node_modules/
-
-# Syncthing
-.stfolder/
-.stignore
-.stversions/
-
-# Ephemeral state
-**/.task/
-**/.taskrc
-**/heartbeat-state.json
-*sync-conflict*
-
-# Financial data
-**/*relay*.csv
-**/*transaction*.csv
-
-# Backups
-*.bak
-*.pre-compile.bak
-target/

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -6,11 +6,11 @@
 #
 # Mirrors the hardcoded default Rust gate (fmt → check → clippy → nextest
 # → lint) but pins per-stage build + test concurrency to 8. Without this
-# cap, cargo defaults to num_cpus (64 on this Threadripper) and parallel
-# rustc + nextest processes peak well over 100GB of RSS — enough to OOM
-# menos when any other fleet work is running. 8 is the budget that keeps
-# a single CI run under ~25GB peak, low enough that serial drains don't
-# OOM even with aletheia.service and the dispatch fleet resident.
+# cap, cargo defaults to num_cpus (32 on verda, the forge CI box) and
+# parallel rustc + nextest processes spike RSS high enough to starve
+# concurrent gate and dispatch work. 8 keeps a single CI run's peak low
+# enough that gates coexist with the resident dispatch fleet on verda;
+# metis is the live-instance box and runs no builds at all.
 #
 # Keep in sync with `crates/archeion/src/ci_config.rs::default_rust_gate`
 # when the upstream default changes — only the `--jobs` / `--test-threads`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,3 +198,11 @@ regex           = "1"
 
 # ── Test ───────────────────────────────────────────────────────────────────────
 rstest          = "0.26"
+
+[profile.dev.package."*"]
+opt-level = 2    # WHY: optimize deps for faster runtime during development
+
+[profile.release]
+lto = "thin"         # WHY: link-time optimization for binary size + speed
+codegen-units = 1    # WHY: single codegen unit for maximum optimization
+strip = true         # WHY: strip debug symbols from release binary

--- a/crates/aitesis/Cargo.toml
+++ b/crates/aitesis/Cargo.toml
@@ -3,6 +3,7 @@ name = "aitesis"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Household media request management for Harmonia"
 
 [dependencies]

--- a/crates/akouo-android/Cargo.toml
+++ b/crates/akouo-android/Cargo.toml
@@ -4,6 +4,7 @@ name = "akouo-android"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Android UniFFI bindings for akouo-core playback"
 
 [lib]

--- a/crates/akouo-core/Cargo.toml
+++ b/crates/akouo-core/Cargo.toml
@@ -4,6 +4,7 @@ name = "akouo-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "High-fidelity audio engine — decode, DSP, and output"
 
 [features]

--- a/crates/apotheke/Cargo.toml
+++ b/crates/apotheke/Cargo.toml
@@ -3,6 +3,7 @@ name = "apotheke"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "SQLite database layer for Harmonia"
 
 [dependencies]

--- a/crates/archon/Cargo.toml
+++ b/crates/archon/Cargo.toml
@@ -3,6 +3,7 @@ name = "archon"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Binary entry point — assembles all subsystems"
 
 [[bin]]

--- a/crates/epignosis/Cargo.toml
+++ b/crates/epignosis/Cargo.toml
@@ -3,6 +3,7 @@ name = "epignosis"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Metadata — enrichment and resolution"
 
 [dependencies]

--- a/crates/ergasia/Cargo.toml
+++ b/crates/ergasia/Cargo.toml
@@ -3,6 +3,7 @@ name = "ergasia"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Download execution and archive extraction for Harmonia"
 
 [dependencies]

--- a/crates/exousia/Cargo.toml
+++ b/crates/exousia/Cargo.toml
@@ -3,6 +3,7 @@ name = "exousia"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Auth — JWT, API keys, user roles"
 
 [dependencies]

--- a/crates/harmonia-convert/Cargo.toml
+++ b/crates/harmonia-convert/Cargo.toml
@@ -3,6 +3,7 @@ name = "metousia"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Ebook format conversion — subprocess wrappers for calibre, kepubify, and pandoc"
 
 [dependencies]

--- a/crates/horismos/Cargo.toml
+++ b/crates/horismos/Cargo.toml
@@ -3,6 +3,7 @@ name = "horismos"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Configuration loading and validation for Harmonia"
 
 [dependencies]

--- a/crates/kathodos/Cargo.toml
+++ b/crates/kathodos/Cargo.toml
@@ -3,6 +3,7 @@ name = "kathodos"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Import and organize — file pipeline and library management"
 
 [dependencies]

--- a/crates/komide/Cargo.toml
+++ b/crates/komide/Cargo.toml
@@ -3,6 +3,7 @@ name = "komide"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 themelion       = { workspace = true }

--- a/crates/kritike/Cargo.toml
+++ b/crates/kritike/Cargo.toml
@@ -3,6 +3,7 @@ name = "kritike"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Curation — quality assessment and health reporting"
 
 [dependencies]

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -3,6 +3,7 @@ name = "paroche"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Paroche — Axum HTTP server, media streaming, and WebSocket events"
 
 [dependencies]

--- a/crates/prostheke/Cargo.toml
+++ b/crates/prostheke/Cargo.toml
@@ -3,6 +3,7 @@ name = "prostheke"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Subtitle management for Harmonia"
 
 [dependencies]

--- a/crates/syndesis/Cargo.toml
+++ b/crates/syndesis/Cargo.toml
@@ -4,6 +4,7 @@ description = "QUIC transport, TLS pairing, renderer authentication"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 themelion.workspace = true

--- a/crates/syndesmos/Cargo.toml
+++ b/crates/syndesmos/Cargo.toml
@@ -3,6 +3,7 @@ name = "syndesmos"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "External API integration for Harmonia — Plex, Last.fm, Tidal"
 
 [dependencies]

--- a/crates/syntaxis/Cargo.toml
+++ b/crates/syntaxis/Cargo.toml
@@ -3,6 +3,7 @@ name = "syntaxis"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Download queue orchestration and post-processing for Harmonia"
 
 [dependencies]

--- a/crates/themelion/Cargo.toml
+++ b/crates/themelion/Cargo.toml
@@ -3,6 +3,7 @@ name = "themelion"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Shared types, newtypes, and event definitions for Harmonia"
 
 [dependencies]

--- a/crates/zetesis/Cargo.toml
+++ b/crates/zetesis/Cargo.toml
@@ -3,6 +3,7 @@ name = "zetesis"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 description = "Indexer protocol and search routing for Harmonia"
 
 [dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -6,47 +6,42 @@ targets = []
 all-features = false
 
 [advisories]
-# WHY: expanded array-of-tables form. TOML 1.0 forbids newlines inside an
-# inline table (cargo-deny tolerates the multi-line form, strict parsers reject
-# it), and a long single-line inline table trips the TOML/inline-table-too-long
-# lint. [[advisories.ignore]] tables satisfy both. Keep the IDs in sync with
-# .cargo/audit.toml and osv-scanner.toml.
+# WHY: This table is the SINGLE SOURCE OF TRUTH for advisory ignores.
+# `.cargo/audit.toml` and `osv-scanner.toml` are derived artifacts; edit
+# this table only, then run `kanon audit derive-ignores --apply`.
+# See SUPPLY-CHAIN.md § Advisory suppression (kanon crates/basanos/standards).
+# NOTE: expanded array-of-tables form. TOML 1.0 forbids newlines inside an
+# inline table (cargo-deny tolerates the multi-line form, strict parsers
+# reject it), and a long single-line inline table trips the
+# TOML/inline-table-too-long lint. [[advisories.ignore]] tables satisfy both.
 
 [[advisories.ignore]]
 id = "RUSTSEC-2023-0071"
-reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use"
+reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use. review-by: 2026-10-01"
 
 [[advisories.ignore]]
 id = "RUSTSEC-2025-0012"
-reason = "backoff unmaintained — transitive dep via librqbit"
+reason = "backoff unmaintained — transitive dep via librqbit. review-by: 2026-10-01"
 
 [[advisories.ignore]]
 id = "RUSTSEC-2025-0141"
-reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol"
+reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol. review-by: 2026-10-01"
 
 [[advisories.ignore]]
 id = "RUSTSEC-2025-0060"
-reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper"
+reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper. review-by: 2026-10-01"
 
 [[advisories.ignore]]
 id = "RUSTSEC-2024-0384"
-reason = "instant unmaintained — transitive dep via backoff/librqbit, no alternative"
+reason = "instant unmaintained — transitive dep via backoff/librqbit, no alternative. review-by: 2026-10-01"
 
 [[advisories.ignore]]
 id = "RUSTSEC-2024-0436"
-reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis"
-
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0009"
-reason = "time RFC2822 stack exhaustion fix requires Rust 1.88; Harmonia CI is pinned to Rust 1.85 until MSRV policy changes"
+reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis. review-by: 2026-10-01"
 
 [[advisories.ignore]]
 id = "RUSTSEC-2026-0150"
-reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available"
-
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0097"
-reason = "rand unsound with custom logger using `rand::rng()` — surfaces via sqlx/axum/quinn/reqwest; harmonia installs no custom logger that re-enters rand::rng(), so the unsound path is unreachable"
+reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available. review-by: 2026-10-01"
 
 [[advisories.ignore]]
 id = "RUSTSEC-2026-0194"
@@ -83,7 +78,11 @@ confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "deny"
-wildcards = "allow"
+wildcards = "deny"
+# WHY: internal path-only deps (themelion, horismos, ...) carry no version
+# requirement, which cargo-deny counts as a wildcard. Path deps are exempted
+# so "deny" binds on registry deps, per REPO-SETUP.md.
+allow-wildcard-paths = true
 skip = [
     # bincode: librqbit-peer-protocol pins 1.x; librqbit itself uses 2.x
     { name = "bincode", version = "1" },
@@ -214,3 +213,8 @@ skip = [
     { name = "wit-bindgen", version = "0.51" },
     { name = "wit-bindgen", version = "0.57" },
 ]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -4,39 +4,31 @@
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2023-0071"
-reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use"
+reason = "rsa timing side-channel via jsonwebtoken/exousia — no safe upgrade, local-only use. review-by: 2026-10-01"
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2025-0012"
-reason = "backoff unmaintained — transitive dep via librqbit"
+reason = "backoff unmaintained — transitive dep via librqbit. review-by: 2026-10-01"
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2025-0141"
-reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol"
+reason = "bincode unmaintained — transitive dep via librqbit-peer-protocol. review-by: 2026-10-01"
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2025-0060"
-reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper"
+reason = "crypto-hash unmaintained — transitive dep via librqbit-sha1-wrapper. review-by: 2026-10-01"
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2024-0384"
-reason = "instant unmaintained — transitive dep via backoff/librqbit, no alternative"
+reason = "instant unmaintained — transitive dep via backoff/librqbit, no alternative. review-by: 2026-10-01"
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2024-0436"
-reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis"
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2026-0009"
-reason = "time RFC2822 stack exhaustion fix requires Rust 1.88; Harmonia CI is pinned to Rust 1.85 until MSRV policy changes"
+reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis. review-by: 2026-10-01"
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0150"
-reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available"
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2026-0097"
-reason = "rand unsound with custom logger using `rand::rng()` — surfaces via sqlx/axum/quinn/reqwest; harmonia installs no custom logger that re-enters rand::rng(), so the unsound path is unreachable"
+reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available. review-by: 2026-10-01"
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0194"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,1 @@
 edition = "2024"
-group_imports = "StdExternalCrate"
-imports_granularity = "Module"


### PR DESCRIPTION
Brings deny/lint/format config to the canonical kanon/basanos standard (part of a CI-canonical conformance pass; workflows are a separate PR).

- **deny.toml**: add `[sources]` (deny unknown-registry/git); `[bans] wildcards = deny` with `allow-wildcard-paths` + `publish = false` on the 20 internal crates (single-binary app — never published); advisory ignores now carry `review-by` dates + the single-source-of-truth header, with `.cargo/audit.toml`/`osv-scanner.toml` **derived** via `kanon audit derive-ignores`. Removed two dead ignores (RUSTSEC-2026-0009 `time` and -0097 `rand` are in patched ranges) and scrubbed the stale Rust-1.85 rationale (pin is 1.89).
- **rustfmt.toml**: reduce to `edition` only (the import options were unstable and silently ignored on stable).
- **Cargo.toml**: canonical dev/release build profiles.
- **.gitignore**: rebuilt from Rust defaults + secrets, dropping non-Rust cruft (incl. blanket `*.png`/`*.svg`/`*.pdf` bans that blocked `docs/media/`).
- **.kanon-ci.toml**: corrected stale host-narrative comments.

`kanon gate --full` green; all four `cargo deny` checks pass.