### PR TITLE
feat(zetesis): wire Cardigann definition-driven indexer client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Cross-tool agent guidance (agents.md standard). Claude Code, Cursor, Codex, Copi
 | Config field | `crates/horismos/src/` | Add to subsystem config struct + `harmonia.toml` default |
 | External API client | `crates/syndesmos/src/` | New module; credentials via horismos |
 | Metadata provider | `crates/epignosis/src/` | Register in provider registry |
-| Indexer protocol | `crates/zetesis/src/` | Torznab/Newznab trait impl |
+| Indexer protocol | `crates/zetesis/src/` | Torznab/Newznab/Cardigann trait impl |
 | Audio DSP stage | `crates/akouo-core/src/dsp/` | Add to pipeline; feature-gate if it needs C deps |
 
 Per-crate `CLAUDE.md` files do not yet exist for all 19 crates - use `_llm/architecture.toml` + source for orientation. Tracking issue: #193 follow-up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1354,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1446,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1515,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1888,6 +1953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2160,16 @@ dependencies = [
  "themelion",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -3043,6 +3127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3222,6 +3317,12 @@ dependencies = [
  "thiserror 2.0.18",
  "winapi",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -3744,6 +3845,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,6 +3980,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -4554,6 +4714,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "scroll"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4620,6 +4795,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4670,6 +4864,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -4743,6 +4950,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -5185,6 +5401,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5521,6 +5761,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -6102,6 +6352,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6251,6 +6507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6280,6 +6542,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -6509,6 +6777,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -7277,16 +7557,21 @@ dependencies = [
  "apotheke",
  "bytes",
  "dashmap",
+ "ego-tree",
  "futures",
  "horismos",
  "jiff",
  "quick-xml 0.41.0",
+ "regex",
  "reqwest",
  "rstest",
+ "scraper",
  "serde",
  "serde_json",
+ "serde_norway",
  "snafu",
  "sqlx",
+ "tempfile",
  "themelion",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,17 @@ clap            = { version = "4", features = ["derive"] }
 # ── XML ───────────────────────────────────────────────────────────────────────
 quick-xml       = { version = "0.41", features = ["serialize"] }
 
+# ── YAML (Cardigann indexer definitions) ─────────────────────────────────────
+# NOTE: serde_norway is the maintained serde_yaml fork (serde_yaml and
+# serde_yml are both unmaintained per RUSTSEC).
+serde_norway    = "0.9"
+
+# ── HTML scraping (Cardigann row/field selectors) ────────────────────────────
+# NOTE: ego-tree is scraper's node-tree crate, needed by name to walk nodes;
+# scraper's API exposes its types without re-exporting them.
+scraper         = "0.27"
+ego-tree        = "0.11"
+
 # ── Concurrency ──────────────────────────────────────────────────────────────
 dashmap         = "6"
 tokio-util      = { version = "0.7", features = ["rt"] }
@@ -198,6 +209,7 @@ regex           = "1"
 
 # ── Test ───────────────────────────────────────────────────────────────────────
 rstest          = "0.26"
+tempfile        = "3"
 
 [profile.dev.package."*"]
 opt-level = 2    # WHY: optimize deps for faster runtime during development

--- a/crates/apotheke/migrations/012_indexer_cardigann_protocol.sql
+++ b/crates/apotheke/migrations/012_indexer_cardigann_protocol.sql
@@ -1,0 +1,79 @@
+-- Widen indexers.protocol to admit 'cardigann' (definition-driven HTML
+-- indexers, zetesis CardigannClient).
+--
+-- WHY the rebuild: SQLite cannot alter a CHECK constraint in place. Both
+-- tables are copied through FK-free backups (child first) so the implicit
+-- DELETE from dropping the parent cannot cascade into live category rows.
+
+CREATE TABLE indexer_categories_backup (
+    indexer_id  INTEGER NOT NULL,
+    category_id INTEGER NOT NULL,
+    name        TEXT NOT NULL
+) STRICT;
+
+INSERT INTO indexer_categories_backup (indexer_id, category_id, name)
+SELECT indexer_id, category_id, name FROM indexer_categories;
+
+CREATE TABLE indexers_backup (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL,
+    url         TEXT NOT NULL,
+    protocol    TEXT NOT NULL,
+    api_key     TEXT,
+    enabled     INTEGER NOT NULL,
+    cf_bypass   INTEGER NOT NULL,
+    status      TEXT NOT NULL,
+    last_tested TEXT,
+    caps_json   TEXT,
+    priority    INTEGER NOT NULL,
+    added_at    TEXT NOT NULL
+) STRICT;
+
+INSERT INTO indexers_backup
+    (id, name, url, protocol, api_key, enabled, cf_bypass, status,
+     last_tested, caps_json, priority, added_at)
+SELECT id, name, url, protocol, api_key, enabled, cf_bypass, status,
+       last_tested, caps_json, priority, added_at
+FROM indexers;
+
+DROP TABLE indexer_categories;
+DROP TABLE indexers;
+
+CREATE TABLE indexers (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL,
+    url         TEXT NOT NULL,
+    protocol    TEXT NOT NULL CHECK (protocol IN ('torznab', 'newznab', 'cardigann')),
+    api_key     TEXT,
+    enabled     INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+    cf_bypass   INTEGER NOT NULL DEFAULT 0 CHECK (cf_bypass IN (0, 1)),
+    status      TEXT NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active', 'degraded', 'failed')),
+    last_tested TEXT,
+    caps_json   TEXT,
+    priority    INTEGER NOT NULL DEFAULT 50,
+    added_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+) STRICT;
+
+INSERT INTO indexers
+    (id, name, url, protocol, api_key, enabled, cf_bypass, status,
+     last_tested, caps_json, priority, added_at)
+SELECT id, name, url, protocol, api_key, enabled, cf_bypass, status,
+       last_tested, caps_json, priority, added_at
+FROM indexers_backup;
+
+CREATE TABLE indexer_categories (
+    indexer_id  INTEGER NOT NULL REFERENCES indexers(id) ON DELETE CASCADE,
+    category_id INTEGER NOT NULL,
+    name        TEXT NOT NULL,
+    PRIMARY KEY (indexer_id, category_id)
+) STRICT;
+
+INSERT INTO indexer_categories (indexer_id, category_id, name)
+SELECT indexer_id, category_id, name FROM indexer_categories_backup;
+
+DROP TABLE indexers_backup;
+DROP TABLE indexer_categories_backup;
+
+CREATE INDEX idx_indexers_enabled_status ON indexers(enabled, status);
+CREATE INDEX idx_indexer_categories_indexer ON indexer_categories(indexer_id);

--- a/crates/apotheke/src/migrate.rs
+++ b/crates/apotheke/src/migrate.rs
@@ -9,3 +9,98 @@ pub static MIGRATOR: Migrator = sqlx::migrate!();
 pub async fn run_migrations(pool: &SqlitePool) -> Result<(), DbError> {
     MIGRATOR.run(pool).await.context(MigrationSnafu)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Applies raw migration SQL through `before_version` (exclusive),
+    /// bypassing migrator bookkeeping so a later migration can be exercised
+    /// against a mid-history schema.
+    async fn apply_until(pool: &SqlitePool, before_version: i64) {
+        for migration in MIGRATOR.iter() {
+            if migration.version < before_version {
+                sqlx::raw_sql(&migration.sql).execute(pool).await.unwrap();
+            }
+        }
+    }
+
+    async fn apply_version(pool: &SqlitePool, version: i64) {
+        let migration = MIGRATOR
+            .iter()
+            .find(|m| m.version == version)
+            .unwrap_or_else(|| panic!("no migration with version {version}"));
+        sqlx::raw_sql(&migration.sql).execute(pool).await.unwrap();
+    }
+
+    // WHY: migration 012 rebuilds indexers + indexer_categories to widen the
+    // protocol CHECK — the rebuild must carry every existing row across.
+    #[tokio::test]
+    async fn indexer_protocol_rebuild_preserves_existing_rows() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        apply_until(&pool, 12).await;
+
+        sqlx::query(
+            "INSERT INTO indexers (id, name, url, protocol, api_key, priority)
+             VALUES (3, 'Pre-existing', 'https://old.example/api', 'torznab', 'key', 10)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO indexer_categories (indexer_id, category_id, name)
+             VALUES (3, 2000, 'Movies')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        apply_version(&pool, 12).await;
+
+        let (id, name, protocol, api_key, priority) =
+            sqlx::query_as::<_, (i64, String, String, String, i64)>(
+                "SELECT id, name, protocol, api_key, priority FROM indexers",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            (
+                id,
+                name.as_str(),
+                protocol.as_str(),
+                api_key.as_str(),
+                priority
+            ),
+            (3, "Pre-existing", "torznab", "key", 10)
+        );
+
+        let categories = sqlx::query_as::<_, (i64, i64, String)>(
+            "SELECT indexer_id, category_id, name FROM indexer_categories",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(categories, vec![(3, 2000, "Movies".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn indexer_protocol_check_admits_cardigann_and_rejects_unknown() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        run_migrations(&pool).await.unwrap();
+
+        sqlx::query(
+            "INSERT INTO indexers (name, url, protocol) VALUES ('C', 'sample-id', 'cardigann')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let err =
+            sqlx::query("INSERT INTO indexers (name, url, protocol) VALUES ('B', 'x', 'bogus')")
+                .execute(&pool)
+                .await
+                .unwrap_err();
+        assert!(err.to_string().contains("CHECK"), "got: {err}");
+    }
+}

--- a/crates/zetesis/Cargo.toml
+++ b/crates/zetesis/Cargo.toml
@@ -16,7 +16,11 @@ tokio.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_norway.workspace = true
 quick-xml.workspace = true
+scraper.workspace = true
+ego-tree.workspace = true
+regex.workspace = true
 dashmap.workspace = true
 tokio-util.workspace = true
 futures.workspace = true
@@ -28,6 +32,7 @@ sqlx.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies.tokio]
 workspace = true

--- a/crates/zetesis/src/client/cardigann/categories.rs
+++ b/crates/zetesis/src/client/cardigann/categories.rs
@@ -1,0 +1,219 @@
+//! Torznab category table and site-category mapping for Cardigann definitions.
+
+use tracing::debug;
+
+use crate::client::cardigann::definition::CategoryMapping;
+use crate::types::IndexerCategory;
+
+/// The standard Torznab/Newznab category tree, as named by Cardigann
+/// definitions in `caps.categorymappings[].cat`.
+const TORZNAB_CATEGORIES: &[(u32, &str)] = &[
+    (1000, "Console"),
+    (1010, "Console/NDS"),
+    (1020, "Console/PSP"),
+    (1030, "Console/Wii"),
+    (1040, "Console/XBox"),
+    (1050, "Console/XBox 360"),
+    (1060, "Console/Wiiware"),
+    (1070, "Console/XBox 360 DLC"),
+    (1080, "Console/PS3"),
+    (1090, "Console/Other"),
+    (1110, "Console/3DS"),
+    (1120, "Console/PS Vita"),
+    (1130, "Console/WiiU"),
+    (1140, "Console/XBox One"),
+    (1180, "Console/PS4"),
+    (2000, "Movies"),
+    (2010, "Movies/Foreign"),
+    (2020, "Movies/Other"),
+    (2030, "Movies/SD"),
+    (2040, "Movies/HD"),
+    (2045, "Movies/UHD"),
+    (2050, "Movies/BluRay"),
+    (2060, "Movies/3D"),
+    (2070, "Movies/DVD"),
+    (2080, "Movies/WEB-DL"),
+    (3000, "Audio"),
+    (3010, "Audio/MP3"),
+    (3020, "Audio/Video"),
+    (3030, "Audio/Audiobook"),
+    (3040, "Audio/Lossless"),
+    (3050, "Audio/Other"),
+    (3060, "Audio/Foreign"),
+    (4000, "PC"),
+    (4010, "PC/0day"),
+    (4020, "PC/ISO"),
+    (4030, "PC/Mac"),
+    (4040, "PC/Mobile-Other"),
+    (4050, "PC/Games"),
+    (4060, "PC/Mobile-iOS"),
+    (4070, "PC/Mobile-Android"),
+    (5000, "TV"),
+    (5010, "TV/WEB-DL"),
+    (5020, "TV/Foreign"),
+    (5030, "TV/SD"),
+    (5040, "TV/HD"),
+    (5045, "TV/UHD"),
+    (5050, "TV/Other"),
+    (5060, "TV/Sport"),
+    (5070, "TV/Anime"),
+    (5080, "TV/Documentary"),
+    (6000, "XXX"),
+    (6010, "XXX/DVD"),
+    (6020, "XXX/WMV"),
+    (6030, "XXX/XviD"),
+    (6040, "XXX/x264"),
+    (6045, "XXX/UHD"),
+    (6050, "XXX/Pack"),
+    (6060, "XXX/ImageSet"),
+    (6070, "XXX/Other"),
+    (6080, "XXX/SD"),
+    (6090, "XXX/WEB-DL"),
+    (7000, "Books"),
+    (7010, "Books/Mags"),
+    (7020, "Books/EBook"),
+    (7030, "Books/Comics"),
+    (7040, "Books/Technical"),
+    (7050, "Books/Other"),
+    (7060, "Books/Foreign"),
+    (8000, "Other"),
+    (8010, "Other/Misc"),
+    (8020, "Other/Hashed"),
+];
+
+pub fn category_id_for_name(name: &str) -> Option<u32> {
+    TORZNAB_CATEGORIES
+        .iter()
+        .find(|(_, n)| n.eq_ignore_ascii_case(name.trim()))
+        .map(|(id, _)| *id)
+}
+
+pub fn category_name_for_id(id: u32) -> Option<&'static str> {
+    TORZNAB_CATEGORIES
+        .iter()
+        .find(|(i, _)| *i == id)
+        .map(|(_, n)| *n)
+}
+
+/// Maps the query's Torznab category ids to the site-native category ids the
+/// definition declares. A top-level request (e.g. 2000) also selects every
+/// mapping in its subtree (2040, 2045, ...).
+pub fn site_categories_for(mappings: &[CategoryMapping], requested: &[u32]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for mapping in mappings {
+        let Some(torznab_id) = category_id_for_name(&mapping.cat) else {
+            continue;
+        };
+        let selected = requested
+            .iter()
+            .any(|r| torznab_id == *r || (*r % 1000 == 0 && torznab_id / 1000 == *r / 1000));
+        if selected && !out.contains(&mapping.id.0) {
+            out.push(mapping.id.0.clone());
+        }
+    }
+    out
+}
+
+/// Maps one extracted site category id back to its Torznab category id.
+pub fn torznab_id_for_site(mappings: &[CategoryMapping], site_id: &str) -> Option<u32> {
+    let site_id = site_id.trim();
+    let mapped = mappings
+        .iter()
+        .find(|m| m.id.0 == site_id)
+        .and_then(|m| category_id_for_name(&m.cat));
+    if mapped.is_none() {
+        debug!(site_id = %site_id, "site category has no Torznab mapping");
+    }
+    mapped
+}
+
+/// The Torznab categories a definition serves, deduplicated and ordered by
+/// id, for `caps()`. Unknown category names are skipped.
+pub fn caps_categories(mappings: &[CategoryMapping]) -> Vec<IndexerCategory> {
+    let mut ids: Vec<u32> = mappings
+        .iter()
+        .filter_map(|m| {
+            let id = category_id_for_name(&m.cat);
+            if id.is_none() {
+                debug!(cat = %m.cat, "unknown Torznab category name in definition; skipped");
+            }
+            id
+        })
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    ids.into_iter()
+        .filter_map(|id| {
+            category_name_for_id(id).map(|name| IndexerCategory {
+                id,
+                name: name.to_string(),
+                subcategories: Vec::new(),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::cardigann::definition::ScalarString;
+
+    fn mapping(id: &str, cat: &str) -> CategoryMapping {
+        CategoryMapping {
+            id: ScalarString(id.to_string()),
+            cat: cat.to_string(),
+            desc: None,
+            default: false,
+        }
+    }
+
+    #[test]
+    fn name_lookup_is_case_insensitive() {
+        assert_eq!(category_id_for_name("Movies/HD"), Some(2040));
+        assert_eq!(category_id_for_name("movies/hd"), Some(2040));
+        assert_eq!(category_id_for_name("Nonsense"), None);
+    }
+
+    #[test]
+    fn exact_category_selects_site_id() {
+        let mappings = [mapping("6", "Movies/HD"), mapping("7", "TV/HD")];
+        assert_eq!(site_categories_for(&mappings, &[2040]), vec!["6"]);
+    }
+
+    #[test]
+    fn top_level_request_selects_subtree() {
+        let mappings = [
+            mapping("6", "Movies/HD"),
+            mapping("8", "Movies/SD"),
+            mapping("7", "TV/HD"),
+        ];
+        assert_eq!(site_categories_for(&mappings, &[2000]), vec!["6", "8"]);
+    }
+
+    #[test]
+    fn duplicate_site_ids_are_deduplicated() {
+        let mappings = [mapping("6", "Movies/HD"), mapping("6", "Movies/SD")];
+        assert_eq!(site_categories_for(&mappings, &[2000]), vec!["6"]);
+    }
+
+    #[test]
+    fn site_id_maps_back_to_torznab() {
+        let mappings = [mapping("6", "Movies/HD")];
+        assert_eq!(torznab_id_for_site(&mappings, "6"), Some(2040));
+        assert_eq!(torznab_id_for_site(&mappings, " 6 "), Some(2040));
+        assert_eq!(torznab_id_for_site(&mappings, "99"), None);
+    }
+
+    #[test]
+    fn caps_categories_dedupes_and_sorts() {
+        let mappings = [
+            mapping("7", "TV/HD"),
+            mapping("6", "Movies/HD"),
+            mapping("9", "Movies/HD"),
+            mapping("x", "Nonsense"),
+        ];
+        let caps = caps_categories(&mappings);
+        let pairs: Vec<(u32, &str)> = caps.iter().map(|c| (c.id, c.name.as_str())).collect();
+        assert_eq!(pairs, vec![(2040, "Movies/HD"), (5040, "TV/HD")]);
+    }
+}

--- a/crates/zetesis/src/client/cardigann/definition.rs
+++ b/crates/zetesis/src/client/cardigann/definition.rs
@@ -487,6 +487,19 @@ fn validate(def: &CardigannDefinition) -> Result<(), SearchIndexerError> {
     if def.search.fields.is_empty() {
         return Err(invalid("no search fields".to_string()));
     }
+    // WHY: result mapping drops every row lacking these fields — a
+    // definition without them (e.g. a typo'd field name) would load fine
+    // and then return zero results forever with no signal.
+    if !def.search.fields.contains_key("title") {
+        return Err(invalid(
+            "search fields are missing required field \"title\"".to_string(),
+        ));
+    }
+    if !def.search.fields.contains_key("download") && !def.search.fields.contains_key("magnet") {
+        return Err(invalid(
+            "search fields are missing a download source (\"download\" or \"magnet\")".to_string(),
+        ));
+    }
     for (name, field) in &def.search.fields {
         if let Some(sel) = &field.selector {
             check_selector(&format!("field {name}"), sel)?;

--- a/crates/zetesis/src/client/cardigann/definition.rs
+++ b/crates/zetesis/src/client/cardigann/definition.rs
@@ -1,0 +1,551 @@
+//! Cardigann YAML definition schema, loading, and load-time validation.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::Path;
+
+use serde::Deserialize;
+use serde::de::{self, Deserializer, SeqAccess, Visitor};
+use tracing::warn;
+
+use crate::client::cardigann::{filters, template};
+use crate::error::SearchIndexerError;
+
+/// One Prowlarr-compatible Cardigann indexer definition, deserialized from a
+/// single YAML file.
+///
+/// Unknown YAML keys are ignored on purpose: real-world definitions carry
+/// many blocks this engine does not model, and a permissive schema keeps a
+/// definition loadable as long as the parts this engine executes are sound.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CardigannDefinition {
+    pub id: String, // kanon:ignore RUST/primitive-for-domain-id -- wire DTO mirroring the external Cardigann YAML schema
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default, rename = "type")]
+    pub site_type: Option<String>,
+    #[serde(default)]
+    pub encoding: Option<String>,
+    #[serde(default)]
+    pub links: Vec<String>,
+    #[serde(default)]
+    pub legacylinks: Vec<String>,
+    pub caps: CapsBlock,
+    #[serde(default)]
+    pub settings: Vec<SettingsField>,
+    #[serde(default)]
+    pub login: Option<LoginBlock>,
+    pub search: SearchBlock,
+    #[serde(default)]
+    pub download: Option<DownloadBlock>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CapsBlock {
+    #[serde(default)]
+    pub categorymappings: Vec<CategoryMapping>,
+    /// Legacy short form: site category id → Torznab category name. Folded
+    /// into `categorymappings` by [`normalize`].
+    #[serde(default)]
+    pub categories: BTreeMap<ScalarString, String>,
+    /// Search mode → supported query fields, e.g. `tv-search: [q, season, ep]`.
+    #[serde(default)]
+    pub modes: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CategoryMapping {
+    /// Site-native category id (number or string in YAML).
+    pub id: ScalarString,
+    /// Torznab category name, e.g. `Movies/HD`.
+    pub cat: String,
+    #[serde(default)]
+    pub desc: Option<String>,
+    #[serde(default)]
+    pub default: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettingsField {
+    pub name: String,
+    #[serde(default, rename = "type")]
+    pub field_type: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub default: Option<ScalarString>,
+    #[serde(default)]
+    pub options: Option<BTreeMap<ScalarString, ScalarString>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LoginBlock {
+    #[serde(default)]
+    pub method: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub inputs: BTreeMap<String, ScalarString>,
+    #[serde(default)]
+    pub test: Option<LoginTest>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LoginTest {
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub selector: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchBlock {
+    #[serde(default)]
+    pub paths: Vec<SearchPath>,
+    /// Legacy single-path form. Folded into `paths` by [`normalize`].
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub inputs: BTreeMap<String, ScalarString>,
+    #[serde(default)]
+    pub keywordsfilters: Vec<FilterSpec>,
+    pub rows: RowsBlock,
+    #[serde(default)]
+    pub fields: BTreeMap<String, FieldBlock>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchPath {
+    pub path: String,
+    #[serde(default)]
+    pub method: Option<String>,
+    /// Site category ids this path is limited to (empty = all queries).
+    #[serde(default)]
+    pub categories: Vec<ScalarString>,
+    /// Extra inputs merged over `search.inputs` for this path.
+    #[serde(default)]
+    pub inputs: BTreeMap<String, ScalarString>,
+    #[serde(default)]
+    pub response: Option<ResponseBlock>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResponseBlock {
+    #[serde(default, rename = "type")]
+    pub response_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RowsBlock {
+    pub selector: String,
+    #[serde(default)]
+    pub filters: Vec<FilterSpec>,
+    #[serde(default)]
+    pub after: Option<u32>,
+    #[serde(default)]
+    pub remove: Option<String>,
+    #[serde(default)]
+    pub dateheaders: Option<FieldBlock>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FieldBlock {
+    #[serde(default)]
+    pub selector: Option<String>,
+    #[serde(default)]
+    pub attribute: Option<String>,
+    /// Constant/template value used instead of selecting from the row.
+    #[serde(default)]
+    pub text: Option<ScalarString>,
+    #[serde(default)]
+    pub filters: Vec<FilterSpec>,
+    #[serde(default)]
+    pub optional: bool,
+    /// Selector → value pairs; the first selector matching the selected
+    /// element (or one of its descendants) supplies the value.
+    ///
+    /// WHY: stored as ordered pairs, not a map — first-match-wins semantics
+    /// depend on the author's YAML order.
+    #[serde(default)]
+    pub case: Option<OrderedPairs>,
+    /// Selector for descendants to exclude from text extraction.
+    #[serde(default)]
+    pub remove: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DownloadBlock {
+    #[serde(default)]
+    pub selector: Option<String>,
+    #[serde(default)]
+    pub attribute: Option<String>,
+    #[serde(default)]
+    pub filters: Vec<FilterSpec>,
+    #[serde(default)]
+    pub method: Option<String>,
+    /// Unmodeled pre-request block; presence is detected and deferred.
+    #[serde(default)]
+    pub before: Option<serde_norway::Value>,
+    /// Unmodeled infohash fallback block; presence is detected and deferred.
+    #[serde(default)]
+    pub infohash: Option<serde_norway::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FilterSpec {
+    pub name: String,
+    #[serde(default)]
+    pub args: Option<FilterArgs>,
+}
+
+impl FilterSpec {
+    pub fn args(&self) -> &[String] {
+        self.args.as_ref().map_or(&[], |a| a.0.as_slice())
+    }
+}
+
+/// A YAML scalar (string, number, or bool) normalized to its string form.
+///
+/// WHY: definition authors write `id: 42` and `id: "42"` interchangeably;
+/// downstream code only ever compares/joins string forms.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ScalarString(pub String);
+
+impl<'de> Deserialize<'de> for ScalarString {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ScalarVisitor;
+
+        impl Visitor<'_> for ScalarVisitor {
+            type Value = ScalarString;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a YAML scalar (string, number, or bool)")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(ScalarString(v.to_string()))
+            }
+
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                Ok(ScalarString(v.to_string()))
+            }
+
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                Ok(ScalarString(v.to_string()))
+            }
+
+            fn visit_f64<E: de::Error>(self, v: f64) -> Result<Self::Value, E> {
+                Ok(ScalarString(v.to_string()))
+            }
+
+            fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
+                Ok(ScalarString(v.to_string()))
+            }
+        }
+
+        deserializer.deserialize_any(ScalarVisitor)
+    }
+}
+
+/// A YAML mapping with author order preserved.
+#[derive(Debug, Clone, Default)]
+pub struct OrderedPairs(pub Vec<(String, ScalarString)>);
+
+impl<'de> Deserialize<'de> for OrderedPairs {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct PairsVisitor;
+
+        impl<'de> Visitor<'de> for PairsVisitor {
+            type Value = OrderedPairs;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a mapping")
+            }
+
+            fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let mut out = Vec::new();
+                while let Some(entry) = map.next_entry::<String, ScalarString>()? {
+                    out.push(entry);
+                }
+                Ok(OrderedPairs(out))
+            }
+        }
+
+        deserializer.deserialize_map(PairsVisitor)
+    }
+}
+
+/// Filter arguments: YAML allows a bare scalar or a list of scalars.
+#[derive(Debug, Clone)]
+pub struct FilterArgs(pub Vec<String>);
+
+impl<'de> Deserialize<'de> for FilterArgs {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ArgsVisitor;
+
+        impl<'de> Visitor<'de> for ArgsVisitor {
+            type Value = FilterArgs;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a scalar or a list of scalars")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut out = Vec::new();
+                while let Some(item) = seq.next_element::<ScalarString>()? {
+                    out.push(item.0);
+                }
+                Ok(FilterArgs(out))
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(FilterArgs(vec![v.to_string()]))
+            }
+
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                Ok(FilterArgs(vec![v.to_string()]))
+            }
+
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                Ok(FilterArgs(vec![v.to_string()]))
+            }
+
+            fn visit_f64<E: de::Error>(self, v: f64) -> Result<Self::Value, E> {
+                Ok(FilterArgs(vec![v.to_string()]))
+            }
+
+            fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
+                Ok(FilterArgs(vec![v.to_string()]))
+            }
+        }
+
+        deserializer.deserialize_any(ArgsVisitor)
+    }
+}
+
+/// Parses, normalizes, and validates one definition file.
+pub fn load_definition_file(path: &Path) -> Result<CardigannDefinition, SearchIndexerError> {
+    let display_path = path.display().to_string();
+    let text = std::fs::read_to_string(path).map_err(|e| SearchIndexerError::DefinitionLoad {
+        path: display_path.clone(),
+        reason: e.to_string(),
+        location: snafu::Location::new(file!(), line!(), column!()),
+    })?;
+    parse_definition(&text, &display_path)
+}
+
+/// Parses, normalizes, and validates definition YAML; `origin` labels load
+/// errors (usually the file path).
+pub fn parse_definition(
+    text: &str,
+    origin: &str,
+) -> Result<CardigannDefinition, SearchIndexerError> {
+    let mut definition: CardigannDefinition =
+        serde_norway::from_str(text).map_err(|e| SearchIndexerError::DefinitionLoad {
+            path: origin.to_string(),
+            reason: e.to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
+    normalize(&mut definition);
+    validate(&definition)?;
+    Ok(definition)
+}
+
+/// Folds legacy schema forms into their modern equivalents.
+fn normalize(def: &mut CardigannDefinition) {
+    if def.search.paths.is_empty()
+        && let Some(path) = def.search.path.take()
+    {
+        def.search.paths.push(SearchPath {
+            path,
+            method: None,
+            categories: Vec::new(),
+            inputs: BTreeMap::new(),
+            response: None,
+        });
+    }
+
+    let legacy: Vec<CategoryMapping> = def
+        .caps
+        .categories
+        .iter()
+        .map(|(id, cat)| CategoryMapping {
+            id: id.clone(),
+            cat: cat.clone(),
+            desc: None,
+            default: false,
+        })
+        .collect();
+    def.caps.categorymappings.extend(legacy);
+    def.caps.categories.clear();
+
+    // WHY: a leading "!" negates a path-category constraint — a feature this
+    // engine defers. Treating the path as unconstrained fetches a superset,
+    // which is correct-but-wider; dropping the path would silently lose rows.
+    for path in &mut def.search.paths {
+        if path.categories.iter().any(|c| c.0.starts_with('!')) {
+            warn!(
+                definition_id = %def.id,
+                path = %path.path,
+                "negated path categories are not supported; treating path as unconstrained"
+            );
+            path.categories.clear();
+        }
+    }
+}
+
+/// Rejects definitions whose executable parts this engine cannot honor.
+///
+/// WHY: a definition that would fail on every search must fail at load with
+/// one clear reason, not degrade into per-query noise. Blocks that only add
+/// information (rows post-filters, date headers) are warned and ignored
+/// instead — skipping them yields a superset of rows, never wrong values.
+fn validate(def: &CardigannDefinition) -> Result<(), SearchIndexerError> {
+    let invalid = |reason: String| SearchIndexerError::DefinitionInvalid {
+        definition_id: def.id.clone(),
+        reason,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    };
+    let unsupported = |feature: String| SearchIndexerError::DefinitionUnsupported {
+        definition_id: def.id.clone(),
+        feature,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    };
+
+    if def.id.trim().is_empty() {
+        return Err(invalid("empty id".to_string()));
+    }
+    if def.links.is_empty() {
+        return Err(invalid("no links".to_string()));
+    }
+    for link in def.links.iter().chain(&def.legacylinks) {
+        if link.contains("{{") {
+            return Err(unsupported(format!("templated link {link}")));
+        }
+        url::Url::parse(link).map_err(|e| invalid(format!("link {link}: {e}")))?;
+    }
+    if def.search.paths.is_empty() {
+        return Err(invalid("no search paths".to_string()));
+    }
+
+    let config_keys: Vec<&str> = def.settings.iter().map(|s| s.name.as_str()).collect();
+    let check_template = |what: &str, tmpl: &str| {
+        template::validate(tmpl, &config_keys).map_err(|e| invalid(format!("{what}: {e}")))
+    };
+    let check_selector = |what: &str, sel: &str| {
+        scraper::Selector::parse(sel)
+            .map(|_| ())
+            .map_err(|e| invalid(format!("{what} selector {sel:?}: {e}")))
+    };
+    let check_filters = |what: &str, specs: &[FilterSpec]| {
+        filters::validate(specs).map_err(|e| invalid(format!("{what}: {e}")))
+    };
+
+    for path in &def.search.paths {
+        match path.method.as_deref() {
+            None | Some("get") => {}
+            Some(other) => return Err(unsupported(format!("search path method {other:?}"))),
+        }
+        if let Some(response) = &path.response
+            && response.response_type.as_deref() != Some("html")
+        {
+            return Err(unsupported(format!(
+                "search response type {:?}",
+                response.response_type
+            )));
+        }
+        check_template("search path", &path.path)?;
+        for (key, value) in &path.inputs {
+            check_template(&format!("search path input {key}"), &value.0)?;
+        }
+    }
+    for (key, value) in &def.search.inputs {
+        check_template(&format!("search input {key}"), &value.0)?;
+    }
+    check_filters("keywordsfilters", &def.search.keywordsfilters)?;
+
+    check_selector("rows", &def.search.rows.selector)?;
+    if !def.search.rows.filters.is_empty() {
+        warn!(
+            definition_id = %def.id,
+            "rows.filters are not supported; rows are not post-filtered"
+        );
+    }
+    if def.search.rows.after.is_some() || def.search.rows.dateheaders.is_some() {
+        warn!(
+            definition_id = %def.id,
+            "rows.after / rows.dateheaders are not supported and are ignored"
+        );
+    }
+    if let Some(remove) = &def.search.rows.remove {
+        check_selector("rows.remove", remove)?;
+    }
+
+    if def.search.fields.is_empty() {
+        return Err(invalid("no search fields".to_string()));
+    }
+    for (name, field) in &def.search.fields {
+        if let Some(sel) = &field.selector {
+            check_selector(&format!("field {name}"), sel)?;
+        }
+        if let Some(remove) = &field.remove {
+            check_selector(&format!("field {name} remove"), remove)?;
+        }
+        if let Some(case) = &field.case {
+            for (case_selector, _) in &case.0 {
+                check_selector(&format!("field {name} case"), case_selector)?;
+            }
+        }
+        if let Some(text) = &field.text {
+            check_template(&format!("field {name} text"), &text.0)?;
+        }
+        check_filters(&format!("field {name}"), &field.filters)?;
+    }
+
+    if let Some(download) = &def.download {
+        if let Some(sel) = &download.selector {
+            check_selector("download", sel)?;
+        }
+        check_filters("download", &download.filters)?;
+        match download.method.as_deref() {
+            None | Some("get") => {}
+            Some(other) => return Err(unsupported(format!("download method {other:?}"))),
+        }
+        if download.before.is_some() {
+            warn!(
+                definition_id = %def.id,
+                "download.before pre-requests are not supported and are ignored"
+            );
+        }
+        if download.infohash.is_some() {
+            warn!(
+                definition_id = %def.id,
+                "download.infohash fallback is not supported and is ignored"
+            );
+        }
+    }
+
+    // NOTE: login templates are only validated for methods this engine runs;
+    // unsupported methods already fail at client construction, and their
+    // inputs routinely use template constructs outside this engine's subset.
+    if let Some(login) = &def.login
+        && matches!(login.method.as_deref(), Some("none" | "cookie") | None)
+    {
+        for (key, value) in &login.inputs {
+            check_template(&format!("login input {key}"), &value.0)?;
+        }
+        if let Some(test) = &login.test
+            && let Some(sel) = &test.selector
+        {
+            check_selector("login test", sel)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/zetesis/src/client/cardigann/definition/tests.rs
+++ b/crates/zetesis/src/client/cardigann/definition/tests.rs
@@ -1,0 +1,383 @@
+//! Cardigann definition schema parse + validation tests.
+
+use super::*;
+
+const SAMPLE: &str = r#"---
+id: sample-tracker
+name: Sample Tracker
+description: A sample tracker for tests
+language: en-US
+type: public
+encoding: UTF-8
+links:
+  - https://sample-tracker.example/
+
+caps:
+  categorymappings:
+    - {id: 6, cat: Movies/HD, desc: "Movies HD"}
+    - {id: 7, cat: Movies/SD}
+    - {id: 12, cat: TV/HD}
+  modes:
+    search: [q]
+    tv-search: [q, season, ep]
+    movie-search: [q]
+
+settings:
+  - name: sort
+    type: select
+    label: Sort by
+    default: created
+    options:
+      created: Created
+      seeders: Seeders
+
+login:
+  method: none
+
+search:
+  paths:
+    - path: /browse
+  inputs:
+    q: "{{ .Keywords }}"
+    cats: "{{ .Categories }}"
+    sort: "{{ .Config.sort }}"
+  keywordsfilters:
+    - name: re_replace
+      args: ["\\s+", "."]
+  rows:
+    selector: table#torrents > tbody > tr
+  fields:
+    title:
+      selector: a.title
+    details:
+      selector: a.title
+      attribute: href
+    category:
+      selector: a.cat
+      attribute: href
+      filters:
+        - name: querystring
+          args: cat
+    download:
+      selector: a.dl
+      attribute: href
+    size:
+      selector: td.size
+    seeders:
+      selector: td.seeds
+    leechers:
+      selector: td.leech
+    date:
+      selector: td.date
+      filters:
+        - name: dateparse
+          args: "2006-01-02 15:04"
+    downloadvolumefactor:
+      case:
+        img.freeleech: 0
+        "*": 1
+    uploadvolumefactor:
+      text: 1
+    description:
+      selector: td.desc
+      optional: true
+
+download:
+  selector: a#dl
+  attribute: href
+"#;
+
+#[test]
+fn parses_representative_definition() {
+    let def = parse_definition(SAMPLE, "test").unwrap();
+    assert_eq!(def.id, "sample-tracker");
+    assert_eq!(def.name, "Sample Tracker");
+    assert_eq!(def.site_type.as_deref(), Some("public"));
+    assert_eq!(def.links, vec!["https://sample-tracker.example/"]);
+
+    assert_eq!(def.caps.categorymappings.len(), 3);
+    assert_eq!(def.caps.categorymappings[0].id.0, "6");
+    assert_eq!(def.caps.categorymappings[0].cat, "Movies/HD");
+    assert_eq!(
+        def.caps.categorymappings[0].desc.as_deref(),
+        Some("Movies HD")
+    );
+    assert_eq!(
+        def.caps.modes.get("tv-search"),
+        Some(&vec![
+            "q".to_string(),
+            "season".to_string(),
+            "ep".to_string()
+        ])
+    );
+
+    assert_eq!(def.settings.len(), 1);
+    assert_eq!(def.settings[0].name, "sort");
+    assert_eq!(def.settings[0].default.as_ref().unwrap().0, "created");
+
+    assert_eq!(def.login.as_ref().unwrap().method.as_deref(), Some("none"));
+
+    assert_eq!(def.search.paths.len(), 1);
+    assert_eq!(def.search.paths[0].path, "/browse");
+    assert_eq!(def.search.inputs.get("q").unwrap().0, "{{ .Keywords }}");
+    assert_eq!(def.search.keywordsfilters.len(), 1);
+    assert_eq!(def.search.keywordsfilters[0].name, "re_replace");
+    assert_eq!(def.search.keywordsfilters[0].args(), ["\\s+", "."]);
+    assert_eq!(def.search.rows.selector, "table#torrents > tbody > tr");
+    assert_eq!(def.search.fields.len(), 11);
+
+    let category = def.search.fields.get("category").unwrap();
+    assert_eq!(category.selector.as_deref(), Some("a.cat"));
+    assert_eq!(category.attribute.as_deref(), Some("href"));
+    assert_eq!(category.filters[0].name, "querystring");
+    assert_eq!(category.filters[0].args(), ["cat"]);
+
+    let dvf = def.search.fields.get("downloadvolumefactor").unwrap();
+    let case = dvf.case.as_ref().unwrap();
+    assert_eq!(
+        case.0[0],
+        ("img.freeleech".to_string(), ScalarString("0".to_string()))
+    );
+    assert_eq!(case.0[1].0, "*");
+
+    assert!(def.search.fields.get("description").unwrap().optional);
+
+    let download = def.download.as_ref().unwrap();
+    assert_eq!(download.selector.as_deref(), Some("a#dl"));
+    assert_eq!(download.attribute.as_deref(), Some("href"));
+}
+
+#[test]
+fn legacy_single_path_and_categories_normalize() {
+    let def = parse_definition(
+        r#"
+id: legacy
+name: Legacy
+links: ["https://legacy.example/"]
+caps:
+  categories:
+    "1": Movies
+    "2": TV
+  modes:
+    search: [q]
+search:
+  path: /torrents
+  rows:
+    selector: tr.torrent
+  fields:
+    title:
+      selector: a
+    download:
+      selector: a
+      attribute: href
+"#,
+        "test",
+    )
+    .unwrap();
+    assert_eq!(def.search.paths.len(), 1);
+    assert_eq!(def.search.paths[0].path, "/torrents");
+    assert_eq!(def.caps.categorymappings.len(), 2);
+    assert!(def.caps.categories.is_empty());
+    assert!(
+        def.caps
+            .categorymappings
+            .iter()
+            .any(|m| m.id.0 == "1" && m.cat == "Movies")
+    );
+}
+
+#[test]
+fn negated_path_categories_are_cleared() {
+    let def = parse_definition(
+        r#"
+id: negated
+name: Negated
+links: ["https://negated.example/"]
+caps:
+  categorymappings:
+    - {id: 1, cat: Movies}
+  modes:
+    search: [q]
+search:
+  paths:
+    - path: /a
+      categories: ["!", "2"]
+  rows:
+    selector: tr
+  fields:
+    title:
+      selector: a
+"#,
+        "test",
+    )
+    .unwrap();
+    assert!(def.search.paths[0].categories.is_empty());
+}
+
+fn minimal_with(search_extra: &str) -> String {
+    format!(
+        r#"
+id: x
+name: X
+links: ["https://x.example/"]
+caps:
+  categorymappings:
+    - {{id: 1, cat: Movies}}
+  modes:
+    search: [q]
+search:
+{search_extra}
+  rows:
+    selector: tr
+  fields:
+    title:
+      selector: a
+"#
+    )
+}
+
+#[test]
+fn unsupported_filter_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a
+  keywordsfilters:
+    - name: diacritics
+      args: replace"#,
+    );
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionInvalid { .. }),
+        "got {err:?}"
+    );
+    assert!(err.to_string().contains("diacritics"), "got {err}");
+}
+
+#[test]
+fn post_search_path_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a
+      method: post"#,
+    );
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn json_response_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a
+      response:
+        type: json"#,
+    );
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn unsupported_template_construct_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a
+  inputs:
+    q: "{{ if .Keywords }}{{ .Keywords }}{{ end }}""#,
+    );
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionInvalid { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn unknown_config_key_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a
+  inputs:
+    q: "{{ .Config.nonexistent }}""#,
+    );
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(err.to_string().contains("nonexistent"), "got {err}");
+}
+
+#[test]
+fn bad_selector_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a"#,
+    )
+    .replace("selector: tr", "selector: \"tr[\"");
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionInvalid { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn templated_link_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a"#,
+    )
+    .replace("https://x.example/", "{{ .Config.sitelink }}");
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn form_login_definition_still_loads() {
+    // WHY: unsupported login methods must fail at client construction
+    // (with a clear pointer), not at load — the definition itself parses.
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a"#,
+    ) + r#"
+login:
+  method: form
+  inputs:
+    username: "{{ .Config.username }}"
+"#;
+    let def = parse_definition(&yaml, "test").unwrap();
+    assert_eq!(def.login.unwrap().method.as_deref(), Some("form"));
+}
+
+#[test]
+fn scalar_and_list_filter_args_both_parse() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a
+  keywordsfilters:
+    - name: append
+      args: " extra"
+    - name: re_replace
+      args: ["\\s+", "+"]
+    - name: trim"#,
+    );
+    let def = parse_definition(&yaml, "test").unwrap();
+    assert_eq!(def.search.keywordsfilters[0].args(), [" extra"]);
+    assert_eq!(def.search.keywordsfilters[1].args(), ["\\s+", "+"]);
+    assert!(def.search.keywordsfilters[2].args().is_empty());
+}
+
+#[test]
+fn malformed_yaml_is_a_load_error() {
+    let err = parse_definition(": not yaml :", "somefile.yml").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionLoad { .. }),
+        "got {err:?}"
+    );
+    assert!(err.to_string().contains("somefile.yml"), "got {err}");
+}

