### PR TITLE
chore(ci): workflow conformance to kanon standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,19 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+# NOTE: no `toolchain:` inputs — setup-rust-toolchain reads rust-toolchain.toml,
+# keeping the repo's toolchain pin single-sourced.
 jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: "1.89"
           components: rustfmt
           cache: false
       - name: Check formatting
@@ -34,13 +36,13 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: "1.89"
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install system dependencies
@@ -53,13 +55,13 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: "1.89"
           components: clippy
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -70,40 +72,28 @@ jobs:
       - name: Lint workspace
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-  audit:
-    name: Audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          toolchain: stable
-          cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Install cargo-deny
-        run: cargo +stable install cargo-deny --locked --version 0.19.6
-      - name: Audit dependencies
-        run: |
-          # WHY: This is the cargo deny check; +stable bypasses the repo's Rust 1.85 toolchain pin for the audit tool itself.
-          cargo +stable deny check
-
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: "1.89"
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends libasound2-dev pkg-config
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        with:
+          tool: nextest
       - name: Test workspace
-        run: cargo test --workspace
+        run: cargo nextest run --workspace
+      - name: Test documentation examples
+        # WHY: nextest does not execute doctests; kathodos carries real ones.
+        run: cargo test --workspace --doc

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,6 +14,13 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    # WHY: `gh pr checks --watch --interval 30 --required` is structurally an
+    # infinite loop — it exits only when polled checks reach a terminal state.
+    # If required checks never terminate (runner outage, queue wedge) the job
+    # would hold this Actions slot until GitHub's 6h hosted ceiling forced it.
+    # 30 min covers a long honest verification cycle and fails clearly on an
+    # indefinite queue.
+    timeout-minutes: 30
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata
@@ -21,35 +28,69 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Wait for CI checks to pass
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
            steps.metadata.outputs.dependency-type == 'direct:development')
         run: |
+          set -euo pipefail
+
+          # WHY exit 1, not exit 0: a "skip" on failed or missing checks shows
+          # this job green while the verification it fronts is red — auto-merge
+          # must refuse loudly, never silently pass.
           if ! gh pr checks "$PR_URL" --watch --interval 30 --required; then
-            echo "Required CI checks did not pass — skipping auto-merge"
-            exit 0
+            echo "Required CI checks did not pass; refusing auto-merge." >&2
+            exit 1
           fi
 
-          checks="$(gh pr checks "$PR_URL" --json name,bucket)"
-          for check in Format Check Clippy Audit Test; do
-            if ! jq --exit-status --arg check "$check" \
-              'any(.[]; .name == $check and .bucket == "pass")' \
-              <<<"$checks" >/dev/null; then
-              echo "CI check did not pass: $check — skipping auto-merge"
-              exit 0
+          failed=0
+
+          require_passed_check() {
+            local label="$1"
+            local jq_filter="$2"
+            local bucket
+
+            bucket=$(gh pr checks "$PR_URL" --json name,bucket,workflow --jq "$jq_filter" | head -n 1)
+            if [ -z "$bucket" ]; then
+              echo "::error::Required verification check '${label}' was not reported."
+              failed=1
+              return
             fi
-          done
+
+            if [ "$bucket" != "pass" ]; then
+              echo "::error::Required verification check '${label}' finished in bucket '${bucket}'."
+              failed=1
+            fi
+          }
+
+          require_passed_check "Format" '.[] | select(.name == "Format") | .bucket'
+          require_passed_check "Check" '.[] | select(.name == "Check") | .bucket'
+          require_passed_check "Clippy" '.[] | select(.name == "Clippy") | .bucket'
+          require_passed_check "Test" '.[] | select(.name == "Test") | .bucket'
+          require_passed_check "gate-attestation" '.[] | select(.name == "gate-attestation") | .bucket'
+          require_passed_check "cargo deny" '.[] | select(.name == "cargo deny") | .bucket'
+          require_passed_check "cargo audit" '.[] | select(.name == "cargo audit") | .bucket'
+          require_passed_check "osv scanner" '.[] | select((.name | ascii_downcase | contains("osv")) or (.workflow == "Security" and (.name | ascii_downcase | contains("scan")))) | .bucket'
+
+          if [ "$failed" -ne 0 ]; then
+            echo "Real verification checks were missing or unsuccessful; refusing auto-merge." >&2
+            exit 1
+          fi
+
+          echo "Required real verification checks passed."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Auto-merge patch updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Auto-merge minor dev dependency updates
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-minor' &&

