### PR TITLE
chore: centralize clippy lint floor and correct CI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Cross-tool agent guidance (agents.md standard). Claude Code, Cursor, Codex, Copi
 ## Rules
 
 - **snafu for all errors, one enum per crate.** Use `.context(VariantSnafu { ... })?`; never bare `?`. `source:` for internal/well-known errors (chain walker continues); `error: String` for opaque external failures (chain stops). See `docs/architecture/errors.md`. WHY: location tracking + predictable chain walking for API responses.
-- **No `unwrap()` / `expect()` / `dbg!()` / `todo!()` in library crates.** Workspace lints set these to `deny`. Use `#[expect(lint, reason = "...")]` over `#[allow]`. WHY: `#[expect]` warns when the suppression becomes stale.
+- **No `unwrap()` / `expect()` / `dbg!()` / `todo!()` in library crates.** Kanon RUST-standard policy, enforced via `kanon lint` and review; the `[workspace.lints]` clippy floor denies `clippy::all` only. Use `#[expect(lint, reason = "...")]` over `#[allow]`. WHY: `#[expect]` warns when the suppression becomes stale.
 - **No `thiserror`, `anyhow`, `Box<dyn Error>` in library crates.** `anyhow` is acceptable only in `archon` startup. WHY: typed errors are part of the public contract.
 - **Newtypes for domain IDs.** `MediaId`, `UserId`, `DownloadId` - not raw `String`/`u64`. All defined in `themelion`.
 - **Cross-subsystem type sharing goes through `themelion`.** Subsystem crates never import another subsystem's internal types. WHY: prevents cycles; the DAG in `docs/architecture/cargo.md` is law.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,19 @@ cargo check --manifest-path crates/theatron/desktop/Cargo.toml   # excluded crat
 
 ## CI
 
-- `rust.yml`: format, clippy, test, MSRV, rustdoc, coverage
-- `security.yml`: cargo-audit, cargo-deny, gitleaks, TruffleHog
+- `ci.yml`: Format, Check, Clippy, Test (nextest + doctests). Toolchain comes
+  from `rust-toolchain.toml`, never workflow inputs.
+- `security.yml`: cargo deny, cargo audit, osv-scanner, gitleaks — on PRs,
+  pushes to `main`, and a daily schedule.
+- `gate-attestation.yml`: requires a `Gate-Passed:` trailer in a PR commit and
+  rejects AI-attribution markers in PR title/body/commits.
+- `pii-scan.yml`: scans the tree against `.github/pii-patterns.txt`.
+- `release.yml`: on `v*` tags — test, build 3-target binaries, SBOM +
+  provenance attestations, upload release assets.
+- `release-please.yml`: version PRs; attests the release source archive.
+- `stale.yml`: weekly issue/PR staleness sweep.
+- `dependabot-auto-merge.yml`: auto-merges patch and dev-minor dependabot PRs
+  after required checks pass.
 
 ## Boundaries
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,12 @@ edition = "2024"
 rust-version = "1.89"
 license = "AGPL-3.0-or-later"
 
+# WHY: declarative mirror of CI's `cargo clippy -- -D warnings` floor; member
+# crates opt in via `[lints] workspace = true`. Stricter per-lint denies
+# (unwrap_used, expect_used, ...) are enforced by `kanon lint`, not here.
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+
 [workspace.dependencies]
 # ── Internal crates ────────────────────────────────────────────────────────────
 themelion     = { path = "crates/themelion" }

--- a/crates/aitesis/Cargo.toml
+++ b/crates/aitesis/Cargo.toml
@@ -24,6 +24,9 @@ tempfile = "3"
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/akouo-android/Cargo.toml
+++ b/crates/akouo-android/Cargo.toml
@@ -19,6 +19,9 @@ uniffi.workspace = true
 [dev-dependencies]
 tempfile = "3"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/akouo-core/Cargo.toml
+++ b/crates/akouo-core/Cargo.toml
@@ -41,6 +41,9 @@ rstest.workspace = true
 rustfft = "6"
 tempfile = "3"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/apotheke/Cargo.toml