--- a/crates/zetesis/src/client/cardigann/definition/tests.rs
+++ b/crates/zetesis/src/client/cardigann/definition/tests.rs
@@ -207,6 +207,9 @@ search:
   fields:
     title:
       selector: a
+    download:
+      selector: a
+      attribute: href
 "#,
         "test",
     )
@@ -232,6 +235,9 @@ search:
   fields:
     title:
       selector: a
+    download:
+      selector: a
+      attribute: href
 "#
     )
 }
@@ -335,6 +341,46 @@ fn templated_link_rejected_at_load() {
         matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
         "got {err:?}"
     );
+}
+
+#[test]
+fn missing_title_field_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a"#,
+    )
+    .replace("title:", "titel:");
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionInvalid { .. }),
+        "got {err:?}"
+    );
+    assert!(err.to_string().contains("\"title\""), "got {err}");
+}
+
+#[test]
+fn missing_download_source_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a"#,
+    )
+    .replace("download:", "downlod:");
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionInvalid { .. }),
+        "got {err:?}"
+    );
+    assert!(err.to_string().contains("download"), "got {err}");
+}
+
+#[test]
+fn magnet_field_satisfies_download_source() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a"#,
+    )
+    .replace("download:", "magnet:");
+    parse_definition(&yaml, "test").unwrap();
 }
 
 #[test]

--- a/crates/zetesis/src/client/cardigann/extract.rs
+++ b/crates/zetesis/src/client/cardigann/extract.rs
@@ -101,16 +101,37 @@ fn resolve_case(
     Ok(None)
 }
 
-/// Concatenated text of `element`, excluding subtrees matched by `remove`.
+/// Whitespace-normalized text of `element`, excluding subtrees matched by
+/// `remove`.
+///
+/// WHY: Cardigann definitions are authored against jsoup's `Element.text()`,
+/// which collapses internal whitespace — source-formatting newlines/indent
+/// must not leak into extracted values. Attribute extraction is never
+/// normalized (jsoup leaves attributes verbatim).
 fn element_text(element: ElementRef, remove: Option<&str>) -> Result<String, String> {
-    let Some(remove) = remove else {
-        return Ok(element.text().collect::<String>());
+    let raw = match remove {
+        None => element.text().collect::<String>(),
+        Some(remove) => {
+            let selector = parse_selector(remove)?;
+            let removed: HashSet<_> = element.select(&selector).map(|e| e.id()).collect();
+            let mut out = String::new();
+            collect_text(*element, &removed, &mut out);
+            out
+        }
     };
-    let selector = parse_selector(remove)?;
-    let removed: HashSet<_> = element.select(&selector).map(|e| e.id()).collect();
-    let mut out = String::new();
-    collect_text(*element, &removed, &mut out);
-    Ok(out)
+    Ok(normalize_whitespace(&raw))
+}
+
+/// Collapses runs of ASCII whitespace to single spaces and trims the ends.
+///
+/// WHY: ASCII-only on purpose — jsoup collapses only ASCII whitespace and
+/// preserves U+00A0 (`&nbsp;`), which definition filters may split on.
+fn normalize_whitespace(value: &str) -> String {
+    value
+        .split(|c: char| c.is_ascii_whitespace())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn collect_text(
@@ -230,6 +251,9 @@ search:
     title:
       selector: span.name
       remove: span.tag
+    download:
+      selector: a
+      attribute: href
 "#,
             "test",
         )
@@ -261,6 +285,9 @@ search:
     selector: li
   fields:
     title: {}
+    download:
+      selector: a
+      attribute: href
 "#,
             "test",
         )
@@ -273,6 +300,48 @@ search:
         )
         .unwrap();
         assert_eq!(rows[0].get("title").map(String::as_str), Some("Whole Row"));