--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -15,20 +15,38 @@ jobs:
   gate-attestation:
     name: gate-attestation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Pass trusted automation PRs
-        if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'release-please[bot]' }}
-        run: echo "Gate attestation waived for trusted automation actor."
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'release-please[bot]' }}
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Verify Gate-Passed trailer
-        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'release-please[bot]' }}
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
+          # WHY author-gated, not actor-gated: github.actor changes to whoever
+          # re-runs the workflow, which silently re-arms the trailer check on
+          # bot PRs. The PR author is the stable identity worth waiving.
+          # WHY branch-shaped for release-please: its PRs are authored as
+          # github-actions[bot] under GITHUB_TOKEN, so an author match on
+          # release-please[bot] never fires — the branch pattern is stable.
+          # Release-PR content is generated version bumps; its verification is
+          # the live deny/audit/osv checks + the --locked release build.
+          case "$PR_HEAD_REF" in
+            release-please--branches--*)
+              echo "Release-please branch ($PR_HEAD_REF): gate attestation exempt."
+              exit 0
+              ;;
+          esac
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "Trusted bot PR author: $PR_AUTHOR"
+            echo "Gate attestation auto-passed for trusted bot PR."
+            exit 0
+          fi
+
           # WHY: Harmonia runs its full cargo and kanon gates locally before push.
           # GitHub Actions provides the app-pinned check-run required by branch protection.
           commits=$(git log --format="%H" "origin/${{ github.base_ref }}..HEAD")
@@ -51,5 +69,64 @@ jobs:
           if [ "$found" = false ]; then
             echo "ERROR: No Gate-Passed trailer found in any PR commit."
             echo "Run the local gate and commit with the trailer."
+            exit 1
+          fi
+
+      - name: Verify no AI attribution
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # WHY: the basanos WORKFLOW/no-ai-attribution gate is local-only; a
+          # GitHub squash-merge folds the PR body into main's history without
+          # running it. This step closes that CI-side hole.
+          # WHY branch-shaped for release-please: same rationale as the trailer
+          # check above — the author varies, the branch pattern does not.
+          case "$PR_HEAD_REF" in
+            release-please--branches--*)
+              echo "Release-please branch ($PR_HEAD_REF): AI attribution check exempt."
+              exit 0
+              ;;
+          esac
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "Trusted bot PR author: $PR_AUTHOR"
+            echo "AI attribution check auto-passed for trusted bot PR."
+            exit 0
+          fi
+
+          # WHY line-anchored: PR bodies may legitimately discuss the policy in
+          # prose (e.g. quoting "Co-authored-by: Claude …"). Only trailer-shaped
+          # lines and explicit generated-with/robot markers are enforcement targets.
+          pattern='^(co-authored-by:.*(claude|gpt|codex|kimi|gemini|anthropic)|🤖|generated with)'
+          violation=0
+
+          title_hits=$(printf '%s\n' "$PR_TITLE" | grep -inE "$pattern" || true)
+          if [ -n "$title_hits" ]; then
+            echo "ERROR: AI attribution marker found in PR title."
+            printf '%s\n' "$title_hits" | sed 's/^/  title: /'
+            violation=1
+          fi
+
+          # Guard null/empty PR body so the step does not crash; grep on an empty
+          # string simply returns no matches, but the explicit || true makes the
+          # intent obvious and protects against unexpected GitHub env quirks.
+          body_hits=$(printf '%s\n' "$PR_BODY" | grep -inE "$pattern" || true)
+          if [ -n "$body_hits" ]; then
+            echo "ERROR: AI attribution marker found in PR body."
+            printf '%s\n' "$body_hits" | sed 's/^/  body: /'
+            violation=1
+          fi
+
+          commit_hits=$(git log --format="%s%n%b" "origin/${{ github.base_ref }}..HEAD" | grep -inE "$pattern" || true)
+          if [ -n "$commit_hits" ]; then
+            echo "ERROR: AI attribution marker found in PR-range commits."
+            printf '%s\n' "$commit_hits" | sed 's/^/  commit: /'
+            violation=1
+          fi
+
+          if [ "$violation" -ne 0 ]; then
+            echo "Remove AI attribution markers (Co-authored-by AI, 🤖, 'generated with') from the PR title, body, and commits."
             exit 1
           fi

