### PR TITLE
fix(paroche): route enqueue_download through the live download queue

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -23,7 +23,7 @@ use prostheke::providers::Provider;
 use prostheke::{SubtitleManager, SubtitleService};
 use snafu::ResultExt;
 use syndesmos::{ScrobbleClient, ScrobbleClientBuilder};
-use syntaxis::{CompletedDownload, DownloadQueue};
+use syntaxis::{CompletedDownload, DownloadQueue, QueueManager};
 use themelion::{MediaId, MediaType, create_event_bus};
 use tokio::signal::unix::SignalKind;
 use tokio::task::JoinHandle;
@@ -258,10 +258,37 @@ struct EngineAdapter(#[expect(dead_code)] Arc<TorrentSession>);
 impl DynDownloadEngine for EngineAdapter {}
 
 /// Bridges the running `DownloadQueue` to paroche's queue-manager trait so an
-/// API cancel/reprioritize reaches the live dispatcher and engine.
+/// API enqueue/cancel/reprioritize reaches the live dispatcher and engine.
 struct QueueAdapter<E: ergasia::DownloadEngine + 'static>(Arc<DownloadQueue<E>>);
 
 impl<E: ergasia::DownloadEngine + 'static> DynQueueManager for QueueAdapter<E> {
+    fn enqueue(&self, item: paroche::state::EnqueueItem) -> ServiceFut<()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            let protocol = syntaxis::DownloadProtocol::parse(&item.protocol).ok_or_else(|| {
+                ServiceError::InvalidInput(format!(
+                    "unsupported download protocol: {}",
+                    item.protocol
+                ))
+            })?;
+            service
+                .enqueue(syntaxis::QueueItem {
+                    id: item.queue_id,
+                    want_id: themelion::WantId::from_uuid(item.want_id),
+                    release_id: themelion::ReleaseId::from_uuid(item.release_id),
+                    download_url: item.download_url,
+                    protocol,
+                    priority: item.priority,
+                    tracker_id: None,
+                    info_hash: item.info_hash,
+                    retry_count: 0,
+                })
+                .await
+                .map(|_| ())
+                .map_err(queue_error)
+        })
+    }
+
     fn cancel(&self, queue_id: uuid::Uuid) -> ServiceFut<()> {
         let service = Arc::clone(&self.0);
         Box::pin(async move {
@@ -1333,6 +1360,117 @@ mod service_adapter_tests {
             .await
             .expect_err("an unknown id must not succeed");
         assert!(matches!(error, ServiceError::NotFound));
+    }
+
+    // ── #499: QueueAdapter enqueue reaches the live queue ──────────────────
+
+    fn enqueue_item(protocol: &str) -> paroche::state::EnqueueItem {
+        paroche::state::EnqueueItem {
+            queue_id: uuid::Uuid::now_v7(),
+            want_id: uuid::Uuid::now_v7(),
+            release_id: uuid::Uuid::now_v7(),
+            download_url: "magnet:?xt=urn:btih:adapter-enqueue".to_string(),
+            protocol: protocol.to_string(),
+            priority: 4,
+            info_hash: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn queue_adapter_enqueue_persists_and_dispatches_to_live_engine() {
+        let pool = migrated_pool().await;
+        let engine = Arc::new(RecordingEngine {
+            started: std::sync::Mutex::new(Vec::new()),
+            cancelled: std::sync::Mutex::new(Vec::new()),
+        });
+        let queue = Arc::new(
+            DownloadQueue::new(
+                pool.clone(),
+                Arc::clone(&engine),
+                Arc::new(StubImportService),
+                horismos::SyntaxisConfig {
+                    max_concurrent_downloads: 2,
+                    max_per_tracker: 3,
+                    retry_count: 1,
+                    retry_backoff_base_seconds: 0,
+                    stalled_download_timeout_hours: 24,
+                },
+            )
+            .await
+            .expect("queue constructs"),
+        );
+
+        let adapter = QueueAdapter(Arc::clone(&queue));
+        let item = enqueue_item("torrent");
+        let queue_id = item.queue_id;
+        adapter
+            .enqueue(item)
+            .await
+            .expect("adapter enqueue succeeds");
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM download_queue WHERE id = ?")
+            .bind(queue_id.as_bytes().as_slice())
+            .fetch_one(&pool)
+            .await
+            .expect("row count query");
+        assert_eq!(count, 1, "the service must persist the enqueued row");
+
+        // The interactive dispatch is spawned; wait for it to reach the engine.
+        for _ in 0..500 {
+            if !engine.started.lock().expect("lock").is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            engine.started.lock().expect("lock").len(),
+            1,
+            "the API-facing enqueue must dispatch to the live engine"
+        );
+    }
+
+    #[tokio::test]
+    async fn queue_adapter_enqueue_rejects_unknown_protocol() {
+        let pool = migrated_pool().await;
+        let engine = Arc::new(RecordingEngine {
+            started: std::sync::Mutex::new(Vec::new()),
+            cancelled: std::sync::Mutex::new(Vec::new()),
+        });
+        let queue = Arc::new(
+            DownloadQueue::new(
+                pool.clone(),
+                Arc::clone(&engine),
+                Arc::new(StubImportService),
+                horismos::SyntaxisConfig {
+                    max_concurrent_downloads: 2,
+                    max_per_tracker: 3,
+                    retry_count: 1,
+                    retry_backoff_base_seconds: 0,
+                    stalled_download_timeout_hours: 24,
+                },
+            )
+            .await
+            .expect("queue constructs"),
+        );
+
+        let adapter = QueueAdapter(queue);
+        let error = adapter
+            .enqueue(enqueue_item("ftp"))
+            .await
+            .expect_err("an unknown protocol must not enqueue");
+        // WHY: user-supplied protocol must map to a 400-class error, never
+        // fold into Internal (which the HTTP layer reports as a 500).
+        assert!(matches!(error, ServiceError::InvalidInput(_)));
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM download_queue")
+            .fetch_one(&pool)
+            .await
+            .expect("row count query");
+        assert_eq!(count, 0, "a rejected protocol must not be persisted");
+        assert!(
+            engine.started.lock().expect("lock").is_empty(),
+            "a rejected protocol must not reach the engine"
+        );
     }
 }
 

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -21,7 +21,7 @@ use paroche::state::{
 use serde_json::{Value, json};
 use snafu::ResultExt;
 use sqlx::SqlitePool;
-use syntaxis::{CompletedDownload, ImportService};
+use syntaxis::{CompletedDownload, ImportService, QueueManager};
 use themelion::create_event_bus;
 use themelion::ids::DownloadId;
 use tokio::sync::mpsc;
@@ -103,6 +103,33 @@ impl ergasia::DownloadEngine for MockEngine {
 struct QueueAdapter(Arc<syntaxis::DownloadQueue<MockEngine>>);
 
 impl DynQueueManager for QueueAdapter {
+    fn enqueue(&self, item: paroche::state::EnqueueItem) -> ServiceFut<()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            let protocol = syntaxis::DownloadProtocol::parse(&item.protocol).ok_or_else(|| {
+                paroche::state::ServiceError::InvalidInput(format!(
+                    "unsupported download protocol: {}",
+                    item.protocol
+                ))
+            })?;
+            service
+                .enqueue(syntaxis::QueueItem {
+                    id: item.queue_id,
+                    want_id: themelion::WantId::from_uuid(item.want_id),
+                    release_id: themelion::ReleaseId::from_uuid(item.release_id),
+                    download_url: item.download_url,
+                    protocol,
+                    priority: item.priority,
+                    tracker_id: None,
+                    info_hash: item.info_hash,
+                    retry_count: 0,
+                })
+                .await
+                .map(|_| ())
+                .map_err(queue_service_error)
+        })
+    }
+
     fn cancel(&self, queue_id: Uuid) -> ServiceFut<()> {
         let service = Arc::clone(&self.0);
         Box::pin(async move {
@@ -313,7 +340,17 @@ async fn test_db() -> Result<SqlitePool, TestError> {
     Ok(pool)
 }
 
-async fn test_state() -> Result<(AppState, Arc<ExousiaServiceImpl>, SqlitePool), TestError> {
+async fn test_state_with_queue(
+    max_concurrent_downloads: usize,
+) -> Result<
+    (
+        AppState,
+        Arc<ExousiaServiceImpl>,
+        SqlitePool,
+        mpsc::UnboundedReceiver<DownloadId>,
+    ),
+    TestError,
+> {
     let pool = test_db().await?;
     let pools = Arc::new(DbPools {
         read: pool.clone(),
@@ -336,9 +373,9 @@ async fn test_state() -> Result<(AppState, Arc<ExousiaServiceImpl>, SqlitePool),
     let import = paroche::state::make_import_service(|| async { Ok(vec![]) });
     let mut state = AppState::with_stubs(pools, config, event_tx, auth.clone(), import);
     state.search = Arc::new(MockSearchService);
-    // WHY: cancel/reprioritize routes delegate to the live syntaxis service;
-    // wiring the real DownloadQueue keeps these tests end-to-end.
-    let (started_tx, _started_rx) = mpsc::unbounded_channel();
+    // WHY: enqueue/cancel/reprioritize routes delegate to the live syntaxis
+    // service; wiring the real DownloadQueue keeps these tests end-to-end.
+    let (started_tx, started_rx) = mpsc::unbounded_channel();
     let (imported_tx, _imported_rx) = mpsc::unbounded_channel();
     let queue_svc = Arc::new(
         syntaxis::DownloadQueue::new(
@@ -346,7 +383,7 @@ async fn test_state() -> Result<(AppState, Arc<ExousiaServiceImpl>, SqlitePool),
             Arc::new(MockEngine { started_tx }),
             Arc::new(MockImportService { imported_tx }) as Arc<dyn ImportService>,
             horismos::SyntaxisConfig {
-                max_concurrent_downloads: 5,
+                max_concurrent_downloads,
                 max_per_tracker: 3,
                 retry_count: 2,
                 retry_backoff_base_seconds: 0,
@@ -366,6 +403,14 @@ async fn test_state() -> Result<(AppState, Arc<ExousiaServiceImpl>, SqlitePool),
             MockRequestMonitor,
         ),
     )));
+    Ok((state, auth, pool, started_rx))
+}
+
+async fn test_state() -> Result<(AppState, Arc<ExousiaServiceImpl>, SqlitePool), TestError> {
+    // WHY: zero slots keeps API-enqueued items deterministically 'queued' for
+    // the snapshot/cancel/reprioritize contract tests; live dispatch is
+    // covered by enqueue_download_dispatches_to_live_engine.
+    let (state, auth, pool, _started_rx) = test_state_with_queue(0).await?;
     Ok((state, auth, pool))
 }
 
@@ -533,6 +578,26 @@ async fn enqueue_download_returns_created() -> Result<(), TestError> {
     assert_eq!(json["data"]["status"], "queued");
     assert_eq!(json["data"]["priority"], 4);
     assert_eq!(json["data"]["protocol"], "torrent");
+    Ok(())
+}
+
+// WHY: the #499 regression — a raw route INSERT persisted the row but the
+// running queue never learned of it, so nothing dispatched until restart.
+#[tokio::test]
+async fn enqueue_download_dispatches_to_live_engine() -> Result<(), TestError> {
+    let (state, auth, _pool, mut started_rx) = test_state_with_queue(5).await?;
+    let token = admin_token(&auth).await?;
+    let app = build_app(state);
+
+    let (status, _json) = enqueue_via_api(&app, &token, 4).await?;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let dispatched =
+        tokio::time::timeout(std::time::Duration::from_secs(5), started_rx.recv()).await;
+    assert!(
+        dispatched.is_ok_and(|d| d.is_some()),
+        "an API enqueue must reach the live engine without a process restart"
+    );
     Ok(())
 }
 

--- a/crates/paroche/src/routes/download.rs
+++ b/crates/paroche/src/routes/download.rs
@@ -168,6 +168,9 @@ pub async fn get_queue_snapshot(
 
 // WHY: admin-only — enqueueing hands an arbitrary URL to the server-side
 // download engine; member-level access is an SSRF primitive.
+// WHY: enqueueing goes through the running syntaxis service, which persists
+// the row and schedules it live — a raw DB INSERT here left the download
+// invisible to the running queue until the next process restart.
 pub async fn enqueue_download(
     State(state): State<AppState>,
     _admin: RequireAdmin,
@@ -181,39 +184,26 @@ pub async fn enqueue_download(
 
     crate::net_validate::validate_download_url(&body.download_url).await?;
 
-    let id = Uuid::now_v7().as_bytes().to_vec();
-    let want_id = Uuid::parse_str(&body.want_id)
-        .map_err(|_| ParocheError::InvalidId)?
-        .as_bytes()
-        .to_vec();
-    let release_id = Uuid::parse_str(&body.release_id)
-        .map_err(|_| ParocheError::InvalidId)?
-        .as_bytes()
-        .to_vec();
-    let now = crate::routes::music::chrono_now_pub();
-    let priority = body.priority.clamp(1, 4) as i64;
+    let queue_id = Uuid::now_v7();
+    let want_id = Uuid::parse_str(&body.want_id).map_err(|_| ParocheError::InvalidId)?;
+    let release_id = Uuid::parse_str(&body.release_id).map_err(|_| ParocheError::InvalidId)?;
 
-    sqlx::query(
-        "INSERT INTO download_queue \
-         (id, want_id, release_id, download_url, protocol, priority, info_hash, \
-          status, added_at, retry_count) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', ?, 0)",
-    )
-    .bind(&id)
-    .bind(&want_id)
-    .bind(&release_id)
-    .bind(&body.download_url)
-    .bind(&body.protocol)
-    .bind(priority)
-    .bind(&body.info_hash)
-    .bind(&now)
-    .execute(&state.db.write)
-    .await
-    .map_err(|_| ParocheError::Internal)?;
+    state
+        .queue
+        .enqueue(crate::state::EnqueueItem {
+            queue_id,
+            want_id,
+            release_id,
+            download_url: body.download_url,
+            protocol: body.protocol,
+            priority: body.priority.clamp(1, 4),
+            info_hash: body.info_hash,
+        })
+        .await?;
 
     let q = format!("{SELECT_DOWNLOAD} WHERE id = ?");
     let row = sqlx::query_as::<_, DownloadRow>(&q)
-        .bind(&id)
+        .bind(queue_id.as_bytes().as_slice())
         .fetch_one(&state.db.read)
         .await
         .map_err(|_| ParocheError::Internal)?;
@@ -410,9 +400,19 @@ mod tests {
         }
     }
 
+    /// Recording queue manager that also persists, mirroring the real
+    /// service's contract (`enqueue` owns the `download_queue` write).
+    fn persisting_queue(pool: &sqlx::SqlitePool) -> std::sync::Arc<RecordingQueueManager> {
+        std::sync::Arc::new(RecordingQueueManager {
+            persist_pool: Some(pool.clone()),
+            ..Default::default()
+        })
+    }
+
     #[tokio::test]
     async fn enqueue_download_accepts_public_url_for_admin() {
-        let (state, auth) = test_state().await;
+        let (mut state, auth) = test_state().await;
+        state.queue = persisting_queue(&app_pool(&auth));
         let token = token_for(&auth, "admin", UserRole::Admin).await;
         let app = crate::build_router(state);
         let resp = post_enqueue(&app, &token, "http://203.0.113.10/f.torrent").await;
@@ -428,11 +428,79 @@ mod tests {
 
     #[tokio::test]
     async fn enqueue_download_accepts_magnet_uri_for_admin() {
-        let (state, auth) = test_state().await;
+        let (mut state, auth) = test_state().await;
+        state.queue = persisting_queue(&app_pool(&auth));
         let token = token_for(&auth, "admin", UserRole::Admin).await;
         let app = crate::build_router(state);
         let resp = post_enqueue(&app, &token, "magnet:?xt=urn:btih:abc123def456").await;
         assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    // ── #499: enqueue reaches the live queue manager ────────────────────────
+
+    #[tokio::test]
+    async fn enqueue_download_reaches_queue_manager_not_raw_db() {
+        let (mut state, auth) = test_state().await;
+        let pool = app_pool(&auth);
+        let queue = persisting_queue(&pool);
+        state.queue = queue.clone();
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+
+        let app = crate::build_router(state);
+        let resp = post_enqueue(&app, &token, "magnet:?xt=urn:btih:live499").await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        let enqueued = queue.enqueued.lock().unwrap().clone();
+        assert_eq!(
+            enqueued.len(),
+            1,
+            "the enqueue must be delegated to the queue manager"
+        );
+        let item = &enqueued[0];
+        assert_eq!(item.download_url, "magnet:?xt=urn:btih:live499");
+        assert_eq!(item.protocol, "torrent");
+        assert_eq!(
+            item.priority, 4,
+            "the interactive default must reach the queue"
+        );
+        assert_eq!(
+            body["data"]["id"],
+            item.queue_id.to_string(),
+            "the response must reference the row the queue manager persisted"
+        );
+        assert_eq!(body["data"]["status"], "queued");
+
+        // The queue manager owns the DB write; a raw route INSERT would add a
+        // second row (or violate the primary key and fail the request).
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM download_queue")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "the route must not raw-INSERT alongside the service"
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_download_unavailable_when_queue_not_wired() {
+        let (state, auth) = test_state().await;
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let pool = app_pool(&auth);
+
+        let app = crate::build_router(state);
+        let resp = post_enqueue(&app, &token, "magnet:?xt=urn:btih:nowire").await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        // A download the live queue never accepted must not be persisted — a
+        // DB-only row is exactly the #499 defect (invisible until restart).
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM download_queue")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "no row may exist without the live queue knowing");
     }
 
     #[tokio::test]
@@ -449,16 +517,48 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
-    // ── #469: cancel/reprioritize reach the live queue manager ─────────────
+    // ── #469/#499: enqueue/cancel/reprioritize reach the live queue manager ─
 
     #[derive(Default)]
     struct RecordingQueueManager {
+        enqueued: std::sync::Mutex<Vec<crate::state::EnqueueItem>>,
         cancelled: std::sync::Mutex<Vec<uuid::Uuid>>,
         reprioritized: std::sync::Mutex<Vec<(uuid::Uuid, u8)>>,
         fail_with: std::sync::Mutex<Option<fn() -> crate::state::ServiceError>>,
+        /// When set, `enqueue` persists the row like the real syntaxis service
+        /// does, so the handler's response SELECT has a row to read.
+        persist_pool: Option<sqlx::SqlitePool>,
     }
 
     impl crate::state::DynQueueManager for RecordingQueueManager {
+        fn enqueue(&self, item: crate::state::EnqueueItem) -> crate::state::ServiceFut<()> {
+            if let Some(make_error) = *self.fail_with.lock().unwrap() {
+                return Box::pin(async move { Err(make_error()) });
+            }
+            self.enqueued.lock().unwrap().push(item.clone());
+            let pool = self.persist_pool.clone();
+            Box::pin(async move {
+                if let Some(pool) = pool {
+                    sqlx::query(
+                        "INSERT INTO download_queue \
+                         (id, want_id, release_id, download_url, protocol, priority, info_hash) \
+                         VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    )
+                    .bind(item.queue_id.as_bytes().as_slice())
+                    .bind(item.want_id.as_bytes().as_slice())
+                    .bind(item.release_id.as_bytes().as_slice())
+                    .bind(&item.download_url)
+                    .bind(&item.protocol)
+                    .bind(i64::from(item.priority))
+                    .bind(&item.info_hash)
+                    .execute(&pool)
+                    .await
+                    .map_err(|e| crate::state::ServiceError::Internal(e.to_string()))?;
+                }
+                Ok(())
+            })
+        }
+
         fn cancel(&self, queue_id: uuid::Uuid) -> crate::state::ServiceFut<()> {
             if let Some(make_error) = *self.fail_with.lock().unwrap() {
                 return Box::pin(async move { Err(make_error()) });

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -108,11 +108,34 @@ pub trait DynSearchService: Send + Sync {
 
 pub trait DynDownloadEngine: Send + Sync {}
 
+// WHY: pure data — enqueue parameters for the live download queue, kept as
+// plain uuid/string fields so paroche stays decoupled from syntaxis types.
+/// A new item for the live download queue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnqueueItem {
+    /// `download_queue` row id (UUIDv7), chosen by the caller so the HTTP
+    /// response can reference the persisted row.
+    pub queue_id: uuid::Uuid,
+    pub want_id: uuid::Uuid,
+    pub release_id: uuid::Uuid,
+    pub download_url: String,
+    /// Protocol in its wire form (`"torrent"` / `"nzb"` / `"usenet"`); an
+    /// unknown value is rejected with `ServiceError::InvalidInput`.
+    pub protocol: String,
+    /// 1-4; priority 4 dispatches immediately when a slot is free.
+    pub priority: u8,
+    pub info_hash: Option<String>,
+}
+
 /// Download queue control via the running syntaxis service.
 ///
 /// Items are keyed by their `download_queue` row id — the identifier the
 /// HTTP API exposes.
 pub trait DynQueueManager: Send + Sync {
+    /// Persists the item to `download_queue` and schedules it in the live
+    /// queue, so it dispatches without waiting for a process restart.
+    fn enqueue(&self, item: EnqueueItem) -> ServiceFut<()>;
+
     /// Cancels the queue item, stopping the live download when one is active.
     fn cancel(&self, queue_id: uuid::Uuid) -> ServiceFut<()>;
 
@@ -280,6 +303,10 @@ impl DynDownloadEngine for NullDownloadEngine {}
 
 struct NullQueueManager;
 impl DynQueueManager for NullQueueManager {
+    fn enqueue(&self, _item: EnqueueItem) -> ServiceFut<()> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
     fn cancel(&self, _queue_id: uuid::Uuid) -> ServiceFut<()> {
         Box::pin(async { Err(ServiceError::NotAvailable) })
     }

--- a/crates/syntaxis/src/recovery.rs
+++ b/crates/syntaxis/src/recovery.rs
@@ -15,17 +15,13 @@ use crate::repo::{self, QueueRow};
 use crate::types::{DownloadProtocol, QueueItem};
 
 fn parse_protocol(s: &str) -> DownloadProtocol {
-    match s {
-        "torrent" => DownloadProtocol::Torrent,
-        "nzb" => DownloadProtocol::Usenet,
-        other => {
-            warn!(
-                protocol = other,
-                "unknown protocol in download_queue; treating as torrent"
-            );
-            DownloadProtocol::Torrent
-        }
-    }
+    DownloadProtocol::parse(s).unwrap_or_else(|| {
+        warn!(
+            protocol = s,
+            "unknown protocol in download_queue; treating as torrent"
+        );
+        DownloadProtocol::Torrent
+    })
 }
 
 fn row_to_queue_item(row: &QueueRow) -> Option<QueueItem> {

--- a/crates/syntaxis/src/types.rs
+++ b/crates/syntaxis/src/types.rs
@@ -23,6 +23,16 @@ impl DownloadProtocol {
             DownloadProtocol::Usenet => "nzb",
         }
     }
+
+    /// Parses the canonical DB form (`"torrent"` / `"nzb"`); also accepts the
+    /// serde form `"usenet"`. Returns `None` for an unknown protocol.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "torrent" => Some(DownloadProtocol::Torrent),
+            "nzb" | "usenet" => Some(DownloadProtocol::Usenet),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for DownloadProtocol {
@@ -100,6 +110,29 @@ mod tests {
     #[test]
     fn protocol_db_str_usenet() {
         assert_eq!(DownloadProtocol::Usenet.as_db_str(), "nzb");
+    }
+
+    #[test]
+    fn protocol_parse_roundtrips_db_forms() {
+        assert_eq!(
+            DownloadProtocol::parse("torrent"),
+            Some(DownloadProtocol::Torrent)
+        );
+        assert_eq!(
+            DownloadProtocol::parse("nzb"),
+            Some(DownloadProtocol::Usenet)
+        );
+        assert_eq!(
+            DownloadProtocol::parse("usenet"),
+            Some(DownloadProtocol::Usenet)
+        );
+    }
+
+    #[test]
+    fn protocol_parse_rejects_unknown() {
+        assert_eq!(DownloadProtocol::parse("ftp"), None);
+        assert_eq!(DownloadProtocol::parse(""), None);
+        assert_eq!(DownloadProtocol::parse("Torrent"), None);
     }
 
     #[test]


### PR DESCRIPTION
`enqueue_download` issued a raw `INSERT` into `download_queue`, never notifying the running `DownloadQueue` — so an API-enqueued download sat invisible in the DB until the next process restart.

Routes enqueue through the live syntaxis service instead (via a new `enqueue` method on `DynQueueManager` + archon `QueueAdapter`), which persists the row AND schedules it in one path. The raw INSERT is dropped entirely (no double-write; the "DB-orphan row" defect is now impossible — an unwired queue returns 503 with zero rows). Bonus: an unknown protocol is now a 422 `InvalidInput` rather than a raw-CHECK 500, via a strict `DownloadProtocol::parse` shared with recovery.

Gate: `kanon gate --full` green (fmt, check, clippy `-D warnings --all-targets`, nextest 1735/1735, deny, lint). Five new tests including an end-to-end assertion that a POST reaches the live engine with no restart.

Closes #499