+    }
+
+    #[test]
+    fn text_extraction_collapses_whitespace_but_attributes_keep_it() {
+        let def = parse_definition(
+            r#"
+id: r
+name: R
+links: ["https://r.example/"]
+caps:
+  categorymappings:
+    - {id: 1, cat: Movies}
+  modes:
+    search: [q]
+search:
+  paths:
+    - path: /
+  rows:
+    selector: div.row
+  fields:
+    title:
+      selector: span
+    download:
+      selector: a
+      attribute: href
+"#,
+            "test",
+        )
+        .unwrap();
+        let html = "<div class=\"row\"><span>Good\n  <b>Title</b>\n  Extra</span>\
+                    <a href=\"x  y.torrent\">dl</a></div>";
+        let rows = extract_rows(html, &def, &TemplateContext::default(), &utc_now()).unwrap();
+        assert_eq!(
+            rows[0].get("title").map(String::as_str),
+            Some("Good Title Extra")
+        );
+        // WHY: attribute values must stay verbatim — jsoup only
+        // normalizes text.
+        assert_eq!(
+            rows[0].get("download").map(String::as_str),
+            Some("x  y.torrent")
+        );
     }
 
     #[test]

--- a/crates/zetesis/src/client/cardigann/extract.rs
+++ b/crates/zetesis/src/client/cardigann/extract.rs
@@ -1,0 +1,317 @@
+//! HTML row/field extraction for Cardigann definitions (CSS selectors via
+//! `scraper`).
+//!
+//! Everything here is synchronous on purpose: `scraper::Html` is `!Send`, so
+//! parsing must start and finish between awaits. Callers fetch the body,
+//! then hand the owned string in and get owned rows back.
+
+use std::collections::{BTreeMap, HashSet};
+
+use jiff::Zoned;
+use scraper::{ElementRef, Html, Selector};
+use tracing::debug;
+
+use crate::client::cardigann::definition::{CardigannDefinition, FieldBlock};
+use crate::client::cardigann::{filters, template::TemplateContext};
+
+/// Extracted field values for the rows in one search-results page, in
+/// definition field order per row.
+pub fn extract_rows(
+    html: &str,
+    def: &CardigannDefinition,
+    ctx: &TemplateContext,
+    now: &Zoned,
+) -> Result<Vec<BTreeMap<String, String>>, String> {
+    let document = Html::parse_document(html);
+    let row_selector = parse_selector(&def.search.rows.selector)?;
+    let mut rows = Vec::new();
+    for row in document.select(&row_selector) {
+        let mut values = BTreeMap::new();
+        for (name, field) in &def.search.fields {
+            match extract_field(row, field, ctx, now) {
+                Ok(Some(value)) => {
+                    values.insert(name.clone(), value);
+                }
+                Ok(None) => {}
+                Err(reason) => {
+                    // WHY: one broken cell must not fail the whole page; the
+                    // row-level required checks (title, download) decide
+                    // whether the row survives.
+                    debug!(
+                        definition_id = %def.id,
+                        field = %name,
+                        reason = %reason,
+                        "field extraction failed; treating as absent"
+                    );
+                }
+            }
+        }
+        rows.push(values);
+    }
+    Ok(rows)
+}
+
+fn extract_field(
+    row: ElementRef,
+    field: &FieldBlock,
+    ctx: &TemplateContext,
+    now: &Zoned,
+) -> Result<Option<String>, String> {
+    let raw: Option<String> = if let Some(text) = &field.text {
+        Some(ctx.render(&text.0)?)
+    } else {
+        let element = match &field.selector {
+            Some(selector) => row.select(&parse_selector(selector)?).next(),
+            None => Some(row),
+        };
+        match element {
+            None => None,
+            Some(element) => {
+                if let Some(case) = &field.case {
+                    resolve_case(element, case)?
+                } else if let Some(attribute) = &field.attribute {
+                    element.value().attr(attribute).map(str::to_string)
+                } else {
+                    Some(element_text(element, field.remove.as_deref())?)
+                }
+            }
+        }
+    };
+
+    let raw = raw.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
+    match raw {
+        None if field.optional => Ok(None),
+        None => Err("no value extracted".to_string()),
+        Some(value) => filters::apply(value, &field.filters, now).map(Some),
+    }
+}
+
+/// Resolves a `case:` block: the first selector matching the element itself
+/// or one of its descendants supplies the value.
+fn resolve_case(
+    element: ElementRef,
+    case: &crate::client::cardigann::definition::OrderedPairs,
+) -> Result<Option<String>, String> {
+    for (selector_str, value) in &case.0 {
+        let selector = parse_selector(selector_str)?;
+        if selector.matches(&element) || element.select(&selector).next().is_some() {
+            return Ok(Some(value.0.clone()));
+        }
+    }
+    Ok(None)
+}
+
+/// Concatenated text of `element`, excluding subtrees matched by `remove`.
+fn element_text(element: ElementRef, remove: Option<&str>) -> Result<String, String> {
+    let Some(remove) = remove else {
+        return Ok(element.text().collect::<String>());
+    };
+    let selector = parse_selector(remove)?;
+    let removed: HashSet<_> = element.select(&selector).map(|e| e.id()).collect();
+    let mut out = String::new();
+    collect_text(*element, &removed, &mut out);
+    Ok(out)
+}
+
+fn collect_text(
+    node: ego_tree::NodeRef<scraper::Node>,
+    removed: &HashSet<ego_tree::NodeId>,
+    out: &mut String,
+) {
+    for child in node.children() {
+        if removed.contains(&child.id()) {
+            continue;
+        }
+        if let Some(text) = child.value().as_text() {
+            out.push_str(text);
+        }
+        collect_text(child, removed, out);
+    }
+}
+
+/// Pulls the follow-on download link out of a details/interstitial page
+/// (the `download:` block's selector + attribute).
+pub fn extract_download_link(
+    html: &str,
+    selector: &str,
+    attribute: Option<&str>,
+) -> Result<String, String> {
+    let document = Html::parse_document(html);
+    let selector = parse_selector(selector)?;
+    let element = document
+        .select(&selector)
+        .next()
+        .ok_or_else(|| "download selector matched nothing".to_string())?;
+    let attribute = attribute.unwrap_or("href");
+    element
+        .value()
+        .attr(attribute)
+        .map(str::to_string)
+        .ok_or_else(|| format!("download element has no {attribute:?} attribute"))
+}
+
+fn parse_selector(selector: &str) -> Result<Selector, String> {
+    Selector::parse(selector).map_err(|e| format!("selector {selector:?}: {e}"))
+}
+
+/// Parses a human-readable size ("1.5 GB", "700MB", "1,024 KiB") to bytes.
+///
+/// NOTE: decimal suffixes are treated as binary multiples (KB = 1024), which
+/// is what Cardigann-compatible indexers conventionally emit.
+pub fn parse_size(value: &str) -> Option<u64> {
+    let cleaned = value.trim().replace(',', "");
+    let unit_start = cleaned.find(|c: char| c.is_ascii_alphabetic())?;
+    let number: f64 = cleaned.get(..unit_start)?.trim().parse().ok()?;
+    if !number.is_finite() || number < 0.0 {
+        return None;
+    }
+    let exponent: i32 = match cleaned
+        .get(unit_start..)?
+        .trim()
+        .to_ascii_uppercase()
+        .as_str()
+    {
+        "B" => 0,
+        "K" | "KB" | "KIB" => 1,
+        "M" | "MB" | "MIB" => 2,
+        "G" | "GB" | "GIB" => 3,
+        "T" | "TB" | "TIB" => 4,
+        "P" | "PB" | "PIB" => 5,
+        _ => return None,
+    };
+    let bytes = number * 1024_f64.powi(exponent);
+    // NOTE: 2^63 bounds the round-trip: every finite f64 below it fits u64.
+    if bytes >= 9_223_372_036_854_775_808.0 {
+        return None;
+    }
+    // kanon:ignore RUST/as-cast -- f64→u64 has no TryFrom; range-guarded above
+    Some(bytes.round() as u64)
+}
+
+/// Parses an integer that may carry thousands separators or whitespace.
+pub fn parse_u32_loose(value: &str) -> Option<u32> {
+    value.trim().replace([',', ' '], "").parse().ok()
+}
+
+pub fn parse_f64_loose(value: &str) -> Option<f64> {
+    value.trim().parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::cardigann::definition::parse_definition;
+
+    fn utc_now() -> Zoned {
+        "2026-06-15T12:00:00Z"
+            .parse::<jiff::Timestamp>()
+            .unwrap()
+            .to_zoned(jiff::tz::TimeZone::UTC)
+    }
+
+    #[test]
+    fn remove_selector_excludes_subtree_text() {
+        let def = parse_definition(
+            r#"
+id: r
+name: R
+links: ["https://r.example/"]
+caps:
+  categorymappings:
+    - {id: 1, cat: Movies}
+  modes:
+    search: [q]
+search:
+  paths:
+    - path: /
+  rows:
+    selector: div.row
+  fields:
+    title:
+      selector: span.name
+      remove: span.tag
+"#,
+            "test",
+        )
+        .unwrap();
+        let html = r#"<div class="row">
+            <span class="name">Good Title<span class="tag"> [FL]</span></span>
+        </div>"#;
+        let rows = extract_rows(html, &def, &TemplateContext::default(), &utc_now()).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get("title").map(String::as_str), Some("Good Title"));
+    }
+
+    #[test]
+    fn field_without_selector_reads_row_text() {
+        let def = parse_definition(
+            r#"
+id: r
+name: R
+links: ["https://r.example/"]
+caps:
+  categorymappings:
+    - {id: 1, cat: Movies}
+  modes:
+    search: [q]
+search:
+  paths:
+    - path: /
+  rows:
+    selector: li
+  fields:
+    title: {}
+"#,
+            "test",
+        )
+        .unwrap();
+        let rows = extract_rows(
+            "<ul><li> Whole Row </li></ul>",
+            &def,
+            &TemplateContext::default(),
+            &utc_now(),
+        )
+        .unwrap();
+        assert_eq!(rows[0].get("title").map(String::as_str), Some("Whole Row"));
+    }
+
+    #[test]
+    fn extract_download_link_reads_attribute() {
+        let html = r#"<html><body><a id="dl" href="/file.torrent">get</a></body></html>"#;
+        assert_eq!(
+            extract_download_link(html, "a#dl", None).unwrap(),
+            "/file.torrent"
+        );
+        assert_eq!(
+            extract_download_link(html, "a#dl", Some("id")).unwrap(),
+            "dl"
+        );
+        assert!(extract_download_link(html, "a.missing", None).is_err());
+        assert!(extract_download_link(html, "a#dl", Some("nope")).is_err());
+    }
+
+    #[test]
+    fn parse_size_units() {
+        assert_eq!(parse_size("700 MB"), Some(700 * 1024 * 1024));
+        assert_eq!(parse_size("700MB"), Some(700 * 1024 * 1024));
+        assert_eq!(parse_size("1.5 GiB"), Some(1_610_612_736));
+        assert_eq!(parse_size("1,024 KB"), Some(1024 * 1024));
+        assert_eq!(parse_size("2 TB"), Some(2 * 1024_u64.pow(4)));
+        assert_eq!(parse_size("512 B"), Some(512));
+    }
+
+    #[test]
+    fn parse_size_rejects_garbage() {
+        assert_eq!(parse_size("unknown"), None);
+        assert_eq!(parse_size("12 XB"), None);
+        assert_eq!(parse_size("-3 GB"), None);
+        assert_eq!(parse_size(""), None);
+    }
+
+    #[test]
+    fn parse_u32_loose_strips_separators() {
+        assert_eq!(parse_u32_loose(" 1,234 "), Some(1234));
+        assert_eq!(parse_u32_loose("42"), Some(42));
+        assert_eq!(parse_u32_loose("n/a"), None);
+    }
+}