--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -1,0 +1,97 @@
+# WHY: .github/pii-patterns.txt defines the repo's PII shapes; without a
+# consuming workflow the pattern file is dead weight and the scan claim in the
+# repo docs is untrue. Mirrors aletheia's pii-scan.yml with the scanner logic
+# inlined — harmonia's patterns need neither PCRE2 lookaround nor Luhn
+# post-filtering, so the full scripts/scan-pii.sh port is unnecessary.
+name: PII Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends ripgrep
+      - name: Run PII scanner
+        run: |
+          set -euo pipefail
+
+          PATTERNS_FILE=".github/pii-patterns.txt"
+          if [ ! -s "${PATTERNS_FILE}" ]; then
+            echo "::error::Missing PII pattern source: ${PATTERNS_FILE}"
+            exit 2
+          fi
+
+          # WHY: vendored third-party assets legitimately contain strings that
+          # overlap the PII shapes (minified zip.js digit runs, pdf.js "Widget"
+          # annotation types); the scanner-adjacent config files quote the
+          # patterns themselves; CHANGELOG.md is release-please generated from
+          # already-public commit subjects.
+          ALLOWLIST=(
+            '^\.github/pii-patterns\.txt$'
+            '^\.gitleaks\.toml$'
+            '^CHANGELOG\.md$'
+            '^crates/paroche/assets/'
+          )
+
+          path_allowed() {
+            local path="$1" allow
+            for allow in "${ALLOWLIST[@]}"; do
+              if [[ "${path}" =~ ${allow} ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          findings=0
+          while IFS= read -r pattern; do
+            [[ -z "${pattern}" || "${pattern}" == \#* ]] && continue
+            # rg output format: path:line:content. .gitignore is honoured, so
+            # target/ and other ignored trees are skipped.
+            while IFS= read -r hit; do
+              [[ -z "${hit}" ]] && continue
+              path="${hit%%:*}"
+              path="${path#./}"
+              rest="${hit#*:}"
+              lineno="${rest%%:*}"
+              line_content="${rest#*:}"
+              if path_allowed "${path}"; then
+                continue
+              fi
+              # Per-line override: a trailing `pii-allow: <reason>` marker
+              # after any comment leader suppresses one match.
+              if [[ "${line_content}" == *"pii-allow:"* ]]; then
+                continue
+              fi
+              # WHY location-only output: echoing the matched text would copy
+              # the potential PII into public CI logs.
+              printf 'PII: %s:%s: pattern=%q\n' "${path}" "${lineno}" "${pattern}" >&2
+              findings=$((findings + 1))
+            done < <(rg --no-heading --line-number --color=never --with-filename \
+                --glob '!.git' -e "${pattern}" . 2>/dev/null || true)
+          done < "${PATTERNS_FILE}"
+
+          if (( findings > 0 )); then
+            printf 'pii-scan: %d unsuppressed finding(s)\n' "${findings}" >&2
+            exit 1
+          fi
+
+          echo "pii-scan: clean"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,13 +9,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# WHY id-token + attestations: required for repos that emit build attestations
+# downstream of the release tag — harmless when unused, required when needed;
+# included unconditionally per FLEET-REPO-SETUP §1.
 permissions:
+  attestations: write
   contents: write
+  id-token: write
   pull-requests: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -25,3 +31,47 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # WHY: SLSA provenance + signed SBOM for the release source archive at
+  # release-creation time, per SUPPLY-CHAIN.md § Required per release. Binary
+  # artifacts are attested separately in release.yml.
+  attest-release-source:
+    needs: [release-please]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Stage source archive
+        id: source
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          archive="harmonia-${TAG_NAME}.tar.gz"
+          git archive --format=tar.gz --output "$archive" HEAD
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          artifact-name: ${{ steps.source.outputs.archive }}.cdx.json
+          format: cyclonedx-json
+          output-file: ${{ steps.source.outputs.archive }}.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest source provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: ${{ steps.source.outputs.archive }}
+
+      - name: Attest CycloneDX SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: ${{ steps.source.outputs.archive }}
+          sbom-path: ${{ steps.source.outputs.archive }}.cdx.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,31 @@
+# WHY workflow_dispatch: release-please creates tags with GITHUB_TOKEN, whose
+# events cannot trigger workflows (GitHub recursion guard) — tag-push alone
+# has never fired this workflow (every release through v0.1.11 shipped zero
+# assets). Dispatch on the tag ref is the manual path; it also serves as the
+# re-run mechanism for any release.
 name: Release
 
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
+  attestations: write
   contents: write
   id-token: write
-  attestations: write
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -23,87 +33,136 @@ jobs:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libasound2-dev pkg-config
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --workspace --locked
 
   build:
     needs: [test]
     strategy:
       fail-fast: false
+      # WHY gnu-not-musl: RELEASES.md § Target matrix mandates
+      # x86_64-unknown-linux-musl, but the harmonia binary hard-wires
+      # akouo-core `native-output` (cpal -> alsa-sys), and ALSA has no
+      # supported static-link path — a musl leg cannot build without a custom
+      # cross image carrying musl-built alsa-lib or a release feature split.
+      # gnu legs build natively against distro ALSA on GitHub-hosted x86_64
+      # and arm64 runners; aarch64-apple-darwin uses CoreAudio via cpal.
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: harmonia-linux-amd64
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            artifact: harmonia-linux-arm64
-            cross: true
+            os: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            os: macos-14
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
           target: ${{ matrix.target }}
           cache: false
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}
-      - name: Install cross
-        if: matrix.cross
-        run: cargo install cross --locked
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libasound2-dev pkg-config
+
       - name: Install cargo-auditable
-        if: ${{ !matrix.cross }}
         run: cargo install cargo-auditable --locked --version 0.7.4
-      - name: Build (native)
-        if: ${{ !matrix.cross }}
-        run: cargo auditable build --release --target ${{ matrix.target }}
-      - name: Build (cross)
-        if: ${{ matrix.cross }}
-        run: cross auditable build --release --target ${{ matrix.target }}
-      - name: Rename binary
-        run: cp target/${{ matrix.target }}/release/harmonia ${{ matrix.artifact }}
-      - name: Generate checksum
-        run: sha256sum ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
-      - name: Generate SBOM
+
+      - name: Build
+        env:
+          BUILD_TARGET: ${{ matrix.target }}
+        run: cargo auditable build --locked --release --target "$BUILD_TARGET"
+
+      - name: Package tarball
+        id: artifact
+        env:
+          BUILD_TARGET: ${{ matrix.target }}
+          VERSION: ${{ steps.version.outputs.version }}
+        # WHY: RELEASES.md § Tarball structure — one tarball per target named
+        # harmonia-<version>-<target>.tar.gz, binary inside named plain
+        # `harmonia` (no version in the binary filename).
+        run: |
+          base="harmonia-${VERSION}-${BUILD_TARGET}"
+          rm -rf "${base}"
+          mkdir -p "${base}"
+          install -m 0755 "target/${BUILD_TARGET}/release/harmonia" "${base}/harmonia"
+          cp LICENSE NOTICE README.md CHANGELOG.md "${base}/"
+          tar czf "${base}.tar.gz" "${base}"
+          echo "base=${base}" >> "$GITHUB_OUTPUT"
+          echo "BASE=${base}" >> "$GITHUB_ENV"
+          echo "TARBALL=${base}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Generate checksum (Linux)
+        if: runner.os == 'Linux'
+        run: sha256sum "$TARBALL" > "$TARBALL.sha256"
+
+      - name: Generate checksum (macOS)
+        if: runner.os == 'macOS'
+        run: shasum -a 256 "$TARBALL" > "$TARBALL.sha256"
+
+      # WHY file-scoped: syft reads the cargo-auditable binary's embedded
+      # dependency manifest, so the SBOM describes the shipped artifact rather
+      # than the source tree.
+      - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          artifact-name: ${{ matrix.artifact }}.sbom.cdx.json
-          output-file: ${{ matrix.artifact }}.sbom.cdx.json
+          file: ${{ steps.artifact.outputs.base }}/harmonia
+          artifact-name: ${{ steps.artifact.outputs.base }}.cdx.json
+          output-file: ${{ steps.artifact.outputs.base }}.cdx.json
           format: cyclonedx-json
+          upload-artifact: false
+          upload-release-assets: false
+
       - name: Attest build provenance
         id: attest-provenance
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-path: ${{ matrix.artifact }}
+          subject-path: ${{ steps.artifact.outputs.base }}.tar.gz
+
       - name: Attest CycloneDX SBOM
         id: attest-cyclonedx-sbom
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
-          subject-path: ${{ matrix.artifact }}
-          sbom-path: ${{ matrix.artifact }}.sbom.cdx.json
-      - name: Upload attestation bundles
-        run: |
-          cp "${{ steps.attest-provenance.outputs.bundle-path }}" "${{ matrix.artifact }}.provenance.intoto.jsonl"
-          cp "${{ steps.attest-cyclonedx-sbom.outputs.bundle-path }}" "${{ matrix.artifact }}.cdx.intoto.jsonl"
-          gh release upload "${GITHUB_REF#refs/tags/}" \
-            "${{ matrix.artifact }}.provenance.intoto.jsonl" \
-            "${{ matrix.artifact }}.cdx.intoto.jsonl" \
-            --clobber
+          subject-path: ${{ steps.artifact.outputs.base }}.tar.gz
+          sbom-path: ${{ steps.artifact.outputs.base }}.cdx.json
+
+      # WHY: step outputs are passed through env vars, not interpolated into
+      # the run block, so the shell never embeds untrusted ${{ }} expansion
+      # (GitHub Actions expression-injection hardening).
+      - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload binary, checksum, and SBOM
+          PROVENANCE_BUNDLE: ${{ steps.attest-provenance.outputs.bundle-path }}
+          CDX_BUNDLE: ${{ steps.attest-cyclonedx-sbom.outputs.bundle-path }}
         run: |
+          cp "$PROVENANCE_BUNDLE" "$BASE.provenance.intoto.jsonl"
+          cp "$CDX_BUNDLE" "$BASE.cdx.intoto.jsonl"
           gh release upload "${GITHUB_REF#refs/tags/}" \
-            ${{ matrix.artifact }} \
-            ${{ matrix.artifact }}.sha256 \
-            ${{ matrix.artifact }}.sbom.cdx.json \
+            "$TARBALL" \
+            "$TARBALL.sha256" \
+            "$BASE.cdx.json" \
+            "$BASE.provenance.intoto.jsonl" \
+            "$BASE.cdx.intoto.jsonl" \
             --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,8 @@
-# WHY: Block merges on known vulnerabilities and license/source/ban
-# violations. Runs `cargo audit` (RustSec DB) and `cargo deny check`
-# (licenses, sources, bans, advisories) on every PR and daily against main
-# so newly-published CVEs against existing deps are caught even when no PR
-# is open. See standards/CI.md § Vulnerability scanning.
+# WHY: Block merges on known vulnerabilities, license/source/ban violations,
+# and leaked secrets. Runs `cargo audit` (RustSec DB), `cargo deny check`
+# (licenses, sources, bans, advisories), OSV-Scanner, and gitleaks on every PR
+# and daily against main so newly-published CVEs against existing deps are
+# caught even when no PR is open. See standards/CI.md § Vulnerability scanning.
 name: Security
 
 on:
@@ -88,3 +88,29 @@ jobs:
       scan-args: |
         --config=osv-scanner.toml
         --lockfile=Cargo.lock
+
+  gitleaks:
+    # WHY: .gitleaks.toml is tuned for this repo but previously had no
+    # consuming CI job, so the no-secrets policy was local-only and bypassable
+    # by a GitHub-side merge. Scans the working tree, not git history: history
+    # is not rewritable and predates the allowlist; new leaks land in the tree.
+    # WHY binary download, not gitleaks/gitleaks-action: the action requires a
+    # GITLEAKS_LICENSE key for organization repos; the CLI itself is MIT.
+    # Checksum-pinned so a compromised release asset cannot pass silently.
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install gitleaks 8.30.1
+        run: |
+          curl -fsSL --retry 3 \
+            "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz" \
+            -o /tmp/gitleaks.tar.gz
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  /tmp/gitleaks.tar.gz" | sha256sum --check
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          /tmp/gitleaks version | grep -qx '8.30.1'
+      - name: gitleaks scan
+        run: /tmp/gitleaks dir . --config .gitleaks.toml --no-banner --redact --exit-code 1

--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -502,3 +502,9 @@ RUST/primitive-for-domain-id:crates/paroche/src/state.rs
 RUST/primitive-for-domain-id:crates/apotheke/src/repo/registry.rs
 RUST/primitive-for-domain-id:crates/apotheke/src/repo/renderer.rs
 RUST/primitive-for-domain-id:crates/apotheke/src/repo/zone.rs
+
+# WHY: ci.yml deliberately omits the cargo-deny check — security.yml runs it
+# (and cargo-audit + osv-scanner) daily and per-PR. The CI/no-deny-check rule is
+# file-scoped and cannot see security.yml, so it false-fires; the dedup avoids
+# double CI spend (both jobs are required checks). Tracked: forkwright/kanon.
+CI/no-deny-check:.github/workflows/ci.yml

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,10 +8,10 @@
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},
     {"type": "perf", "section": "Performance"},
+    {"type": "refactor", "section": "Refactoring"},
+    {"type": "docs", "section": "Documentation"},
+    {"type": "test", "section": "Testing", "hidden": true},
     {"type": "chore", "section": "Maintenance", "hidden": true},
-    {"type": "docs", "hidden": true},
-    {"type": "test", "hidden": true},
-    {"type": "refactor", "hidden": true},
     {"type": "ci", "hidden": true},
     {"type": "style", "hidden": true}
   ],
@@ -23,6 +23,11 @@
           "type": "toml",
           "path": "Cargo.toml",
           "jsonpath": "$.workspace.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(!@.source)].version"
         }
       ]
     }


