### PR TITLE
fix(media): low-severity audit batch findings (komide/epignosis/prostheke)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3903,6 +3903,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/epignosis/src/cache.rs
+++ b/crates/epignosis/src/cache.rs
@@ -37,7 +37,10 @@ where
         let entry = self.store.get(key)?;
         if entry.is_expired() {
             drop(entry);
-            self.store.remove(key);
+            // WHY: remove_if re-checks expiry under the shard lock — a plain
+            // remove(key) could evict a fresh entry inserted between the
+            // expiry check above and the removal.
+            self.store.remove_if(key, |_, v| v.is_expired());
             return None;
         }
         Some(entry.value.clone())
@@ -127,6 +130,35 @@ mod tests {
         cache.evict_expired();
         assert_eq!(cache.len(), 1);
         assert_eq!(cache.get(&"fresh".to_string()), Some("new".to_string()));
+    }
+
+    #[test]
+    fn expired_get_race_cannot_evict_fresh_insert() {
+        // WHY: probabilistic regression guard for the get()/insert() race —
+        // a get() observing a stale entry must never remove a fresh value
+        // inserted concurrently for the same key.
+        for _ in 0..100 {
+            let cache: Arc<MetadataCache<String, String>> =
+                Arc::new(MetadataCache::new(Duration::from_millis(1)));
+            cache.insert("key".to_string(), "stale".to_string());
+            let deadline = Instant::now() + Duration::from_millis(5);
+            while Instant::now() < deadline {
+                std::hint::spin_loop();
+            }
+
+            let racer = Arc::clone(&cache);
+            let getter = std::thread::spawn(move || {
+                let _ = racer.get(&"key".to_string());
+            });
+            cache.insert_permanent("key".to_string(), "fresh".to_string());
+            getter.join().expect("getter thread must not panic");
+
+            assert_eq!(
+                cache.get(&"key".to_string()),
+                Some("fresh".to_string()),
+                "a racing expired-entry eviction must not delete the fresh value"
+            );
+        }
     }
 
     #[test]

--- a/crates/epignosis/src/error.rs
+++ b/crates/epignosis/src/error.rs
@@ -24,6 +24,14 @@ pub enum EpignosisError {
         location: snafu::Location,
     },
 
+    #[snafu(display("response FROM {provider} exceeds the {limit}-byte cap"))]
+    ProviderResponseTooLarge {
+        provider: String,
+        limit: u64,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("request to {provider} timed out: {url}"))]
     ProviderTimeout {
         provider: String,

--- a/crates/epignosis/src/identity.rs
+++ b/crates/epignosis/src/identity.rs
@@ -78,6 +78,7 @@ pub struct FingerprintResult {
 /// - `"Album - 01 - Track.flac"` → album + track_number + title
 /// - `"Artist - Album - Title.flac"` → artist + album + title
 /// - `"01 - Track.flac"` → track_number + title
+/// - `"Artist - Title.flac"` → title (second segment) when the prefix is not numeric
 /// - `"Track.flac"` → title only
 pub fn parse_filename(path: &std::path::Path) -> ParsedFilename {
     let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
@@ -117,11 +118,14 @@ pub fn parse_filename(path: &std::path::Path) -> ParsedFilename {
                     title: title.trim().to_string(),
                 }
             } else {
+                // WHY: a non-numeric prefix in "A - B" is ambiguous between
+                // artist and album; keep only the title segment rather than
+                // discarding the split entirely.
                 ParsedFilename {
                     artist: None,
                     album: None,
                     track_number: None,
-                    title: stem.to_string(),
+                    title: title.trim().to_string(),
                 }
             }
         }
@@ -165,6 +169,15 @@ mod tests {
         assert_eq!(result.album, None);
         assert_eq!(result.track_number, Some(1));
         assert_eq!(result.title, "Track");
+    }
+
+    #[test]
+    fn parse_two_part_non_numeric_prefix_keeps_title_segment() {
+        let result = parse_filename(Path::new("Artist - Title.mp3"));
+        assert_eq!(result.artist, None);
+        assert_eq!(result.album, None);
+        assert_eq!(result.track_number, None);
+        assert_eq!(result.title, "Title", "must not fall back to the full stem");
     }
 
     #[test]

--- a/crates/epignosis/src/providers/acoustid.rs
+++ b/crates/epignosis/src/providers/acoustid.rs
@@ -12,6 +12,7 @@ pub struct AcoustIdProvider {
     client: reqwest::Client,
     api_key: String,
     base_url: String,
+    pub(crate) max_body_bytes: u64,
 }
 
 impl AcoustIdProvider {
@@ -28,6 +29,7 @@ impl AcoustIdProvider {
             client,
             api_key: api_key.into(),
             base_url,
+            max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
         }
     }
 
@@ -54,9 +56,7 @@ impl AcoustIdProvider {
                 provider: "acoustid",
             })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "acoustid",
-        })?;
+        let text = super::read_body_limited(response, "acoustid", self.max_body_bytes).await?;
 
         let parsed: AcoustIdResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "acoustid",
@@ -153,9 +153,7 @@ impl MetadataProvider for AcoustIdProvider {
                 provider: "acoustid",
             })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "acoustid",
-        })?;
+        let text = super::read_body_limited(response, "acoustid", self.max_body_bytes).await?;
 
         let parsed: AcoustIdResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "acoustid",

--- a/crates/epignosis/src/providers/audnexus.rs
+++ b/crates/epignosis/src/providers/audnexus.rs
@@ -9,11 +9,15 @@ const BASE_URL: &str = "https://api.audnex.us";
 
 pub struct AudnexusProvider {
     client: reqwest::Client,
+    pub(crate) max_body_bytes: u64,
 }
 
 impl AudnexusProvider {
     pub fn new(client: reqwest::Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
+        }
     }
 }
 
@@ -122,9 +126,7 @@ impl AudnexusProvider {
             return Ok(None);
         }
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "audnexus",
-        })?;
+        let text = super::read_body_limited(response, "audnexus", self.max_body_bytes).await?;
 
         let chapters: AudnexusChaptersResponse =
             serde_json::from_str(&text).context(ProviderParseSnafu {
@@ -153,9 +155,7 @@ impl MetadataProvider for AudnexusProvider {
                 provider: "audnexus",
             })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "audnexus",
-        })?;
+        let text = super::read_body_limited(response, "audnexus", self.max_body_bytes).await?;
 
         let parsed: AudnexusSearchResponse =
             serde_json::from_str(&text).context(ProviderParseSnafu {
@@ -199,9 +199,7 @@ impl MetadataProvider for AudnexusProvider {
                 provider: "audnexus",
             })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "audnexus",
-        })?;
+        let text = super::read_body_limited(response, "audnexus", self.max_body_bytes).await?;
 
         let book: AudnexusBook = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "audnexus",

--- a/crates/epignosis/src/providers/comicvine.rs
+++ b/crates/epignosis/src/providers/comicvine.rs
@@ -10,6 +10,7 @@ const BASE_URL: &str = "https://comicvine.gamespot.com/api";
 pub struct ComicVineProvider {
     client: reqwest::Client,
     api_key: String,
+    pub(crate) max_body_bytes: u64,
 }
 
 impl ComicVineProvider {
@@ -17,6 +18,7 @@ impl ComicVineProvider {
         Self {
             client,
             api_key: api_key.into(),
+            max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
         }
     }
 }
@@ -75,9 +77,7 @@ impl MetadataProvider for ComicVineProvider {
                 provider: "comicvine",
             })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "comicvine",
-        })?;
+        let text = super::read_body_limited(response, "comicvine", self.max_body_bytes).await?;
 
         let parsed: CvSearchResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "comicvine",
@@ -120,9 +120,7 @@ impl MetadataProvider for ComicVineProvider {
                 provider: "comicvine",
             })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "comicvine",
-        })?;
+        let text = super::read_body_limited(response, "comicvine", self.max_body_bytes).await?;
 
         let detail: CvVolumeDetail = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "comicvine",

--- a/crates/epignosis/src/providers/googlebooks.rs
+++ b/crates/epignosis/src/providers/googlebooks.rs
@@ -10,11 +10,16 @@ const BASE_URL: &str = "https://www.googleapis.com/books/v1";
 pub struct GoogleBooksProvider {
     client: reqwest::Client,
     api_key: Option<String>,
+    pub(crate) max_body_bytes: u64,
 }
 
 impl GoogleBooksProvider {
     pub fn new(client: reqwest::Client, api_key: Option<String>) -> Self {
-        Self { client, api_key }
+        Self {
+            client,
+            api_key,
+            max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
+        }
     }
 }
 
@@ -100,9 +105,7 @@ impl MetadataProvider for GoogleBooksProvider {
                     provider: "google_books",
                 })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "google_books",
-        })?;
+        let text = super::read_body_limited(response, "google_books", self.max_body_bytes).await?;
 
         let parsed: GbSearchResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "google_books",
@@ -187,9 +190,7 @@ impl MetadataProvider for GoogleBooksProvider {
                     provider: "google_books",
                 })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "google_books",
-        })?;
+        let text = super::read_body_limited(response, "google_books", self.max_body_bytes).await?;
 
         let volume: GbVolume = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "google_books",

--- a/crates/epignosis/src/providers/itunes.rs
+++ b/crates/epignosis/src/providers/itunes.rs
@@ -9,11 +9,15 @@ const BASE_URL: &str = "https://itunes.apple.com";
 
 pub struct ItunesProvider {
     client: reqwest::Client,
+    pub(crate) max_body_bytes: u64,
 }
 
 impl ItunesProvider {
     pub fn new(client: reqwest::Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
+        }
     }
 }
 
@@ -56,10 +60,7 @@ impl MetadataProvider for ItunesProvider {
             .await
             .context(ProviderRequestSnafu { provider: "itunes" })?;
 
-        let text = response
-            .text()
-            .await
-            .context(ProviderRequestSnafu { provider: "itunes" })?;
+        let text = super::read_body_limited(response, "itunes", self.max_body_bytes).await?;
 
         let parsed: ItunesSearchResponse =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "itunes" })?;
@@ -105,10 +106,7 @@ impl MetadataProvider for ItunesProvider {
             .await
             .context(ProviderRequestSnafu { provider: "itunes" })?;
 
-        let text = response
-            .text()
-            .await
-            .context(ProviderRequestSnafu { provider: "itunes" })?;
+        let text = super::read_body_limited(response, "itunes", self.max_body_bytes).await?;
 
         let parsed: ItunesSearchResponse =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "itunes" })?;