--- a/crates/zetesis/src/client/cardigann/filters.rs
+++ b/crates/zetesis/src/client/cardigann/filters.rs
@@ -1,0 +1,501 @@
+//! Cardigann filter pipeline — string transforms applied to extracted values.
+//!
+//! Implemented: `regexp`, `re_replace`, `replace`, `split`, `trim`,
+//! `prepend`, `append`, `tolower`, `toupper`, `querystring`, `dateparse`,
+//! `timeago`. Unknown filters are rejected at definition load by [`validate`].
+
+use jiff::Zoned;
+use jiff::civil::DateTime;
+use jiff::fmt::strtime;
+use jiff::tz::TimeZone;
+use regex::Regex;
+use tracing::debug;
+
+use crate::client::cardigann::definition::FilterSpec;
+
+/// Runs `value` through `specs` in order.
+///
+/// `now` anchors the relative-time filters; injecting it keeps them
+/// deterministic under test.
+pub fn apply(value: String, specs: &[FilterSpec], now: &Zoned) -> Result<String, String> {
+    let mut value = value;
+    for spec in specs {
+        value = apply_one(value, spec, now)?;
+    }
+    Ok(value)
+}
+
+/// Checks filter names, arity, and static arguments (regex syntax, split
+/// index) so an unusable definition fails at load with one clear reason.
+pub fn validate(specs: &[FilterSpec]) -> Result<(), String> {
+    for spec in specs {
+        let args = spec.args();
+        let arity = |min: usize, max: usize| {
+            if args.len() < min || args.len() > max {
+                Err(format!(
+                    "filter {:?} takes {min}..={max} args, got {}",
+                    spec.name,
+                    args.len()
+                ))
+            } else {
+                Ok(())
+            }
+        };
+        match spec.name.as_str() {
+            "regexp" | "re_replace" => {
+                arity(1, 2)?;
+                if spec.name == "re_replace" && args.len() != 2 {
+                    return Err("filter \"re_replace\" takes exactly 2 args".to_string());
+                }
+                let pattern = args.first().map(String::as_str).unwrap_or_default();
+                Regex::new(pattern).map_err(|e| format!("filter {:?} pattern: {e}", spec.name))?;
+            }
+            "replace" => arity(2, 2)?,
+            "split" => {
+                arity(2, 2)?;
+                let index = args.get(1).map(String::as_str).unwrap_or_default();
+                index
+                    .parse::<i64>()
+                    .map_err(|_| format!("split index {index:?} is not an integer"))?;
+            }
+            "trim" => arity(0, 1)?,
+            "prepend" | "append" | "querystring" | "dateparse" => arity(1, 1)?,
+            "tolower" | "toupper" | "timeago" => arity(0, 1)?,
+            other => {
+                return Err(format!(
+                    "unsupported filter {other:?} (supported: regexp, re_replace, replace, \
+                     split, trim, prepend, append, tolower, toupper, querystring, dateparse, \
+                     timeago)"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_one(value: String, spec: &FilterSpec, now: &Zoned) -> Result<String, String> {
+    let args = spec.args();
+    // WHY: arity is checked at definition load, but this accessor keeps the
+    // pipeline panic-free if a spec ever arrives unvalidated.
+    let arg = |i: usize| {
+        args.get(i)
+            .map(String::as_str)
+            .ok_or_else(|| format!("filter {:?} is missing argument {i}", spec.name))
+    };
+    match spec.name.as_str() {
+        "regexp" => {
+            let pattern = arg(0)?;
+            let re = Regex::new(pattern).map_err(|e| format!("regexp: {e}"))?;
+            let caps = re
+                .captures(&value)
+                .ok_or_else(|| format!("regexp {pattern:?} did not match {value:?}"))?;
+            // WHY: Cardigann yields the first capture group; a group-less
+            // pattern falls back to the whole match.
+            let m = caps.get(1).or_else(|| caps.get(0));
+            Ok(m.map_or_else(String::new, |m| m.as_str().to_string()))
+        }
+        "re_replace" => {
+            let re = Regex::new(arg(0)?).map_err(|e| format!("re_replace: {e}"))?;
+            Ok(re.replace_all(&value, arg(1)?).into_owned())
+        }
+        "replace" => Ok(value.replace(arg(0)?, arg(1)?)),
+        "split" => {
+            let separator = arg(0)?;
+            let index_arg = arg(1)?;
+            let parts: Vec<&str> = value.split(separator).collect();
+            let index: i64 = index_arg
+                .parse()
+                .map_err(|_| "split: bad index".to_string())?;
+            let index = if index < 0 {
+                i64::try_from(parts.len()).unwrap_or(i64::MAX) + index
+            } else {
+                index
+            };
+            usize::try_from(index)
+                .ok()
+                .and_then(|i| parts.get(i))
+                .map(|s| (*s).to_string())
+                .ok_or_else(|| {
+                    format!(
+                        "split index {index_arg} out of range for {} parts",
+                        parts.len()
+                    )
+                })
+        }
+        "trim" => match args.first().map(String::as_str) {
+            None | Some("") => Ok(value.trim().to_string()),
+            Some(chars) => Ok(value.trim_matches(|c| chars.contains(c)).to_string()),
+        },
+        "prepend" => Ok(format!("{}{value}", arg(0)?)),
+        "append" => Ok(format!("{value}{}", arg(0)?)),
+        "tolower" => Ok(value.to_lowercase()),
+        "toupper" => Ok(value.to_uppercase()),
+        "querystring" => {
+            let param = arg(0)?;
+            // WHY: extracted hrefs are usually relative; a fixed placeholder
+            // base makes them parseable without affecting query extraction.
+            let url = url::Url::parse("https://cardigann.invalid/")
+                .and_then(|base| base.join(&value))
+                .map_err(|e| format!("querystring: {value:?}: {e}"))?;
+            url.query_pairs()
+                .find(|(k, _)| k.as_ref() == param)
+                .map(|(_, v)| v.into_owned())
+                .ok_or_else(|| format!("querystring: no {param:?} parameter in {value:?}"))
+        }
+        "dateparse" => Ok(dateparse(&value, arg(0)?, now)),
+        "timeago" => Ok(timeago(&value, now)),
+        other => Err(format!("unsupported filter {other:?}")),
+    }
+}
+
+/// Best-effort Go-layout date parse; the raw value passes through unchanged
+/// when the layout or the value cannot be handled.
+///
+/// WHY: `publication_date` is an advisory string downstream — a raw site
+/// date is more useful than a hard row failure over a locale quirk.
+fn dateparse(value: &str, go_layout: &str, now: &Zoned) -> String {
+    let Some(fmt) = go_layout_to_strptime(go_layout) else {
+        debug!(layout = %go_layout, "dateparse layout has unsupported tokens; passing raw value");
+        return value.to_string();
+    };
+    let Ok(mut parsed) = strtime::parse(&fmt, value.trim()) else {
+        debug!(layout = %go_layout, value = %value, "dateparse failed; passing raw value");
+        return value.to_string();
+    };
+    if parsed.year().is_none() && parsed.set_year(Some(now.year())).is_err() {
+        return value.to_string();
+    }
+    if let Ok(ts) = parsed.to_timestamp() {
+        return ts.to_string();
+    }
+    render_civil(parsed.to_datetime(), value)
+}
+
+fn render_civil(datetime: Result<DateTime, jiff::Error>, raw: &str) -> String {
+    datetime
+        .and_then(|dt| dt.to_zoned(TimeZone::UTC))
+        .map(|z| z.timestamp().to_string())
+        .unwrap_or_else(|_| raw.to_string())
+}
+
+/// Converts a Go reference-time layout (`2006-01-02 15:04:05`) into a
+/// strptime format string. Returns `None` when the layout uses tokens with
+/// no strptime equivalent (e.g. `MST`, `Z07:00`).
+fn go_layout_to_strptime(layout: &str) -> Option<String> {
+    const TOKENS: &[(&str, Option<&str>)] = &[
+        ("January", Some("%B")),
+        ("Monday", Some("%A")),
+        ("Jan", Some("%b")),
+        ("Mon", Some("%a")),
+        ("Z07:00", None),
+        ("-07:00", Some("%:z")),
+        ("-0700", Some("%z")),
+        ("MST", None),
+        ("2006", Some("%Y")),
+        ("_2", Some("%e")),
+        ("15", Some("%H")),
+        ("06", Some("%y")),
+        ("05", Some("%S")),
+        ("04", Some("%M")),
+        ("03", Some("%I")),
+        ("02", Some("%d")),
+        ("01", Some("%m")),
+        ("PM", Some("%p")),
+        ("pm", Some("%P")),
+        // NOTE: single-digit Go tokens; jiff parses %-padded specifiers
+        // leniently, so unpadded values still parse.
+        ("5", Some("%S")),
+        ("4", Some("%M")),
+        ("3", Some("%I")),
+        ("2", Some("%d")),
+        ("1", Some("%m")),
+    ];
+
+    let mut out = String::with_capacity(layout.len() + 8);
+    let mut rest = layout;
+    'outer: while !rest.is_empty() {
+        for (token, replacement) in TOKENS {
+            if let Some(tail) = rest.strip_prefix(token) {
+                out.push_str((*replacement)?);
+                rest = tail;
+                continue 'outer;
+            }
+        }
+        let ch = rest.chars().next()?;
+        if ch == '%' {
+            out.push_str("%%");
+        } else {
+            out.push(ch);
+        }
+        rest = rest.get(ch.len_utf8()..).unwrap_or("");
+    }
+    Some(out)
+}
+
+/// Best-effort relative-time parse ("2 hours ago"); the raw value passes
+/// through unchanged when no duration can be read.
+fn timeago(value: &str, now: &Zoned) -> String {
+    let cleaned = value.to_lowercase().replace(',', " ");
+    let mut total_seconds: i64 = 0;
+    let mut pending_number: Option<i64> = None;
+    for token in cleaned.split_whitespace() {
+        if token == "ago" {
+            continue;
+        }
+        if let Ok(n) = token.parse::<i64>() {
+            pending_number = Some(n);
+            continue;
+        }
+        if token == "a" || token == "an" {
+            pending_number = Some(1);
+            continue;
+        }
+        let Some(n) = pending_number.take() else {
+            continue;
+        };
+        let unit_seconds = match token {
+            t if t.starts_with("mo") => 30 * 86_400,
+            t if t.starts_with('y') => 365 * 86_400,
+            t if t.starts_with('w') => 7 * 86_400,
+            t if t.starts_with('d') => 86_400,
+            t if t.starts_with('h') => 3_600,
+            t if t.starts_with('m') => 60,
+            t if t.starts_with('s') => 1,
+            _ => continue,
+        };
+        total_seconds = total_seconds.saturating_add(n.saturating_mul(unit_seconds));
+    }
+    if total_seconds == 0 {
+        debug!(value = %value, "timeago could not read a duration; passing raw value");
+        return value.to_string();
+    }
+    jiff::Timestamp::from_second(now.timestamp().as_second().saturating_sub(total_seconds))
+        .map(|ts| ts.to_string())
+        .unwrap_or_else(|_| value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(name: &str, args: &[&str]) -> FilterSpec {
+        FilterSpec {
+            name: name.to_string(),
+            args: if args.is_empty() {
+                None
+            } else {
+                Some(crate::client::cardigann::definition::FilterArgs(
+                    args.iter().map(|s| (*s).to_string()).collect(),
+                ))
+            },
+        }
+    }
+
+    fn now() -> Zoned {
+        "2026-06-15T12:00:00Z"
+            .parse::<jiff::Timestamp>()
+            .unwrap()
+            .to_zoned(TimeZone::UTC)
+    }
+
+    fn run(value: &str, specs: &[FilterSpec]) -> Result<String, String> {
+        apply(value.to_string(), specs, &now())
+    }
+
+    #[test]
+    fn regexp_returns_first_capture_group() {
+        assert_eq!(
+            run("Size: 1.4 GB", &[spec("regexp", &[r"Size: ([\d.]+ \w+)"])]).unwrap(),
+            "1.4 GB"
+        );
+    }
+
+    #[test]
+    fn regexp_without_groups_returns_whole_match() {
+        assert_eq!(
+            run("abc123def", &[spec("regexp", &[r"\d+"])]).unwrap(),
+            "123"
+        );
+    }
+
+    #[test]
+    fn regexp_no_match_errors() {
+        assert!(run("nope", &[spec("regexp", &[r"\d+"])]).is_err());
+    }
+
+    #[test]
+    fn re_replace_supports_group_references() {
+        // NOTE: `${1}` (braced) — both Go's regexp and the regex crate parse
+        // a bare `$1x` as the group named "1x", so definition semantics match.
+        assert_eq!(
+            run(
+                "S01E02",
+                &[spec("re_replace", &[r"S(\d+)E(\d+)", "${1}x$2"])]
+            )
+            .unwrap(),
+            "01x02"
+        );
+        assert_eq!(
+            run("a  b", &[spec("re_replace", &[r"\s+", "."])]).unwrap(),
+            "a.b"
+        );
+    }
+
+    #[test]
+    fn replace_literal() {
+        assert_eq!(
+            run("a.b.c", &[spec("replace", &[".", " "])]).unwrap(),
+            "a b c"
+        );
+    }
+
+    #[test]
+    fn split_positive_and_negative_index() {
+        assert_eq!(run("a/b/c", &[spec("split", &["/", "1"])]).unwrap(), "b");
+        assert_eq!(run("a/b/c", &[spec("split", &["/", "-1"])]).unwrap(), "c");
+        assert!(run("a/b", &[spec("split", &["/", "5"])]).is_err());
+    }
+
+    #[test]
+    fn trim_whitespace_and_chars() {
+        assert_eq!(run("  x  ", &[spec("trim", &[])]).unwrap(), "x");
+        assert_eq!(run("--x--", &[spec("trim", &["-"])]).unwrap(), "x");
+    }
+
+    #[test]
+    fn prepend_append() {
+        assert_eq!(run("path", &[spec("prepend", &["/"])]).unwrap(), "/path");
+        assert_eq!(
+            run("file", &[spec("append", &[".torrent"])]).unwrap(),
+            "file.torrent"
+        );
+    }
+
+    #[test]
+    fn case_folding() {
+        assert_eq!(run("MiXeD", &[spec("tolower", &[])]).unwrap(), "mixed");
+        assert_eq!(run("MiXeD", &[spec("toupper", &[])]).unwrap(), "MIXED");
+    }
+
+    #[test]
+    fn querystring_extracts_parameter() {
+        assert_eq!(
+            run("/browse.php?cat=6&page=2", &[spec("querystring", &["cat"])]).unwrap(),
+            "6"
+        );
+        assert_eq!(
+            run("https://x.example/t?id=42", &[spec("querystring", &["id"])]).unwrap(),
+            "42"
+        );
+        assert!(run("/browse.php?cat=6", &[spec("querystring", &["id"])]).is_err());
+    }
+
+    #[test]
+    fn dateparse_iso_layout() {
+        assert_eq!(
+            run(
+                "2024-01-15 10:30:00",
+                &[spec("dateparse", &["2006-01-02 15:04:05"])]
+            )
+            .unwrap(),
+            "2024-01-15T10:30:00Z"
+        );
+    }
+
+    #[test]
+    fn dateparse_month_name_layout() {
+        assert_eq!(
+            run("Jan 15, 2024", &[spec("dateparse", &["Jan 2, 2006"])]).unwrap(),
+            "2024-01-15T00:00:00Z"
+        );
+    }
+
+    #[test]
+    fn dateparse_missing_year_uses_now() {
+        assert_eq!(
+            run("06-15 08:00", &[spec("dateparse", &["01-02 15:04"])]).unwrap(),
+            "2026-06-15T08:00:00Z"
+        );
+    }
+
+    #[test]
+    fn dateparse_failure_passes_raw_value() {
+        assert_eq!(
+            run("yesterday", &[spec("dateparse", &["2006-01-02"])]).unwrap(),
+            "yesterday"
+        );
+        assert_eq!(
+            run(
+                "2024-01-15 10:30:00 MST",
+                &[spec("dateparse", &["2006-01-02 15:04:05 MST"])]
+            )
+            .unwrap(),
+            "2024-01-15 10:30:00 MST"
+        );
+    }
+
+    #[test]
+    fn timeago_hours() {
+        assert_eq!(
+            run("2 hours ago", &[spec("timeago", &[])]).unwrap(),
+            "2026-06-15T10:00:00Z"
+        );
+    }
+
+    #[test]
+    fn timeago_compound_and_articles() {
+        assert_eq!(
+            run("1 day, 2 hours ago", &[spec("timeago", &[])]).unwrap(),
+            "2026-06-14T10:00:00Z"
+        );
+        assert_eq!(
+            run("an hour ago", &[spec("timeago", &[])]).unwrap(),
+            "2026-06-15T11:00:00Z"
+        );
+    }
+
+    #[test]
+    fn timeago_month_vs_minute_disambiguation() {
+        assert_eq!(
+            run("1 month ago", &[spec("timeago", &[])]).unwrap(),
+            "2026-05-16T12:00:00Z"
+        );
+        assert_eq!(
+            run("5 min ago", &[spec("timeago", &[])]).unwrap(),
+            "2026-06-15T11:55:00Z"
+        );
+    }
+
+    #[test]
+    fn timeago_unreadable_passes_raw_value() {
+        assert_eq!(
+            run("just now", &[spec("timeago", &[])]).unwrap(),
+            "just now"
+        );
+    }
+
+    #[test]
+    fn chain_applies_in_order() {
+        assert_eq!(
+            run(
+                " Size: 700 MB ",
+                &[
+                    spec("trim", &[]),
+                    spec("regexp", &[r"Size: (.+)"]),
+                    spec("append", &["!"]),
+                ],
+            )
+            .unwrap(),
+            "700 MB!"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_unknown_filter_and_bad_args() {
+        assert!(validate(&[spec("regexp", &[r"\d+"])]).is_ok());
+        assert!(validate(&[spec("andmatch", &[])]).is_err());
+        assert!(validate(&[spec("regexp", &["("])]).is_err());
+        assert!(validate(&[spec("split", &["/", "x"])]).is_err());
+        assert!(validate(&[spec("replace", &["only-one"])]).is_err());
+    }
+}

--- a/crates/zetesis/src/client/cardigann/mod.rs
+++ b/crates/zetesis/src/client/cardigann/mod.rs
@@ -1,0 +1,754 @@
+//! Cardigann definition-driven indexer client.
+//!
+//! Executes Prowlarr-compatible YAML definitions (loaded at startup from
+//! `cardigann_definitions_dir`) against HTML trackers that lack a native
+//! Torznab/Newznab API: templated search URLs, CSS row/field selectors, a
+//! filter pipeline, and category mapping. Login support covers `none` and
+//! `cookie`; form/multi-step login defers to a Torznab sidecar.
+
+pub mod categories;
+pub mod definition;
+mod extract;
+mod filters;
+mod template;
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use horismos::SearchSubsystemConfig;
+use jiff::Zoned;
+use snafu::ResultExt;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, instrument, warn};
+use url::Url;
+
+use crate::cf_bypass::CloudflareProxy;
+use crate::client::{
+    IndexerClient, IndexerConfig, read_body_bounded, read_body_bytes_bounded, redact_api_key,
+    validate_fetch_url,
+};
+use crate::error::{self, SearchIndexerError};
+use crate::types::{
+    DownloadResponse, IndexerCaps, IndexerStatus, ReleaseProtocol, SearchFunction, SearchLimits,
+    SearchQuery, SearchResult, ServerInfo,
+};
+use definition::{CardigannDefinition, SearchPath};
+use template::TemplateContext;
+
+/// Cardigann definitions loaded from `cardigann_definitions_dir`, keyed by
+/// definition id.
+pub struct CardigannRegistry {
+    config: Arc<SearchSubsystemConfig>,
+    definitions: HashMap<String, Arc<CardigannDefinition>>,
+}
+
+impl CardigannRegistry {
+    /// Reads every `.yml`/`.yaml` file under the configured definitions
+    /// directory. Files that fail to parse or validate are skipped with a
+    /// warning; a broken definition must not take down startup.
+    pub fn load(config: Arc<SearchSubsystemConfig>) -> Self {
+        let mut definitions = HashMap::new();
+        if let Some(dir) = &config.cardigann_definitions_dir {
+            match std::fs::read_dir(dir) {
+                Ok(entries) => {
+                    let mut paths: Vec<_> = entries
+                        .filter_map(Result::ok)
+                        .map(|entry| entry.path())
+                        .filter(|path| {
+                            matches!(
+                                path.extension().and_then(|e| e.to_str()),
+                                Some("yml" | "yaml")
+                            )
+                        })
+                        .collect();
+                    // WHY: deterministic load order makes duplicate-id
+                    // resolution (first file wins) reproducible.
+                    paths.sort();
+                    for path in paths {
+                        match definition::load_definition_file(&path) {
+                            Ok(def) => {
+                                if definitions.contains_key(&def.id) {
+                                    warn!(
+                                        definition_id = %def.id,
+                                        path = %path.display(),
+                                        "duplicate Cardigann definition id; keeping the first"
+                                    );
+                                    continue;
+                                }
+                                info!(
+                                    definition_id = %def.id,
+                                    name = %def.name,
+                                    "loaded Cardigann definition"
+                                );
+                                definitions.insert(def.id.clone(), Arc::new(def));
+                            }
+                            Err(e) => {
+                                warn!(
+                                    path = %path.display(),
+                                    error = %e,
+                                    "skipping Cardigann definition"
+                                );
+                            }
+                        }
+                    }
+                    info!(count = definitions.len(), "Cardigann definitions loaded");
+                }
+                Err(e) => {
+                    warn!(
+                        dir = %dir.display(),
+                        error = %e,
+                        "cannot read cardigann_definitions_dir"
+                    );
+                }
+            }
+        }
+        Self {
+            config,
+            definitions,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.definitions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.definitions.is_empty()
+    }
+
+    /// Resolves an indexer row's `url` column to a loaded definition: an
+    /// exact definition-id match first, then a match against the
+    /// definition's declared site links (so a row may carry either form).
+    pub fn resolve(&self, indexer_url: &str) -> Option<Arc<CardigannDefinition>> {
+        if let Some(def) = self.definitions.get(indexer_url) {
+            return Some(Arc::clone(def));
+        }
+        let normalized = indexer_url.trim_end_matches('/');
+        self.definitions
+            .values()
+            .find(|def| {
+                def.links
+                    .iter()
+                    .chain(&def.legacylinks)
+                    .any(|link| link.trim_end_matches('/').eq_ignore_ascii_case(normalized))
+            })
+            .cloned()
+    }
+
+    pub fn client_for(
+        &self,
+        indexer: IndexerConfig,
+        http_client: reqwest::Client,
+        cf_proxy: Arc<dyn CloudflareProxy>,
+        timeout: Duration,
+    ) -> Result<CardigannClient, SearchIndexerError> {
+        let definition =
+            self.resolve(&indexer.url)
+                .ok_or_else(|| SearchIndexerError::DefinitionNotFound {
+                    indexer_id: indexer.id,
+                    url: indexer.url.clone(),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+        CardigannClient::new(
+            Arc::clone(&self.config),
+            http_client,
+            cf_proxy,
+            timeout,
+            indexer,
+            definition,
+        )
+    }
+}
+
+pub struct CardigannClient {
+    config: Arc<SearchSubsystemConfig>,
+    http_client: reqwest::Client,
+    cf_proxy: Arc<dyn CloudflareProxy>,
+    timeout: Duration,
+    indexer: IndexerConfig,
+    definition: Arc<CardigannDefinition>,
+    base_url: Url,
+    /// Cookie header for `login.method: cookie`, taken from the indexer
+    /// row's `api_key` column (the per-instance secret slot).
+    cookie: Option<String>,
+}
+
+impl std::fmt::Debug for CardigannClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CardigannClient")
+            .field("indexer_id", &self.indexer.id)
+            .field("definition_id", &self.definition.id)
+            .field("base_url", &self.base_url.as_str())
+            .field("cookie", &self.cookie.as_ref().map(|_| "[redacted]"))
+            .finish_non_exhaustive()
+    }
+}
+
+impl CardigannClient {
+    pub fn new(
+        config: Arc<SearchSubsystemConfig>,
+        http_client: reqwest::Client,
+        cf_proxy: Arc<dyn CloudflareProxy>,
+        timeout: Duration,
+        indexer: IndexerConfig,
+        definition: Arc<CardigannDefinition>,
+    ) -> Result<Self, SearchIndexerError> {
+        let base_url = resolve_base_url(&indexer, &definition)?;
+        let cookie = resolve_login(&indexer, &definition)?;
+        if cookie.is_some() && indexer.cf_bypass {
+            // WHY: the bypass proxy carries no request headers, so a session
+            // cookie silently vanishes — fail loudly instead.
+            return Err(SearchIndexerError::DefinitionUnsupported {
+                definition_id: definition.id.clone(),
+                feature: "cf_bypass combined with cookie login".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        Ok(Self {
+            config,
+            http_client,
+            cf_proxy,
+            timeout,
+            indexer,
+            definition,
+            base_url,
+            cookie,
+        })
+    }
+
+    fn invalid(&self, reason: String) -> SearchIndexerError {
+        SearchIndexerError::DefinitionInvalid {
+            definition_id: self.definition.id.clone(),
+            reason,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        }
+    }
+
+    fn template_context(
+        &self,
+        query: &SearchQuery,
+        site_categories: Vec<String>,
+        now: &Zoned,
+    ) -> Result<TemplateContext, SearchIndexerError> {
+        let keywords = filters::apply(
+            build_keywords(query),
+            &self.definition.search.keywordsfilters,
+            now,
+        )
+        .map_err(|e| self.invalid(format!("keywordsfilters: {e}")))?;
+
+        let mut config = BTreeMap::new();
+        for setting in &self.definition.settings {
+            config.insert(
+                setting.name.clone(),
+                setting
+                    .default
+                    .as_ref()
+                    .map(|d| d.0.clone())
+                    .unwrap_or_default(),
+            );
+        }
+        if let Some(cookie) = &self.cookie {
+            config.insert("cookie".to_string(), cookie.clone());
+        }
+
+        Ok(TemplateContext {
+            keywords,
+            categories: site_categories,
+            config,
+            query: query_vars(query),
+        })
+    }
+
+    fn build_search_url(
+        &self,
+        path: &SearchPath,
+        ctx: &TemplateContext,
+    ) -> Result<Url, SearchIndexerError> {
+        let rendered = ctx
+            .render(&path.path)
+            .map_err(|e| self.invalid(format!("search path: {e}")))?;
+        // WHY: Cardigann paths resolve under the site link even when they
+        // start with "/" — stripping the slash keeps a sub-path base
+        // (https://host/sub/) intact under Url::join. A rare absolute
+        // http(s) path replaces the base wholesale.
+        let mut url = match parse_absolute_http(&rendered) {
+            Some(absolute) => absolute,
+            None => self
+                .base_url
+                .join(rendered.trim_start_matches('/'))
+                .map_err(|e| self.invalid(format!("search path {rendered:?}: {e}")))?,
+        };
+
+        let mut inputs: BTreeMap<&str, &str> = BTreeMap::new();
+        for (key, value) in &self.definition.search.inputs {
+            inputs.insert(key, &value.0);
+        }
+        for (key, value) in &path.inputs {
+            inputs.insert(key, &value.0);
+        }
+
+        let mut raw_parts: Vec<String> = Vec::new();
+        {
+            let mut pairs = url.query_pairs_mut();
+            for (key, value) in inputs {
+                let rendered = ctx
+                    .render(value)
+                    .map_err(|e| self.invalid(format!("search input {key}: {e}")))?;
+                if key == "$raw" {
+                    raw_parts.push(rendered);
+                } else {
+                    pairs.append_pair(key, &rendered);
+                }
+            }
+        }
+        if !raw_parts.is_empty() {
+            let extra = raw_parts.join("");
+            let extra = extra.trim_matches('&');
+            let combined = match url.query() {
+                Some(q) if !q.is_empty() => format!("{q}&{extra}"),
+                _ => extra.to_string(),
+            };
+            url.set_query(Some(&combined));
+        }
+        Ok(url)
+    }
+
+    async fn send(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> Result<reqwest::Response, SearchIndexerError> {
+        let mut request = self.http_client.get(url).timeout(self.timeout);
+        if let Some(cookie) = &self.cookie {
+            request = request.header(reqwest::header::COOKIE, cookie);
+        }
+        let fut = request.send();
+        let response = tokio::select! {
+            result = fut => result.context(error::HttpRequestSnafu { url: redact_api_key(url) })?,
+            () = ct.cancelled() => {
+                return Err(SearchIndexerError::Cancelled {
+                    url: redact_api_key(url),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+        };
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(SearchIndexerError::AuthFailed {
+                indexer_id: self.indexer.id,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse().ok());
+            return Err(SearchIndexerError::RateLimited {
+                indexer_id: self.indexer.id,
+                retry_after_seconds: retry_after,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        Ok(response)
+    }
+
+    async fn fetch_text(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> Result<String, SearchIndexerError> {
+        if self.indexer.cf_bypass {
+            let response = self.cf_proxy.get(url, ct).await?;
+            return Ok(response.body);
+        }
+        let response = self.send(url, ct).await?;
+        read_body_bounded(response, url, self.config.max_response_body_bytes).await
+    }
+
+    async fn fetch_bytes(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> Result<Bytes, SearchIndexerError> {
+        if self.indexer.cf_bypass {
+            let response = self.cf_proxy.get(url, ct).await?;
+            return Ok(Bytes::from(response.body));
+        }
+        let response = self.send(url, ct).await?;
+        read_body_bytes_bounded(response, url, self.config.max_response_body_bytes)
+            .await
+            .map(Bytes::from)
+    }
+
+    /// Joins a row-extracted link against the site base; magnet and absolute
+    /// links pass through unchanged.
+    fn absolutize(&self, link: &str) -> Result<String, url::ParseError> {
+        if link.starts_with("magnet:") {
+            return Ok(link.to_string());
+        }
+        self.base_url.join(link).map(String::from)
+    }
+
+    fn rows_to_results(&self, rows: Vec<BTreeMap<String, String>>) -> Vec<SearchResult> {
+        let mappings = &self.definition.caps.categorymappings;
+        rows.into_iter()
+            .filter_map(|mut row| {
+                let Some(title) = row.remove("title") else {
+                    warn!(
+                        indexer_id = self.indexer.id,
+                        "skipping Cardigann row without a title"
+                    );
+                    return None;
+                };
+                let Some(raw_link) = row.remove("magnet").or_else(|| row.remove("download")) else {
+                    warn!(
+                        indexer_id = self.indexer.id,
+                        title = %title,
+                        "skipping Cardigann row without a download/magnet link"
+                    );
+                    return None;
+                };
+                let download_url = match self.absolutize(&raw_link) {
+                    Ok(link) => link,
+                    Err(e) => {
+                        warn!(
+                            indexer_id = self.indexer.id,
+                            title = %title,
+                            error = %e,
+                            "skipping Cardigann row with an unjoinable link"
+                        );
+                        return None;
+                    }
+                };
+                let guid = row
+                    .remove("details")
+                    .and_then(|details| self.absolutize(&details).ok());
+                let size_bytes = row.remove("size").and_then(|s| extract::parse_size(&s));
+                let seeders = row
+                    .remove("seeders")
+                    .and_then(|s| extract::parse_u32_loose(&s));
+                let leechers = row
+                    .remove("leechers")
+                    .and_then(|s| extract::parse_u32_loose(&s));
+                let category_id = row
+                    .remove("category")
+                    .and_then(|c| categories::torznab_id_for_site(mappings, &c));
+                let publication_date = row.remove("date");
+                let info_hash = row.remove("infohash");
+                let download_volume_factor = row
+                    .remove("downloadvolumefactor")
+                    .and_then(|v| extract::parse_f64_loose(&v))
+                    .unwrap_or(1.0);
+                let upload_volume_factor = row
+                    .remove("uploadvolumefactor")
+                    .and_then(|v| extract::parse_f64_loose(&v))
+                    .unwrap_or(1.0);
+
+                Some(SearchResult {
+                    title,
+                    guid,
+                    download_url,
+                    size_bytes,
+                    seeders,
+                    leechers,
+                    info_hash,
+                    category_id,
+                    publication_date,
+                    indexer_id: self.indexer.id,
+                    // NOTE: Cardigann definitions describe torrent trackers;
+                    // there is no protocol field in the schema.
+                    protocol: ReleaseProtocol::Torrent,
+                    download_volume_factor,
+                    upload_volume_factor,
+                    custom_attrs: row.into_iter().collect(),
+                })
+            })
+            .collect()
+    }
+
+    fn definition_caps(&self) -> IndexerCaps {
+        const MODE_FUNCTIONS: &[(&str, &str)] = &[
+            ("search", "search"),
+            ("tv-search", "tvsearch"),
+            ("movie-search", "movie"),
+            ("music-search", "music"),
+            ("book-search", "book"),
+        ];
+        IndexerCaps {
+            server: ServerInfo {
+                title: Some(self.definition.name.clone()),
+                version: None,
+            },
+            limits: SearchLimits::default(),
+            search_functions: MODE_FUNCTIONS
+                .iter()
+                .map(|(mode, function)| SearchFunction {
+                    function_type: (*function).to_string(),
+                    available: self.definition.caps.modes.contains_key(*mode),
+                })
+                .collect(),
+            categories: categories::caps_categories(&self.definition.caps.categorymappings),
+        }
+    }
+}
+
+impl IndexerClient for CardigannClient {
+    #[instrument(skip(self, ct), fields(indexer_id = self.indexer.id, indexer_name = %self.indexer.name))]
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        ct: CancellationToken,
+    ) -> Result<Vec<SearchResult>, SearchIndexerError> {
+        let mappings = &self.definition.caps.categorymappings;
+        let site_categories = categories::site_categories_for(mappings, &query.category_ids);
+        if !query.category_ids.is_empty() && !mappings.is_empty() && site_categories.is_empty() {
+            // WHY: the tracker carries none of the requested categories — an
+            // empty result is the answer, not an error.
+            return Ok(Vec::new());
+        }
+
+        let now = Zoned::now();
+        let ctx = self.template_context(query, site_categories.clone(), &now)?;
+        let unconstrained = query.category_ids.is_empty();
+
+        let mut results = Vec::new();
+        for path in &self.definition.search.paths {
+            if !path_applies(path, &site_categories, unconstrained) {
+                continue;
+            }
+            let url = self.build_search_url(path, &ctx)?;
+            let body = self.fetch_text(url.as_str(), ct.clone()).await?;
+            let rows = extract::extract_rows(&body, &self.definition, &ctx, &now).map_err(|e| {
+                SearchIndexerError::ParseResponse {
+                    url: redact_api_key(url.as_str()),
+                    error: e,
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                }
+            })?;
+            results.extend(self.rows_to_results(rows));
+        }
+
+        let limit = usize::try_from(query.limit).unwrap_or(usize::MAX);
+        if limit > 0 && results.len() > limit {
+            results.truncate(limit);
+        }
+        Ok(results)
+    }
+
+    #[instrument(skip(self, _ct), fields(indexer_id = self.indexer.id))]
+    async fn caps(&self, _ct: CancellationToken) -> Result<IndexerCaps, SearchIndexerError> {
+        Ok(self.definition_caps())
+    }
+
+    #[instrument(skip(self, ct), fields(indexer_id = self.indexer.id))]
+    async fn test(&self, ct: CancellationToken) -> Result<IndexerStatus, SearchIndexerError> {
+        // NOTE: login.test.selector checks are deferred — this probe only
+        // verifies the page is reachable (HTTP success).
+        let test_path = self
+            .definition
+            .login
+            .as_ref()
+            .and_then(|login| login.test.as_ref())
+            .and_then(|test| test.path.clone());
+        let probe = async {
+            let url = match test_path {
+                Some(path) => self
+                    .base_url
+                    .join(path.trim_start_matches('/'))
+                    .map_err(|e| self.invalid(format!("login test path {path:?}: {e}")))?,
+                None => self.base_url.clone(),
+            };
+            if self.indexer.cf_bypass {
+                self.cf_proxy.get(url.as_str(), ct).await?;
+                return Ok(());
+            }
+            let response = self.send(url.as_str(), ct).await?;
+            response
+                .error_for_status()
+                .map(|_| ())
+                .context(error::HttpRequestSnafu {
+                    url: redact_api_key(url.as_str()),
+                })
+        };
+        match probe.await {
+            Ok(()) => Ok(IndexerStatus {
+                healthy: true,
+                caps: Some(self.definition_caps()),
+                error: None,
+            }),
+            Err(e) => Ok(IndexerStatus {
+                healthy: false,
+                caps: None,
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+
+    #[instrument(skip(self, ct), fields(indexer_id = self.indexer.id))]
+    async fn download(
+        &self,
+        url: &str,
+        ct: CancellationToken,
+    ) -> Result<DownloadResponse, SearchIndexerError> {
+        if url.starts_with("magnet:") {
+            return Ok(DownloadResponse::MagnetUri(url.to_string()));
+        }
+        // SAFETY: download URLs originate in scraped third-party HTML —
+        // validate scheme + resolved addresses before any fetch.
+        validate_fetch_url(url).await?;
+
+        let final_url = match &self.definition.download {
+            Some(block) if block.selector.is_some() => {
+                let page = self.fetch_text(url, ct.clone()).await?;
+                let link = extract::extract_download_link(
+                    &page,
+                    block.selector.as_deref().unwrap_or_default(),
+                    block.attribute.as_deref(),
+                )
+                .map_err(|e| self.invalid(format!("download: {e}")))?;
+                let link = filters::apply(link, &block.filters, &Zoned::now())
+                    .map_err(|e| self.invalid(format!("download filters: {e}")))?;
+                let absolute = self
+                    .absolutize(&link)
+                    .map_err(|e| self.invalid(format!("download link {link:?}: {e}")))?;
+                if absolute.starts_with("magnet:") {
+                    return Ok(DownloadResponse::MagnetUri(absolute));
+                }
+                validate_fetch_url(&absolute).await?;
+                absolute
+            }
+            _ => url.to_string(),
+        };
+
+        let bytes = self.fetch_bytes(&final_url, ct).await?;
+        Ok(DownloadResponse::TorrentFile(bytes))
+    }
+}
+
+fn resolve_base_url(
+    indexer: &IndexerConfig,
+    definition: &CardigannDefinition,
+) -> Result<Url, SearchIndexerError> {
+    let invalid = |reason: String| SearchIndexerError::DefinitionInvalid {
+        definition_id: definition.id.clone(),
+        reason,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    };
+    let mut url = match parse_absolute_http(&indexer.url) {
+        Some(from_row) => from_row,
+        None => {
+            let link = definition
+                .links
+                .first()
+                .ok_or_else(|| invalid("no links".to_string()))?;
+            Url::parse(link).map_err(|e| invalid(format!("base url {link}: {e}")))?
+        }
+    };
+    // WHY: Url::join replaces the last path segment unless the base ends in
+    // "/" — a sub-path site link must keep its directory.
+    if !url.path().ends_with('/') {
+        let path = format!("{}/", url.path());
+        url.set_path(&path);
+    }
+    Ok(url)
+}
+
+/// Parses `raw` as an absolute http(s) URL; anything else (definition ids,
+/// relative paths, other schemes) yields `None`.
+fn parse_absolute_http(raw: &str) -> Option<Url> {
+    Url::parse(raw)
+        .ok()
+        .filter(|url| matches!(url.scheme(), "http" | "https"))
+}
+
+/// Resolves the login block to an optional Cookie header value.
+fn resolve_login(
+    indexer: &IndexerConfig,
+    definition: &CardigannDefinition,
+) -> Result<Option<String>, SearchIndexerError> {
+    let Some(login) = &definition.login else {
+        return Ok(None);
+    };
+    // NOTE: Cardigann's default method when the login block omits one is
+    // "form", which this engine defers.
+    match login.method.as_deref().unwrap_or("form") {
+        "none" => Ok(None),
+        "cookie" => match &indexer.api_key {
+            Some(cookie) if !cookie.trim().is_empty() => Ok(Some(cookie.clone())),
+            _ => Err(SearchIndexerError::CookieAuthRequired {
+                definition_id: definition.id.clone(),
+                indexer_id: indexer.id,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            }),
+        },
+        other => Err(SearchIndexerError::LoginUnsupported {
+            definition_id: definition.id.clone(),
+            method: other.to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        }),
+    }
+}
+
+fn path_applies(path: &SearchPath, site_categories: &[String], unconstrained: bool) -> bool {
+    if path.categories.is_empty() || unconstrained {
+        return true;
+    }
+    path.categories
+        .iter()
+        .any(|c| site_categories.contains(&c.0))
+}
+
+fn build_keywords(query: &SearchQuery) -> String {
+    let mut keywords = query.query_text.clone().unwrap_or_default();
+    match (query.season, query.episode) {
+        (Some(season), Some(episode)) => {
+            keywords.push_str(&format!(" S{season:02}E{episode:02}"));
+        }
+        (Some(season), None) => keywords.push_str(&format!(" S{season:02}")),
+        // NOTE: an episode without a season has no SxxEyy rendering.
+        (None, _) => {}
+    }
+    keywords.trim().to_string()
+}
+
+fn query_vars(query: &SearchQuery) -> BTreeMap<&'static str, String> {
+    let mut vars = BTreeMap::new();
+    vars.insert("Q", query.query_text.clone().unwrap_or_default());
+    if let Some(season) = query.season {
+        vars.insert("Season", season.to_string());
+    }
+    if let Some(episode) = query.episode {
+        vars.insert("Ep", episode.to_string());
+    }
+    if let Some(imdb) = &query.imdb_id {
+        vars.insert("IMDBID", imdb.clone());
+        vars.insert("IMDBIDShort", imdb.trim_start_matches("tt").to_string());
+    }
+    if let Some(tvdb) = query.tvdb_id {
+        vars.insert("TVDBID", tvdb.to_string());
+    }
+    if let Some(tmdb) = query.tmdb_id {
+        vars.insert("TMDBID", tmdb.to_string());
+    }
+    if let Some(artist) = &query.artist {
+        vars.insert("Artist", artist.clone());
+    }
+    if let Some(album) = &query.album {
+        vars.insert("Album", album.clone());
+    }
+    if let Some(author) = &query.author {
+        vars.insert("Author", author.clone());
+    }
+    vars.insert("Limit", query.limit.to_string());
+    vars.insert("Offset", query.offset.to_string());
+    vars
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/zetesis/src/client/cardigann/mod.rs
+++ b/crates/zetesis/src/client/cardigann/mod.rs
@@ -239,6 +239,9 @@ impl CardigannClient {
         )
         .map_err(|e| self.invalid(format!("keywordsfilters: {e}")))?;
 
+        // NOTE: per-indexer `settings:` overrides are not plumbed yet —
+        // `.Config.<key>` always resolves to the definition's YAML
+        // `default:` (plus the injected session cookie).
         let mut config = BTreeMap::new();
         for setting in &self.definition.settings {
             config.insert(
@@ -268,7 +271,7 @@ impl CardigannClient {
         ctx: &TemplateContext,
     ) -> Result<Url, SearchIndexerError> {
         let rendered = ctx
-            .render(&path.path)
+            .render_url(&path.path)
             .map_err(|e| self.invalid(format!("search path: {e}")))?;
         // WHY: Cardigann paths resolve under the site link even when they
         // start with "/" — stripping the slash keeps a sub-path base
@@ -291,17 +294,23 @@ impl CardigannClient {
         }
 
         let mut raw_parts: Vec<String> = Vec::new();
-        {
-            let mut pairs = url.query_pairs_mut();
-            for (key, value) in inputs {
-                let rendered = ctx
-                    .render(value)
-                    .map_err(|e| self.invalid(format!("search input {key}: {e}")))?;
-                if key == "$raw" {
-                    raw_parts.push(rendered);
-                } else {
-                    pairs.append_pair(key, &rendered);
-                }
+        let mut pairs: Vec<(&str, String)> = Vec::new();
+        for (key, value) in inputs {
+            let rendered = ctx
+                .render(value)
+                .map_err(|e| self.invalid(format!("search input {key}: {e}")))?;
+            if key == "$raw" {
+                raw_parts.push(rendered);
+            } else {
+                pairs.push((key, rendered));
+            }
+        }
+        // WHY: query_pairs_mut leaves a spurious bare "?" behind even when
+        // nothing is appended — only touch the query when pairs exist.
+        if !pairs.is_empty() {
+            let mut serializer = url.query_pairs_mut();
+            for (key, value) in &pairs {
+                serializer.append_pair(key, value);
             }
         }
         if !raw_parts.is_empty() {

--- a/crates/zetesis/src/client/cardigann/template.rs
+++ b/crates/zetesis/src/client/cardigann/template.rs
@@ -1,0 +1,251 @@
+//! Minimal evaluator for the Go-template subset Cardigann definitions use.
+//!
+//! Supported: `{{ .Keywords }}`, `{{ .Categories }}` (comma-joined),
+//! `{{ .Config.<key> }}`, `{{ .Query.<field> }}`, and
+//! `{{ join .Categories "<sep>" }}`. Anything else — `if`, `range`, `with`,
+//! pipelines — is rejected with a clear reason at definition load time.
+
+use std::collections::BTreeMap;
+
+/// Values a template can reference during one search.
+#[derive(Clone, Default)]
+pub struct TemplateContext {
+    // NOTE: search keywords, not a credential — the name trips the
+    // key-shaped-field heuristic.
+    pub keywords: String, // kanon:ignore RUST/plain-string-secret -- search keywords, not a secret
+    /// Site-native category ids mapped from the query's Torznab categories.
+    pub categories: Vec<String>,
+    /// Setting name → value (definition defaults, plus the session cookie).
+    pub config: BTreeMap<String, String>,
+    /// `.Query.<field>` values; absent query parts render as empty strings.
+    pub query: BTreeMap<&'static str, String>,
+}
+
+// WHY: manual Debug — `config` can carry the session cookie, so values are
+// redacted and only the referenceable key names are shown.
+impl std::fmt::Debug for TemplateContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TemplateContext")
+            .field("keywords", &self.keywords)
+            .field("categories", &self.categories)
+            .field("config_keys", &self.config.keys().collect::<Vec<_>>())
+            .field("query", &self.query)
+            .finish()
+    }
+}
+
+impl TemplateContext {
+    /// Renders `template` against this context. Errors carry a
+    /// human-readable reason.
+    pub fn render(&self, template: &str) -> Result<String, String> {
+        walk(template, &mut |expr| eval_expr(expr, self))
+    }
+}
+
+/// `.Query.` fields this evaluator resolves.
+pub const QUERY_FIELDS: &[&str] = &[
+    "Q",
+    "Season",
+    "Ep",
+    "IMDBID",
+    "IMDBIDShort",
+    "TVDBID",
+    "TMDBID",
+    "Artist",
+    "Album",
+    "Author",
+    "Limit",
+    "Offset",
+];
+
+/// Checks every `{{ ... }}` expression in `template` without a runtime
+/// context, so unsupported constructs surface at definition load.
+pub fn validate(template: &str, config_keys: &[&str]) -> Result<(), String> {
+    walk(template, &mut |expr| {
+        validate_expr(expr, config_keys).map(|()| String::new())
+    })
+    .map(|_| ())
+}
+
+fn walk(
+    template: &str,
+    on_expr: &mut dyn FnMut(&str) -> Result<String, String>,
+) -> Result<String, String> {
+    let unclosed = || format!("unclosed {{{{ in template {template:?}");
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("{{") {
+        out.push_str(rest.get(..start).unwrap_or_default());
+        let after = rest.get(start + 2..).ok_or_else(unclosed)?;
+        let end = after.find("}}").ok_or_else(unclosed)?;
+        let expr = after.get(..end).ok_or_else(unclosed)?;
+        out.push_str(&on_expr(expr.trim())?);
+        rest = after.get(end + 2..).unwrap_or_default();
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+fn eval_expr(expr: &str, ctx: &TemplateContext) -> Result<String, String> {
+    match classify(expr)? {
+        Expr::Keywords => Ok(ctx.keywords.clone()),
+        Expr::Categories => Ok(ctx.categories.join(",")),
+        Expr::Join(sep) => Ok(ctx.categories.join(&sep)),
+        Expr::Config(key) => ctx
+            .config
+            .get(&key)
+            .cloned()
+            .ok_or_else(|| format!("unknown config key {key:?}")),
+        Expr::Query(field) => Ok(ctx.query.get(field).cloned().unwrap_or_default()),
+    }
+}
+
+fn validate_expr(expr: &str, config_keys: &[&str]) -> Result<(), String> {
+    match classify(expr)? {
+        Expr::Keywords | Expr::Categories | Expr::Join(_) | Expr::Query(_) => Ok(()),
+        // WHY: "cookie" is injected at client construction from the indexer
+        // row, so cookie-login definitions may reference it without a
+        // matching settings entry.
+        Expr::Config(key) if key == "cookie" || config_keys.contains(&key.as_str()) => Ok(()),
+        Expr::Config(key) => Err(format!("unknown config key {key:?}")),
+    }
+}
+
+enum Expr {
+    Keywords,
+    Categories,
+    Config(String),
+    Query(&'static str),
+    Join(String),
+}
+
+fn classify(expr: &str) -> Result<Expr, String> {
+    if expr == ".Keywords" {
+        return Ok(Expr::Keywords);
+    }
+    if expr == ".Categories" {
+        return Ok(Expr::Categories);
+    }
+    if let Some(key) = expr.strip_prefix(".Config.") {
+        if key.is_empty() || key.contains(char::is_whitespace) {
+            return Err(format!("malformed config reference {expr:?}"));
+        }
+        return Ok(Expr::Config(key.to_string()));
+    }
+    if let Some(field) = expr.strip_prefix(".Query.") {
+        return QUERY_FIELDS
+            .iter()
+            .find(|known| **known == field)
+            .map(|known| Expr::Query(known))
+            .ok_or_else(|| format!("unsupported query field {field:?}"));
+    }
+    if let Some(rest) = expr.strip_prefix("join ") {
+        let rest = rest.trim();
+        let args = rest
+            .strip_prefix(".Categories")
+            .ok_or_else(|| format!("join supports only .Categories, got {rest:?}"))?
+            .trim();
+        let sep = args
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .ok_or_else(|| format!("join separator must be a quoted string, got {args:?}"))?;
+        return Ok(Expr::Join(sep.to_string()));
+    }
+    Err(format!(
+        "unsupported template construct {expr:?} (supported: .Keywords, .Categories, \
+         .Config.<key>, .Query.<field>, join .Categories \"<sep>\")"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> TemplateContext {
+        TemplateContext {
+            keywords: "test query".to_string(),
+            categories: vec!["6".to_string(), "12".to_string()],
+            config: BTreeMap::from([("sort".to_string(), "created".to_string())]),
+            query: BTreeMap::from([("Season", "3".to_string())]),
+        }
+    }
+
+    #[test]
+    fn plain_text_passes_through() {
+        assert_eq!(
+            ctx().render("no templates here").unwrap(),
+            "no templates here"
+        );
+    }
+
+    #[test]
+    fn keywords_and_surrounding_text() {
+        assert_eq!(
+            ctx().render("/search?q={{ .Keywords }}&x=1").unwrap(),
+            "/search?q=test query&x=1"
+        );
+    }
+
+    #[test]
+    fn categories_join_comma_by_default() {
+        assert_eq!(ctx().render("{{ .Categories }}").unwrap(), "6,12");
+    }
+
+    #[test]
+    fn join_with_custom_separator() {
+        assert_eq!(
+            ctx().render("{{ join .Categories \";\" }}").unwrap(),
+            "6;12"
+        );
+    }
+
+    #[test]
+    fn config_lookup() {
+        assert_eq!(ctx().render("{{ .Config.sort }}").unwrap(), "created");
+    }
+
+    #[test]
+    fn config_unknown_key_errors() {
+        let err = ctx().render("{{ .Config.missing }}").unwrap_err();
+        assert!(err.contains("missing"), "got: {err}");
+    }
+
+    #[test]
+    fn query_field_lookup_and_default_empty() {
+        assert_eq!(ctx().render("S{{ .Query.Season }}").unwrap(), "S3");
+        assert_eq!(ctx().render("[{{ .Query.Ep }}]").unwrap(), "[]");
+    }
+
+    #[test]
+    fn unsupported_constructs_error() {
+        for tmpl in [
+            "{{ if .Keywords }}x{{ end }}",
+            "{{ range .Categories }}{{.}}{{ end }}",
+            "{{ .Keywords | tolower }}",
+            "{{ .Result.date }}",
+        ] {
+            assert!(ctx().render(tmpl).is_err(), "should reject {tmpl}");
+        }
+    }
+
+    #[test]
+    fn unclosed_braces_error() {
+        assert!(ctx().render("{{ .Keywords").is_err());
+    }
+
+    #[test]
+    fn multiple_expressions() {
+        assert_eq!(
+            ctx().render("{{ .Keywords }}-{{ .Config.sort }}").unwrap(),
+            "test query-created"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_known_and_rejects_unknown() {
+        assert!(validate("{{ .Keywords }} {{ .Config.sort }}", &["sort"]).is_ok());
+        assert!(validate("{{ .Config.cookie }}", &[]).is_ok());
+        assert!(validate("{{ .Config.nope }}", &["sort"]).is_err());
+        assert!(validate("{{ if .x }}{{ end }}", &[]).is_err());
+    }
+}

--- a/crates/zetesis/src/client/cardigann/template.rs
+++ b/crates/zetesis/src/client/cardigann/template.rs
@@ -40,6 +40,24 @@ impl TemplateContext {
     pub fn render(&self, template: &str) -> Result<String, String> {
         walk(template, &mut |expr| eval_expr(expr, self))
     }
+
+    /// Renders `template` for a URL context: literal template text (the
+    /// path's own `?`/`&`/`=` structure) passes through untouched while
+    /// every variable expansion is form-urlencoded.
+    ///
+    /// WHY: expansions are data, not URL structure — a keyword containing
+    /// `&` must not split the query and `#` must not start a fragment.
+    /// Upstream Cardigann engines encode substituted values the same way.
+    pub fn render_url(&self, template: &str) -> Result<String, String> {
+        walk(template, &mut |expr| {
+            eval_expr(expr, self).map(|value| encode_value(&value))
+        })
+    }
+}
+
+/// Form-urlencodes one expanded value (`&`→`%26`, `#`→`%23`, space→`+`).
+fn encode_value(value: &str) -> String {
+    url::form_urlencoded::byte_serialize(value.as_bytes()).collect()
 }
 
 /// `.Query.` fields this evaluator resolves.
@@ -238,6 +256,25 @@ mod tests {
         assert_eq!(
             ctx().render("{{ .Keywords }}-{{ .Config.sort }}").unwrap(),
             "test query-created"
+        );
+    }
+
+    #[test]
+    fn render_url_encodes_expansions_but_not_structure() {
+        let c = TemplateContext {
+            keywords: "AT&T #1".to_string(),
+            ..ctx()
+        };
+        assert_eq!(
+            c.render_url("/browse.php?search={{ .Keywords }}&cat=0")
+                .unwrap(),
+            "/browse.php?search=AT%26T+%231&cat=0"
+        );
+        // WHY: join output is data too — an "&" separator must not
+        // masquerade as a query delimiter.
+        assert_eq!(
+            c.render_url("{{ join .Categories \"&\" }}").unwrap(),
+            "6%2612"
         );
     }
 

--- a/crates/zetesis/src/client/cardigann/tests.rs
+++ b/crates/zetesis/src/client/cardigann/tests.rs
@@ -186,6 +186,68 @@ async fn search_extracts_rows_fields_and_maps_categories() {
     assert!(request_line.contains("sort=created"), "got: {request_line}");
 }
 
+const PATH_TEMPLATE_DEF: &str = r#"---
+id: path-template
+name: Path Template
+links:
+  - https://path-template.example/
+caps:
+  categorymappings:
+    - {id: 6, cat: Movies/HD}
+  modes:
+    search: [q]
+search:
+  paths:
+    - path: "/browse.php?search={{ .Keywords }}&cat=0"
+  rows:
+    selector: table#torrents > tbody > tr
+  fields:
+    title:
+      selector: a.title
+    download:
+      selector: a.dl
+      attribute: href
+"#;
+
+#[tokio::test]
+async fn keywords_inline_in_path_template_are_percent_encoded() {
+    let (url, server) = spawn_one_shot_http(200, "OK", &[], "<html/>").await;
+    let query = SearchQuery {
+        query_text: Some("AT&T #1".to_string()),
+        limit: 100,
+        ..Default::default()
+    };
+    client(PATH_TEMPLATE_DEF, url, None)
+        .unwrap()
+        .search(&query, CancellationToken::new())
+        .await
+        .unwrap();
+
+    let request_head = server.await.unwrap();
+    let request_line = request_head.lines().next().unwrap_or_default().to_string();
+    // WHY: the raw keyword must not smuggle query structure — "&" would
+    // split a bogus param and "#" would truncate at a fragment. The value
+    // form-urlencodes wholesale; the template's own "?"/"&"/"=" survive.
+    assert_eq!(
+        request_line,
+        "GET /browse.php?search=AT%26T+%231&cat=0 HTTP/1.1"
+    );
+}
+
+#[tokio::test]
+async fn search_without_inputs_appends_no_bare_question_mark() {
+    let yaml = PATH_TEMPLATE_DEF.replace("/browse.php?search={{ .Keywords }}&cat=0", "/browse");
+    let (url, server) = spawn_one_shot_http(200, "OK", &[], "<html/>").await;
+    client(&yaml, url, None)
+        .unwrap()
+        .search(&movie_query(), CancellationToken::new())
+        .await
+        .unwrap();
+    let request_head = server.await.unwrap();
+    let request_line = request_head.lines().next().unwrap_or_default().to_string();
+    assert_eq!(request_line, "GET /browse HTTP/1.1");
+}
+
 #[tokio::test]
 async fn search_respects_query_limit() {
     let (url, _server) = spawn_one_shot_http(200, "OK", &[], SAMPLE_HTML).await;

--- a/crates/zetesis/src/client/cardigann/tests.rs
+++ b/crates/zetesis/src/client/cardigann/tests.rs
@@ -1,0 +1,494 @@
+//! CardigannClient + CardigannRegistry behavior tests (mock HTTP).
+
+use super::*;
+use crate::cf_bypass::noop::NoProxy;
+use crate::test_support::{spawn_one_shot_http, spawn_raw_http};
+
+const SAMPLE_DEF: &str = r#"---
+id: sample-tracker
+name: Sample Tracker
+type: public
+links:
+  - https://sample-tracker.example/
+caps:
+  categorymappings:
+    - {id: 6, cat: Movies/HD}
+    - {id: 7, cat: Movies/SD}
+    - {id: 12, cat: TV/HD}
+  modes:
+    search: [q]
+    tv-search: [q, season, ep]
+    movie-search: [q]
+settings:
+  - name: sort
+    type: select
+    default: created
+search:
+  paths:
+    - path: /browse
+  inputs:
+    q: "{{ .Keywords }}"
+    cats: "{{ .Categories }}"
+    sort: "{{ .Config.sort }}"
+  keywordsfilters:
+    - name: re_replace
+      args: ["\\s+", "."]
+  rows:
+    selector: table#torrents > tbody > tr
+  fields:
+    title:
+      selector: a.title
+    details:
+      selector: a.title
+      attribute: href
+    category:
+      selector: a.cat
+      attribute: href
+      filters:
+        - name: querystring
+          args: cat
+    download:
+      selector: a.dl
+      attribute: href
+    size:
+      selector: td.size
+    seeders:
+      selector: td.seeds
+    leechers:
+      selector: td.leech
+    date:
+      selector: td.date
+      filters:
+        - name: dateparse
+          args: "2006-01-02 15:04"
+    downloadvolumefactor:
+      case:
+        img.freeleech: 0
+        "*": 1
+    uploadvolumefactor:
+      text: 1
+    description:
+      selector: td.desc
+      optional: true
+"#;
+
+const SAMPLE_HTML: &str = r#"<html><body>
+<table id="torrents"><tbody>
+<tr>
+  <td><a class="title" href="/details/101">Example.Movie.2160p.WEB</a><img class="freeleech" src="/fl.png"></td>
+  <td><a class="cat" href="/browse?cat=6">Movies</a></td>
+  <td><a class="dl" href="/download/101.torrent">DL</a></td>
+  <td class="size">1.5 GiB</td>
+  <td class="seeds">42</td>
+  <td class="leech">7</td>
+  <td class="date">2024-01-15 10:30</td>
+  <td class="desc">Great release</td>
+</tr>
+<tr>
+  <td><a class="title" href="/details/102">Example.Show.S01E02.720p</a></td>
+  <td><a class="cat" href="/browse?cat=12">TV</a></td>
+  <td><a class="dl" href="/download/102.torrent">DL</a></td>
+  <td class="size">700 MB</td>
+  <td class="seeds">1,024</td>
+  <td class="leech">2</td>
+  <td class="date">2024-02-01 08:00</td>
+  <td class="desc"></td>
+</tr>
+</tbody></table>
+</body></html>"#;
+
+fn definition(yaml: &str) -> Arc<CardigannDefinition> {
+    Arc::new(definition::parse_definition(yaml, "test").unwrap())
+}
+
+fn client(
+    yaml: &str,
+    url: String,
+    api_key: Option<&str>,
+) -> Result<CardigannClient, SearchIndexerError> {
+    CardigannClient::new(
+        Arc::new(SearchSubsystemConfig::default()),
+        reqwest::Client::new(),
+        Arc::new(NoProxy),
+        Duration::from_secs(5),
+        IndexerConfig {
+            id: 1,
+            name: "Test".to_string(),
+            url,
+            api_key: api_key.map(str::to_string),
+            cf_bypass: false,
+        },
+        definition(yaml),
+    )
+}
+
+fn movie_query() -> SearchQuery {
+    SearchQuery {
+        query_text: Some("test query".to_string()),
+        category_ids: vec![2000],
+        limit: 100,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn search_extracts_rows_fields_and_maps_categories() {
+    let (url, server) = spawn_one_shot_http(200, "OK", &[], SAMPLE_HTML).await;
+    let results = client(SAMPLE_DEF, url.clone(), None)
+        .unwrap()
+        .search(&movie_query(), CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 2);
+
+    let first = &results[0];
+    assert_eq!(first.title, "Example.Movie.2160p.WEB");
+    assert_eq!(first.download_url, format!("{url}/download/101.torrent"));
+    assert_eq!(
+        first.guid.as_deref(),
+        Some(format!("{url}/details/101").as_str())
+    );
+    assert_eq!(first.size_bytes, Some(1_610_612_736));
+    assert_eq!(first.seeders, Some(42));
+    assert_eq!(first.leechers, Some(7));
+    assert_eq!(first.category_id, Some(2040));
+    assert_eq!(
+        first.publication_date.as_deref(),
+        Some("2024-01-15T10:30:00Z")
+    );
+    assert_eq!(first.protocol, ReleaseProtocol::Torrent);
+    assert_eq!(first.download_volume_factor, 0.0);
+    assert_eq!(first.upload_volume_factor, 1.0);
+    assert_eq!(first.indexer_id, 1);
+    assert_eq!(
+        first.custom_attrs.get("description").map(String::as_str),
+        Some("Great release")
+    );
+
+    let second = &results[1];
+    assert_eq!(second.title, "Example.Show.S01E02.720p");
+    assert_eq!(second.category_id, Some(5040));
+    assert_eq!(second.seeders, Some(1024));
+    assert_eq!(second.size_bytes, Some(700 * 1024 * 1024));
+    assert_eq!(second.download_volume_factor, 1.0);
+    // WHY: the empty optional description cell must be absent, not "".
+    assert!(!second.custom_attrs.contains_key("description"));
+
+    let request_head = server.await.unwrap();
+    let request_line = request_head.lines().next().unwrap_or_default().to_string();
+    assert!(
+        request_line.starts_with("GET /browse?"),
+        "got: {request_line}"
+    );
+    assert!(request_line.contains("q=test.query"), "got: {request_line}");
+    assert!(request_line.contains("cats=6%2C7"), "got: {request_line}");
+    assert!(request_line.contains("sort=created"), "got: {request_line}");
+}
+
+#[tokio::test]
+async fn search_respects_query_limit() {
+    let (url, _server) = spawn_one_shot_http(200, "OK", &[], SAMPLE_HTML).await;
+    let query = SearchQuery {
+        limit: 1,
+        ..movie_query()
+    };
+    let results = client(SAMPLE_DEF, url, None)
+        .unwrap()
+        .search(&query, CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+}
+
+#[tokio::test]
+async fn search_unmapped_categories_short_circuits_empty() {
+    // WHY: the refusing port proves no request is made when the tracker
+    // has none of the requested categories.
+    let query = SearchQuery {
+        category_ids: vec![7000],
+        ..movie_query()
+    };
+    let results = client(SAMPLE_DEF, "http://127.0.0.1:9/".to_string(), None)
+        .unwrap()
+        .search(&query, CancellationToken::new())
+        .await
+        .unwrap();
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn search_401_maps_to_auth_failed() {
+    let (url, _server) = spawn_one_shot_http(401, "Unauthorized", &[], "").await;
+    let err = client(SAMPLE_DEF, url, None)
+        .unwrap()
+        .search(&movie_query(), CancellationToken::new())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        SearchIndexerError::AuthFailed { indexer_id: 1, .. }
+    ));
+}
+
+#[tokio::test]
+async fn search_429_maps_to_rate_limited() {
+    let (url, _server) =
+        spawn_one_shot_http(429, "Too Many Requests", &[("retry-after", "60")], "").await;
+    let err = client(SAMPLE_DEF, url, None)
+        .unwrap()
+        .search(&movie_query(), CancellationToken::new())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        SearchIndexerError::RateLimited {
+            retry_after_seconds: Some(60),
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn search_cancelled_returns_cancelled() {
+    let (url, server) = crate::test_support::spawn_hang_http().await;
+    let ct = CancellationToken::new();
+    ct.cancel();
+    let err = client(SAMPLE_DEF, url, None)
+        .unwrap()
+        .search(&movie_query(), ct)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::Cancelled { .. }),
+        "got {err:?}"
+    );
+    server.abort();
+}
+
+const COOKIE_DEF_SUFFIX: &str = r#"
+login:
+  method: cookie
+  test:
+    path: /profile
+"#;
+
+#[tokio::test]
+async fn cookie_login_sends_cookie_header() {
+    let yaml = format!("{SAMPLE_DEF}{COOKIE_DEF_SUFFIX}");
+    let (url, server) = spawn_one_shot_http(200, "OK", &[], SAMPLE_HTML).await;
+    client(&yaml, url, Some("uid=1; pass=abc"))
+        .unwrap()
+        .search(&movie_query(), CancellationToken::new())
+        .await
+        .unwrap();
+    let request_head = server.await.unwrap().to_lowercase();
+    assert!(
+        request_head.contains("cookie: uid=1; pass=abc"),
+        "got: {request_head}"
+    );
+}
+
+#[test]
+fn cookie_login_without_api_key_errors() {
+    let yaml = format!("{SAMPLE_DEF}{COOKIE_DEF_SUFFIX}");
+    let err = client(&yaml, "http://127.0.0.1:9/".to_string(), None).unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::CookieAuthRequired { .. }),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn form_login_is_unsupported_at_construction() {
+    let yaml = format!("{SAMPLE_DEF}\nlogin:\n  method: form\n");
+    let err = client(&yaml, "http://127.0.0.1:9/".to_string(), None).unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::LoginUnsupported { ref method, .. } if method == "form"),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn caps_derive_from_definition() {
+    let caps = client(SAMPLE_DEF, "http://127.0.0.1:9/".to_string(), None)
+        .unwrap()
+        .caps(CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(caps.server.title.as_deref(), Some("Sample Tracker"));
+    let available: Vec<&str> = caps
+        .search_functions
+        .iter()
+        .filter(|f| f.available)
+        .map(|f| f.function_type.as_str())
+        .collect();
+    assert_eq!(available, vec!["search", "tvsearch", "movie"]);
+    let ids: Vec<u32> = caps.categories.iter().map(|c| c.id).collect();
+    assert_eq!(ids, vec![2030, 2040, 5040]);
+}
+
+#[tokio::test]
+async fn test_reports_healthy_on_success() {
+    let yaml = format!("{SAMPLE_DEF}{COOKIE_DEF_SUFFIX}");
+    let (url, server) = spawn_one_shot_http(200, "OK", &[], "<html/>").await;
+    let status = client(&yaml, url, Some("uid=1"))
+        .unwrap()
+        .test(CancellationToken::new())
+        .await
+        .unwrap();
+    assert!(status.healthy);
+    assert!(status.caps.is_some());
+    assert!(status.error.is_none());
+    // WHY: the login test path must drive the probe, not the site root.
+    let request_head = server.await.unwrap();
+    assert!(
+        request_head.starts_with("GET /profile"),
+        "got: {request_head}"
+    );
+}
+
+#[tokio::test]
+async fn test_reports_unhealthy_on_server_error() {
+    let (url, _server) = spawn_one_shot_http(500, "Internal Server Error", &[], "").await;
+    let status = client(SAMPLE_DEF, url, None)
+        .unwrap()
+        .test(CancellationToken::new())
+        .await
+        .unwrap();
+    assert!(!status.healthy);
+    assert!(status.error.is_some());
+}
+
+#[tokio::test]
+async fn download_magnet_short_circuits_without_network() {
+    let magnet = "magnet:?xt=urn:btih:abc123";
+    let response = client(SAMPLE_DEF, "http://127.0.0.1:9/".to_string(), None)
+        .unwrap()
+        .download(magnet, CancellationToken::new())
+        .await
+        .unwrap();
+    assert!(matches!(response, DownloadResponse::MagnetUri(uri) if uri == magnet));
+}
+
+#[tokio::test]
+async fn download_rejects_ssrf_targets() {
+    for target in [
+        "http://127.0.0.1:8080/steal",
+        "http://169.254.169.254/latest/meta-data/",
+        "file:///etc/passwd",
+    ] {
+        let err = client(SAMPLE_DEF, "http://127.0.0.1:9/".to_string(), None)
+            .unwrap()
+            .download(target, CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, SearchIndexerError::UnsafeUrl { .. }),
+            "expected UnsafeUrl for {target}, got {err:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn fetch_bytes_returns_binary_body() {
+    // WHY: torrent files are bencoded binary — the byte path must not
+    // round-trip through UTF-8.
+    let body: Vec<u8> = vec![0x64, 0x38, 0xFF, 0x80, 0x00, 0x65];
+    let mut raw = format!(
+        "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    raw.extend_from_slice(&body);
+    let (url, _server) = spawn_raw_http(raw).await;
+    let bytes = client(SAMPLE_DEF, url.clone(), None)
+        .unwrap()
+        .fetch_bytes(&url, CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(bytes.as_ref(), body.as_slice());
+}
+
+#[test]
+fn base_url_prefers_http_indexer_url_and_falls_back_to_links() {
+    let from_row = client(SAMPLE_DEF, "http://row.example/sub".to_string(), None).unwrap();
+    assert_eq!(from_row.base_url.as_str(), "http://row.example/sub/");
+
+    let from_links = client(SAMPLE_DEF, "sample-tracker".to_string(), None).unwrap();
+    assert_eq!(
+        from_links.base_url.as_str(),
+        "https://sample-tracker.example/"
+    );
+}
+
+// ── registry ──────────────────────────────────────────────────────────────
+
+fn registry_with(files: &[(&str, &str)]) -> (CardigannRegistry, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    for (name, content) in files {
+        std::fs::write(dir.path().join(name), content).unwrap();
+    }
+    let config = SearchSubsystemConfig {
+        cardigann_definitions_dir: Some(dir.path().to_path_buf()),
+        ..SearchSubsystemConfig::default()
+    };
+    (CardigannRegistry::load(Arc::new(config)), dir)
+}
+
+#[test]
+fn registry_loads_valid_and_skips_broken_definitions() {
+    let (registry, _dir) = registry_with(&[
+        ("sample.yml", SAMPLE_DEF),
+        ("broken.yml", ": not yaml :"),
+        ("ignored.txt", "not a definition"),
+    ]);
+    assert_eq!(registry.len(), 1);
+    assert!(registry.resolve("sample-tracker").is_some());
+}
+
+#[test]
+fn registry_resolves_by_id_and_by_link() {
+    let (registry, _dir) = registry_with(&[("sample.yml", SAMPLE_DEF)]);
+    assert!(registry.resolve("sample-tracker").is_some());
+    assert!(
+        registry
+            .resolve("https://sample-tracker.example/")
+            .is_some()
+    );
+    assert!(registry.resolve("https://sample-tracker.example").is_some());
+    assert!(registry.resolve("https://other.example/").is_none());
+    assert!(registry.resolve("unknown-id").is_none());
+}
+
+#[test]
+fn registry_client_for_unknown_url_errors() {
+    let (registry, _dir) = registry_with(&[("sample.yml", SAMPLE_DEF)]);
+    let err = registry
+        .client_for(
+            IndexerConfig {
+                id: 7,
+                name: "Nope".to_string(),
+                url: "no-such-definition".to_string(),
+                api_key: None,
+                cf_bypass: false,
+            },
+            reqwest::Client::new(),
+            Arc::new(NoProxy),
+            Duration::from_secs(5),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SearchIndexerError::DefinitionNotFound { indexer_id: 7, .. }
+        ),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn registry_without_configured_dir_is_empty() {
+    let registry = CardigannRegistry::load(Arc::new(SearchSubsystemConfig::default()));
+    assert!(registry.is_empty());
+}

--- a/crates/zetesis/src/client/mod.rs
+++ b/crates/zetesis/src/client/mod.rs
@@ -1,3 +1,4 @@
+pub mod cardigann;
 pub mod newznab;
 pub mod torznab;
 pub mod xml;
@@ -175,17 +176,31 @@ pub(crate) fn redact_api_key(url: &str) -> String {
 }
 
 /// Reads a response body into a UTF-8 string, enforcing `max_bytes`.
+pub(crate) async fn read_body_bounded(
+    response: reqwest::Response,
+    url: &str,
+    max_bytes: u64,
+) -> Result<String, SearchIndexerError> {
+    let body = read_body_bytes_bounded(response, url, max_bytes).await?;
+    String::from_utf8(body).map_err(|e| SearchIndexerError::ParseResponse {
+        url: redact_api_key(url),
+        error: e.to_string(),
+        location: snafu::Location::new(file!(), line!(), column!()),
+    })
+}
+
+/// Reads a response body into raw bytes, enforcing `max_bytes`.
 ///
 /// Rejects on a declared `Content-Length` above the cap before reading any
 /// body bytes, then enforces the cap again while streaming.
 ///
 /// WHY: `Content-Length` is attacker-controlled and may be absent or wrong;
 /// only a running counter over the actual stream bounds allocation.
-pub(crate) async fn read_body_bounded(
+pub(crate) async fn read_body_bytes_bounded(
     response: reqwest::Response,
     url: &str,
     max_bytes: u64,
-) -> Result<String, SearchIndexerError> {
+) -> Result<Vec<u8>, SearchIndexerError> {
     if let Some(declared) = response.content_length()
         && declared > max_bytes
     {
@@ -215,11 +230,7 @@ pub(crate) async fn read_body_bounded(
         body.extend_from_slice(&chunk);
     }
 
-    String::from_utf8(body).map_err(|e| SearchIndexerError::ParseResponse {
-        url: redact_api_key(url),
-        error: e.to_string(),
-        location: snafu::Location::new(file!(), line!(), column!()),
-    })
+    Ok(body)
 }
 
 /// SSRF guard for attacker-supplied download URLs.

--- a/crates/zetesis/src/error.rs
+++ b/crates/zetesis/src/error.rs
@@ -112,4 +112,62 @@ pub enum SearchIndexerError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    #[snafu(display("failed to load Cardigann definition {path}: {reason}"))]
+    DefinitionLoad {
+        path: String,
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("Cardigann definition {definition_id} is invalid: {reason}"))]
+    DefinitionInvalid {
+        definition_id: String,
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("Cardigann definition {definition_id} needs unsupported feature: {feature}"))]
+    DefinitionUnsupported {
+        definition_id: String,
+        feature: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display(
+        "no loaded Cardigann definition matches indexer {indexer_id} (url {url:?}; \
+         set the indexer url to a definition id or a site link)"
+    ))]
+    DefinitionNotFound {
+        indexer_id: i64,
+        url: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display(
+        "Cardigann definition {definition_id} uses login method {method:?}; only \
+         'none' and 'cookie' are supported — expose the tracker via a Torznab \
+         sidecar instead"
+    ))]
+    LoginUnsupported {
+        definition_id: String,
+        method: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display(
+        "Cardigann definition {definition_id} uses cookie login; set indexer \
+         {indexer_id}'s api_key field to the session cookie"
+    ))]
+    CookieAuthRequired {
+        definition_id: String,
+        indexer_id: i64,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }

--- a/crates/zetesis/src/lib.rs
+++ b/crates/zetesis/src/lib.rs
@@ -7,21 +7,12 @@ pub mod search;
 pub(crate) mod test_support;
 pub mod types;
 
-use std::sync::Arc;
-
 pub use cf_bypass::CloudflareProxy;
 pub use client::IndexerClient;
+pub use client::cardigann::{CardigannClient, CardigannRegistry};
 pub use error::SearchIndexerError;
-use horismos::SearchSubsystemConfig;
 pub use search::SearchIndexerService;
 pub use types::{
     DownloadResponse, IndexerCaps, IndexerStatus, ReleaseProtocol, SearchMediaType, SearchQuery,
     SearchResult,
 };
-
-pub struct CardigannClient {
-    #[expect(dead_code)]
-    config: Arc<SearchSubsystemConfig>,
-    #[expect(dead_code)]
-    http_client: reqwest::Client,
-}

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -12,6 +12,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, instrument, warn};
 
 use crate::cf_bypass::CloudflareProxy;
+use crate::client::cardigann::CardigannRegistry;
 use crate::client::newznab::NewznabClient;
 use crate::client::torznab::TorznabClient;
 use crate::client::{DynIndexerClient, IndexerConfig};
@@ -33,6 +34,7 @@ pub struct SearchIndexerService {
     rate_limiter: RateLimiter,
     http: reqwest::Client,
     config: SearchSubsystemConfig,
+    cardigann: CardigannRegistry,
     event_tx: EventSender,
 }
 
@@ -54,6 +56,11 @@ impl SearchIndexerService {
             .build()
             .unwrap_or_default(); // WHY: reqwest::Client::default() is a valid fallback; build fails only with invalid TLS config
 
+        // WHY: definitions are read once at startup — this is the read site
+        // for `cardigann_definitions_dir`; per-search dispatch only resolves
+        // against the loaded set.
+        let cardigann = CardigannRegistry::load(Arc::new(config.clone()));
+
         Self {
             read_pool,
             write_pool,
@@ -61,6 +68,7 @@ impl SearchIndexerService {
             rate_limiter,
             http,
             config,
+            cardigann,
             event_tx,
         }
     }
@@ -114,7 +122,26 @@ impl SearchIndexerService {
                         );
                         return Vec::new();
                     }
-                    let client = make_client(&indexer, h, cf, timeout, max_body_bytes);
+                    let client = match make_client(
+                        &indexer,
+                        h,
+                        cf,
+                        timeout,
+                        max_body_bytes,
+                        &self.cardigann,
+                    ) {
+                        Ok(client) => client,
+                        Err(e) => {
+                            warn!(
+                                indexer_id = indexer.id,
+                                indexer_name = %indexer.name,
+                                error = %e,
+                                "failed to construct indexer client"
+                            );
+                            self.handle_search_error(&indexer, &e).await;
+                            return Vec::new();
+                        }
+                    };
                     match client.search_boxed(&q, ct).await {
                         Ok(results) => results,
                         Err(e @ SearchIndexerError::Cancelled { .. }) => {
@@ -178,7 +205,8 @@ impl SearchIndexerService {
             Arc::clone(&self.cf_proxy),
             Duration::from_secs(self.config.request_timeout_secs),
             self.config.max_response_body_bytes,
-        );
+            &self.cardigann,
+        )?;
         let status = client.test_boxed(ct).await?;
         let db_status = if status.healthy { "active" } else { "degraded" };
         repo::update_indexer_status(&self.write_pool, indexer_id, db_status)
@@ -202,7 +230,8 @@ impl SearchIndexerService {
             Arc::clone(&self.cf_proxy),
             Duration::from_secs(self.config.request_timeout_secs),
             self.config.max_response_body_bytes,
-        );
+            &self.cardigann,
+        )?;
         let caps =
             client
                 .caps_boxed(ct)
@@ -289,6 +318,14 @@ impl SearchIndexerService {
             // WHY: cancellation is caller intent and a 429 is back-pressure —
             // neither says the indexer itself is unhealthy.
             SearchIndexerError::Cancelled { .. } | SearchIndexerError::RateLimited { .. } => None,
+            // WHY: a missing/unsupported/misconfigured Cardigann definition
+            // fails every search identically until the operator intervenes.
+            SearchIndexerError::DefinitionNotFound { .. }
+            | SearchIndexerError::DefinitionLoad { .. }
+            | SearchIndexerError::DefinitionInvalid { .. }
+            | SearchIndexerError::DefinitionUnsupported { .. }
+            | SearchIndexerError::LoginUnsupported { .. }
+            | SearchIndexerError::CookieAuthRequired { .. } => Some("failed"),
             _ => None,
         };
 
@@ -378,7 +415,8 @@ fn make_client(
     cf_proxy: Arc<dyn CloudflareProxy>,
     timeout: Duration,
     max_body_bytes: u64,
-) -> Box<dyn DynIndexerClient> {
+    cardigann: &CardigannRegistry,
+) -> Result<Box<dyn DynIndexerClient>, SearchIndexerError> {
     let config = IndexerConfig {
         id: indexer.id,
         name: indexer.name.clone(),
@@ -387,7 +425,7 @@ fn make_client(
         cf_bypass: indexer.cf_bypass,
     };
 
-    match indexer.protocol.as_str() {
+    Ok(match indexer.protocol.as_str() {
         "newznab" => Box::new(NewznabClient::new(
             config,
             http,
@@ -395,6 +433,7 @@ fn make_client(
             timeout,
             max_body_bytes,
         )),
+        "cardigann" => Box::new(cardigann.client_for(config, http, cf_proxy, timeout)?),
         _ => Box::new(TorznabClient::new(
             config,
             http,
@@ -402,496 +441,8 @@ fn make_client(
             timeout,
             max_body_bytes,
         )),
-    }
+    })
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::types::ReleaseProtocol;
-
-    fn make_result(
-        title: &str,
-        info_hash: Option<&str>,
-        guid: Option<&str>,
-        indexer_id: i64,
-    ) -> SearchResult {
-        SearchResult {
-            title: title.to_string(),
-            guid: guid.map(str::to_string),
-            download_url: format!("https://example.com/{title}"),
-            size_bytes: Some(1_000_000),
-            seeders: Some(10),
-            leechers: Some(2),
-            info_hash: info_hash.map(str::to_string),
-            category_id: Some(2000),
-            publication_date: None,
-            indexer_id,
-            protocol: ReleaseProtocol::Torrent,
-            download_volume_factor: 1.0,
-            upload_volume_factor: 1.0,
-            custom_attrs: HashMap::new(),
-        }
-    }
-
-    #[test]
-    fn dedup_by_info_hash() {
-        let results = vec![
-            make_result("Release.A", Some("abc123"), None, 1),
-            make_result("Release.A.dupe", Some("abc123"), None, 2),
-            make_result("Release.B", Some("def456"), None, 1),
-        ];
-
-        let deduped = deduplicate(results);
-        assert_eq!(deduped.len(), 2);
-        assert_eq!(deduped[0].title, "Release.A");
-        assert_eq!(deduped[1].title, "Release.B");
-    }
-
-    #[test]
-    fn dedup_by_guid() {
-        let results = vec![
-            make_result("NZB.A", None, Some("guid-1"), 1),
-            make_result("NZB.A.dupe", None, Some("guid-1"), 2),
-            make_result("NZB.B", None, Some("guid-2"), 1),
-        ];
-
-        let deduped = deduplicate(results);
-        assert_eq!(deduped.len(), 2);
-        assert_eq!(deduped[0].title, "NZB.A");
-        assert_eq!(deduped[1].title, "NZB.B");
-    }
-
-    #[test]
-    fn dedup_registers_guid_of_hash_bearing_result() {
-        // WHY: a result carrying both keys must register its guid too — a later
-        // copy sharing only the guid must not slip past dedup.
-        let results = vec![
-            make_result("Release.A", Some("abc123"), Some("guid-1"), 1),
-            make_result("Release.A.guid-dupe", None, Some("guid-1"), 2),
-        ];
-
-        let deduped = deduplicate(results);
-        assert_eq!(deduped.len(), 1);
-        assert_eq!(deduped[0].title, "Release.A");
-    }
-
-    #[test]
-    fn dedup_same_hash_different_guid_still_dedupes() {
-        let results = vec![
-            make_result("Release.A", Some("abc123"), Some("guid-1"), 1),
-            make_result("Release.A.hash-dupe", Some("abc123"), Some("guid-2"), 2),
-        ];
-
-        let deduped = deduplicate(results);
-        assert_eq!(deduped.len(), 1);
-        assert_eq!(deduped[0].title, "Release.A");
-    }
-
-    #[test]
-    fn dedup_case_insensitive_hash() {
-        let results = vec![
-            make_result("Release.A", Some("ABC123"), None, 1),
-            make_result("Release.A.dupe", Some("abc123"), None, 2),
-        ];
-
-        let deduped = deduplicate(results);
-        assert_eq!(deduped.len(), 1);
-    }
-
-    #[test]
-    fn dedup_keeps_higher_priority() {
-        let results = vec![
-            make_result("Release.Priority1", Some("hash1"), None, 1),
-            make_result("Release.Priority2", Some("hash1"), None, 2),
-        ];
-
-        let deduped = deduplicate(results);
-        assert_eq!(deduped.len(), 1);
-        assert_eq!(deduped[0].indexer_id, 1);
-    }
-
-    #[test]
-    fn dedup_no_hash_no_guid_keeps_all() {
-        let results = vec![
-            make_result("Release.A", None, None, 1),
-            make_result("Release.B", None, None, 2),
-        ];
-
-        let deduped = deduplicate(results);
-        assert_eq!(deduped.len(), 2);
-    }
-
-    #[test]
-    fn filter_capability_any_includes_all() {
-        let indexers = vec![IndexerRow {
-            id: 1,
-            name: "Test1".to_string(),
-            url: "https://example.com/api".to_string(),
-            protocol: "torznab".to_string(),
-            api_key: None,
-            enabled: true,
-            cf_bypass: false,
-            status: "active".to_string(),
-            last_tested: None,
-            caps_json: None,
-            priority: 50,
-            added_at: "2024-01-01T00:00:00Z".to_string(),
-        }];
-
-        let query = SearchQuery {
-            media_type: SearchMediaType::Any,
-            ..Default::default()
-        };
-
-        let eligible = filter_by_capability(&indexers, &query);
-        assert_eq!(eligible.len(), 1);
-    }
-
-    #[test]
-    fn filter_capability_typed_excludes_no_caps() {
-        let indexers = vec![IndexerRow {
-            id: 1,
-            name: "NoCaps".to_string(),
-            url: "https://example.com/api".to_string(),
-            protocol: "torznab".to_string(),
-            api_key: None,
-            enabled: true,
-            cf_bypass: false,
-            status: "active".to_string(),
-            last_tested: None,
-            caps_json: None,
-            priority: 50,
-            added_at: "2024-01-01T00:00:00Z".to_string(),
-        }];
-
-        let query = SearchQuery {
-            media_type: SearchMediaType::Tv,
-            ..Default::default()
-        };
-
-        let eligible = filter_by_capability(&indexers, &query);
-        assert!(eligible.is_empty());
-    }
-
-    #[test]
-    fn filter_capability_typed_includes_supported() {
-        let caps = IndexerCaps {
-            server: crate::types::ServerInfo {
-                title: None,
-                version: None,
-            },
-            limits: crate::types::SearchLimits::default(),
-            search_functions: vec![crate::types::SearchFunction {
-                function_type: "tvsearch".to_string(),
-                available: true,
-            }],
-            categories: vec![],
-        };
-
-        let indexers = vec![IndexerRow {
-            id: 1,
-            name: "TVIndexer".to_string(),
-            url: "https://example.com/api".to_string(),
-            protocol: "torznab".to_string(),
-            api_key: None,
-            enabled: true,
-            cf_bypass: false,
-            status: "active".to_string(),
-            last_tested: None,
-            caps_json: Some(serde_json::to_string(&caps).unwrap()),
-            priority: 50,
-            added_at: "2024-01-01T00:00:00Z".to_string(),
-        }];
-
-        let query = SearchQuery {
-            media_type: SearchMediaType::Tv,
-            ..Default::default()
-        };
-
-        let eligible = filter_by_capability(&indexers, &query);
-        assert_eq!(eligible.len(), 1);
-    }
-
-    // ── handle_search_error / refresh_caps (live service over in-memory db) ──
-
-    use apotheke::migrate::MIGRATOR;
-    use themelion::create_event_bus;
-
-    use crate::cf_bypass::noop::NoProxy;
-    use crate::repo::InsertIndexerParams;
-    use crate::test_support::spawn_one_shot_http;
-
-    async fn make_service() -> (SearchIndexerService, SqlitePool) {
-        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        MIGRATOR.run(&pool).await.unwrap();
-        let (event_tx, _) = create_event_bus(16);
-        let service = SearchIndexerService::new(
-            pool.clone(),
-            pool.clone(),
-            Arc::new(NoProxy),
-            SearchSubsystemConfig::default(),
-            event_tx,
-        );
-        (service, pool)
-    }
-
-    async fn seed_indexer(pool: &SqlitePool, url: &str) -> IndexerRow {
-        let id = repo::insert_indexer(
-            pool,
-            InsertIndexerParams {
-                name: "Seeded",
-                url,
-                protocol: "torznab",
-                api_key: Some("key"),
-                cf_bypass: false,
-                priority: 50,
-            },
-        )
-        .await
-        .unwrap();
-        repo::get_indexer(pool, id).await.unwrap().unwrap()
-    }
-
-    fn cancelled_error() -> SearchIndexerError {
-        SearchIndexerError::Cancelled {
-            url: "https://example.com/api".to_string(),
-            location: snafu::Location::new(file!(), line!(), column!()),
-        }
-    }
-
-    fn rate_limited_error(retry_after_seconds: Option<u64>) -> SearchIndexerError {
-        SearchIndexerError::RateLimited {
-            indexer_id: 1,
-            retry_after_seconds,
-            location: snafu::Location::new(file!(), line!(), column!()),
-        }
-    }
-
-    #[tokio::test]
-    async fn handle_search_error_cancelled_leaves_status_unchanged() {
-        let (service, pool) = make_service().await;
-        let indexer = seed_indexer(&pool, "https://example.com/api").await;
-        assert_eq!(indexer.status, "active");
-
-        service
-            .handle_search_error(&indexer, &cancelled_error())
-            .await;
-
-        let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
-        assert_eq!(row.status, "active");
-    }
-
-    #[tokio::test]
-    async fn handle_search_error_auth_failed_marks_failed() {
-        let (service, pool) = make_service().await;
-        let indexer = seed_indexer(&pool, "https://example.com/api").await;
-
-        let error = SearchIndexerError::AuthFailed {
-            indexer_id: indexer.id,
-            location: snafu::Location::new(file!(), line!(), column!()),
-        };
-        service.handle_search_error(&indexer, &error).await;
-
-        let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
-        assert_eq!(row.status, "failed");
-    }
-
-    #[tokio::test]
-    async fn handle_search_error_parse_response_marks_degraded() {
-        let (service, pool) = make_service().await;
-        let indexer = seed_indexer(&pool, "https://example.com/api").await;
-
-        let error = SearchIndexerError::ParseResponse {
-            url: "https://example.com/api".to_string(),
-            error: "bad xml".to_string(),
-            location: snafu::Location::new(file!(), line!(), column!()),
-        };
-        service.handle_search_error(&indexer, &error).await;
-
-        let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
-        assert_eq!(row.status, "degraded");
-    }
-
-    #[tokio::test]
-    async fn handle_search_error_http_request_active_marks_degraded() {
-        let (service, pool) = make_service().await;
-        let indexer = seed_indexer(&pool, "https://example.com/api").await;
-        assert_eq!(indexer.status, "active");
-
-        let error = SearchIndexerError::HttpRequest {
-            url: "https://example.com/api".to_string(),
-            source: reqwest::Client::new()
-                .get("http://127.0.0.1:9/")
-                .send()
-                .await
-                .unwrap_err(),
-            location: snafu::Location::new(file!(), line!(), column!()),
-        };
-        service.handle_search_error(&indexer, &error).await;
-
-        let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
-        assert_eq!(row.status, "degraded");
-    }
-
-    #[tokio::test]
-    async fn handle_search_error_http_request_degraded_escalates_to_failed() {
-        let (service, pool) = make_service().await;
-        let mut indexer = seed_indexer(&pool, "https://example.com/api").await;
-        repo::update_indexer_status(&pool, indexer.id, "degraded")
-            .await
-            .unwrap();
-        indexer.status = "degraded".to_string();
-
-        let error = SearchIndexerError::HttpRequest {
-            url: "https://example.com/api".to_string(),
-            source: reqwest::Client::new()
-                .get("http://127.0.0.1:9/")
-                .send()
-                .await
-                .unwrap_err(),
-            location: snafu::Location::new(file!(), line!(), column!()),
-        };
-        service.handle_search_error(&indexer, &error).await;
-
-        let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
-        assert_eq!(row.status, "failed");
-    }
-
-    // WHY: the clock is paused only around the limiter interaction — sqlx's
-    // sqlite worker runs on a real thread, and a paused clock during pool
-    // setup auto-advances straight into PoolTimedOut.
-    #[tokio::test]
-    async fn handle_search_error_rate_limited_engages_retry_after() {
-        let (service, pool) = make_service().await;
-        let indexer = seed_indexer(&pool, "https://example.com/api").await;
-
-        tokio::time::pause();
-        service
-            .handle_search_error(&indexer, &rate_limited_error(Some(120)))
-            .await;
-
-        let before = tokio::time::Instant::now();
-        assert!(
-            service
-                .rate_limiter
-                .acquire(indexer.id, &CancellationToken::new())
-                .await
-        );
-        let elapsed = before.elapsed();
-        tokio::time::resume();
-        assert!(
-            elapsed >= Duration::from_secs(120),
-            "expected >=120s back-off, got {elapsed:?}"
-        );
-
-        // 429 is back-pressure, not indexer failure — status must not change.
-        let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
-        assert_eq!(row.status, "active");
-    }
-
-    #[tokio::test]
-    async fn handle_search_error_rate_limited_without_header_uses_default() {
-        let (service, pool) = make_service().await;
-        let indexer = seed_indexer(&pool, "https://example.com/api").await;
-
-        tokio::time::pause();
-        service
-            .handle_search_error(&indexer, &rate_limited_error(None))
-            .await;
-
-        let before = tokio::time::Instant::now();
-        assert!(
-            service
-                .rate_limiter
-                .acquire(indexer.id, &CancellationToken::new())
-                .await
-        );
-        let elapsed = before.elapsed();
-        tokio::time::resume();
-        assert!(
-            elapsed >= Duration::from_secs(DEFAULT_RETRY_AFTER_SECS),
-            "expected >={DEFAULT_RETRY_AFTER_SECS}s default back-off, got {elapsed:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn handle_search_error_rate_limited_clamps_hostile_retry_after() {
-        let (service, pool) = make_service().await;
-        let indexer = seed_indexer(&pool, "https://example.com/api").await;
-
-        tokio::time::pause();
-        service
-            .handle_search_error(&indexer, &rate_limited_error(Some(999_999)))
-            .await;
-
-        let before = tokio::time::Instant::now();
-        assert!(
-            service
-                .rate_limiter
-                .acquire(indexer.id, &CancellationToken::new())
-                .await
-        );
-        let elapsed = before.elapsed();
-        tokio::time::resume();
-        assert!(
-            elapsed >= Duration::from_secs(MAX_RETRY_AFTER_SECS),
-            "expected the cap to engage, got {elapsed:?}"
-        );
-        assert!(
-            elapsed < Duration::from_secs(MAX_RETRY_AFTER_SECS + 60),
-            "expected clamp at {MAX_RETRY_AFTER_SECS}s, got {elapsed:?}"
-        );
-    }
-
-    const CAPS_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
-<caps>
-  <server title="Test Indexer" version="1.0"/>
-  <limits default="100" max="500"/>
-  <searching>
-    <search available="yes"/>
-  </searching>
-  <categories>
-    <category id="2000" name="Movies">
-      <subcat id="2010" name="Movies/Foreign"/>
-    </category>
-  </categories>
-</caps>"#;
-
-    #[tokio::test]
-    async fn refresh_caps_commits_caps_categories_and_status_together() {
-        let (service, pool) = make_service().await;
-        let (url, _server) = spawn_one_shot_http(200, "OK", &[], CAPS_XML).await;
-        let indexer = seed_indexer(&pool, &url).await;
-        repo::update_indexer_status(&pool, indexer.id, "degraded")
-            .await
-            .unwrap();
-
-        let caps = service
-            .refresh_caps(indexer.id, CancellationToken::new())
-            .await
-            .unwrap();
-        assert_eq!(caps.categories.len(), 1);
-
-        let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
-        assert_eq!(row.status, "active");
-        assert!(row.caps_json.is_some());
-        assert!(row.last_tested.is_some());
-
-        let categories = sqlx::query_as::<_, (i64, String)>(
-            "SELECT category_id, name FROM indexer_categories
-             WHERE indexer_id = ? ORDER BY category_id",
-        )
-        .bind(indexer.id)
-        .fetch_all(&pool)
-        .await
-        .unwrap();
-        assert_eq!(
-            categories,
-            vec![
-                (2000, "Movies".to_string()),
-                (2010, "Movies/Foreign".to_string())
-            ]
-        );
-    }
-}
+mod tests;

--- a/crates/zetesis/src/search/tests.rs
+++ b/crates/zetesis/src/search/tests.rs
@@ -1,0 +1,620 @@
+//! SearchIndexerService behavior tests (in-memory db + mock HTTP).
+
+use super::*;
+use crate::types::ReleaseProtocol;
+
+fn make_result(
+    title: &str,
+    info_hash: Option<&str>,
+    guid: Option<&str>,
+    indexer_id: i64,
+) -> SearchResult {
+    SearchResult {
+        title: title.to_string(),
+        guid: guid.map(str::to_string),
+        download_url: format!("https://example.com/{title}"),
+        size_bytes: Some(1_000_000),
+        seeders: Some(10),
+        leechers: Some(2),
+        info_hash: info_hash.map(str::to_string),
+        category_id: Some(2000),
+        publication_date: None,
+        indexer_id,
+        protocol: ReleaseProtocol::Torrent,
+        download_volume_factor: 1.0,
+        upload_volume_factor: 1.0,
+        custom_attrs: HashMap::new(),
+    }
+}
+
+#[test]
+fn dedup_by_info_hash() {
+    let results = vec![
+        make_result("Release.A", Some("abc123"), None, 1),
+        make_result("Release.A.dupe", Some("abc123"), None, 2),
+        make_result("Release.B", Some("def456"), None, 1),
+    ];
+
+    let deduped = deduplicate(results);
+    assert_eq!(deduped.len(), 2);
+    assert_eq!(deduped[0].title, "Release.A");
+    assert_eq!(deduped[1].title, "Release.B");
+}
+
+#[test]
+fn dedup_by_guid() {
+    let results = vec![
+        make_result("NZB.A", None, Some("guid-1"), 1),
+        make_result("NZB.A.dupe", None, Some("guid-1"), 2),
+        make_result("NZB.B", None, Some("guid-2"), 1),
+    ];
+
+    let deduped = deduplicate(results);
+    assert_eq!(deduped.len(), 2);
+    assert_eq!(deduped[0].title, "NZB.A");
+    assert_eq!(deduped[1].title, "NZB.B");
+}
+
+#[test]
+fn dedup_registers_guid_of_hash_bearing_result() {
+    // WHY: a result carrying both keys must register its guid too — a later
+    // copy sharing only the guid must not slip past dedup.
+    let results = vec![
+        make_result("Release.A", Some("abc123"), Some("guid-1"), 1),
+        make_result("Release.A.guid-dupe", None, Some("guid-1"), 2),
+    ];
+
+    let deduped = deduplicate(results);
+    assert_eq!(deduped.len(), 1);
+    assert_eq!(deduped[0].title, "Release.A");
+}
+
+#[test]
+fn dedup_same_hash_different_guid_still_dedupes() {
+    let results = vec![
+        make_result("Release.A", Some("abc123"), Some("guid-1"), 1),
+        make_result("Release.A.hash-dupe", Some("abc123"), Some("guid-2"), 2),
+    ];
+
+    let deduped = deduplicate(results);
+    assert_eq!(deduped.len(), 1);
+    assert_eq!(deduped[0].title, "Release.A");
+}
+
+#[test]
+fn dedup_case_insensitive_hash() {
+    let results = vec![
+        make_result("Release.A", Some("ABC123"), None, 1),
+        make_result("Release.A.dupe", Some("abc123"), None, 2),
+    ];
+
+    let deduped = deduplicate(results);
+    assert_eq!(deduped.len(), 1);
+}
+
+#[test]
+fn dedup_keeps_higher_priority() {
+    let results = vec![
+        make_result("Release.Priority1", Some("hash1"), None, 1),
+        make_result("Release.Priority2", Some("hash1"), None, 2),
+    ];
+
+    let deduped = deduplicate(results);
+    assert_eq!(deduped.len(), 1);
+    assert_eq!(deduped[0].indexer_id, 1);
+}
+
+#[test]
+fn dedup_no_hash_no_guid_keeps_all() {
+    let results = vec![
+        make_result("Release.A", None, None, 1),
+        make_result("Release.B", None, None, 2),
+    ];
+
+    let deduped = deduplicate(results);
+    assert_eq!(deduped.len(), 2);
+}
+
+#[test]
+fn filter_capability_any_includes_all() {
+    let indexers = vec![IndexerRow {
+        id: 1,
+        name: "Test1".to_string(),
+        url: "https://example.com/api".to_string(),
+        protocol: "torznab".to_string(),
+        api_key: None,
+        enabled: true,
+        cf_bypass: false,
+        status: "active".to_string(),
+        last_tested: None,
+        caps_json: None,
+        priority: 50,
+        added_at: "2024-01-01T00:00:00Z".to_string(),
+    }];
+
+    let query = SearchQuery {
+        media_type: SearchMediaType::Any,
+        ..Default::default()
+    };
+
+    let eligible = filter_by_capability(&indexers, &query);
+    assert_eq!(eligible.len(), 1);
+}
+
+#[test]
+fn filter_capability_typed_excludes_no_caps() {
+    let indexers = vec![IndexerRow {
+        id: 1,
+        name: "NoCaps".to_string(),
+        url: "https://example.com/api".to_string(),
+        protocol: "torznab".to_string(),
+        api_key: None,
+        enabled: true,
+        cf_bypass: false,
+        status: "active".to_string(),
+        last_tested: None,
+        caps_json: None,
+        priority: 50,
+        added_at: "2024-01-01T00:00:00Z".to_string(),
+    }];
+
+    let query = SearchQuery {
+        media_type: SearchMediaType::Tv,
+        ..Default::default()
+    };
+
+    let eligible = filter_by_capability(&indexers, &query);
+    assert!(eligible.is_empty());
+}
+
+#[test]
+fn filter_capability_typed_includes_supported() {
+    let caps = IndexerCaps {
+        server: crate::types::ServerInfo {
+            title: None,
+            version: None,
+        },
+        limits: crate::types::SearchLimits::default(),
+        search_functions: vec![crate::types::SearchFunction {
+            function_type: "tvsearch".to_string(),
+            available: true,
+        }],
+        categories: vec![],
+    };
+
+    let indexers = vec![IndexerRow {
+        id: 1,
+        name: "TVIndexer".to_string(),
+        url: "https://example.com/api".to_string(),
+        protocol: "torznab".to_string(),
+        api_key: None,
+        enabled: true,
+        cf_bypass: false,
+        status: "active".to_string(),
+        last_tested: None,
+        caps_json: Some(serde_json::to_string(&caps).unwrap()),
+        priority: 50,
+        added_at: "2024-01-01T00:00:00Z".to_string(),
+    }];
+
+    let query = SearchQuery {
+        media_type: SearchMediaType::Tv,
+        ..Default::default()
+    };
+
+    let eligible = filter_by_capability(&indexers, &query);
+    assert_eq!(eligible.len(), 1);
+}
+
+// ── handle_search_error / refresh_caps (live service over in-memory db) ──
+
+use apotheke::migrate::MIGRATOR;
+use themelion::create_event_bus;
+
+use crate::cf_bypass::noop::NoProxy;
+use crate::repo::InsertIndexerParams;
+use crate::test_support::spawn_one_shot_http;
+
+async fn make_service() -> (SearchIndexerService, SqlitePool) {
+    make_service_with(SearchSubsystemConfig::default()).await
+}
+
+async fn make_service_with(config: SearchSubsystemConfig) -> (SearchIndexerService, SqlitePool) {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    MIGRATOR.run(&pool).await.unwrap();
+    let (event_tx, _) = create_event_bus(16);
+    let service = SearchIndexerService::new(
+        pool.clone(),
+        pool.clone(),
+        Arc::new(NoProxy),
+        config,
+        event_tx,
+    );
+    (service, pool)
+}
+
+async fn seed_indexer(pool: &SqlitePool, url: &str) -> IndexerRow {
+    let id = repo::insert_indexer(
+        pool,
+        InsertIndexerParams {
+            name: "Seeded",
+            url,
+            protocol: "torznab",
+            api_key: Some("key"),
+            cf_bypass: false,
+            priority: 50,
+        },
+    )
+    .await
+    .unwrap();
+    repo::get_indexer(pool, id).await.unwrap().unwrap()
+}
+
+fn cancelled_error() -> SearchIndexerError {
+    SearchIndexerError::Cancelled {
+        url: "https://example.com/api".to_string(),
+        location: snafu::Location::new(file!(), line!(), column!()),
+    }
+}
+
+fn rate_limited_error(retry_after_seconds: Option<u64>) -> SearchIndexerError {
+    SearchIndexerError::RateLimited {
+        indexer_id: 1,
+        retry_after_seconds,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    }
+}
+
+#[tokio::test]
+async fn handle_search_error_cancelled_leaves_status_unchanged() {
+    let (service, pool) = make_service().await;
+    let indexer = seed_indexer(&pool, "https://example.com/api").await;
+    assert_eq!(indexer.status, "active");
+
+    service
+        .handle_search_error(&indexer, &cancelled_error())
+        .await;
+
+    let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
+    assert_eq!(row.status, "active");
+}
+
+#[tokio::test]
+async fn handle_search_error_auth_failed_marks_failed() {
+    let (service, pool) = make_service().await;
+    let indexer = seed_indexer(&pool, "https://example.com/api").await;
+
+    let error = SearchIndexerError::AuthFailed {
+        indexer_id: indexer.id,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    };
+    service.handle_search_error(&indexer, &error).await;
+
+    let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
+    assert_eq!(row.status, "failed");
+}
+
+#[tokio::test]
+async fn handle_search_error_parse_response_marks_degraded() {
+    let (service, pool) = make_service().await;
+    let indexer = seed_indexer(&pool, "https://example.com/api").await;
+
+    let error = SearchIndexerError::ParseResponse {
+        url: "https://example.com/api".to_string(),
+        error: "bad xml".to_string(),
+        location: snafu::Location::new(file!(), line!(), column!()),
+    };
+    service.handle_search_error(&indexer, &error).await;
+
+    let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
+    assert_eq!(row.status, "degraded");
+}
+
+#[tokio::test]
+async fn handle_search_error_http_request_active_marks_degraded() {
+    let (service, pool) = make_service().await;
+    let indexer = seed_indexer(&pool, "https://example.com/api").await;
+    assert_eq!(indexer.status, "active");
+
+    let error = SearchIndexerError::HttpRequest {
+        url: "https://example.com/api".to_string(),
+        source: reqwest::Client::new()
+            .get("http://127.0.0.1:9/")
+            .send()
+            .await
+            .unwrap_err(),
+        location: snafu::Location::new(file!(), line!(), column!()),
+    };
+    service.handle_search_error(&indexer, &error).await;
+
+    let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
+    assert_eq!(row.status, "degraded");
+}
+
+#[tokio::test]
+async fn handle_search_error_http_request_degraded_escalates_to_failed() {
+    let (service, pool) = make_service().await;
+    let mut indexer = seed_indexer(&pool, "https://example.com/api").await;
+    repo::update_indexer_status(&pool, indexer.id, "degraded")
+        .await
+        .unwrap();
+    indexer.status = "degraded".to_string();
+
+    let error = SearchIndexerError::HttpRequest {
+        url: "https://example.com/api".to_string(),
+        source: reqwest::Client::new()
+            .get("http://127.0.0.1:9/")
+            .send()
+            .await
+            .unwrap_err(),
+        location: snafu::Location::new(file!(), line!(), column!()),
+    };
+    service.handle_search_error(&indexer, &error).await;
+
+    let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
+    assert_eq!(row.status, "failed");
+}
+
+// WHY: the clock is paused only around the limiter interaction — sqlx's
+// sqlite worker runs on a real thread, and a paused clock during pool
+// setup auto-advances straight into PoolTimedOut.
+#[tokio::test]
+async fn handle_search_error_rate_limited_engages_retry_after() {
+    let (service, pool) = make_service().await;
+    let indexer = seed_indexer(&pool, "https://example.com/api").await;
+
+    tokio::time::pause();
+    service
+        .handle_search_error(&indexer, &rate_limited_error(Some(120)))
+        .await;
+
+    let before = tokio::time::Instant::now();
+    assert!(
+        service
+            .rate_limiter
+            .acquire(indexer.id, &CancellationToken::new())
+            .await
+    );
+    let elapsed = before.elapsed();
+    tokio::time::resume();
+    assert!(
+        elapsed >= Duration::from_secs(120),
+        "expected >=120s back-off, got {elapsed:?}"
+    );
+
+    // 429 is back-pressure, not indexer failure — status must not change.
+    let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
+    assert_eq!(row.status, "active");
+}
+
+#[tokio::test]
+async fn handle_search_error_rate_limited_without_header_uses_default() {
+    let (service, pool) = make_service().await;
+    let indexer = seed_indexer(&pool, "https://example.com/api").await;
+
+    tokio::time::pause();
+    service
+        .handle_search_error(&indexer, &rate_limited_error(None))
+        .await;
+
+    let before = tokio::time::Instant::now();
+    assert!(
+        service
+            .rate_limiter
+            .acquire(indexer.id, &CancellationToken::new())
+            .await
+    );
+    let elapsed = before.elapsed();
+    tokio::time::resume();
+    assert!(
+        elapsed >= Duration::from_secs(DEFAULT_RETRY_AFTER_SECS),
+        "expected >={DEFAULT_RETRY_AFTER_SECS}s default back-off, got {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn handle_search_error_rate_limited_clamps_hostile_retry_after() {
+    let (service, pool) = make_service().await;
+    let indexer = seed_indexer(&pool, "https://example.com/api").await;
+
+    tokio::time::pause();
+    service
+        .handle_search_error(&indexer, &rate_limited_error(Some(999_999)))
+        .await;
+
+    let before = tokio::time::Instant::now();
+    assert!(
+        service
+            .rate_limiter
+            .acquire(indexer.id, &CancellationToken::new())
+            .await
+    );
+    let elapsed = before.elapsed();
+    tokio::time::resume();
+    assert!(
+        elapsed >= Duration::from_secs(MAX_RETRY_AFTER_SECS),
+        "expected the cap to engage, got {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(MAX_RETRY_AFTER_SECS + 60),
+        "expected clamp at {MAX_RETRY_AFTER_SECS}s, got {elapsed:?}"
+    );
+}
+
+// ── cardigann dispatch (definitions dir → make_client → search) ──────────
+
+fn cardigann_definition_yaml(link: &str) -> String {
+    format!(
+        r#"---
+id: sample-tracker
+name: Sample Tracker
+links:
+  - {link}/
+caps:
+  categorymappings:
+    - {{id: 6, cat: Movies/HD}}
+  modes:
+    search: [q]
+search:
+  paths:
+    - path: /browse
+  inputs:
+    q: "{{{{ .Keywords }}}}"
+  rows:
+    selector: table#torrents > tbody > tr
+  fields:
+    title:
+      selector: a.title
+    download:
+      selector: a.dl
+      attribute: href
+    size:
+      selector: td.size
+    seeders:
+      selector: td.seeds
+"#
+    )
+}
+
+const CARDIGANN_HTML: &str = r#"<html><body><table id="torrents"><tbody>
+<tr><td><a class="title" href="/d/1">Cardigann.Result.One</a></td>
+<td><a class="dl" href="/dl/1.torrent">DL</a></td>
+<td class="size">700 MB</td><td class="seeds">5</td></tr>
+<tr><td><a class="title" href="/d/2">Cardigann.Result.Two</a></td>
+<td><a class="dl" href="/dl/2.torrent">DL</a></td>
+<td class="size">1 GB</td><td class="seeds">9</td></tr>
+</tbody></table></body></html>"#;
+
+#[tokio::test]
+async fn cardigann_search_end_to_end_through_dispatch() {
+    let (url, server) = spawn_one_shot_http(200, "OK", &[], CARDIGANN_HTML).await;
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("sample-tracker.yml"),
+        cardigann_definition_yaml(&url),
+    )
+    .unwrap();
+
+    let (service, pool) = make_service_with(SearchSubsystemConfig {
+        cardigann_definitions_dir: Some(dir.path().to_path_buf()),
+        ..SearchSubsystemConfig::default()
+    })
+    .await;
+    let indexer_id = repo::insert_indexer(
+        &pool,
+        InsertIndexerParams {
+            name: "Cardigann Sample",
+            // WHY: the url column carries the definition id — base URL
+            // resolution must fall back to the definition's links.
+            url: "sample-tracker",
+            protocol: "cardigann",
+            api_key: None,
+            cf_bypass: false,
+            priority: 50,
+        },
+    )
+    .await
+    .unwrap();
+
+    let query = SearchQuery {
+        query_text: Some("hello".to_string()),
+        limit: 100,
+        ..Default::default()
+    };
+    let results = service
+        .search(query, CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].title, "Cardigann.Result.One");
+    assert_eq!(results[0].download_url, format!("{url}/dl/1.torrent"));
+    assert_eq!(results[0].size_bytes, Some(700 * 1024 * 1024));
+    assert_eq!(results[0].seeders, Some(5));
+    assert_eq!(results[0].indexer_id, indexer_id);
+    assert_eq!(results[1].title, "Cardigann.Result.Two");
+
+    let request_head = server.await.unwrap();
+    assert!(
+        request_head.starts_with("GET /browse?q=hello"),
+        "got: {request_head}"
+    );
+}
+
+#[tokio::test]
+async fn cardigann_row_without_definition_marks_failed() {
+    let (service, pool) = make_service().await;
+    let indexer_id = repo::insert_indexer(
+        &pool,
+        InsertIndexerParams {
+            name: "Ghost",
+            url: "no-such-definition",
+            protocol: "cardigann",
+            api_key: None,
+            cf_bypass: false,
+            priority: 50,
+        },
+    )
+    .await
+    .unwrap();
+
+    let results = service
+        .search(SearchQuery::new(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert!(results.is_empty());
+
+    let row = repo::get_indexer(&pool, indexer_id).await.unwrap().unwrap();
+    assert_eq!(row.status, "failed");
+}
+
+const CAPS_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+  <server title="Test Indexer" version="1.0"/>
+  <limits default="100" max="500"/>
+  <searching>
+    <search available="yes"/>
+  </searching>
+  <categories>
+    <category id="2000" name="Movies">
+      <subcat id="2010" name="Movies/Foreign"/>
+    </category>
+  </categories>
+</caps>"#;
+
+#[tokio::test]
+async fn refresh_caps_commits_caps_categories_and_status_together() {
+    let (service, pool) = make_service().await;
+    let (url, _server) = spawn_one_shot_http(200, "OK", &[], CAPS_XML).await;
+    let indexer = seed_indexer(&pool, &url).await;
+    repo::update_indexer_status(&pool, indexer.id, "degraded")
+        .await
+        .unwrap();
+
+    let caps = service
+        .refresh_caps(indexer.id, CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(caps.categories.len(), 1);
+
+    let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
+    assert_eq!(row.status, "active");
+    assert!(row.caps_json.is_some());
+    assert!(row.last_tested.is_some());
+
+    let categories = sqlx::query_as::<_, (i64, String)>(
+        "SELECT category_id, name FROM indexer_categories
+             WHERE indexer_id = ? ORDER BY category_id",
+    )
+    .bind(indexer.id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        categories,
+        vec![
+            (2000, "Movies".to_string()),
+            (2010, "Movies/Foreign".to_string())
+        ]
+    );
+}

--- a/docs/download/indexer-protocol.md
+++ b/docs/download/indexer-protocol.md
@@ -415,6 +415,7 @@ Indexer rows select the client with `protocol = 'cardigann'`; the row's `url` co
 | Filter chains | Common set | `regexp`, `re_replace`, `replace`, `split`, `trim`, `prepend`, `append`, `tolower`, `toupper`, `querystring`, `dateparse`, `timeago` (best-effort); unknown filters rejected at load |
 | `download` | `selector`/`attribute`/filters | `before` pre-requests and `infohash` fallback warned and ignored |
 | `login` | `none`, `cookie` | Form/post/get/oneurl fail at client construction with a clear error |
+| `settings` | Defaults only | `.Config.<key>` always resolves to the definition's `default:` value; per-indexer overrides are not plumbed yet (deferred) |
 | `ratio` | No | Deferred |
 
 **Definition source**: Harmonia reads Prowlarr-compatible YAML definitions from `config.zetesis.cardigann_definitions_dir`, one indexer per `.yml`/`.yaml` file, at startup (`SearchIndexerService::new` → `CardigannRegistry::load`). Definitions that fail validation are skipped with a warning naming the unsupported construct. Third-party definitions are not vendored into the repo.

--- a/docs/download/indexer-protocol.md
+++ b/docs/download/indexer-protocol.md
@@ -200,7 +200,7 @@ pub trait IndexerClient: Send + Sync {
 |--------|-----------|-------------|
 | `TorznabClient` | `IndexerClient` | Native HTTP + XML for Torznab indexers. Handles magnet URI extraction from enclosure elements. |
 | `NewznabClient` | `IndexerClient` | Same protocol as Torznab, NZB-specific response handling. Parses NZB file URL from enclosure. |
-| `CardigannClient` (future) | `IndexerClient` | YAML-driven scraping for indexers without native API. See Cardigann Compatibility section. |
+| `CardigannClient` | `IndexerClient` | YAML-definition-driven HTML scraping for indexers without native API. See Cardigann Compatibility section. |
 
 `TorznabClient` and `NewznabClient` share the XML parsing and HTTP transport layer; they differ primarily in how they interpret the download link and which `TorznabAttr` fields they extract.
 
@@ -395,46 +395,31 @@ Results are returned to the monitoring layer as `Vec<SearchResult>`. Monitoring 
 
 ---
 
-## Cardigann compatibility: future extension
+## Cardigann compatibility
 
-Prowlarr's Cardigann definitions provide 500+ indexer definitions for trackers that lack native Torznab/Newznab APIs. Full Cardigann support is out of scope for v1; it requires a Go-style template engine, CSS/JSON/XML selectors, filter chains, and multi-step login flows (approximately 15K lines of implementation).
+Prowlarr's Cardigann definitions provide 500+ indexer definitions for trackers that lack native Torznab/Newznab APIs. `CardigannClient` (`crates/zetesis/src/client/cardigann/`) executes the core Cardigann subset: templated GET search paths, CSS row/field selectors, a filter pipeline, and category mapping. The abstraction boundary is unchanged: any tracker that supports Torznab/Newznab natively uses `TorznabClient` or `NewznabClient`; Cardigann is only for trackers that require HTML scraping.
 
-### V1 scope: interface only
+Indexer rows select the client with `protocol = 'cardigann'`; the row's `url` column carries either a definition id or one of the definition's site links. For `login.method: cookie`, the row's `api_key` column carries the session cookie.
 
-Phase 5 defines `CardigannClient` as a future `IndexerClient` implementation. The abstraction boundary is clear: any tracker that supports Torznab/Newznab natively uses `TorznabClient` or `NewznabClient`. Cardigann is only for trackers that require HTML scraping.
+### Supported Cardigann YAML subset
 
-```rust
-// Future implementation placeholder — not implemented in v1
-pub struct CardigannClient {
-    config: Arc<ZetesisConfig>,
-    definition: CardigannDefinition,
-    http_client: reqwest::Client,
-}
-
-// CardigannClient will implement IndexerClient when built
-// impl IndexerClient for CardigannClient { ... }
-```
-
-### Cardigann YAML subset for v1 implementation
-
-When Cardigann support is built, the first iteration should handle this YAML subset from Prowlarr-compatible definitions:
-
-| YAML Section | v1 Support | Notes |
+| YAML Section | Support | Notes |
 |-------------|-----------|-------|
-| `id`, `name`, `description` | Yes | Identity fields |
-| `caps.categorymappings` | Yes | Category ID mapping |
+| `id`, `name`, `description`, `links` | Yes | Identity fields; templated links rejected |
+| `caps.categorymappings` (+ legacy `caps.categories`) | Yes | Category ID mapping via the standard Torznab table |
 | `caps.modes` | Yes | Supported search functions |
-| `search.paths` | Yes | URL path and parameter templates |
-| `search.rows` | Yes | CSS selector for result rows |
-| `search.fields` | Yes | Field extractors (CSS, JSON, regex) |
-| `download` | Yes | Download link construction |
-| `login` | **No** | Multi-step login adds major complexity; deferred |
-| `ratio` | No | Ratio parsing; deferred |
-| Filter chains (`re_replace`, `split`, etc.) | Partial | Common filters only |
+| `search.paths` (+ legacy `search.path`) | GET only | POST paths and JSON responses rejected at load |
+| `search.inputs` / `keywordsfilters` | Yes | Template subset: `.Keywords`, `.Categories`, `.Config.<key>`, `.Query.<field>`, `join`; `$raw` input supported. `if`/`range` rejected at load |
+| `search.rows` | `selector` + `remove` | `filters` (andmatch), `after`, `dateheaders` warned and ignored |
+| `search.fields` | Yes | `selector`, `attribute`, `text`, `optional`, `case`, `remove`, filters |
+| Filter chains | Common set | `regexp`, `re_replace`, `replace`, `split`, `trim`, `prepend`, `append`, `tolower`, `toupper`, `querystring`, `dateparse`, `timeago` (best-effort); unknown filters rejected at load |
+| `download` | `selector`/`attribute`/filters | `before` pre-requests and `infohash` fallback warned and ignored |
+| `login` | `none`, `cookie` | Form/post/get/oneurl fail at client construction with a clear error |
+| `ratio` | No | Deferred |
 
-**Definition source**: Harmonia reads Prowlarr-compatible YAML definitions from `config.zetesis.cardigann_definitions_dir`. Prowlarr's definition repository is the reference. Definitions are read at startup (or on directory watch trigger, future).
+**Definition source**: Harmonia reads Prowlarr-compatible YAML definitions from `config.zetesis.cardigann_definitions_dir`, one indexer per `.yml`/`.yaml` file, at startup (`SearchIndexerService::new` → `CardigannRegistry::load`). Definitions that fail validation are skipped with a warning naming the unsupported construct. Third-party definitions are not vendored into the repo.
 
-**Authentication-required trackers**: Trackers that require login (cookie-based sessions, form submission) are excluded from v1 Cardigann support. The `login` section is the primary source of Cardigann complexity. Users who need these trackers should use a Prowlarr sidecar and expose it as a Torznab feed to Harmonia; this is the practical escape hatch for the most complex trackers.
+**Authentication-required trackers**: Only `login.method: none` and `cookie` are executed. Trackers that require form submission or multi-step login should use a Prowlarr sidecar and expose it as a Torznab feed to Harmonia; this is the practical escape hatch for the most complex trackers.
 
 ---
 


### PR DESCRIPTION
Wires the previously-inert `CardigannClient` (a bare unconstructed stub) into a working, definition-driven indexer client, closing the extensibility gap where `cardigann_definitions_dir` was configured but never read.

**What works (core):** YAML definitions runtime-loaded from `cardigann_definitions_dir` (one indexer per file, invalid files skipped with a warning); `IndexerClient` fully implemented (search/caps/test/download); HTML response parsing via CSS selectors (rows + fields, `case:`/`text:`/`remove:`); template substitution (`.Keywords`, `.Categories`, `.Config.*`, `.Query.*`, `join`, `$raw`); the common filter pipeline (regexp, re_replace, replace, split, trim, prepend/append, tolower/toupper, querystring, dateparse, timeago); full Torznab category mapping; `none` + `cookie` login. Wired into the live dispatch via a `make_client` "cardigann" arm; a migration widens the `indexers.protocol` CHECK to admit `cardigann` (rows were previously uninsertable).

**Honestly deferred** (rejected at load with a clear reason — never silently faked): form/post/captcha login, JSON/XML responses, POST search paths, templated links, Go-template control flow, and rare filters. Follow-up issues will track these.

**Security:** user keywords are URL-encoded via `append_pair`; regex filters use the linear-time `regex` crate (ReDoS-immune); request hosts are operator-controlled (not user-influenced); result download URLs are SSRF-validated.

Gate: `kanon gate --full` green (clippy `-D warnings`, workspace nextest 1808, deny, lint). Deps: `serde_norway`, `scraper`, `ego-tree` (deny-clean).

Closes #472