+++ b/crates/apotheke/Cargo.toml
@@ -20,6 +20,9 @@ rstest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/archon/Cargo.toml
+++ b/crates/archon/Cargo.toml
@@ -68,6 +68,9 @@ tokio = { workspace = true, features = [
     "test-util",
 ] }
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/epignosis/Cargo.toml
+++ b/crates/epignosis/Cargo.toml
@@ -23,6 +23,9 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = "3"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/ergasia/Cargo.toml
+++ b/crates/ergasia/Cargo.toml
@@ -29,6 +29,9 @@ rstest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/exousia/Cargo.toml
+++ b/crates/exousia/Cargo.toml
@@ -29,6 +29,9 @@ sqlx = { workspace = true }
 tower = { workspace = true }
 http = "1"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/harmonia-convert/Cargo.toml
+++ b/crates/harmonia-convert/Cargo.toml
@@ -14,6 +14,9 @@ tracing.workspace = true
 [dev-dependencies]
 tokio = { workspace = true }
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/horismos/Cargo.toml
+++ b/crates/horismos/Cargo.toml
@@ -21,6 +21,9 @@ tempfile = "3"
 figment = { workspace = true, features = ["toml", "env", "test"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/kathodos/Cargo.toml
+++ b/crates/kathodos/Cargo.toml
@@ -25,6 +25,9 @@ tokio = { workspace = true, features = ["test-util"] }
 rstest.workspace = true
 tempfile = "3"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/komide/Cargo.toml
+++ b/crates/komide/Cargo.toml
@@ -25,6 +25,9 @@ tokio           = { workspace = true, features = ["full"] }
 sqlx            = { workspace = true }
 tempfile        = "3"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/kritike/Cargo.toml
+++ b/crates/kritike/Cargo.toml
@@ -21,6 +21,9 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 rstest.workspace = true
 uuid.workspace = true
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -47,6 +47,9 @@ sqlx.workspace = true
 apotheke.workspace = true
 http-body-util = "0.1"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/prostheke/Cargo.toml
+++ b/crates/prostheke/Cargo.toml
@@ -27,6 +27,9 @@ rstest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/syndesis/Cargo.toml
+++ b/crates/syndesis/Cargo.toml
@@ -37,6 +37,9 @@ sqlx.workspace = true
 apotheke = { workspace = true }
 toml.workspace = true
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/syndesmos/Cargo.toml
+++ b/crates/syndesmos/Cargo.toml
@@ -30,6 +30,9 @@ tokio = { workspace = true, features = [
   "test-util",
 ] }
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/syntaxis/Cargo.toml
+++ b/crates/syntaxis/Cargo.toml
@@ -29,6 +29,9 @@ tokio = { workspace = true, features = [
 ] }
 tempfile = "3"
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/theatron/core/Cargo.toml
+++ b/crates/theatron/core/Cargo.toml
@@ -13,6 +13,9 @@ serde_json = { workspace = true }
 snafu = { workspace = true }
 tracing = { workspace = true }
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/themelion/Cargo.toml
+++ b/crates/themelion/Cargo.toml
@@ -20,6 +20,9 @@ rstest.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"

--- a/crates/zetesis/Cargo.toml
+++ b/crates/zetesis/Cargo.toml
@@ -33,6 +33,9 @@ rstest.workspace = true
 workspace = true
 features = ["rt-multi-thread", "macros", "test-util"]
 
+[lints]
+workspace = true
+
 [package.metadata.kanon]
 maturity = "alpha"
 since = "2026-05-26"


### PR DESCRIPTION
Two CI/standards-conformance fixes.

**Centralize the clippy lint floor** — adds `[workspace.lints.clippy] all = { level = "deny", priority = -1 }` to the root `Cargo.toml` and `[lints] workspace = true` to all 21 member crates, making the lint floor declarative (Cargo 1.74+) instead of relying solely on the CI `-D warnings` flag. **Zero burndown**: mirrors only the floor the code already passes; no `.rs` changes. Deliberately does NOT add stricter lints (`unwrap_used`/`unsafe_code`) — those are enforced by `kanon lint` + review and would break test code / legitimate `unsafe`.

**Correct the CI docs** — `CLAUDE.md` `## CI` and `AGENTS.md` described a nonexistent `rust.yml`, TruffleHog (not used), and falsely claimed workspace lints deny unwrap/expect. Rewritten to describe the 8 actual workflows (ci/security/gate-attestation/pii-scan/release/release-please/stale/dependabot-auto-merge) accurately.

Gate: `kanon gate --full` green (1728 tests, clippy, deny, lint).