--- a/crates/epignosis/src/providers/mod.rs
+++ b/crates/epignosis/src/providers/mod.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, ensure};
 use themelion::MediaType;
 
-use crate::error::EpignosisError;
+use crate::error::{EpignosisError, ProviderRequestSnafu, ProviderResponseTooLargeSnafu};
 
 pub mod acoustid;
 pub mod audnexus;
@@ -14,6 +15,49 @@ pub mod tmdb;
 pub mod tvdb;
 
 pub use crate::identity::MetadataProviderId;
+
+/// Default cap on a buffered provider response body.
+///
+/// Overridden per resolver FROM `horismos::EpignosisConfig::provider_response_max_bytes`.
+pub(crate) const DEFAULT_MAX_BODY_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Read a response body up to `max_bytes`, failing with
+/// `ProviderResponseTooLarge` once the declared or accumulated size exceeds it.
+///
+/// WHY: `reqwest::Response::text()` buffers unbounded — a misbehaving provider
+/// response must not be able to exhaust memory.
+pub(crate) async fn read_body_limited(
+    mut response: reqwest::Response,
+    provider: &str,
+    max_bytes: u64,
+) -> Result<String, EpignosisError> {
+    if let Some(declared) = response.content_length() {
+        ensure!(
+            declared <= max_bytes,
+            ProviderResponseTooLargeSnafu {
+                provider,
+                limit: max_bytes,
+            }
+        );
+    }
+
+    let mut bytes: Vec<u8> = Vec::new();
+    while let Some(chunk) = response.chunk().await.context(ProviderRequestSnafu {
+        provider: provider.to_string(),
+    })? {
+        let total = (bytes.len() as u64).saturating_add(chunk.len() as u64);
+        ensure!(
+            total <= max_bytes,
+            ProviderResponseTooLargeSnafu {
+                provider,
+                limit: max_bytes,
+            }
+        );
+        bytes.extend_from_slice(&chunk);
+    }
+
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
 
 // WHY: pure data — query parameters for a metadata provider search.
 #[derive(Debug, Clone)]
@@ -55,4 +99,41 @@ pub trait MetadataProvider: Send + Sync {
     async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError>;
 
     async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::spawn_sequential_http;
+
+    #[tokio::test]
+    async fn read_body_limited_accepts_body_within_cap() {
+        let (base_url, handle) = spawn_sequential_http(vec![(200, "small body".to_string())]).await;
+        let response = reqwest::get(&base_url).await.unwrap();
+
+        let text = read_body_limited(response, "test", 1024).await.unwrap();
+
+        assert_eq!(text, "small body");
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn read_body_limited_rejects_oversized_body() {
+        let big = "x".repeat(2048);
+        let (base_url, handle) = spawn_sequential_http(vec![(200, big)]).await;
+        let response = reqwest::get(&base_url).await.unwrap();
+
+        let err = read_body_limited(response, "test", 1024).await.unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                EpignosisError::ProviderResponseTooLarge { limit: 1024, .. }
+            ),
+            "oversized body must abort before buffering: {err:?}"
+        );
+        // WHY: the server may see a reset mid-write once the client aborts;
+        // await it only to avoid a task leak, without asserting on its result.
+        handle.await.ok();
+    }
 }

--- a/crates/epignosis/src/providers/musicbrainz.rs
+++ b/crates/epignosis/src/providers/musicbrainz.rs
@@ -10,12 +10,60 @@ const USER_AGENT: &str = "Harmonia/0.1 (https://github.com/harmonia)";
 
 pub struct MusicBrainzProvider {
     client: reqwest::Client,
+    pub(crate) max_body_bytes: u64,
 }
 
 impl MusicBrainzProvider {
     pub fn new(client: reqwest::Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
+        }
     }
+}
+
+/// Escape Lucene query syntax characters in a user-supplied term.
+///
+/// WHY: title/artist come FROM user-controlled file tags; unescaped quotes or
+/// operators would alter the structure of the query sent to MusicBrainz.
+fn lucene_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(
+            c,
+            '+' | '-'
+                | '&'
+                | '|'
+                | '!'
+                | '('
+                | ')'
+                | '{'
+                | '}'
+                | '['
+                | ']'
+                | '^'
+                | '"'
+                | '~'
+                | '*'
+                | '?'
+                | ':'
+                | '\\'
+                | '/'
+        ) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Build the Lucene search expression for a recording query.
+fn build_lucene_query(query: &SearchQuery) -> String {
+    let mut lucene = format!("recording:\"{}\"", lucene_escape(&query.title));
+    if let Some(artist) = &query.artist {
+        lucene.push_str(&format!(" AND artist:\"{}\"", lucene_escape(artist)));
+    }
+    lucene
 }
 
 #[derive(Debug, Deserialize)]
@@ -60,10 +108,7 @@ impl MetadataProvider for MusicBrainzProvider {
 
     #[instrument(skip(self), fields(provider = "musicbrainz"))]
     async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
-        let mut lucene = format!("recording:\"{}\"", query.title);
-        if let Some(artist) = &query.artist {
-            lucene.push_str(&format!(" AND artist:\"{}\"", artist));
-        }
+        let lucene = build_lucene_query(query);
 
         let url = format!("{BASE_URL}/recording");
         let response = self
@@ -81,9 +126,7 @@ impl MetadataProvider for MusicBrainzProvider {
                 provider: "musicbrainz",
             })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "musicbrainz",
-        })?;
+        let text = super::read_body_limited(response, "musicbrainz", self.max_body_bytes).await?;
 
         let parsed: MbSearchResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "musicbrainz",
@@ -133,9 +176,7 @@ impl MetadataProvider for MusicBrainzProvider {
                 provider: "musicbrainz",
             })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "musicbrainz",
-        })?;
+        let text = super::read_body_limited(response, "musicbrainz", self.max_body_bytes).await?;
 
         let release: MbRelease = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "musicbrainz",
@@ -159,5 +200,57 @@ impl MetadataProvider for MusicBrainzProvider {
             year,
             extra: serde_json::Value::Null,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use themelion::MediaType;
+
+    use super::*;
+
+    fn query(title: &str, artist: Option<&str>) -> SearchQuery {
+        SearchQuery {
+            media_type: MediaType::Music,
+            title: title.to_string(),
+            artist: artist.map(str::to_owned),
+            year: None,
+            isbn: None,
+            extra: None,
+        }
+    }
+
+    #[test]
+    fn build_lucene_query_plain_terms_unchanged() {
+        let q = query("Song Title", Some("The Artist"));
+        assert_eq!(
+            build_lucene_query(&q),
+            "recording:\"Song Title\" AND artist:\"The Artist\""
+        );
+    }
+
+    #[test]
+    fn build_lucene_query_escapes_embedded_quotes() {
+        let q = query("foo\" OR *:*", None);
+        let lucene = build_lucene_query(&q);
+        assert_eq!(lucene, "recording:\"foo\\\" OR \\*\\:\\*\"");
+        assert!(
+            !lucene.contains("foo\" OR"),
+            "an unescaped quote must not break out of the recording clause"
+        );
+    }
+
+    #[test]
+    fn build_lucene_query_escapes_artist_operators() {
+        let q = query("Song", Some("a && b (c)"));
+        assert_eq!(
+            build_lucene_query(&q),
+            "recording:\"Song\" AND artist:\"a \\&\\& b \\(c\\)\""
+        );
+    }
+
+    #[test]
+    fn lucene_escape_passes_through_safe_text() {
+        assert_eq!(lucene_escape("plain text 123"), "plain text 123");
     }
 }

--- a/crates/epignosis/src/providers/openlibrary.rs
+++ b/crates/epignosis/src/providers/openlibrary.rs
@@ -10,11 +10,21 @@ const COVERS_URL: &str = "https://covers.openlibrary.org";
 
 pub struct OpenLibraryProvider {
     client: reqwest::Client,
+    base_url: String,
+    pub(crate) max_body_bytes: u64,
 }
 
 impl OpenLibraryProvider {
     pub fn new(client: reqwest::Client) -> Self {
-        Self { client }
+        Self::with_base_url(client, BASE_URL.to_string())
+    }
+
+    pub fn with_base_url(client: reqwest::Client, base_url: String) -> Self {
+        Self {
+            client,
+            base_url,
+            max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
+        }
     }
 
     /// Fetch an edition by ISBN, OCLC, LCCN, or OLID.
@@ -25,7 +35,7 @@ impl OpenLibraryProvider {
         &self,
         key_or_isbn: &str,
     ) -> Result<Option<OlEdition>, EpignosisError> {
-        let url = format!("{BASE_URL}/isbn/{key_or_isbn}.json");
+        let url = format!("{}/isbn/{key_or_isbn}.json", self.base_url);
         let response = self
             .client
             .get(&url)
@@ -39,9 +49,7 @@ impl OpenLibraryProvider {
             return Ok(None);
         }
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "openlibrary",
-        })?;
+        let text = super::read_body_limited(response, "openlibrary", self.max_body_bytes).await?;
 
         let edition: OlEdition = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "openlibrary",
@@ -50,9 +58,10 @@ impl OpenLibraryProvider {
         Ok(Some(edition))
     }
 
+    /// Fetch a work record; a 404 is a clean miss, mirroring `fetch_edition`.
     #[instrument(skip(self), fields(provider = "openlibrary"))]
-    async fn fetch_work(&self, work_key: &str) -> Result<OlWork, EpignosisError> {
-        let url = format!("{BASE_URL}{work_key}.json");
+    async fn fetch_work(&self, work_key: &str) -> Result<Option<OlWork>, EpignosisError> {
+        let url = format!("{}{work_key}.json", self.base_url);
         let response = self
             .client
             .get(&url)
@@ -62,15 +71,17 @@ impl OpenLibraryProvider {
                 provider: "openlibrary",
             })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "openlibrary",
-        })?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let text = super::read_body_limited(response, "openlibrary", self.max_body_bytes).await?;
 
         let work: OlWork = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "openlibrary",
         })?;
 
-        Ok(work)
+        Ok(Some(work))
     }
 
     /// Derive a cover URL from edition data, falling back to ISBN.