### PR DESCRIPTION
CI-canonical conformance pass for GitHub Actions (config is a separate PR: chore/ci-config-conformance).

## Changes (per gap, matched to kanon/aletheia exemplars)
- **gate-attestation**: gate the bot waiver on the PR author (`pull_request.user.login`), not `github.actor` (which flips to a maintainer on re-run and false-fails the required check); add the `release-please--branches--*` exemption (release PRs are authored `github-actions[bot]`); add a CI-side no-AI-attribution scan (the local basanos gate is bypassed by a squash-merge).
- **release-please**: `id-token`/`attestations` permissions + timeout; source-archive SLSA/SBOM attestation; show `refactor`/`docs` in the changelog.
- **dependabot-auto-merge**: 30m timeout; refuse (`exit 1`) on a failed/absent check instead of silently skipping; require gate-attestation + cargo deny/audit + osv.
- **security.yml**: gitleaks job (config already tuned); new **pii-scan.yml** consumes the previously-orphaned `pii-patterns.txt`.
- **ci.yml**: drop the redundant `Audit` job (security.yml runs cargo-deny — removes double CI spend, both are required checks); read the toolchain from `rust-toolchain.toml`; job timeouts; nextest + doctests.
- **release.yml**: `--locked` builds, release-please bumps `Cargo.lock`, RELEASES tarball contract, provenance/SBOM, and **`workflow_dispatch`**.

