### PR TITLE
fix(paroche): report real list totals instead of page-slice length

### DIFF
--- a/crates/apotheke/src/repo/audiobook.rs
+++ b/crates/apotheke/src/repo/audiobook.rs
@@ -111,6 +111,15 @@ pub async fn list_audiobooks(
     })
 }
 
+pub async fn count_audiobooks(pool: &SqlitePool) -> Result<i64, DbError> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM audiobooks")
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu {
+            table: "audiobooks",
+        })
+}
+
 pub async fn update_audiobook(
     pool: &SqlitePool,
     id: &[u8],

--- a/crates/apotheke/src/repo/book.rs
+++ b/crates/apotheke/src/repo/book.rs
@@ -92,6 +92,13 @@ pub async fn list_books(pool: &SqlitePool, limit: i64, offset: i64) -> Result<Ve
     .context(QuerySnafu { table: "books" })
 }
 
+pub async fn count_books(pool: &SqlitePool) -> Result<i64, DbError> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM books")
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu { table: "books" })
+}
+
 /// Distinct book author names, sorted, paginated.
 ///
 /// WHY: authors live in `media_registry` (entity_type = 'person') joined
@@ -242,5 +249,37 @@ mod tests {
         let pool = setup().await;
         let err = delete_book(&pool, &make_id()).await.unwrap_err();
         assert!(matches!(err, DbError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn count_books_returns_total_row_count() {
+        let pool = setup().await;
+        assert_eq!(count_books(&pool).await.unwrap(), 0);
+        for i in 0..5 {
+            let book = Book {
+                id: make_id(),
+                registry_id: None,
+                title: format!("Book {i}"),
+                subtitle: None,
+                isbn: None,
+                isbn13: None,
+                openlibrary_id: None,
+                goodreads_id: None,
+                publisher: None,
+                publish_date: None,
+                language: None,
+                page_count: None,
+                description: None,
+                file_path: None,
+                file_format: None,
+                file_size_bytes: None,
+                quality_score: None,
+                quality_profile_id: None,
+                source_type: "local".to_string(),
+                added_at: "2026-01-01T00:00:00Z".to_string(),
+            };
+            insert_book(&pool, &book).await.unwrap();
+        }
+        assert_eq!(count_books(&pool).await.unwrap(), 5);
     }
 }

--- a/crates/apotheke/src/repo/comic.rs
+++ b/crates/apotheke/src/repo/comic.rs
@@ -103,6 +103,13 @@ pub async fn list_comics(
     .context(QuerySnafu { table: "comics" })
 }
 
+pub async fn count_comics(pool: &SqlitePool) -> Result<i64, DbError> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM comics")
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu { table: "comics" })
+}
+
 pub async fn update_comic(
     pool: &SqlitePool,
     id: &[u8],

--- a/crates/apotheke/src/repo/movie.rs
+++ b/crates/apotheke/src/repo/movie.rs
@@ -96,6 +96,13 @@ pub async fn list_movies(
     .context(QuerySnafu { table: "movies" })
 }
 
+pub async fn count_movies(pool: &SqlitePool) -> Result<i64, DbError> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM movies")
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu { table: "movies" })
+}
+
 pub async fn update_movie(
     pool: &SqlitePool,
     id: &[u8],
@@ -193,5 +200,37 @@ mod tests {
         let pool = setup().await;
         let err = delete_movie(&pool, &make_id()).await.unwrap_err();
         assert!(matches!(err, DbError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn count_movies_returns_total_row_count() {
+        let pool = setup().await;
+        assert_eq!(count_movies(&pool).await.unwrap(), 0);
+        for i in 0..5 {
+            let movie = Movie {
+                id: make_id(),
+                registry_id: None,
+                title: format!("Movie {i}"),
+                original_title: None,
+                year: Some(2020),
+                tmdb_id: None,
+                imdb_id: None,
+                runtime_min: None,
+                overview: None,
+                certification: None,
+                file_path: None,
+                file_format: None,
+                file_size_bytes: None,
+                resolution: None,
+                codec: None,
+                hdr_type: None,
+                quality_score: None,
+                quality_profile_id: None,
+                source_type: "local".to_string(),
+                added_at: "2026-01-01T00:00:00Z".to_string(),
+            };
+            insert_movie(&pool, &movie).await.unwrap();
+        }
+        assert_eq!(count_movies(&pool).await.unwrap(), 5);
     }
 }

--- a/crates/apotheke/src/repo/music.rs
+++ b/crates/apotheke/src/repo/music.rs
@@ -131,6 +131,15 @@ pub async fn list_release_groups(
     })
 }
 
+pub async fn count_release_groups(pool: &SqlitePool) -> Result<i64, DbError> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM music_release_groups")
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu {
+            table: "music_release_groups",
+        })
+}
+
 pub async fn update_release_group(
     pool: &SqlitePool,
     id: &[u8],
@@ -1050,5 +1059,25 @@ mod tests {
         assert_eq!(count_tracks(&pool, "").await.unwrap(), 7);
         assert_eq!(count_tracks(&pool, "Track 03").await.unwrap(), 1);
         assert_eq!(count_tracks(&pool, "No Such Title").await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn count_release_groups_returns_total_row_count() {
+        let pool = setup().await;
+        assert_eq!(count_release_groups(&pool).await.unwrap(), 0);
+        for i in 0..4 {
+            let group = MusicReleaseGroup {
+                id: make_id(),
+                registry_id: None,
+                title: format!("Album {i}"),
+                rg_type: "album".to_string(),
+                mb_release_group_id: None,
+                year: Some(1971),
+                quality_profile_id: None,
+                added_at: now(),
+            };
+            insert_release_group(&pool, &group).await.unwrap();
+        }
+        assert_eq!(count_release_groups(&pool).await.unwrap(), 4);
     }
 }

--- a/crates/apotheke/src/repo/news.rs
+++ b/crates/apotheke/src/repo/news.rs
@@ -98,6 +98,15 @@ pub async fn list_feeds(
     })
 }
 