@@ -161,7 +172,7 @@ impl MetadataProvider for OpenLibraryProvider {
 
     #[instrument(skip(self), fields(provider = "openlibrary"))]
     async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
-        let url = format!("{BASE_URL}/search.json");
+        let url = format!("{}/search.json", self.base_url);
         let mut params = vec![
             ("title", query.title.as_str()),
             ("limit", "10"),
@@ -186,9 +197,7 @@ impl MetadataProvider for OpenLibraryProvider {
                     provider: "openlibrary",
                 })?;
 
-        let text = response.text().await.context(ProviderRequestSnafu {
-            provider: "openlibrary",
-        })?;
+        let text = super::read_body_limited(response, "openlibrary", self.max_body_bytes).await?;
 
         let parsed: OlSearchResponse = serde_json::from_str(&text).context(ProviderParseSnafu {
             provider: "openlibrary",
@@ -231,7 +240,7 @@ impl MetadataProvider for OpenLibraryProvider {
 
             let work = if let Some(ref ed) = edition {
                 if let Some(work_ref) = ed.works.as_deref().and_then(|w| w.first()) {
-                    self.fetch_work(&work_ref.key).await.ok()
+                    self.fetch_work(&work_ref.key).await.ok().flatten()
                 } else {
                     None
                 }
@@ -248,7 +257,7 @@ impl MetadataProvider for OpenLibraryProvider {
             // is best-effort.  In practice the work response is the primary source.
             let edition = None;
 
-            (Some(work), edition)
+            (work, edition)
         };
 
         let title = edition
@@ -333,6 +342,34 @@ impl MetadataProvider for OpenLibraryProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::spawn_sequential_http;
+
+    #[tokio::test]
+    async fn fetch_work_404_returns_none() {
+        let (base_url, handle) =
+            spawn_sequential_http(vec![(404, "{\"error\": \"notfound\"}".to_string())]).await;
+        let provider = OpenLibraryProvider::with_base_url(reqwest::Client::new(), base_url);
+
+        let work = provider.fetch_work("/works/OL0W").await.unwrap();
+
+        assert!(
+            work.is_none(),
+            "a 404 is a clean miss, not a parse error masquerading as one"
+        );
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fetch_work_200_returns_work() {
+        let body = r#"{"key": "/works/OL123W", "title": "Dune"}"#.to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, body)]).await;
+        let provider = OpenLibraryProvider::with_base_url(reqwest::Client::new(), base_url);
+
+        let work = provider.fetch_work("/works/OL123W").await.unwrap();
+
+        assert_eq!(work.unwrap().title, "Dune");
+        handle.await.unwrap();
+    }
 
     #[test]
     fn parse_search_doc_full() {

--- a/crates/epignosis/src/providers/tmdb.rs
+++ b/crates/epignosis/src/providers/tmdb.rs
@@ -9,8 +9,13 @@ const BASE_URL: &str = "https://api.themoviedb.org/3";
 
 pub struct TmdbProvider {
     client: reqwest::Client,
+    /// TMDB API Read Access Token (v4), sent as a Bearer header.
+    ///
+    /// WHY: a v3 `api_key` query parameter leaks the credential INTO server
+    /// and proxy access logs; header auth keeps it out of the URL.
     api_key: String,
     base_url: String,
+    pub(crate) max_body_bytes: u64,
 }
 
 impl TmdbProvider {
@@ -27,6 +32,7 @@ impl TmdbProvider {
             client,
             api_key: api_key.into(),
             base_url,
+            max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
         }
     }
 
@@ -43,18 +49,13 @@ impl TmdbProvider {
         let response = self
             .client
             .get(&url)
-            .query(&[
-                ("api_key", self.api_key.as_str()),
-                ("external_source", external_source),
-            ])
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .query(&[("external_source", external_source)])
             .send()
             .await
             .context(ProviderRequestSnafu { provider: "tmdb" })?;
 
-        let text = response
-            .text()
-            .await
-            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+        let text = super::read_body_limited(response, "tmdb", self.max_body_bytes).await?;
 
         let parsed: TmdbFindResponse =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tmdb" })?;
@@ -80,15 +81,12 @@ impl TmdbProvider {
         let response = self
             .client
             .get(&url)
-            .query(&[("api_key", self.api_key.as_str())])
+            .header("Authorization", format!("Bearer {}", self.api_key))
             .send()
             .await
             .context(ProviderRequestSnafu { provider: "tmdb" })?;
 
-        let text = response
-            .text()
-            .await
-            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+        let text = super::read_body_limited(response, "tmdb", self.max_body_bytes).await?;
 
         let series: TmdbTvDetail =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tmdb" })?;
@@ -183,19 +181,13 @@ impl MetadataProvider for TmdbProvider {
         let response = self
             .client
             .get(&url)
-            .query(&[
-                ("api_key", self.api_key.as_str()),
-                ("query", &query.title),
-                ("page", "1"),
-            ])
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .query(&[("query", query.title.as_str()), ("page", "1")])
             .send()
             .await
             .context(ProviderRequestSnafu { provider: "tmdb" })?;
 
-        let text = response
-            .text()
-            .await
-            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+        let text = super::read_body_limited(response, "tmdb", self.max_body_bytes).await?;
 
         let parsed: TmdbSearchResponse =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tmdb" })?;
@@ -234,15 +226,12 @@ impl MetadataProvider for TmdbProvider {
         let response = self
             .client
             .get(&url)
-            .query(&[("api_key", self.api_key.as_str())])
+            .header("Authorization", format!("Bearer {}", self.api_key))
             .send()
             .await
             .context(ProviderRequestSnafu { provider: "tmdb" })?;
 
-        let text = response
-            .text()
-            .await
-            .context(ProviderRequestSnafu { provider: "tmdb" })?;
+        let text = super::read_body_limited(response, "tmdb", self.max_body_bytes).await?;
 
         let movie: TmdbMovieDetail =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tmdb" })?;
@@ -360,6 +349,29 @@ mod tests {
         assert!(
             requests[0].starts_with("GET /tv/1396"),
             "TV detail must address the /tv namespace, not /movie"
+        );
+    }
+
+    #[tokio::test]
+    async fn requests_carry_bearer_auth_and_no_api_key_query_param() {
+        let body = serde_json::json!({ "movie_results": [], "tv_results": [] }).to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, body)]).await;
+        let provider =
+            TmdbProvider::with_base_url(reqwest::Client::new(), "secret-token", base_url);
+
+        provider
+            .find_by_external_id("81189", "tvdb_id")
+            .await
+            .unwrap();
+
+        let requests = handle.await.unwrap();
+        assert!(
+            requests[0].contains("authorization: Bearer secret-token"),
+            "the credential must travel in the Authorization header"
+        );
+        assert!(
+            !requests[0].contains("api_key"),
+            "the credential must not appear in the URL query string"
         );
     }
 }

--- a/crates/epignosis/src/providers/tvdb.rs
+++ b/crates/epignosis/src/providers/tvdb.rs
@@ -21,6 +21,7 @@ pub struct TvdbProvider {
     // NOTE: interior mutability — MetadataProvider methods take &self.
     // Holds the bearer token and the instant it stops being valid.
     token: RwLock<Option<(String, Instant)>>,
+    pub(crate) max_body_bytes: u64,
 }
 
 impl TvdbProvider {
@@ -38,6 +39,7 @@ impl TvdbProvider {
             api_key: api_key.into(),
             base_url,
             token: RwLock::new(None),
+            max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
         }
     }
 
@@ -70,10 +72,7 @@ impl TvdbProvider {
             .await
             .context(ProviderRequestSnafu { provider: "tvdb" })?;
 
-        let text = response
-            .text()
-            .await
-            .context(ProviderRequestSnafu { provider: "tvdb" })?;
+        let text = super::read_body_limited(response, "tvdb", self.max_body_bytes).await?;
 
         let parsed: TvdbLoginResponse =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tvdb" })?;
@@ -151,10 +150,7 @@ impl MetadataProvider for TvdbProvider {
             .await
             .context(ProviderRequestSnafu { provider: "tvdb" })?;
 
-        let text = response
-            .text()
-            .await
-            .context(ProviderRequestSnafu { provider: "tvdb" })?;
+        let text = super::read_body_limited(response, "tvdb", self.max_body_bytes).await?;
 
         let parsed: TvdbSearchResponse =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tvdb" })?;
@@ -194,10 +190,7 @@ impl MetadataProvider for TvdbProvider {
             .await
             .context(ProviderRequestSnafu { provider: "tvdb" })?;
 
-        let text = response
-            .text()
-            .await
-            .context(ProviderRequestSnafu { provider: "tvdb" })?;
+        let text = super::read_body_limited(response, "tvdb", self.max_body_bytes).await?;
 
         let detail: TvdbSeriesDetail =
             serde_json::from_str(&text).context(ProviderParseSnafu { provider: "tvdb" })?;

--- a/crates/epignosis/src/resolver.rs
+++ b/crates/epignosis/src/resolver.rs
@@ -29,6 +29,8 @@ use crate::rate_limit::ProviderQueues;
 #[derive(Debug, Clone, Default)]
 pub struct ProviderCredentials {
     pub acoustid_key: String,
+    /// TMDB API Read Access Token (v4); sent as an Authorization Bearer
+    /// header, never as a URL query parameter.
     pub tmdb_key: String,
     pub tvdb_key: String,
     pub comicvine_key: String,
@@ -68,15 +70,28 @@ impl ProviderBackedResolver {
         )));
         let queues = Arc::new(ProviderQueues::new());
 
-        let musicbrainz = MusicBrainzProvider::new(client.clone());
-        let acoustid = AcoustIdProvider::new(client.clone(), credentials.acoustid_key.clone());
-        let tmdb = TmdbProvider::new(client.clone(), credentials.tmdb_key.clone());
-        let tvdb = TvdbProvider::new(client.clone(), credentials.tvdb_key.clone());
-        let audnexus = AudnexusProvider::new(client.clone());
-        let openlibrary = OpenLibraryProvider::new(client.clone());
-        let google_books = GoogleBooksProvider::new(client.clone(), credentials.google_books_key);
-        let itunes = ItunesProvider::new(client.clone());
-        let comicvine = ComicVineProvider::new(client.clone(), credentials.comicvine_key.clone());
+        let mut musicbrainz = MusicBrainzProvider::new(client.clone());
+        let mut acoustid = AcoustIdProvider::new(client.clone(), credentials.acoustid_key.clone());
+        let mut tmdb = TmdbProvider::new(client.clone(), credentials.tmdb_key.clone());
+        let mut tvdb = TvdbProvider::new(client.clone(), credentials.tvdb_key.clone());
+        let mut audnexus = AudnexusProvider::new(client.clone());
+        let mut openlibrary = OpenLibraryProvider::new(client.clone());
+        let mut google_books =
+            GoogleBooksProvider::new(client.clone(), credentials.google_books_key);
+        let mut itunes = ItunesProvider::new(client.clone());
+        let mut comicvine =
+            ComicVineProvider::new(client.clone(), credentials.comicvine_key.clone());
+
+        let body_cap = config.provider_response_max_bytes;
+        musicbrainz.max_body_bytes = body_cap;
+        acoustid.max_body_bytes = body_cap;
+        tmdb.max_body_bytes = body_cap;
+        tvdb.max_body_bytes = body_cap;
+        audnexus.max_body_bytes = body_cap;
+        openlibrary.max_body_bytes = body_cap;
+        google_books.max_body_bytes = body_cap;
+        itunes.max_body_bytes = body_cap;
+        comicvine.max_body_bytes = body_cap;
 
         Self {
             client,
@@ -165,8 +180,12 @@ impl ProviderBackedResolver {
         // title+author+year
         let title_match =
             !query.title.is_empty() && result.title.to_lowercase() == query.title.to_lowercase();
-        let author_match = result.artist.as_ref().map(|a| a.to_lowercase())
-            == query.artist.as_ref().map(|a| a.to_lowercase());
+        // WHY: both-None must not count as an author match — an
+        // author-unknown result would otherwise claim the author-match tier.
+        let author_match = matches!(
+            (result.artist.as_deref(), query.artist.as_deref()),
+            (Some(a), Some(b)) if a.eq_ignore_ascii_case(b)
+        );
         let year_match = result.year == query.year;
 
         if title_match && author_match && year_match {
@@ -307,11 +326,22 @@ impl MetadataResolver for ProviderBackedResolver {
             }),
         };
 
-        if let Ok(data) = primary_result {
-            enrichments.push(ProviderEnrichment {
-                provider: identity.provider.clone(),
-                data,
-            });
+        match primary_result {
+            Ok(data) => {
+                enrichments.push(ProviderEnrichment {
+                    provider: identity.provider.clone(),
+                    data,
+                });
+            }
+            // WHY: the failure is downgraded to a partial-success return
+            // here, so this is the handled site — log it before dropping it.
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    provider = %identity.provider,
+                    "canonical enrichment failed"
+                );
+            }
         }
 
         let secondary_result = tokio::select! {
@@ -916,6 +946,227 @@ mod tests {
         assert!(
             (ProviderBackedResolver::score_book_result(&result, &query) - 0.2).abs() < f64::EPSILON
         );
+    }
+
+    #[test]
+    fn book_score_no_query_artist_does_not_inflate() {
+        let query = SearchQuery {
+            media_type: MediaType::Book,
+            title: "Dune".to_string(),
+            artist: None,
+            year: Some(1965),
+            isbn: None,
+            extra: None,
+        };
+
+        let result = ProviderResult {
+            provider_id: MetadataProviderId("/works/OL123W".to_string()),
+            title: "Dune".to_string(),
+            artist: None,
+            year: Some(1965),
+            score: 1.0,
+            raw: serde_json::json!({}),
+        };
+
+        assert!(
+            (ProviderBackedResolver::score_book_result(&result, &query) - 0.4).abs() < f64::EPSILON,
+            "None == None must not claim the title+author+year tier"
+        );
+    }
+
+    fn music_item(tags: Option<crate::identity::EmbeddedTags>) -> UnidentifiedItem {
+        UnidentifiedItem {
+            media_id: MediaId::new(),
+            media_type: MediaType::Music,
+            file_path: std::path::PathBuf::from("/library/track.flac"),
+            filename_hint: Some("Fallback Title".to_string()),
+            tags,
+        }
+    }
+
+    #[test]
+    fn build_query_prefers_tags_over_filename() {
+        let item = music_item(Some(crate::identity::EmbeddedTags {
+            title: Some("Tag Title".to_string()),
+            artist: Some("Tag Artist".to_string()),
+            year: Some(1999),
+            ..Default::default()
+        }));
+
+        let query = ProviderBackedResolver::build_query(&item);
+
+        assert_eq!(query.title, "Tag Title");
+        assert_eq!(query.artist.as_deref(), Some("Tag Artist"));
+        assert_eq!(query.year, Some(1999));
+    }
+
+    #[test]
+    fn build_query_falls_back_to_filename_hint() {
+        let item = music_item(Some(crate::identity::EmbeddedTags {
+            title: None,
+            ..Default::default()
+        }));
+
+        let query = ProviderBackedResolver::build_query(&item);
+
+        assert_eq!(query.title, "Fallback Title");
+    }
+
+    #[test]
+    fn build_query_prefers_album_artist_when_artist_missing() {
+        let item = music_item(Some(crate::identity::EmbeddedTags {
+            title: Some("Tag Title".to_string()),
+            artist: None,
+            album_artist: Some("Album Artist".to_string()),
+            ..Default::default()
+        }));
+
+        let query = ProviderBackedResolver::build_query(&item);
+
+        assert_eq!(query.artist.as_deref(), Some("Album Artist"));
+    }
+
+    #[test]
+    fn build_query_no_tags_uses_filename_only() {
+        let item = music_item(None);
+
+        let query = ProviderBackedResolver::build_query(&item);
+
+        assert_eq!(query.title, "Fallback Title");
+        assert_eq!(query.artist, None);
+        assert_eq!(query.year, None);
+        assert_eq!(query.isbn, None);
+    }
+
+    fn movie_item(title: &str) -> UnidentifiedItem {
+        UnidentifiedItem {
+            media_id: MediaId::new(),
+            media_type: MediaType::Movie,
+            file_path: std::path::PathBuf::from("/library/movie.mkv"),
+            filename_hint: Some(title.to_string()),
+            tags: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_identity_picks_best_result_and_caches_it() {
+        let search_body = serde_json::json!({
+            "results": [
+                { "id": 27205, "title": "Inception", "release_date": "2010-07-16", "popularity": 900.0 },
+                { "id": 999, "title": "Inception Parody", "release_date": "2012-01-01", "popularity": 10.0 },
+            ],
+        })
+        .to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, search_body)]).await;
+
+        let mut resolver = test_resolver();
+        resolver.tmdb = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+        let item = movie_item("Inception");
+        let ct = tokio_util::sync::CancellationToken::new();
+
+        let identity = resolver.resolve_identity(&item, ct.clone()).await.unwrap();
+
+        assert_eq!(identity.provider, "tmdb");
+        assert_eq!(identity.provider_id.0, "27205");
+        assert_eq!(identity.canonical_title, "Inception");
+        assert_eq!(identity.year, Some(2010));
+
+        // WHY: the scripted server answers exactly one request — a second
+        // resolve must come FROM the cache, not the network.
+        let cached = resolver.resolve_identity(&item, ct).await.unwrap();
+        assert_eq!(cached.provider_id.0, "27205");
+
+        let requests = handle.await.unwrap();
+        assert_eq!(requests.len(), 1, "second resolve must not hit the network");
+    }
+
+    #[tokio::test]
+    async fn resolve_identity_no_results_is_identity_not_resolved() {
+        let search_body = serde_json::json!({ "results": [] }).to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, search_body)]).await;
+
+        let mut resolver = test_resolver();
+        resolver.tmdb = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        let err = resolver
+            .resolve_identity(
+                &movie_item("Nonexistent"),
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, EpignosisError::IdentityNotResolved { .. }),
+            "empty provider results must surface as IdentityNotResolved: {err:?}"
+        );
+        handle.await.unwrap();
+    }
+
+    fn movie_identity(tmdb_id: &str) -> MediaIdentity {
+        MediaIdentity {
+            media_id: MediaId::new(),
+            media_type: MediaType::Movie,
+            provider: "tmdb".to_string(),
+            provider_id: MetadataProviderId(tmdb_id.to_string()),
+            canonical_title: "Inception".to_string(),
+            canonical_artist: None,
+            year: Some(2010),
+            extra: serde_json::Value::Null,
+        }
+    }
+
+    #[tokio::test]
+    async fn enrich_movie_attaches_canonical_metadata() {
+        let detail_body = serde_json::json!({
+            "id": 27205,
+            "title": "Inception",
+            "release_date": "2010-07-16",
+            "overview": "Dream heist.",
+            "runtime": 148,
+            "genres": [{ "name": "Sci-Fi" }],
+        })
+        .to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, detail_body)]).await;
+
+        let mut resolver = test_resolver();
+        resolver.tmdb = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        let enriched = resolver
+            .enrich(
+                &movie_identity("27205"),
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(enriched.enrichments.len(), 1);
+        assert_eq!(enriched.enrichments[0].provider, "tmdb");
+        assert_eq!(enriched.enrichments[0].data["overview"], "Dream heist.");
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn enrich_primary_failure_returns_partial_success() {
+        let (base_url, handle) = spawn_sequential_http(vec![(500, "not json".to_string())]).await;
+
+        let mut resolver = test_resolver();
+        resolver.tmdb = TmdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+
+        let enriched = resolver
+            .enrich(
+                &movie_identity("27205"),
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            enriched.enrichments.is_empty(),
+            "a failed canonical enrichment is dropped, not propagated"
+        );
+        assert_eq!(enriched.identity.provider_id.0, "27205");
+        handle.await.unwrap();
     }
 
     #[test]

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -170,6 +170,13 @@ pub struct EpignosisConfig {
     /// Minimum AcoustID confidence score to consider a fingerprint match
     /// at all.
     pub fingerprint_ambiguous_threshold: f64,
+    /// Maximum bytes buffered FROM a single metadata-provider response.
+    #[serde(default = "default_provider_response_max_bytes")]
+    pub provider_response_max_bytes: u64,
+}
+
+fn default_provider_response_max_bytes() -> u64 {
+    10 * 1024 * 1024
 }
 
 impl Default for EpignosisConfig {
@@ -180,6 +187,7 @@ impl Default for EpignosisConfig {
             provider_timeout_secs: 10,
             fingerprint_accept_threshold: 0.8,
             fingerprint_ambiguous_threshold: 0.5,
+            provider_response_max_bytes: default_provider_response_max_bytes(),
         }
     }
 }
@@ -339,7 +347,15 @@ pub struct OpenSubtitlesConfig {
     pub password: Option<String>,
     /// Maximum API requests per second.
     pub rate_limit_per_second: u32,
+    /// Maximum bytes buffered FROM a single subtitle download.
+    #[serde(default = "default_max_download_bytes")]
+    pub max_download_bytes: u64,
 }
+
+fn default_max_download_bytes() -> u64 {
+    10 * 1024 * 1024
+}
+
 impl std::fmt::Debug for OpenSubtitlesConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpenSubtitlesConfig")
@@ -347,6 +363,7 @@ impl std::fmt::Debug for OpenSubtitlesConfig {
             .field("username", &self.username)
             .field("password", &"[redacted]")
             .field("rate_limit_per_second", &self.rate_limit_per_second)
+            .field("max_download_bytes", &self.max_download_bytes)
             .finish()
     }
 }
@@ -358,6 +375,7 @@ impl Default for OpenSubtitlesConfig {
             username: None,
             password: None,
             rate_limit_per_second: 5,
+            max_download_bytes: default_max_download_bytes(),
         }
     }
 }

