### PR TITLE
fix(paroche): scope get_request to caller and redact indexer creds

### DIFF
--- a/crates/aitesis/src/lib.rs
+++ b/crates/aitesis/src/lib.rs
@@ -58,7 +58,15 @@ pub trait RequestService: Send + Sync {
     ) -> Result<MediaRequest, AitesisError>;
 
     /// Returns a single request by ID.
-    async fn get_request(&self, request_id: RequestId) -> Result<MediaRequest, AitesisError>;
+    ///
+    /// Authorization: admins may read any request; members may only read
+    /// their own (a non-owner member is rejected with
+    /// [`AitesisError::InsufficientPermission`]).
+    async fn get_request(
+        &self,
+        request_id: RequestId,
+        caller_id: UserId,
+    ) -> Result<MediaRequest, AitesisError>;
 
     /// Lists requests, optionally filtered by user or status, windowed by
     /// `limit`/`offset` (newest first).
@@ -235,16 +243,33 @@ where
         approval::deny_request(&self.write, request_id, admin_id, role, reason).await
     }
 
-    #[instrument(skip(self), fields(request_id = %request_id))]
-    async fn get_request(&self, request_id: RequestId) -> Result<MediaRequest, AitesisError> {
-        repo::get_request(&self.read, &request_id)
+    #[instrument(skip(self), fields(request_id = %request_id, caller_id = %caller_id))]
+    async fn get_request(
+        &self,
+        request_id: RequestId,
+        caller_id: UserId,
+    ) -> Result<MediaRequest, AitesisError> {
+        let request = repo::get_request(&self.read, &request_id)
             .await?
             .ok_or_else(|| {
                 RequestNotFoundSnafu {
                     id: request_id.to_string(),
                 }
                 .build()
-            })
+            })?;
+
+        // WHY: same ownership boundary as cancel_request — a member reading
+        // another user's request by UUID is an IDOR (title, decided_by,
+        // deny_reason, want_id all leak).
+        let role = self.user_roles.role_of(caller_id).await?;
+        let is_owner = request.user_id == caller_id;
+        let is_admin = role == UserRole::Admin;
+
+        if !is_owner && !is_admin {
+            return InsufficientPermissionSnafu.fail();
+        }
+
+        Ok(request)
     }
 
     #[instrument(skip(self), fields(caller_id = %caller_id))]
@@ -613,7 +638,7 @@ mod tests {
 
         svc.cancel_request(req.id, user_id).await.unwrap();
 
-        let result = svc.get_request(req.id).await;
+        let result = svc.get_request(req.id, user_id).await;
         assert!(matches!(result, Err(AitesisError::RequestNotFound { .. })));
     }
 
