### PR TITLE
fix(epignosis): reject non-success HTTP responses and deflake rate-limit test

### DIFF
--- a/crates/epignosis/Cargo.toml
+++ b/crates/epignosis/Cargo.toml
@@ -20,7 +20,7 @@ dashmap = "6"
 tokio-util = { version = "0.7", features = ["rt"] }
 
 [dev-dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 tempfile = "3"
 
 [package.metadata.kanon]

--- a/crates/epignosis/src/error.rs
+++ b/crates/epignosis/src/error.rs
@@ -32,6 +32,14 @@ pub enum EpignosisError {
         location: snafu::Location,
     },
 
+    #[snafu(display("{provider} answered with HTTP {status}"))]
+    ProviderHttpStatus {
+        provider: String,
+        status: reqwest::StatusCode,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("request to {provider} timed out: {url}"))]
     ProviderTimeout {
         provider: String,

--- a/crates/epignosis/src/providers/audnexus.rs
+++ b/crates/epignosis/src/providers/audnexus.rs
@@ -9,13 +9,19 @@ const BASE_URL: &str = "https://api.audnex.us";
 
 pub struct AudnexusProvider {
     client: reqwest::Client,
+    base_url: String,
     pub(crate) max_body_bytes: u64,
 }
 
 impl AudnexusProvider {
     pub fn new(client: reqwest::Client) -> Self {
+        Self::with_base_url(client, BASE_URL.to_string())
+    }
+
+    pub fn with_base_url(client: reqwest::Client, base_url: String) -> Self {
         Self {
             client,
+            base_url,
             max_body_bytes: super::DEFAULT_MAX_BODY_BYTES,
         }
     }
@@ -112,7 +118,7 @@ impl AudnexusProvider {
         &self,
         asin: &str,
     ) -> Result<Option<AudnexusChaptersResponse>, EpignosisError> {
-        let url = format!("{BASE_URL}/chapters/{asin}");
+        let url = format!("{}/chapters/{asin}", self.base_url);
         let response = self
             .client
             .get(&url)
@@ -144,7 +150,7 @@ impl MetadataProvider for AudnexusProvider {
 
     #[instrument(skip(self), fields(provider = "audnexus"))]
     async fn search(&self, query: &SearchQuery) -> Result<Vec<ProviderResult>, EpignosisError> {
-        let url = format!("{BASE_URL}/books");
+        let url = format!("{}/books", self.base_url);
         let response = self
             .client
             .get(&url)
@@ -189,7 +195,7 @@ impl MetadataProvider for AudnexusProvider {
 
     #[instrument(skip(self), fields(provider = "audnexus"))]
     async fn get_metadata(&self, provider_id: &str) -> Result<ProviderMetadata, EpignosisError> {
-        let url = format!("{BASE_URL}/books/{provider_id}");
+        let url = format!("{}/books/{provider_id}", self.base_url);
         let response = self
             .client
             .get(&url)
@@ -290,6 +296,39 @@ impl MetadataProvider for AudnexusProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::spawn_sequential_http;
+
+    // ── HTTP behavior ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn fetch_chapters_404_returns_none() {
+        let (base_url, handle) =
+            spawn_sequential_http(vec![(404, "{\"message\": \"not found\"}".to_string())]).await;
+        let provider = AudnexusProvider::with_base_url(reqwest::Client::new(), base_url);
+
+        let chapters = provider.fetch_chapters("B000000000").await.unwrap();
+
+        assert!(
+            chapters.is_none(),
+            "a missing chapter record is a clean miss, not an error"
+        );
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fetch_chapters_200_returns_chapters() {
+        let body = r#"{"asin": "B002V1CBBG", "chapters": [{"title": "Ch 1"}]}"#.to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, body)]).await;
+        let provider = AudnexusProvider::with_base_url(reqwest::Client::new(), base_url);
+
+        let chapters = provider.fetch_chapters("B002V1CBBG").await.unwrap();
+
+        assert_eq!(
+            chapters.unwrap().chapters.as_ref().map(|ch| ch.len()),
+            Some(1)
+        );
+        handle.await.unwrap();
+    }
 
     // ── Struct parsing ────────────────────────────────────────────────────────
 

--- a/crates/epignosis/src/providers/mod.rs
+++ b/crates/epignosis/src/providers/mod.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, ensure};
 use themelion::MediaType;
 
-use crate::error::{EpignosisError, ProviderRequestSnafu, ProviderResponseTooLargeSnafu};
+use crate::error::{
+    EpignosisError, ProviderHttpStatusSnafu, ProviderRequestSnafu, ProviderResponseTooLargeSnafu,
+};
 
 pub mod acoustid;
 pub mod audnexus;
@@ -21,16 +23,28 @@ pub use crate::identity::MetadataProviderId;
 /// Overridden per resolver FROM `horismos::EpignosisConfig::provider_response_max_bytes`.
 pub(crate) const DEFAULT_MAX_BODY_BYTES: u64 = 10 * 1024 * 1024;
 
-/// Read a response body up to `max_bytes`, failing with
-/// `ProviderResponseTooLarge` once the declared or accumulated size exceeds it.
+/// Reject a non-2xx response with `ProviderHttpStatus`, then read the body up
+/// to `max_bytes`, failing with `ProviderResponseTooLarge` once the declared
+/// or accumulated size exceeds it.
 ///
 /// WHY: `reqwest::Response::text()` buffers unbounded — a misbehaving provider
-/// response must not be able to exhaust memory.
+/// response must not be able to exhaust memory. The status guard keeps a 4xx/
+/// 5xx error page from reaching `serde_json` and surfacing as a parse error.
+///
+/// NOTE: callers that treat a specific status as data (the 404 = clean-miss
+/// paths in audnexus and openlibrary) must branch on `response.status()`
+/// BEFORE calling this.
 pub(crate) async fn read_body_limited(
     mut response: reqwest::Response,
     provider: &str,
     max_bytes: u64,
 ) -> Result<String, EpignosisError> {
+    let status = response.status();
+    ensure!(
+        status.is_success(),
+        ProviderHttpStatusSnafu { provider, status }
+    );
+
     if let Some(declared) = response.content_length() {
         ensure!(
             declared <= max_bytes,
@@ -114,6 +128,44 @@ mod tests {
         let text = read_body_limited(response, "test", 1024).await.unwrap();
 
         assert_eq!(text, "small body");
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn read_body_limited_rejects_non_success_status() {
+        let (base_url, handle) =
+            spawn_sequential_http(vec![(500, "upstream error page".to_string())]).await;
+        let response = reqwest::get(&base_url).await.unwrap();
+
+        let err = read_body_limited(response, "test", 1024).await.unwrap_err();
+
+        assert!(
+            matches!(
+                &err,
+                EpignosisError::ProviderHttpStatus { status, .. }
+                    if *status == reqwest::StatusCode::INTERNAL_SERVER_ERROR
+            ),
+            "a non-2xx response must surface as a status error, not a parse error: {err:?}"
+        );
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn read_body_limited_rejects_client_error_status() {
+        let (base_url, handle) =
+            spawn_sequential_http(vec![(404, "{\"error\": \"missing\"}".to_string())]).await;
+        let response = reqwest::get(&base_url).await.unwrap();
+
+        let err = read_body_limited(response, "test", 1024).await.unwrap_err();
+
+        assert!(
+            matches!(
+                &err,
+                EpignosisError::ProviderHttpStatus { status, .. }
+                    if *status == reqwest::StatusCode::NOT_FOUND
+            ),
+            "a 4xx that reaches the general guard must fail on status: {err:?}"
+        );
         handle.await.unwrap();
     }
 

--- a/crates/epignosis/src/providers/openlibrary.rs
+++ b/crates/epignosis/src/providers/openlibrary.rs
@@ -345,6 +345,21 @@ mod tests {
     use crate::test_support::spawn_sequential_http;
 
     #[tokio::test]
+    async fn fetch_edition_404_returns_none() {
+        let (base_url, handle) =
+            spawn_sequential_http(vec![(404, "{\"error\": \"notfound\"}".to_string())]).await;
+        let provider = OpenLibraryProvider::with_base_url(reqwest::Client::new(), base_url);
+
+        let edition = provider.fetch_edition("9780000000000").await.unwrap();
+
+        assert!(
+            edition.is_none(),
+            "a 404 edition lookup is a clean miss, not an error"
+        );
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn fetch_work_404_returns_none() {
         let (base_url, handle) =
             spawn_sequential_http(vec![(404, "{\"error\": \"notfound\"}".to_string())]).await;

--- a/crates/epignosis/src/providers/tvdb.rs
+++ b/crates/epignosis/src/providers/tvdb.rs
@@ -82,6 +82,17 @@ impl TvdbProvider {
         Ok(token)
     }
 
+    /// Drops the cached bearer when the API answers 401 Unauthorized.
+    ///
+    /// WHY: a 401 means the server no longer honors the cached token; keeping
+    /// it would fail every call until the TTL expires. Clearing it makes the
+    /// next call re-authenticate.
+    async fn invalidate_token_on_unauthorized(&self, status: reqwest::StatusCode) {
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            *self.token.write().await = None;
+        }
+    }
+
     #[cfg(test)]
     async fn seed_token(&self, token: &str, valid_until: Instant) {
         *self.token.write().await = Some((token.to_string(), valid_until));
@@ -150,6 +161,8 @@ impl MetadataProvider for TvdbProvider {
             .await
             .context(ProviderRequestSnafu { provider: "tvdb" })?;
 
+        self.invalidate_token_on_unauthorized(response.status())
+            .await;
         let text = super::read_body_limited(response, "tvdb", self.max_body_bytes).await?;
 
         let parsed: TvdbSearchResponse =
@@ -190,6 +203,8 @@ impl MetadataProvider for TvdbProvider {
             .await
             .context(ProviderRequestSnafu { provider: "tvdb" })?;
 
+        self.invalidate_token_on_unauthorized(response.status())
+            .await;
         let text = super::read_body_limited(response, "tvdb", self.max_body_bytes).await?;
 
         let detail: TvdbSeriesDetail =
@@ -324,6 +339,45 @@ mod tests {
             requests[0]
                 .to_ascii_lowercase()
                 .contains("authorization: bearer tok-live")
+        );
+    }
+
+    #[tokio::test]
+    async fn unauthorized_response_clears_cached_token() {
+        let (base_url, handle) = spawn_sequential_http(vec![
+            (401, "{}".to_string()),
+            (200, login_body("tok-next")),
+            (200, empty_search_body()),
+        ])
+        .await;
+        let provider = TvdbProvider::with_base_url(reqwest::Client::new(), "key", base_url);
+        provider
+            .seed_token("tok-revoked", Instant::now() + Duration::from_secs(60))
+            .await;
+
+        let err = provider.search(&tv_query("Andor")).await.unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                EpignosisError::ProviderHttpStatus { status, .. }
+                    if *status == reqwest::StatusCode::UNAUTHORIZED
+            ),
+            "a 401 must surface as a status error: {err:?}"
+        );
+
+        provider.search(&tv_query("Andor")).await.unwrap();
+
+        let requests = handle.await.unwrap();
+        assert!(requests[0].starts_with("GET /search"));
+        assert!(
+            requests[1].starts_with("POST /login"),
+            "a 401 must clear the cached token and force a fresh login"
+        );
+        assert!(
+            requests[2]
+                .to_ascii_lowercase()
+                .contains("authorization: bearer tok-next"),
+            "the retried call must carry the re-issued token"
         );
     }
 

--- a/crates/epignosis/src/rate_limit.rs
+++ b/crates/epignosis/src/rate_limit.rs
@@ -89,38 +89,38 @@ impl Default for ProviderQueues {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
+    use tokio::time::Instant;
 
     use super::*;
 
-    /// 3 requests in a 100ms window  -  all three should complete quickly,
-    /// a fourth request must wait for the next slot.
-    #[tokio::test]
+    /// 3 requests per 300ms window — each permit waits one 100ms interval.
+    ///
+    /// WHY: `start_paused` runs the limiter's `tokio::time::interval` on the
+    /// mock clock, so the schedule is exact logical time — no wall-clock
+    /// slack, no flake under load.
+    #[tokio::test(start_paused = true)]
     async fn rate_limiter_allows_burst_then_throttles() {
-        // 3 req per 300ms → ~100ms interval
+        // 3 req per 300ms → 100ms interval
         let queue = ProviderQueue::new(3, 300);
 
         let start = Instant::now();
 
-        // First three permits  -  each waits one interval after the previous.
         queue.acquire().await;
         queue.acquire().await;
         queue.acquire().await;
 
-        let elapsed = start.elapsed();
-        // Three permits should complete within ~500ms with some slack.
-        assert!(
-            elapsed < Duration::from_millis(600),
-            "three permits took too long: {elapsed:?}"
+        assert_eq!(
+            start.elapsed(),
+            Duration::from_millis(300),
+            "each of the first three permits waits exactly one interval"
         );
 
-        // Fourth permit must wait at least one more interval.
         let before_fourth = Instant::now();
         queue.acquire().await;
-        let fourth_wait = before_fourth.elapsed();
-        assert!(
-            fourth_wait >= Duration::from_millis(50),
-            "fourth permit did not throttle: {fourth_wait:?}"
+        assert_eq!(
+            before_fourth.elapsed(),
+            Duration::from_millis(100),
+            "the fourth permit waits exactly one more interval"
         );
     }
 


### PR DESCRIPTION
Two verified epignosis fixes.

**#498 — providers never inspect HTTP status codes.** `read_body_limited`
(the shared choke point for all 9 metadata providers) now rejects any non-2xx
response with a new `ProviderHttpStatus { provider, status }` error before the
body reaches `serde_json`, so an upstream error page surfaces as a clear HTTP
error instead of a confusing parse failure. The narrow 404 clean-miss paths
(audnexus `fetch_chapters`, openlibrary `fetch_edition`/`fetch_work`) branch on
`NOT_FOUND` before the guard, so they still return `Ok(None)`. TVDB now
invalidates its cached bearer on 401 (write-lock → `None`) so the next call
re-authenticates instead of looping on a revoked token until TTL expiry.

**#482 — flaky wall-clock rate-limit test.** `rate_limiter_allows_burst_then_throttles`
now runs under `#[tokio::test(start_paused = true)]` on the mock clock with
exact logical-time assertions — no wall-clock slack, deterministic under load
(10/10 green, ~5ms vs ~400ms). No production timing change.

Gate: `kanon gate --full` green (fmt, check, clippy `-D warnings --all-targets`,
nextest 114/114, deny, lint).

Closes #498
Closes #482