--- a/crates/komide/src/error.rs
+++ b/crates/komide/src/error.rs
@@ -65,6 +65,13 @@ pub enum KomideError {
         location: snafu::Location,
     },
 
+    #[snafu(display("corrupt feed id bytes in database row: {source}"))]
+    CorruptFeedId {
+        source: uuid::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("database error: {source}"))]
     Database {
         source: DbError,

--- a/crates/komide/src/scheduler.rs
+++ b/crates/komide/src/scheduler.rs
@@ -6,7 +6,9 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{Instrument, debug, error, info, instrument};
 
-use crate::error::KomideError;
+use snafu::ResultExt;
+
+use crate::error::{DatabaseSnafu, KomideError};
 use crate::service::FeedSchedulerService;
 
 /// Per-feed polling state tracked by the scheduler.
@@ -75,10 +77,13 @@ pub struct FeedScheduler {
     handles: Vec<JoinHandle<()>>,
 }
 
+/// Rows fetched per repository page while enumerating feeds at startup.
+const FEED_PAGE_SIZE: i64 = 1000;
+
 impl FeedScheduler {
     /// Start scheduler tasks for all active podcast and news feeds.
     ///
-    /// Loads feeds FROM the database, then spawns a tokio task per feed that
+    /// Pages through the database, then spawns a tokio task per feed that
     /// polls on the configured interval (with jitter and backoff).
     #[instrument(skip_all)]
     pub async fn start(
@@ -88,54 +93,69 @@ impl FeedScheduler {
     ) -> Result<Self, KomideError> {
         let mut handles = Vec::new();
 
-        let podcast_subs = apotheke::repo::podcast::list_subscriptions(&db.read, 1000, 0)
-            .await
-            .map_err(|source| KomideError::Database {
-                source,
-                location: snafu::location!(),
-            })?;
+        // WHY: page until a short page — a single LIMIT-1000 fetch silently
+        // dropped every feed past the first 1000 FROM the poll schedule.
+        let mut offset = 0i64;
+        loop {
+            let page =
+                apotheke::repo::podcast::list_subscriptions(&db.read, FEED_PAGE_SIZE, offset)
+                    .await
+                    .context(DatabaseSnafu)?;
+            let page_len = page.len();
 
-        for sub in podcast_subs {
-            if sub.auto_download == 0 {
-                continue;
-            }
-            let interval = config.podcast_poll_interval_minutes;
-            let state = FeedState::new(interval, &config);
-            let svc = service.clone();
-            let feed_id_uuid = uuid::Uuid::from_slice(&sub.id).ok();
-
-            let handle = tokio::spawn(
-                async move {
-                    poll_feed_loop(svc, state, feed_id_uuid).await;
+            for sub in page {
+                if sub.auto_download == 0 {
+                    continue;
                 }
-                .instrument(tracing::info_span!("poll_feed", feed_id = ?feed_id_uuid)),
-            );
-            handles.push(handle);
+                let interval = config.podcast_poll_interval_minutes;
+                let state = FeedState::new(interval, &config);
+                let svc = service.clone();
+                let feed_id_uuid = uuid::Uuid::from_slice(&sub.id).ok();
+
+                let handle = tokio::spawn(
+                    async move {
+                        poll_feed_loop(svc, state, feed_id_uuid).await;
+                    }
+                    .instrument(tracing::info_span!("poll_feed", feed_id = ?feed_id_uuid)),
+                );
+                handles.push(handle);
+            }
+
+            if page_len < FEED_PAGE_SIZE as usize {
+                break;
+            }
+            offset += FEED_PAGE_SIZE;
         }
 
-        let news_feeds = apotheke::repo::news::list_feeds(&db.read, 1000, 0)
-            .await
-            .map_err(|source| KomideError::Database {
-                source,
-                location: snafu::location!(),
-            })?;
+        let mut offset = 0i64;
+        loop {
+            let page = apotheke::repo::news::list_feeds(&db.read, FEED_PAGE_SIZE, offset)
+                .await
+                .context(DatabaseSnafu)?;
+            let page_len = page.len();
 
-        for feed in news_feeds {
-            if feed.is_active == 0 {
-                continue;
-            }
-            let interval = u64::try_from(feed.fetch_interval_minutes).unwrap_or_default(); // WHY: fetch_interval_minutes is a DB i64 bounded by config; conversion cannot overflow u64
-            let state = FeedState::new(interval, &config);
-            let svc = service.clone();
-            let feed_id_uuid = uuid::Uuid::from_slice(&feed.id).ok();
-
-            let handle = tokio::spawn(
-                async move {
-                    poll_feed_loop(svc, state, feed_id_uuid).await;
+            for feed in page {
+                if feed.is_active == 0 {
+                    continue;
                 }
-                .instrument(tracing::info_span!("poll_feed", feed_id = ?feed_id_uuid)),
-            );
-            handles.push(handle);
+                let interval = u64::try_from(feed.fetch_interval_minutes).unwrap_or_default(); // WHY: fetch_interval_minutes is a DB i64 bounded by config; conversion cannot overflow u64
+                let state = FeedState::new(interval, &config);
+                let svc = service.clone();
+                let feed_id_uuid = uuid::Uuid::from_slice(&feed.id).ok();
+
+                let handle = tokio::spawn(
+                    async move {
+                        poll_feed_loop(svc, state, feed_id_uuid).await;
+                    }
+                    .instrument(tracing::info_span!("poll_feed", feed_id = ?feed_id_uuid)),
+                );
+                handles.push(handle);
+            }
+
+            if page_len < FEED_PAGE_SIZE as usize {
+                break;
+            }
+            offset += FEED_PAGE_SIZE;
         }
 
         info!(feeds = handles.len(), "feed scheduler started");
@@ -143,10 +163,22 @@ impl FeedScheduler {
     }
 
     /// Abort all scheduled polling tasks.
-    pub fn shutdown(self) {
-        for handle in self.handles {
+    pub fn shutdown(mut self) {
+        self.abort_all();
+    }
+
+    fn abort_all(&mut self) {
+        for handle in self.handles.drain(..) {
             handle.abort();
         }
+    }
+}
+
+// WHY: JoinHandle::drop detaches; without this, any exit path that skips
+// shutdown() (early return, error, panic) leaks poll loops running forever.
+impl Drop for FeedScheduler {
+    fn drop(&mut self) {
+        self.abort_all();
     }
 }
 
@@ -301,6 +333,82 @@ mod tests {
             seen_durations.len() > 1,
             "jitter should vary across samples"
         );
+    }
+
+    #[tokio::test]
+    async fn drop_aborts_spawned_tasks() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            let _tx = tx;
+            std::future::pending::<()>().await;
+        });
+        let scheduler = FeedScheduler {
+            handles: vec![handle],
+        };
+
+        drop(scheduler);
+
+        // WHY: abort drops the task's future, which drops tx and closes the
+        // channel; without the Drop impl the task pends forever and this times out.
+        let result = tokio::time::timeout(Duration::from_secs(5), rx).await;
+        assert!(
+            matches!(result, Ok(Err(_))),
+            "dropping FeedScheduler must abort its tasks"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_schedules_feeds_beyond_one_page() {
+        use apotheke::migrate::MIGRATOR;
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let db = DbPools {
+            read: pool.clone(),
+            write: pool.clone(),
+        };
+        let service_db = DbPools {
+            read: pool.clone(),
+            write: pool,
+        };
+
+        let total = usize::try_from(FEED_PAGE_SIZE).unwrap() + 500;
+        for i in 0..total {
+            let sub = apotheke::repo::podcast::PodcastSubscription {
+                id: uuid::Uuid::new_v4().as_bytes().to_vec(),
+                feed_url: format!("https://example.com/feed-{i}.xml"),
+                title: Some(format!("Feed {i}")),
+                description: None,
+                author: None,
+                image_url: None,
+                language: None,
+                last_checked_at: None,
+                auto_download: 1,
+                quality_profile_id: None,
+                added_at: "2024-01-01T00:00:00Z".to_string(),
+            };
+            apotheke::repo::podcast::insert_subscription(&db.write, &sub)
+                .await
+                .unwrap();
+        }
+
+        let (tx, _rx) = themelion::aggelia::create_event_bus(64);
+        let service = std::sync::Arc::new(FeedSchedulerService::new(
+            service_db,
+            tx,
+            reqwest::Client::new(),
+            test_config(),
+        ));
+
+        let scheduler = FeedScheduler::start(service, test_config(), db)
+            .await
+            .unwrap();
+        assert_eq!(
+            scheduler.handles.len(),
+            total,
+            "all feeds past the first page must be scheduled"
+        );
+        scheduler.shutdown();
     }
 
     #[test]

--- a/crates/komide/src/service/mod.rs
+++ b/crates/komide/src/service/mod.rs
@@ -10,7 +10,9 @@ use themelion::media::MediaType;
 use tracing::{debug, info, instrument, warn};
 use uuid::Uuid;
 
-use crate::error::{DatabaseSnafu, FeedNotFoundSnafu, InvalidUrlSnafu, KomideError};
+use crate::error::{
+    CorruptFeedIdSnafu, DatabaseSnafu, FeedNotFoundSnafu, InvalidUrlSnafu, KomideError,
+};
 use crate::fetch::{FetchResult, fetch_feed};
 use crate::news::apply_retention;
 use crate::parser::parse_feed;
@@ -72,7 +74,7 @@ impl FeedSchedulerService {
             .await
             .context(DatabaseSnafu)?
         {
-            let id = bytes_to_feed_id(&existing.id);
+            let id = bytes_to_feed_id(&existing.id)?;
             return Ok(id);
         }
 
@@ -127,7 +129,7 @@ impl FeedSchedulerService {
             .await
             .context(DatabaseSnafu)?
         {
-            return Ok(bytes_to_feed_id(&existing.id));
+            return bytes_to_feed_id(&existing.id);
         }
 
         let feed_bytes = fetch_bytes(&self.client, url, self.config.max_feed_bytes).await?;
@@ -235,33 +237,36 @@ impl FeedSchedulerService {
                 let subs = podcast::list_subscriptions(&self.db.read, 1000, 0)
                     .await
                     .context(DatabaseSnafu)?;
-                Ok(subs
-                    .into_iter()
-                    .map(|s| FeedSummary {
-                        id: bytes_to_feed_id(&s.id),
-                        title: s.title.unwrap_or_default(),
-                        url: s.feed_url,
-                        media_type: MediaType::Podcast,
-                        last_fetched_at: s.last_checked_at,
-                        is_active: true,
+                subs.into_iter()
+                    .map(|s| {
+                        Ok(FeedSummary {
+                            id: bytes_to_feed_id(&s.id)?,
+                            title: s.title.unwrap_or_default(),
+                            url: s.feed_url,
+                            media_type: MediaType::Podcast,
+                            last_fetched_at: s.last_checked_at,
+                            is_active: true,
+                        })
                     })
-                    .collect())
+                    .collect()
             }
             MediaType::News => {
                 let feeds = news::list_feeds(&self.db.read, 1000, 0)
                     .await
                     .context(DatabaseSnafu)?;
-                Ok(feeds
+                feeds
                     .into_iter()
-                    .map(|f| FeedSummary {
-                        id: bytes_to_feed_id(&f.id),
-                        title: f.title,
-                        url: f.url,
-                        media_type: MediaType::News,
-                        last_fetched_at: f.last_fetched_at,
-                        is_active: f.is_active != 0,
+                    .map(|f| {
+                        Ok(FeedSummary {
+                            id: bytes_to_feed_id(&f.id)?,
+                            title: f.title,
+                            url: f.url,
+                            media_type: MediaType::News,
+                            last_fetched_at: f.last_fetched_at,
+                            is_active: f.is_active != 0,
+                        })
                     })
-                    .collect())
+                    .collect()
             }
             other => {
                 warn!(media_type = %other, "list_feeds called for non-feed media type");
@@ -618,10 +623,12 @@ async fn fetch_bytes(
     crate::fetch::read_body_capped(response, url, max_bytes).await
 }
 
-pub(crate) fn bytes_to_feed_id(bytes: &[u8]) -> FeedId {
+// WHY: fallible by design — silently minting a fresh FeedId on corrupt DB
+// bytes masked data corruption as a legitimately new feed.
+pub(crate) fn bytes_to_feed_id(bytes: &[u8]) -> Result<FeedId, KomideError> {
     Uuid::from_slice(bytes)
         .map(FeedId::from_uuid)
-        .unwrap_or_else(|_| FeedId::new())
+        .context(CorruptFeedIdSnafu)
 }
 
 fn now_iso8601() -> String {

--- a/crates/komide/src/service/tests.rs
+++ b/crates/komide/src/service/tests.rs
@@ -228,7 +228,7 @@ async fn refresh_podcast_feed_inserts_items_and_emits_event() {
     )])
     .await;
     let sub_id = make_subscription(&svc, &url).await;
-    let feed_id = bytes_to_feed_id(&sub_id);
+    let feed_id = bytes_to_feed_id(&sub_id).unwrap();
 
     let result = svc.refresh_feed(feed_id).await.unwrap();
     assert_eq!(result.new_items, 2);
@@ -266,7 +266,7 @@ async fn refresh_news_feed_inserts_articles_and_emits_event() {
     let (url, _handle) =
         spawn_scripted_http(vec![http_response(200, "OK", &[], &atom_two_articles())]).await;
     let feed_bytes = make_news_feed(&svc, &url).await;
-    let feed_id = bytes_to_feed_id(&feed_bytes);
+    let feed_id = bytes_to_feed_id(&feed_bytes).unwrap();
 
     let result = svc.refresh_feed(feed_id).await.unwrap();
     assert_eq!(result.new_items, 2);
@@ -316,7 +316,7 @@ async fn refresh_feed_http_500_is_error_and_leaves_db_untouched() {
     .await;
     let sub_id = make_subscription(&svc, &url).await;
 
-    let result = svc.refresh_feed(bytes_to_feed_id(&sub_id)).await;
+    let result = svc.refresh_feed(bytes_to_feed_id(&sub_id).unwrap()).await;
     assert!(matches!(result, Err(KomideError::FeedFetch { .. })));
 
     let episodes = podcast::list_episodes(&svc.db.read, &sub_id, 10, 0)
@@ -343,7 +343,7 @@ async fn refresh_podcast_feed_second_call_with_304_returns_zero_new_items() {
     ])
     .await;
     let sub_id = make_subscription(&svc, &url).await;
-    let feed_id = bytes_to_feed_id(&sub_id);
+    let feed_id = bytes_to_feed_id(&sub_id).unwrap();
 
     let first = svc.refresh_feed(feed_id).await.unwrap();
     assert_eq!(first.new_items, 2);
@@ -375,7 +375,7 @@ async fn refresh_news_feed_second_call_with_304_returns_zero_new_items() {
     ])
     .await;
     let feed_bytes = make_news_feed(&svc, &url).await;
-    let feed_id = bytes_to_feed_id(&feed_bytes);
+    let feed_id = bytes_to_feed_id(&feed_bytes).unwrap();
 
     let first = svc.refresh_feed(feed_id).await.unwrap();
     assert_eq!(first.new_items, 2);
@@ -492,4 +492,20 @@ fn make_news_entry(guid: &str, title: &str) -> crate::parser::NormalizedEntry {
         enclosures: vec![],
         link: Some(format!("https://example.com/{guid}")),
     }
+}
+
+#[test]
+fn bytes_to_feed_id_accepts_valid_uuid_bytes() {
+    let uuid = Uuid::new_v4();
+    let id = bytes_to_feed_id(uuid.as_bytes()).unwrap();
+    assert_eq!(id, FeedId::from_uuid(uuid));
+}
+
+#[test]
+fn bytes_to_feed_id_rejects_corrupt_bytes() {
+    let result = bytes_to_feed_id(&[1, 2, 3]);
+    assert!(
+        matches!(result, Err(KomideError::CorruptFeedId { .. })),
+        "short id bytes must surface as CorruptFeedId, not a phantom FeedId"
+    );
 }

--- a/crates/prostheke/Cargo.toml
+++ b/crates/prostheke/Cargo.toml
@@ -18,6 +18,7 @@ tokio-util.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+url.workspace = true
 uuid.workspace = true
 jiff.workspace = true
 

--- a/crates/prostheke/src/error.rs
+++ b/crates/prostheke/src/error.rs
@@ -56,6 +56,21 @@ pub enum ProsthekeError {
         location: snafu::Location,
     },
 
+    #[snafu(display("corrupt subtitle row: {detail}"))]
+    CorruptSubtitleRow {
+        detail: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("invalid provider id (expected numeric file id): {provider_id}"))]
+    InvalidProviderId {
+        provider_id: String,
+        source: std::num::ParseIntError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("database error: {source}"))]
     Database {
         source: DbError,

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -10,13 +10,16 @@ use themelion::{MediaId, MediaType};
 use tracing::{debug, instrument, warn};
 
 use crate::error::{
-    AcquisitionFailedSnafu, DownloadFailedSnafu, ProsthekeError, ProviderDownSnafu,
+    AcquisitionFailedSnafu, DownloadFailedSnafu, InvalidProviderIdSnafu, ProsthekeError,
+    ProviderDownSnafu,
 };
 use crate::providers::SubtitleProvider;
 use crate::types::{SubtitleMatch, SubtitleProviderId};
 
 const BASE_URL: &str = "https://api.opensubtitles.com/api/v1";
 const USER_AGENT: &str = "Harmonia/1.0";
+/// Fallback download cap when the provider is exercised without a config.
+const DEFAULT_MAX_DOWNLOAD_BYTES: u64 = 10 * 1024 * 1024;
 
 /// Computes the OpenSubtitles-specific file hash.
 ///
@@ -139,6 +142,77 @@ fn score_result(attr: &SubtitleAttributes, requested_lang: &str) -> f64 {
     base * lang_match
 }
 
+// ── Download safety ───────────────────────────────────────────────────────────
+
+/// Validate a provider-supplied download link before fetching it.
+///
+/// WHY: the link comes FROM the OpenSubtitles API response body — a
+/// compromised or spoofed response must not be able to redirect the fetch at
+/// internal hosts (SSRF) or downgrade to plaintext.
+fn validate_download_url(link: &str) -> Result<url::Url, ProsthekeError> {
+    let parsed = url::Url::parse(link).map_err(|e| {
+        DownloadFailedSnafu {
+            detail: format!("invalid download link: {e}"),
+        }
+        .build()
+    })?;
+
+    if parsed.scheme() != "https" {
+        return DownloadFailedSnafu {
+            detail: format!(
+                "download link scheme must be https, got {}",
+                parsed.scheme()
+            ),
+        }
+        .fail();
+    }
+
+    let host_ok = parsed
+        .host_str()
+        .is_some_and(|host| host == "opensubtitles.com" || host.ends_with(".opensubtitles.com"));
+    if !host_ok {
+        return DownloadFailedSnafu {
+            detail: format!(
+                "download link host is not an opensubtitles.com domain: {}",
+                parsed.host_str().unwrap_or("<none>")
+            ),
+        }
+        .fail();
+    }
+
+    Ok(parsed)
+}
+
+/// Read a response body up to `max_bytes`, failing once the declared or
+/// accumulated size exceeds the cap.
+async fn read_body_capped(
+    mut response: reqwest::Response,
+    max_bytes: u64,
+) -> Result<Vec<u8>, ProsthekeError> {
+    if let Some(declared) = response.content_length()
+        && declared > max_bytes
+    {
+        return DownloadFailedSnafu {
+            detail: format!("subtitle download exceeds the {max_bytes}-byte cap"),
+        }
+        .fail();
+    }
+
+    let mut bytes: Vec<u8> = Vec::new();
+    while let Some(chunk) = response.chunk().await.context(ProviderDownSnafu)? {
+        let total = (bytes.len() as u64).saturating_add(chunk.len() as u64);
+        if total > max_bytes {
+            return DownloadFailedSnafu {
+                detail: format!("subtitle download exceeds the {max_bytes}-byte cap"),
+            }
+            .fail();
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+
+    Ok(bytes)
+}
+
 // ── Provider implementation ───────────────────────────────────────────────────
 
 impl SubtitleProvider for OpenSubtitlesProvider {
@@ -259,10 +333,15 @@ impl SubtitleProvider for OpenSubtitlesProvider {
         };
 
         // First request the download link FROM the API.
-        let file_id: u64 = subtitle.provider_id.0.parse().unwrap_or_else(|e| {
-            tracing::warn!(error = %e, provider_id = %subtitle.provider_id.0, "opensubtitles: invalid file_id; defaulting to 0");
-            0
-        });
+        // WHY: a non-numeric provider id must fail the request — a silent
+        // file_id=0 fallback would download the wrong subtitle.
+        let file_id: u64 = subtitle
+            .provider_id
+            .0
+            .parse()
+            .context(InvalidProviderIdSnafu {
+                provider_id: subtitle.provider_id.0.clone(),
+            })?;
 
         let download_req = serde_json::json!({ "file_id": file_id });
         let dl_resp = self
@@ -286,17 +365,19 @@ impl SubtitleProvider for OpenSubtitlesProvider {
         debug!(file_name = %dl_info.file_name, "obtained download link");
 
         // Fetch the actual subtitle file.
-        let content = self
+        let download_url = validate_download_url(&dl_info.link)?;
+        let max_bytes = self
+            .config
+            .as_ref()
+            .map_or(DEFAULT_MAX_DOWNLOAD_BYTES, |c| c.max_download_bytes);
+        let response = self
             .client
-            .get(&dl_info.link)
+            .get(download_url)
             .send()
-            .await
-            .context(ProviderDownSnafu)?
-            .bytes()
             .await
             .context(ProviderDownSnafu)?;
 
-        Ok(content.to_vec())
+        read_body_capped(response, max_bytes).await
     }
 }
 
@@ -314,9 +395,7 @@ mod tests {
     fn empty_api_key_treated_as_unconfigured() {
         let config = OpenSubtitlesConfig {
             api_key: String::new(),
-            username: None,
-            password: None,
-            rate_limit_per_second: 5,
+            ..OpenSubtitlesConfig::default()
         };
         let provider = OpenSubtitlesProvider::new(Some(config));
         assert_eq!(provider.api_key(), Some(""));
@@ -408,6 +487,116 @@ mod tests {
     fn compute_file_hash_missing_file_errors() {
         let dir = tempfile::tempdir().unwrap();
         assert!(compute_file_hash(&dir.path().join("absent.bin")).is_err());
+    }
+
+    #[test]
+    fn validate_download_url_accepts_opensubtitles_hosts() {
+        assert!(validate_download_url("https://www.opensubtitles.com/download/abc.srt").is_ok());
+        assert!(validate_download_url("https://opensubtitles.com/download/abc.srt").is_ok());
+    }
+
+    #[test]
+    fn validate_download_url_rejects_foreign_and_internal_hosts() {
+        for link in [
+            "http://169.254.169.254/latest/meta-data",
+            "http://localhost:1234/x.srt",
+            "https://evil.com/x.srt",
+            "https://evilopensubtitles.com/x.srt",
+            "https://opensubtitles.com.evil.com/x.srt",
+            "not a url",
+        ] {
+            let err = validate_download_url(link).unwrap_err();
+            assert!(
+                matches!(err, ProsthekeError::DownloadFailed { .. }),
+                "{link} must be rejected before any request is issued"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_download_url_rejects_plain_http_even_on_allowed_host() {
+        assert!(validate_download_url("https://www.opensubtitles.com/x.srt").is_ok());
+        assert!(validate_download_url("http://www.opensubtitles.com/x.srt").is_err());
+    }
+
+    #[tokio::test]
+    async fn download_rejects_non_numeric_provider_id_before_any_request() {
+        let provider = OpenSubtitlesProvider::new(Some(OpenSubtitlesConfig {
+            api_key: "key".to_string(),
+            ..OpenSubtitlesConfig::default()
+        }));
+        let subtitle = SubtitleMatch {
+            provider: "opensubtitles".to_string(),
+            provider_id: SubtitleProviderId("abc".to_string()),
+            language: "en".to_string(),
+            hearing_impaired: false,
+            forced: false,
+            score: 0.9,
+            download_url: "https://www.opensubtitles.com/x.srt".to_string(),
+        };
+
+        let err = provider.download(&subtitle).await.unwrap_err();
+        assert!(
+            matches!(err, ProsthekeError::InvalidProviderId { .. }),
+            "non-numeric provider id must error, not silently become file_id=0: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_body_capped_rejects_oversized_declared_body() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            // WHY: the request content is irrelevant — one read drains
+            // enough of it to keep the client happy before responding.
+            let _bytes_read = stream.read(&mut buf).await.unwrap();
+            let body = "x".repeat(2048);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(response.as_bytes()).await.ok();
+        });
+
+        let response = reqwest::get(format!("http://{addr}")).await.unwrap();
+        let err = read_body_capped(response, 1024).await.unwrap_err();
+
+        assert!(
+            matches!(err, ProsthekeError::DownloadFailed { .. }),
+            "oversized body must abort before buffering: {err:?}"
+        );
+        server.await.ok();
+    }
+
+    #[tokio::test]
+    async fn read_body_capped_accepts_body_within_cap() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            // WHY: the request content is irrelevant — one read drains
+            // enough of it to keep the client happy before responding.
+            let _bytes_read = stream.read(&mut buf).await.unwrap();
+            let body = "subtitle content";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let response = reqwest::get(format!("http://{addr}")).await.unwrap();
+        let bytes = read_body_capped(response, 1024).await.unwrap();
+
+        assert_eq!(bytes, b"subtitle content");
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/prostheke/src/repo.rs
+++ b/crates/prostheke/src/repo.rs
@@ -6,7 +6,7 @@ use sqlx::SqlitePool;
 use themelion::MediaId;
 use uuid::Uuid;
 
-use crate::error::{DatabaseSnafu, ProsthekeError};
+use crate::error::{CorruptSubtitleRowSnafu, DatabaseSnafu, ProsthekeError};
 use crate::types::{SubtitleFormat, SubtitleProviderId, SubtitleTrack};
 
 // ── Row type ─────────────────────────────────────────────────────────────────
@@ -27,13 +27,35 @@ struct SubtitleRow {
 }
 
 impl SubtitleRow {
-    fn into_domain(self) -> Option<SubtitleTrack> {
-        let id = Uuid::from_slice(&self.id).ok()?;
-        let media_id_uuid = Uuid::from_slice(&self.media_id).ok()?;
-        let format = parse_format(&self.format)?;
-        let acquired_at = self.acquired_at.parse::<jiff::Timestamp>().ok()?;
+    // WHY: fallible by design — a corrupt row must decode to a diagnosable
+    // error, not silently vanish FROM query results.
+    fn into_domain(self) -> Result<SubtitleTrack, ProsthekeError> {
+        let id = Uuid::from_slice(&self.id).map_err(|e| {
+            CorruptSubtitleRowSnafu {
+                detail: format!("invalid id bytes: {e}"),
+            }
+            .build()
+        })?;
+        let media_id_uuid = Uuid::from_slice(&self.media_id).map_err(|e| {
+            CorruptSubtitleRowSnafu {
+                detail: format!("invalid media_id bytes: {e}"),
+            }
+            .build()
+        })?;
+        let format = parse_format(&self.format).ok_or_else(|| {
+            CorruptSubtitleRowSnafu {
+                detail: format!("unknown subtitle format: {}", self.format),
+            }
+            .build()
+        })?;
+        let acquired_at = self.acquired_at.parse::<jiff::Timestamp>().map_err(|e| {
+            CorruptSubtitleRowSnafu {
+                detail: format!("invalid acquired_at timestamp: {e}"),
+            }
+            .build()
+        })?;
 
-        Some(SubtitleTrack {
+        Ok(SubtitleTrack {
             id,
             media_id: MediaId::from_uuid(media_id_uuid),
             language: self.language,
@@ -122,10 +144,16 @@ pub async fn get_subtitles_for_media(
     .context(DbQuerySnafu { table: "subtitles" })
     .context(DatabaseSnafu)?;
 
-    Ok(rows
-        .into_iter()
-        .filter_map(SubtitleRow::into_domain)
-        .collect())
+    let mut tracks = Vec::with_capacity(rows.len());
+    for row in rows {
+        match row.into_domain() {
+            Ok(track) => tracks.push(track),
+            // WHY: this is the handled site — one corrupt row is skipped
+            // (observable), the rest of the query still succeeds.
+            Err(e) => tracing::warn!(error = %e, "skipping corrupt subtitle row"),
+        }
+    }
+    Ok(tracks)
 }
 
 /// Return media IDs that have subtitle records but are missing at least one of
@@ -141,32 +169,22 @@ pub async fn list_media_missing_subtitles(
         return Ok(vec![]);
     }
 
-    // Fetch all subtitle rows and filter in Rust to avoid dynamic SQL.
-    let rows = sqlx::query_as::<_, SubtitleRow>(
-        "SELECT id, media_id, language, format, file_path, provider, provider_id,
-                hearing_impaired, forced, score, acquired_at
-         FROM subtitles",
+    // WHY: group in SQL (one row per media_id, static statement) instead of
+    // materializing every subtitle row in memory and grouping in Rust.
+    let rows = sqlx::query_as::<_, (Vec<u8>, String)>(
+        "SELECT media_id, GROUP_CONCAT(DISTINCT language)
+         FROM subtitles GROUP BY media_id",
     )
     .fetch_all(pool)
     .await
     .context(DbQuerySnafu { table: "subtitles" })
     .context(DatabaseSnafu)?;
 
-    // Group acquired languages by media_id.
-    let mut by_media: std::collections::HashMap<Vec<u8>, std::collections::HashSet<String>> =
-        std::collections::HashMap::new();
-
-    for row in &rows {
-        by_media
-            .entry(row.media_id.clone())
-            .or_default()
-            .insert(row.language.clone());
-    }
-
     // Return media_ids missing at least one requested language.
     let mut missing: Vec<MediaId> = Vec::new();
-    for (raw_id, acquired_langs) in by_media {
-        let has_all = languages.iter().all(|l| acquired_langs.contains(l));
+    for (raw_id, langs) in rows {
+        let acquired: std::collections::HashSet<&str> = langs.split(',').collect();
+        let has_all = languages.iter().all(|l| acquired.contains(l.as_str()));
         if !has_all && let Ok(uuid) = Uuid::from_slice(&raw_id) {
             missing.push(MediaId::from_uuid(uuid));
         }
@@ -311,5 +329,128 @@ mod tests {
         let pool = setup().await;
         let result = list_media_missing_subtitles(&pool, &[]).await.unwrap();
         assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_media_missing_subtitles_large_library() {
+        let pool = setup().await;
+        let requested = vec!["en".to_string(), "fr".to_string(), "de".to_string()];
+
+        // WHY: 50 complete + 50 incomplete media items exercise the grouped
+        // SQL path with many rows per media_id.
+        let mut expect_missing: Vec<MediaId> = Vec::new();
+        for i in 0..100 {
+            let media_id = MediaId::new();
+            let langs: &[&str] = if i % 2 == 0 {
+                &["en", "fr", "de"]
+            } else {
+                expect_missing.push(media_id);
+                &["en"]
+            };
+            for lang in langs {
+                insert_subtitle(&pool, &make_track(media_id, lang, false))
+                    .await
+                    .unwrap();
+            }
+        }
+
+        let missing: std::collections::HashSet<MediaId> =
+            list_media_missing_subtitles(&pool, &requested)
+                .await
+                .unwrap()
+                .into_iter()
+                .collect();
+        let expected: std::collections::HashSet<MediaId> = expect_missing.into_iter().collect();
+        assert_eq!(missing, expected);
+    }
+
+    fn valid_row() -> SubtitleRow {
+        SubtitleRow {
+            id: Uuid::now_v7().as_bytes().to_vec(),
+            media_id: MediaId::new().as_bytes().to_vec(),
+            language: "en".to_string(),
+            format: "srt".to_string(),
+            file_path: "/library/movie.en.srt".to_string(),
+            provider: "opensubtitles".to_string(),
+            provider_id: "12345".to_string(),
+            hearing_impaired: false,
+            forced: false,
+            score: 0.95,
+            acquired_at: jiff::Timestamp::now().to_string(),
+        }
+    }
+
+    #[test]
+    fn into_domain_success() {
+        let row = valid_row();
+        let track = row.into_domain().unwrap();
+        assert_eq!(track.language, "en");
+        assert_eq!(track.format, SubtitleFormat::Srt);
+    }
+
+    #[test]
+    fn into_domain_bad_id_bytes() {
+        let row = SubtitleRow {
+            id: vec![1, 2, 3],
+            ..valid_row()
+        };
+        let err = row.into_domain().unwrap_err();
+        assert!(matches!(err, ProsthekeError::CorruptSubtitleRow { .. }));
+        assert!(err.to_string().contains("invalid id bytes"));
+    }
+
+    #[test]
+    fn into_domain_bad_media_id_bytes() {
+        let row = SubtitleRow {
+            media_id: vec![9],
+            ..valid_row()
+        };
+        let err = row.into_domain().unwrap_err();
+        assert!(err.to_string().contains("invalid media_id bytes"));
+    }
+
+    #[test]
+    fn into_domain_bad_format() {
+        let row = SubtitleRow {
+            format: "docx".to_string(),
+            ..valid_row()
+        };
+        let err = row.into_domain().unwrap_err();
+        assert!(err.to_string().contains("unknown subtitle format: docx"));
+    }
+
+    #[test]
+    fn into_domain_bad_timestamp() {
+        let row = SubtitleRow {
+            acquired_at: "not-a-timestamp".to_string(),
+            ..valid_row()
+        };
+        let err = row.into_domain().unwrap_err();
+        assert!(err.to_string().contains("invalid acquired_at timestamp"));
+    }
+
+    #[tokio::test]
+    async fn corrupt_row_is_skipped_not_fatal() {
+        let pool = setup().await;
+        let media_id = MediaId::new();
+        insert_subtitle(&pool, &make_track(media_id, "en", false))
+            .await
+            .unwrap();
+
+        // Corrupt the stored timestamp directly, bypassing the typed insert.
+        // NOTE: format has a schema CHECK constraint, so acquired_at is the
+        // corruptible column here.
+        sqlx::query("UPDATE subtitles SET acquired_at = 'not-a-timestamp' WHERE media_id = ?")
+            .bind(media_id.as_bytes().as_slice())
+            .execute(&pool)
+            .await
+            .unwrap();
+        insert_subtitle(&pool, &make_track(media_id, "fr", false))
+            .await
+            .unwrap();
+
+        let results = get_subtitles_for_media(&pool, &media_id).await.unwrap();
+        assert_eq!(results.len(), 1, "only the intact row survives");
+        assert_eq!(results[0].language, "fr");
     }
 }

--- a/crates/prostheke/src/search.rs
+++ b/crates/prostheke/src/search.rs
@@ -190,4 +190,229 @@ mod tests {
         let top = select_top_per_language(&matches, &["ja".to_string()]);
         assert!(top.is_empty());
     }
+
+    /// Scripted provider for exercising `search_all_providers` without I/O.
+    struct MockProvider {
+        name: &'static str,
+        fail: bool,
+        matches: Vec<SubtitleMatch>,
+    }
+
+    impl crate::providers::SubtitleProvider for MockProvider {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        async fn search(
+            &self,
+            _media_id: &MediaId,
+            _media_type: MediaType,
+            _title: &str,
+            _year: Option<u16>,
+            _season: Option<u32>,
+            _episode: Option<u32>,
+            _languages: &[String],
+            _file_hash: Option<&str>,
+        ) -> Result<Vec<SubtitleMatch>, ProsthekeError> {
+            if self.fail {
+                return crate::error::AcquisitionFailedSnafu {
+                    detail: "scripted failure".to_string(),
+                }
+                .fail();
+            }
+            Ok(self.matches.clone())
+        }
+
+        async fn download(&self, _subtitle: &SubtitleMatch) -> Result<Vec<u8>, ProsthekeError> {
+            Ok(vec![])
+        }
+    }
+
+    fn preferences() -> LanguagePreference {
+        LanguagePreference {
+            languages: vec!["en".to_string()],
+            include_hearing_impaired: true,
+            include_forced: true,
+        }
+    }
+
+    fn flagged_match(id: &str, hearing_impaired: bool, forced: bool) -> SubtitleMatch {
+        SubtitleMatch {
+            provider: "mock".to_string(),
+            provider_id: crate::types::SubtitleProviderId(id.to_string()),
+            language: "en".to_string(),
+            hearing_impaired,
+            forced,
+            score: 0.9,
+            download_url: "https://example.com/subs/en".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn search_all_providers_isolates_single_provider_failure() {
+        let providers = vec![
+            MockProvider {
+                name: "broken",
+                fail: true,
+                matches: vec![],
+            },
+            MockProvider {
+                name: "working",
+                fail: false,
+                matches: vec![make_match("en", 0.9, false)],
+            },
+        ];
+
+        let result = search_all_providers(
+            &providers,
+            &MediaId::new(),
+            MediaType::Movie,
+            "Inception",
+            Some(2010),
+            None,
+            None,
+            &preferences(),
+            None,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.len(),
+            1,
+            "the working provider's match must survive a sibling failure"
+        );
+        assert_eq!(result[0].language, "en");
+    }
+
+    #[tokio::test]
+    async fn search_all_providers_all_fail_returns_empty_not_error() {
+        let providers = vec![
+            MockProvider {
+                name: "broken-a",
+                fail: true,
+                matches: vec![],
+            },
+            MockProvider {
+                name: "broken-b",
+                fail: true,
+                matches: vec![],
+            },
+        ];
+
+        let result = search_all_providers(
+            &providers,
+            &MediaId::new(),
+            MediaType::Movie,
+            "Inception",
+            None,
+            None,
+            None,
+            &preferences(),
+            None,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_excludes_hearing_impaired_when_preference_false() {
+        let providers = vec![MockProvider {
+            name: "mock",
+            fail: false,
+            matches: vec![
+                flagged_match("hi", true, false),
+                flagged_match("plain", false, false),
+            ],
+        }];
+        let prefs = LanguagePreference {
+            include_hearing_impaired: false,
+            ..preferences()
+        };
+
+        let result = search_all_providers(
+            &providers,
+            &MediaId::new(),
+            MediaType::Movie,
+            "Inception",
+            None,
+            None,
+            None,
+            &prefs,
+            None,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].provider_id.0, "plain");
+        assert!(!result[0].hearing_impaired);
+    }
+
+    #[tokio::test]
+    async fn search_keeps_hearing_impaired_when_preference_true() {
+        let providers = vec![MockProvider {
+            name: "mock",
+            fail: false,
+            matches: vec![flagged_match("hi", true, false)],
+        }];
+
+        let result = search_all_providers(
+            &providers,
+            &MediaId::new(),
+            MediaType::Movie,
+            "Inception",
+            None,
+            None,
+            None,
+            &preferences(),
+            None,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].provider_id.0, "hi");
+    }
+
+    #[tokio::test]
+    async fn search_excludes_forced_when_preference_false() {
+        let providers = vec![MockProvider {
+            name: "mock",
+            fail: false,
+            matches: vec![
+                flagged_match("forced", false, true),
+                flagged_match("plain", false, false),
+            ],
+        }];
+        let prefs = LanguagePreference {
+            include_forced: false,
+            ..preferences()
+        };
+
+        let result = search_all_providers(
+            &providers,
+            &MediaId::new(),
+            MediaType::Movie,
+            "Inception",
+            None,
+            None,
+            None,
+            &prefs,
+            None,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].provider_id.0, "plain");
+        assert!(!result[0].forced);
+    }
 }

--- a/crates/prostheke/src/types.rs
+++ b/crates/prostheke/src/types.rs
@@ -13,6 +13,7 @@ pub struct SubtitleProviderId(pub String);
 
 // WHY: API schema
 /// A subtitle track acquired and stored for a media item.
+#[derive(Debug)]
 pub struct SubtitleTrack {
     pub id: Uuid,
     pub media_id: MediaId,

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -55,8 +55,9 @@ torznab_timeout_secs = 15
 [epignosis]
 # Metadata providers
 cache_ttl_secs = 86400            # 24 hours
-max_provider_retries = 3
+max_retries = 3
 provider_timeout_secs = 10
+provider_response_max_bytes = 10485760  # cap on a buffered provider response
 
 [kritike]
 # Quality curation


### PR DESCRIPTION
Applies the verified low-severity findings (scheduler pagination + Drop-abort safety, provider hardening, OpenSubtitles/provider fixes + coverage). Closes #382, #464, #440, #444, #466. 21 findings fixed. `kanon gate --full` green.