+pub async fn count_feeds(pool: &SqlitePool) -> Result<i64, DbError> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM news_feeds")
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu {
+            table: "news_feeds",
+        })
+}
+
 pub async fn update_feed(
     pool: &SqlitePool,
     id: &[u8],

--- a/crates/apotheke/src/repo/podcast.rs
+++ b/crates/apotheke/src/repo/podcast.rs
@@ -106,6 +106,15 @@ pub async fn list_subscriptions(
     })
 }
 
+pub async fn count_subscriptions(pool: &SqlitePool) -> Result<i64, DbError> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM podcast_subscriptions")
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu {
+            table: "podcast_subscriptions",
+        })
+}
+
 pub async fn update_subscription(
     pool: &SqlitePool,
     id: &[u8],

--- a/crates/apotheke/src/repo/tv.rs
+++ b/crates/apotheke/src/repo/tv.rs
@@ -108,6 +108,13 @@ pub async fn list_series(
     .context(QuerySnafu { table: "tv_series" })
 }
 
+pub async fn count_series(pool: &SqlitePool) -> Result<i64, DbError> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM tv_series")
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu { table: "tv_series" })
+}
+
 pub async fn update_series(
     pool: &SqlitePool,
     id: &[u8],

--- a/crates/apotheke/src/repo/want.rs
+++ b/crates/apotheke/src/repo/want.rs
@@ -160,6 +160,13 @@ pub async fn list_wants(pool: &SqlitePool, limit: i64, offset: i64) -> Result<Ve
     .context(QuerySnafu { table: "wants" })
 }
 
+pub async fn count_wants(pool: &SqlitePool) -> Result<i64, DbError> {
+    sqlx::query_scalar("SELECT COUNT(*) FROM wants")
+        .fetch_one(pool)
+        .await
+        .context(QuerySnafu { table: "wants" })
+}
+
 pub async fn list_wants_by_type_and_status(
     pool: &SqlitePool,
     media_type: &str,

--- a/crates/paroche/src/routes/audiobook.rs
+++ b/crates/paroche/src/routes/audiobook.rs
@@ -83,7 +83,7 @@ pub async fn list_audiobooks(
         apotheke::repo::audiobook::list_audiobooks(&state.db.read, per_page as i64, offset as i64)
             .await?;
 
-    let total = books.len() as u64;
+    let total = apotheke::repo::audiobook::count_audiobooks(&state.db.read).await? as u64;
     let data: Vec<AudiobookResponse> = books.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }

--- a/crates/paroche/src/routes/book.rs
+++ b/crates/paroche/src/routes/book.rs
@@ -88,7 +88,7 @@ pub async fn list_books(
     )
     .await?;
 
-    let total = books.len() as u64;
+    let total = apotheke::repo::book::count_books(&state.db.read).await? as u64;
     let data: Vec<BookResponse> = books.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }

--- a/crates/paroche/src/routes/comic.rs
+++ b/crates/paroche/src/routes/comic.rs
@@ -91,7 +91,7 @@ pub async fn list_comics(
     )
     .await?;
 