@@ -1126,7 +1151,56 @@ mod tests {
         .await
         .unwrap();
 
-        let fulfilled = admin_svc.get_request(req.id).await.unwrap();
+        let fulfilled = admin_svc.get_request(req.id, admin_id).await.unwrap();
         assert_eq!(fulfilled.status, RequestStatus::Fulfilled);
+    }
+
+    // ── Get tests ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn owner_gets_own_request() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let user_id = UserId::new();
+        let req = svc.submit_request(user_id, music_input()).await.unwrap();
+
+        let fetched = svc.get_request(req.id, user_id).await.unwrap();
+        assert_eq!(fetched.id, req.id);
+        assert_eq!(fetched.user_id, user_id);
+    }
+
+    #[tokio::test]
+    async fn member_cannot_get_other_user_request() {
+        let (svc, _pool) = make_service(UserRole::Member).await;
+        let alice = UserId::new();
+        let bob = UserId::new();
+        let req = svc.submit_request(alice, music_input()).await.unwrap();
+
+        let err = svc.get_request(req.id, bob).await.unwrap_err();
+        assert!(matches!(err, AitesisError::InsufficientPermission { .. }));
+    }
+
+    #[tokio::test]
+    async fn admin_gets_any_user_request() {
+        let (member_svc, pool) = make_service(UserRole::Member).await;
+        let alice = UserId::new();
+        let req = member_svc
+            .submit_request(alice, music_input())
+            .await
+            .unwrap();
+
+        let admin_svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            MockRoles {
+                role: UserRole::Admin,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let admin_id = UserId::new();
+        let fetched = admin_svc.get_request(req.id, admin_id).await.unwrap();
+        assert_eq!(fetched.id, req.id);
+        assert_eq!(fetched.user_id, alice);
     }
 }

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -368,9 +368,15 @@ impl DynRequestService for RequestAdapter {
     fn get_request(
         &self,
         request_id: themelion::RequestId,
+        caller_id: themelion::UserId,
     ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
         let service = Arc::clone(&self.0);
-        Box::pin(async move { service.get_request(request_id).await.map_err(Into::into) })
+        Box::pin(async move {
+            service
+                .get_request(request_id, caller_id)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     fn list_requests(

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -231,9 +231,15 @@ impl DynRequestService for MockRequestAdapter {
     fn get_request(
         &self,
         request_id: themelion::RequestId,
+        caller_id: themelion::UserId,
     ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
         let service = Arc::clone(&self.0);
-        Box::pin(async move { service.get_request(request_id).await.map_err(Into::into) })
+        Box::pin(async move {
+            service
+                .get_request(request_id, caller_id)
+                .await
+                .map_err(Into::into)
+        })
     }
 
     fn list_requests(

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod middleware;
 pub mod net_validate;
 pub mod opds;
+pub mod redact;
 pub mod response;
 pub mod routes;
 pub mod state;

--- a/crates/paroche/src/redact.rs
+++ b/crates/paroche/src/redact.rs
@@ -1,0 +1,178 @@
+//! Credential redaction for indexer URLs leaving the API boundary.
+
+/// Replacement value for redacted credential query parameters.
+const REDACTED: &str = "REDACTED";
+
+/// Query keys that are credentials when matched exactly (case-insensitive).
+///
+/// `r` is the conventional Torznab passkey parameter; `api` is used bare by
+/// several Newznab indexers.
+const EXACT_CREDENTIAL_KEYS: &[&str] = &["r", "api"];
+
+/// Substrings that mark a query key as credential-bearing (case-insensitive).
+///
+/// Covers the Torznab/Newznab conventions: `apikey`, `api_key`, `passkey`,
+/// `torrent_pass`, `authkey`, `auth_key`, `token`, `secret`, and variants.
+/// Over-matching is deliberate — a redacted-but-harmless parameter costs
+/// nothing, a leaked passkey compromises a private-tracker account.
+const CREDENTIAL_KEY_SUBSTRINGS: &[&str] = &["key", "pass", "token", "secret", "auth"];
+
+fn is_credential_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    EXACT_CREDENTIAL_KEYS.contains(&key.as_str())
+        || CREDENTIAL_KEY_SUBSTRINGS
+            .iter()
+            .any(|marker| key.contains(marker))
+}
+
+/// Redacts credential-bearing query parameter values from a download URL.
+///
+/// Torznab/Newznab download URLs embed the indexer `apikey`/`passkey` in the
+/// query string; returning them raw hands the operator's private-tracker
+/// credentials to any authenticated member. Only parameter VALUES are
+/// replaced — keys, ordering, separators, and the fragment survive, so the
+/// URL stays recognizable in the UI.
+///
+/// The transformation is purely lexical (split on `#`, `?`, `&`, `=`), so a
+/// URL the `url` crate would reject (for example a magnet URI) is still
+/// redacted rather than passed through raw.
+#[must_use]
+pub fn redact_download_url(url: &str) -> String {
+    let (head, fragment) = match url.split_once('#') {
+        Some((head, fragment)) => (head, Some(fragment)),
+        None => (url, None),
+    };
+    let Some((base, query)) = head.split_once('?') else {
+        return url.to_string();
+    };
+
+    let redacted_query = query
+        .split('&')
+        .map(|pair| match pair.split_once('=') {
+            Some((key, _)) if is_credential_key(key) => format!("{key}={REDACTED}"),
+            _ => pair.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+
+    match fragment {
+        Some(fragment) => format!("{base}?{redacted_query}#{fragment}"),
+        None => format!("{base}?{redacted_query}"),
+    }
+}
+
+/// Recursively redacts every `download_url` string field in a JSON value.
+///
+/// Search results flow through paroche as opaque `serde_json::Value` trees
+/// (indexer -> zetesis -> route), so the redaction walks the tree instead of
+/// a typed response struct.
+pub fn redact_download_urls_in_json(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, entry) in map.iter_mut() {
+                if key == "download_url" {
+                    if let serde_json::Value::String(url) = entry {
+                        *url = redact_download_url(url);
+                    }
+                } else {
+                    redact_download_urls_in_json(entry);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items.iter_mut() {
+                redact_download_urls_in_json(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_apikey_value_keeping_structure() {
+        assert_eq!(
+            redact_download_url("https://indexer.example/api?t=get&id=42&apikey=SECRET"),
+            "https://indexer.example/api?t=get&id=42&apikey=REDACTED"
+        );
+    }
+
+    #[test]
+    fn redacts_all_conventional_credential_keys() {
+        for key in [
+            "apikey",
+            "api_key",
+            "passkey",
+            "authkey",
+            "auth_key",
+            "token",
+            "secret",
+            "r",
+            "torrent_pass",
+            "password",
+        ] {
+            let url = format!("https://indexer.example/dl?{key}=SECRET&file=x.torrent");
+            let redacted = redact_download_url(&url);
+            assert_eq!(
+                redacted,
+                format!("https://indexer.example/dl?{key}=REDACTED&file=x.torrent"),
+                "{key} must be redacted"
+            );
+        }
+    }
+
+    #[test]
+    fn matches_keys_case_insensitively() {
+        assert_eq!(
+            redact_download_url("https://indexer.example/dl?ApiKey=SECRET"),
+            "https://indexer.example/dl?ApiKey=REDACTED"
+        );
+    }
+
+    #[test]
+    fn keeps_non_credential_params_and_fragment() {
+        assert_eq!(
+            redact_download_url("https://indexer.example/dl?t=get&id=42#frag"),
+            "https://indexer.example/dl?t=get&id=42#frag"
+        );
+    }
+
+    #[test]
+    fn leaves_query_free_urls_untouched() {
+        assert_eq!(
+            redact_download_url("https://indexer.example/dl/42.torrent"),
+            "https://indexer.example/dl/42.torrent"
+        );
+    }
+
+    #[test]
+    fn redacts_magnet_uri_credentials_without_touching_xt() {
+        assert_eq!(
+            redact_download_url("magnet:?xt=urn:btih:abc123&passkey=SECRET"),
+            "magnet:?xt=urn:btih:abc123&passkey=REDACTED"
+        );
+    }
+
+    #[test]
+    fn json_walk_redacts_nested_download_urls_only() {
+        let mut value = serde_json::json!({
+            "results": [{
+                "title": "Album",
+                "download_url": "https://indexer.example/dl?apikey=SECRET",
+                "info_url": "https://indexer.example/details/42"
+            }]
+        });
+        redact_download_urls_in_json(&mut value);
+        assert_eq!(
+            value["results"][0]["download_url"],
+            "https://indexer.example/dl?apikey=REDACTED"
+        );
+        assert_eq!(
+            value["results"][0]["info_url"],
+            "https://indexer.example/details/42"
+        );
+    }
+}

--- a/crates/paroche/src/routes/download.rs
+++ b/crates/paroche/src/routes/download.rs
@@ -71,7 +71,12 @@ impl From<DownloadRow> for DownloadResponse {
             id: bytes_to_uuid_str(&r.id),
             want_id: bytes_to_uuid_str(&r.want_id),
             release_id: bytes_to_uuid_str(&r.release_id),
-            download_url: r.download_url,
+            // WHY: the stored URL embeds the indexer apikey/passkey
+            // (Torznab/Newznab convention); the queue snapshot is
+            // member-visible, so raw URLs hand out the operator's
+            // private-tracker credentials. The DB row and the enqueue path
+            // keep the real URL — only the outbound response is redacted.
+            download_url: crate::redact::redact_download_url(&r.download_url),
             protocol: r.protocol,
             priority: r.priority,
             info_hash: r.info_hash,
@@ -749,6 +754,55 @@ mod tests {
             *queue.reprioritized.lock().unwrap(),
             vec![(id, 4)],
             "the re-prioritization must be delegated to the queue manager"
+        );
+    }
+
+    // ── #539: member-visible responses must not leak indexer credentials ────
+
+    #[tokio::test]
+    async fn queue_snapshot_redacts_indexer_credentials() {
+        let (state, auth) = test_state().await;
+        let token = token_for(&auth, "member", UserRole::Member).await;
+        let pool = app_pool(&auth);
+
+        let id = uuid::Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO download_queue \
+             (id, want_id, release_id, download_url, protocol, priority, \
+              status, added_at, retry_count) \
+             VALUES (?, ?, ?, ?, 'torrent', 2, 'queued', \
+                     '2026-01-01T00:00:00Z', 0)",
+        )
+        .bind(id.as_bytes().as_slice())
+        .bind(uuid::Uuid::now_v7().as_bytes().as_slice())
+        .bind(uuid::Uuid::now_v7().as_bytes().as_slice())
+        .bind("https://indexer.example/api?t=get&id=42&apikey=SECRET")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/downloads")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            body["data"]["queued"][0]["download_url"],
+            "https://indexer.example/api?t=get&id=42&apikey=REDACTED"
+        );
+        assert!(
+            !String::from_utf8_lossy(&bytes).contains("SECRET"),
+            "the raw indexer credential must never reach the response body"
         );
     }
 

--- a/crates/paroche/src/routes/request.rs
+++ b/crates/paroche/src/routes/request.rs
@@ -182,13 +182,16 @@ pub async fn list_requests(
 
 pub async fn get_request(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    auth: AuthenticatedUser,
     Path(id): Path<String>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let request_id = parse_request_id(&id)?;
+    // WHY: the caller's identity is threaded to aitesis so the ownership
+    // boundary (owner-or-admin, same as cancel_request) is enforced where the
+    // row is read — a member cannot read another user's request by UUID.
     let request = state
         .requests
-        .get_request(request_id)
+        .get_request(request_id, auth.user_id)
         .await
         .map_err(map_request_service_error)?;
 
@@ -365,9 +368,15 @@ mod tests {
         fn get_request(
             &self,
             request_id: themelion::RequestId,
+            caller_id: UserId,
         ) -> crate::state::RequestServiceFut<'_, aitesis::MediaRequest> {
             let service = Arc::clone(&self.0);
-            Box::pin(async move { service.get_request(request_id).await.map_err(Into::into) })
+            Box::pin(async move {
+                service
+                    .get_request(request_id, caller_id)
+                    .await
+                    .map_err(Into::into)
+            })
         }
 
         fn list_requests(
@@ -417,14 +426,28 @@ mod tests {
         }
     }
 
-    struct TestRoles;
+    /// Role provider backed by the exousia users table, mirroring the
+    /// production `RequestRoleProvider` so HTTP-level tests exercise the real
+    /// owner-or-admin boundary.
+    struct TestRoles {
+        pool: sqlx::SqlitePool,
+    }
 
     impl UserRoleProvider for TestRoles {
         async fn role_of(
             &self,
-            _user_id: UserId,
+            user_id: UserId,
         ) -> Result<aitesis::UserRole, aitesis::AitesisError> {
-            Ok(aitesis::UserRole::Member)
+            let user = apotheke::repo::user::get_user(&self.pool, user_id.as_bytes().as_slice())
+                .await
+                .context(aitesis::error::DatabaseSnafu)?;
+            let Some(user) = user else {
+                return aitesis::error::InsufficientPermissionSnafu.fail();
+            };
+            match exousia::UserRole::parse(&user.role) {
+                Some(UserRole::Admin) => Ok(aitesis::UserRole::Admin),
+                _ => Ok(aitesis::UserRole::Member),
+            }
         }
     }
 
@@ -450,6 +473,28 @@ mod tests {
         ) -> Result<WantId, aitesis::AitesisError> {
             Ok(WantId::new())
         }
+    }
+
+    async fn get_request_status(
+        app: &axum::Router,
+        token: &str,
+        id: &str,
+    ) -> TestResult<StatusCode> {
+        let resp = match app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/requests/{id}"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .context(BuildRequestSnafu)?,
+            )
+            .await
+        {
+            Ok(resp) => resp,
+            Err(error) => match error {},
+        };
+        Ok(resp.status())
     }
 
     async fn post_request(app: &axum::Router, token: &str) -> TestResult<StatusCode> {
@@ -491,7 +536,9 @@ mod tests {
             state.db.read.clone(),
             state.db.write.clone(),
             config,
-            TestRoles,
+            TestRoles {
+                pool: state.db.read.clone(),
+            },
             TestIdentity,
             TestMonitor,
         ));
@@ -568,7 +615,9 @@ mod tests {
             state.db.read.clone(),
             state.db.write.clone(),
             config,
-            TestRoles,
+            TestRoles {
+                pool: state.db.read.clone(),
+            },
             TestIdentity,
             TestMonitor,
         ));
@@ -593,6 +642,109 @@ mod tests {
         assert_eq!(
             post_request(&app, &token).await?,
             StatusCode::TOO_MANY_REQUESTS
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_request_is_scoped_to_owner_or_admin() -> TestResult<()> {
+        let (mut state, auth) = test_state().await;
+        let config = horismos::AitesisConfig {
+            max_pending_per_user: 10,
+            max_requests_per_day: 100,
+            auto_approve_admins: false,
+        };
+        let service = Arc::new(aitesis::AitesisServiceImpl::new(
+            state.db.read.clone(),
+            state.db.write.clone(),
+            config,
+            TestRoles {
+                pool: state.db.read.clone(),
+            },
+            TestIdentity,
+            TestMonitor,
+        ));
+        state.requests = Arc::new(TestRequestAdapter(service));
+
+        for (name, role) in [
+            ("alice", UserRole::Member),
+            ("bob", UserRole::Member),
+            ("boss", UserRole::Admin),
+        ] {
+            auth.create_user(CreateUserRequest {
+                username: name.to_string(),
+                display_name: name.to_string(),
+                password: "password123".to_string(),
+                role,
+            })
+            .await
+            .context(CreateUserSnafu)?;
+        }
+        let alice = auth
+            .login("alice", "password123")
+            .await
+            .context(LoginSnafu)?
+            .access_token;
+        let bob = auth
+            .login("bob", "password123")
+            .await
+            .context(LoginSnafu)?
+            .access_token;
+        let admin = auth
+            .login("boss", "password123")
+            .await
+            .context(LoginSnafu)?
+            .access_token;
+        let app = crate::build_router(state);
+
+        let body = json!({
+            "media_type": "music",
+            "title": "Kind of Blue",
+            "external_id": null
+        });
+        let resp = match app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/requests")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {alice}"))
+                    .body(Body::from(
+                        serde_json::to_vec(&body).context(SerializeRequestBodySnafu)?,
+                    ))
+                    .context(BuildRequestSnafu)?,
+            )
+            .await
+        {
+            Ok(resp) => resp,
+            Err(error) => match error {},
+        };
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap_or_default();
+        let created: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        let id = created["data"]["id"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        assert!(!id.is_empty(), "created request must carry an id");
+
+        assert_eq!(
+            get_request_status(&app, &alice, &id).await?,
+            StatusCode::OK,
+            "owner must read their own request"
+        );
+        assert_eq!(
+            get_request_status(&app, &bob, &id).await?,
+            StatusCode::FORBIDDEN,
+            "a non-owner member must not read another user's request"
+        );
+        assert_eq!(
+            get_request_status(&app, &admin, &id).await?,
+            StatusCode::OK,
+            "an admin may read any request"
         );
         Ok(())
     }

--- a/crates/paroche/src/routes/search.rs
+++ b/crates/paroche/src/routes/search.rs
@@ -49,7 +49,11 @@ pub async fn search(
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     let query = serde_json::to_value(&body).map_err(|_| ParocheError::Internal)?;
 
-    let results = state.search.search(query).await?;
+    let mut results = state.search.search(query).await?;
+    // WHY: result download_urls embed indexer apikey/passkey credentials
+    // (Torznab/Newznab convention); this endpoint is member-visible, so raw
+    // URLs hand out the operator's private-tracker credentials.
+    crate::redact::redact_download_urls_in_json(&mut results);
 
     Ok(ApiResponse::ok(results))
 }
@@ -64,7 +68,10 @@ pub async fn get_search_results(
     // wired this returns 503.
     let query = serde_json::json!({ "query_id": query_id });
 
-    let results = state.search.search(query).await?;
+    let mut results = state.search.search(query).await?;
+    // WHY: same credential exposure as `search` — cached results carry the
+    // same raw download_urls.
+    crate::redact::redact_download_urls_in_json(&mut results);
 
     Ok(ApiResponse::ok(results))
 }
@@ -78,4 +85,126 @@ pub fn search_routes() -> axum::Router<AppState> {
     axum::Router::new()
         .route("/", post(search))
         .route("/{query_id}/results", get(get_search_results))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use exousia::AuthService;
+    use exousia::user::{CreateUserRequest, UserRole};
+    use tower::ServiceExt;
+
+    #[expect(
+        unused_imports,
+        reason = "kanon: test-missing-use-super; parent items accessed via explicit super:: prefix in test bodies"
+    )]
+    use super::*;
+    use crate::state::{DynSearchService, ServiceError, ServiceFut};
+    use crate::test_helpers::test_state;
+
+    /// Search stub returning a fixed result payload, standing in for zetesis.
+    struct FixedSearch(serde_json::Value);
+
+    impl DynSearchService for FixedSearch {
+        fn search(&self, _query: serde_json::Value) -> ServiceFut<serde_json::Value> {
+            let results = self.0.clone();
+            Box::pin(async move { Ok(results) })
+        }
+        fn test_indexer(&self, _indexer_id: i64) -> ServiceFut<serde_json::Value> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+        fn refresh_caps(&self, _indexer_id: i64) -> ServiceFut<serde_json::Value> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+    }
+
+    async fn member_token(auth: &Arc<exousia::ExousiaServiceImpl>) -> String {
+        auth.create_user(CreateUserRequest {
+            username: "member".to_string(),
+            display_name: "Member".to_string(),
+            password: "password123".to_string(),
+            role: UserRole::Member,
+        })
+        .await
+        .unwrap();
+        auth.login("member", "password123")
+            .await
+            .unwrap()
+            .access_token
+    }
+
+    #[tokio::test]
+    async fn search_redacts_indexer_credentials_in_results() {
+        let (mut state, auth) = test_state().await;
+        state.search = Arc::new(FixedSearch(serde_json::json!({
+            "results": [{
+                "title": "Kind of Blue",
+                "download_url":
+                    "https://indexer.example/dl/42?apikey=SECRET&file=x.torrent",
+            }]
+        })));
+        let token = member_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/search")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            body["data"]["results"][0]["download_url"],
+            "https://indexer.example/dl/42?apikey=REDACTED&file=x.torrent"
+        );
+        assert!(
+            !String::from_utf8_lossy(&bytes).contains("SECRET"),
+            "the raw indexer credential must never reach the response body"
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_search_results_redact_indexer_credentials() {
+        let (mut state, auth) = test_state().await;
+        state.search = Arc::new(FixedSearch(serde_json::json!({
+            "results": [{
+                "title": "Kind of Blue",
+                "download_url": "https://indexer.example/dl/42?passkey=SECRET",
+            }]
+        })));
+        let token = member_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/search/q-123/results")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            body["data"]["results"][0]["download_url"],
+            "https://indexer.example/dl/42?passkey=REDACTED"
+        );
+        assert!(!String::from_utf8_lossy(&bytes).contains("SECRET"));
+    }
 }

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -168,6 +168,7 @@ pub trait DynRequestService: Send + Sync {
     fn get_request(
         &self,
         request_id: themelion::RequestId,
+        caller_id: themelion::UserId,
     ) -> RequestServiceFut<'_, aitesis::MediaRequest>;
 
     fn list_requests(
@@ -346,6 +347,7 @@ impl DynRequestService for NullRequestService {
     fn get_request(
         &self,
         _request_id: themelion::RequestId,
+        _caller_id: themelion::UserId,
     ) -> RequestServiceFut<'_, aitesis::MediaRequest> {
         Box::pin(async { Err(RequestServiceError::NotAvailable) })
     }


### PR DESCRIPTION
Two auth-boundary defects (deep-audit).

- **IDOR (#522)** — `get_request` accepted any authenticated user and never scoped to the caller, so any member could read any other user's request record by UUID. The caller's `user_id` is now threaded through `RequestService::get_request` and enforced `is_owner || is_admin` (non-owner non-admin → 403), mirroring `cancel_request`.
- **Indexer credentials in download_url (#539)** — the queue snapshot and search endpoints returned raw `download_url`s that embed the indexer `apikey`/`passkey`. A `redact_download_url` helper now replaces credential-param values with `REDACTED` on the outbound response (queue snapshot + search); the internal enqueue/fetch path keeps the real URL. Inclusive key matching (apikey/api_key/passkey/torrent_pass/authkey/token/secret/…).

Gate `kanon gate --full` green; endpoint-level tests assert owner/non-owner/admin access and `apikey=REDACTED` in both response bodies.

Closes #522
Closes #539