## Reviewer caveats (honest)
1. **The release workflow has never run** — release-please's `GITHUB_TOKEN` tags cannot trigger workflows, so `v0.1.11` shipped **zero assets**. `workflow_dispatch` is added so it can be validated on the existing tag. **release.yml is static-checked only** (yaml + `bash -n`); the runner legs (`ubuntu-24.04-arm`, macos-14), `libasound2-dev` sufficiency, and the attestation flow need a real `workflow_dispatch` run to confirm.
2. **No musl leg** — blocked by archon's ALSA hard-dependency (`akouo-core` `native-output` → cpal → alsa-sys, no static-link path). Ships gnu (x86 + native arm64) + macOS instead; a `WHY` comment records it. Making musl work needs a `native-output`-optional feature split or a custom cross image (repo-level decision).
3. **gate-attestation PR-author gating** changes required-check behavior for all PRs; validated with `bash -n` + yaml parse but not a live Actions run — the next PR after this merges exercises it (recoverable if it misbehaves).
4. `CI/no-deny-check` on ci.yml is a file-scoped kanon-lint false positive (it can't see security.yml's deny job); suppressed in `.kanon-lint-ignore` with a WHY.

## Validation
`kanon gate --full` green; yaml `safe_load` on all workflows; `bash -n` on all run blocks; pii-scan + gitleaks executed locally against the tree (clean + a firing negative test); auto-merge jq filters tested against a mock payload.