-    let total = comics.len() as u64;
+    let total = apotheke::repo::comic::count_comics(&state.db.read).await? as u64;
     let data: Vec<ComicResponse> = comics.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }

--- a/crates/paroche/src/routes/indexer.rs
+++ b/crates/paroche/src/routes/indexer.rs
@@ -138,9 +138,13 @@ pub async fn list_indexers(
         .await
         .map_err(|_| ParocheError::Internal)?;
 
-    let total = rows.len() as u64;
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM indexers")
+        .fetch_one(&state.db.read)
+        .await
+        .map_err(|_| ParocheError::Internal)?;
+
     let data: Vec<IndexerResponse> = rows.into_iter().map(Into::into).collect();
-    Ok(ApiResponse::paginated(data, page, per_page, total))
+    Ok(ApiResponse::paginated(data, page, per_page, total as u64))
 }
 
 pub async fn get_indexer(

--- a/crates/paroche/src/routes/movie.rs
+++ b/crates/paroche/src/routes/movie.rs
@@ -84,7 +84,7 @@ pub async fn list_movies(
     let movies =
         apotheke::repo::movie::list_movies(&state.db.read, per_page as i64, offset as i64).await?;
 
-    let total = movies.len() as u64;
+    let total = apotheke::repo::movie::count_movies(&state.db.read).await? as u64;
     let data: Vec<MovieResponse> = movies.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }

--- a/crates/paroche/src/routes/music.rs
+++ b/crates/paroche/src/routes/music.rs
@@ -105,7 +105,7 @@ pub async fn list_release_groups(
         apotheke::repo::music::list_release_groups(&state.db.read, per_page as i64, offset as i64)
             .await?;
 
-    let total = groups.len() as u64;
+    let total = apotheke::repo::music::count_release_groups(&state.db.read).await? as u64;
     let data: Vec<ReleaseGroupResponse> = groups.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }

--- a/crates/paroche/src/routes/news.rs
+++ b/crates/paroche/src/routes/news.rs
@@ -86,7 +86,7 @@ pub async fn list_feeds(
     )
     .await?;
 
-    let total = feeds.len() as u64;
+    let total = apotheke::repo::news::count_feeds(&state.db.read).await? as u64;
     let data: Vec<FeedResponse> = feeds.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }

--- a/crates/paroche/src/routes/podcast.rs
+++ b/crates/paroche/src/routes/podcast.rs
@@ -83,7 +83,7 @@ pub async fn list_subscriptions(
         apotheke::repo::podcast::list_subscriptions(&state.db.read, per_page as i64, offset as i64)
             .await?;
 
-    let total = subs.len() as u64;
+    let total = apotheke::repo::podcast::count_subscriptions(&state.db.read).await? as u64;
     let data: Vec<SubscriptionResponse> = subs.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }

--- a/crates/paroche/src/routes/tv.rs
+++ b/crates/paroche/src/routes/tv.rs
@@ -105,7 +105,7 @@ pub async fn list_series(
     let series =
         apotheke::repo::tv::list_series(&state.db.read, per_page as i64, offset as i64).await?;
 
-    let total = series.len() as u64;
+    let total = apotheke::repo::tv::count_series(&state.db.read).await? as u64;
     let data: Vec<TvSeriesResponse> = series.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }

--- a/crates/paroche/src/routes/wanted.rs
+++ b/crates/paroche/src/routes/wanted.rs
@@ -94,7 +94,7 @@ pub async fn list_wanted(
     )
     .await?;
 
-    let total = wants.len() as u64;
+    let total = apotheke::repo::want::count_wants(&state.db.read).await? as u64;
     let data: Vec<WantedResponse> = wants.into_iter().map(Into::into).collect();
     Ok(ApiResponse::paginated(data, page, per_page, total))
 }


### PR DESCRIPTION
Paginated list handlers reported `total = items.len() as u64` — the page-slice length, not the collection total — so pagination metadata was wrong for any list larger than one page.

Adds 9 `count_*` repo fns in apotheke (mirroring the #372 `count_tracks` pattern) and fixes all 10 affected handlers (movie/book/comic/audiobook/tv/news/podcast/music-release-groups/wanted via the repo fns; indexer via an inline `SELECT COUNT(*)` matching its existing inline-sqlx style). Each now reports the real total.

Gate: `kanon gate --full` green (fmt, check, clippy `-D warnings --all-targets`, nextest 1731/1731, deny, lint).

Closes #478
