### PR TITLE
fix(aitesis): compare-and-swap request status to close approval lost-update race

### DIFF
--- a/crates/aitesis/src/approval.rs
+++ b/crates/aitesis/src/approval.rs
@@ -39,6 +39,22 @@ pub trait MonitorService: Send + Sync {
     /// relies on this contract to make a retried approval safe after a
     /// partial failure.
     async fn create_want(&self, request: &MediaRequest) -> Result<WantId, AitesisError>;
+
+    /// Removes the wanted-media entry previously created for `request`.
+    ///
+    /// Compensation hook: when an approval loses the request-status
+    /// compare-and-swap after `create_want` already ran, the request settled
+    /// in a state that does not own the want (denied, or cancelled and
+    /// deleted). Leaving the entry behind would let the monitor acquire media
+    /// the household refused, so the losing approval retracts it.
+    ///
+    /// INVARIANT: implementations MUST be idempotent — removing a want that
+    /// no longer exists succeeds.
+    async fn remove_want(
+        &self,
+        request: &MediaRequest,
+        want_id: WantId,
+    ) -> Result<(), AitesisError>;
 }
 
 /// Trait boundary to Exousia — looks up a user's role without coupling to the auth crate.
@@ -61,6 +77,17 @@ pub trait UserRoleProvider: Send + Sync {
 /// failure after `create_want` leaves the row `Submitted`, and a retried
 /// approval resolves to the same want via the [`MonitorService::create_want`]
 /// idempotency contract, then completes the status update.
+///
+/// Concurrency: the status update is the commit point. It compares-and-swaps
+/// on the status read at entry, so a decision committed during the
+/// identity/create_want awaits (an admin deny, a cancel) wins and this
+/// approval returns [`AitesisError::StaleTransition`] (or
+/// [`AitesisError::RequestNotFound`]) instead of overwriting it. A lost
+/// approval retracts the want it created when the surviving state does not
+/// own it — see [`retract_lost_want`].
+///
+/// [`AitesisError::StaleTransition`]: crate::error::AitesisError::StaleTransition
+/// [`AitesisError::RequestNotFound`]: crate::error::AitesisError::RequestNotFound
 #[instrument(skip(pool, identity, monitor), fields(request_id = %request_id, admin_id = %admin_id))]
 pub(crate) async fn approve_request<I, M>(
     pool: &SqlitePool,
@@ -101,10 +128,11 @@ where
     let monitoring = validate_transition(approved.to(), RequestStatus::Monitoring)?;
 
     let now = jiff::Timestamp::now();
-    crate::repo::update_status(
+    let committed = crate::repo::update_status(
         pool,
         crate::repo::UpdateStatusParams {
             id: &request_id,
+            expected_status: request.status,
             status: monitoring.to(),
             decided_by: Some(&admin_id),
             decided_at: Some(now),
@@ -112,7 +140,17 @@ where
             want_id: Some(&want_id),
         },
     )
-    .await?;
+    .await;
+
+    if let Err(error) = committed {
+        if matches!(
+            error,
+            AitesisError::StaleTransition { .. } | AitesisError::RequestNotFound { .. }
+        ) {
+            retract_lost_want(pool, &request, want_id, monitor).await;
+        }
+        return Err(error);
+    }
 
     crate::repo::get_request(pool, &request_id)
         .await?
@@ -124,9 +162,63 @@ where
         })
 }
 
+/// Best-effort retraction of the want created by an approval that lost the
+/// status compare-and-swap.
+///
+/// Retracts only when the surviving row provably does not own the want:
+/// `Denied` is terminal (no transition leaves it) and a deleted row cannot
+/// return, so in both cases the want could only acquire media the household
+/// refused. Any other status means a concurrent approval won and owns the
+/// want, so it stays. Failures log rather than propagate — the caller already
+/// surfaces the conflict, and a want leaked here requires a crash inside this
+/// window (the same residual as the documented create_want/update_status
+/// retry window).
+async fn retract_lost_want<M>(
+    pool: &SqlitePool,
+    request: &MediaRequest,
+    want_id: WantId,
+    monitor: &M,
+) where
+    M: MonitorService,
+{
+    let surviving = match crate::repo::get_request(pool, &request.id).await {
+        Ok(row) => row,
+        Err(error) => {
+            tracing::warn!(
+                request_id = %request.id,
+                want_id = %want_id,
+                %error,
+                "lost-approval want retraction skipped: request re-read failed"
+            );
+            return;
+        }
+    };
+
+    let owned = surviving.is_some_and(|row| row.status != RequestStatus::Denied);
+    if owned {
+        return;
+    }
+
+    if let Err(error) = monitor.remove_want(request, want_id).await {
+        tracing::warn!(
+            request_id = %request.id,
+            want_id = %want_id,
+            %error,
+            "lost-approval want retraction failed: want may linger for a refused request"
+        );
+    }
+}
+
 /// Denies a request: transitions to Denied with an optional reason.
 ///
 /// Requires `admin_id` to have the Admin role.
+///
+/// Concurrency: the status update compares-and-swaps on the status read at
+/// entry, so a decision that commits between the read and the write wins and
+/// the stale deny surfaces [`AitesisError::StaleTransition`] instead of
+/// overwriting it.
+///
+/// [`AitesisError::StaleTransition`]: crate::error::AitesisError::StaleTransition
 #[instrument(skip(pool), fields(request_id = %request_id, admin_id = %admin_id))]
 pub(crate) async fn deny_request(
     pool: &SqlitePool,
@@ -155,6 +247,7 @@ pub(crate) async fn deny_request(
         pool,
         crate::repo::UpdateStatusParams {
             id: &request_id,
+            expected_status: request.status,
             status: denied.to(),
             decided_by: Some(&admin_id),
             decided_at: Some(now),
@@ -201,6 +294,14 @@ pub(crate) mod tests {
         async fn create_want(&self, _request: &MediaRequest) -> Result<WantId, AitesisError> {
             Ok(WantId::new())
         }
+
+        async fn remove_want(
+            &self,
+            _request: &MediaRequest,
+            _want_id: WantId,
+        ) -> Result<(), AitesisError> {
+            Ok(())
+        }
     }
 
     /// Mirrors the production upsert semantics: one want per request id.
@@ -215,6 +316,15 @@ pub(crate) mod tests {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             let mut wants = self.wants.lock().unwrap();
             Ok(*wants.entry(request.id).or_default())
+        }
+
+        async fn remove_want(
+            &self,
+            request: &MediaRequest,
+            _want_id: WantId,
+        ) -> Result<(), AitesisError> {
+            self.wants.lock().unwrap().remove(&request.id);
+            Ok(())
         }
     }
 
@@ -398,5 +508,213 @@ pub(crate) mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, AitesisError::InvalidTransition { .. }));
+    }
+
+    /// Interposes a concurrent deny inside the approve flow's external await,
+    /// making the lost-update race deterministic: the deny commits after
+    /// approve read the row but before approve's status write runs.
+    struct DenyDuringCreateWant {
+        pool: SqlitePool,
+        denier: UserId,
+        created: std::sync::Mutex<Option<WantId>>,
+        removed: std::sync::Mutex<Vec<WantId>>,
+    }
+
+    impl MonitorService for DenyDuringCreateWant {
+        async fn create_want(&self, request: &MediaRequest) -> Result<WantId, AitesisError> {
+            deny_request(
+                &self.pool,
+                request.id,
+                self.denier,
+                UserRole::Admin,
+                Some("denied mid-approve".to_string()),
+            )
+            .await?;
+            let want_id = WantId::new();
+            *self.created.lock().unwrap() = Some(want_id);
+            Ok(want_id)
+        }
+
+        async fn remove_want(
+            &self,
+            _request: &MediaRequest,
+            want_id: WantId,
+        ) -> Result<(), AitesisError> {
+            self.removed.lock().unwrap().push(want_id);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn approve_losing_to_concurrent_deny_keeps_denial_and_retracts_want() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let approver = UserId::new();
+        let denier = UserId::new();
+        let req = submitted_request(user_id);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        let monitor = DenyDuringCreateWant {
+            pool: pool.clone(),
+            denier,
+            created: std::sync::Mutex::new(None),
+            removed: std::sync::Mutex::new(Vec::new()),
+        };
+
+        let err = approve_request(
+            &pool,
+            req_id,
+            approver,
+            UserRole::Admin,
+            &AlwaysValidIdentity,
+            &monitor,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, AitesisError::StaleTransition { .. }),
+            "losing approve must surface the conflict, got: {err:?}"
+        );
+
+        // The deny that won the race is untouched — not clobbered to Monitoring.
+        let row = crate::repo::get_request(&pool, &req_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, RequestStatus::Denied);
+        assert_eq!(row.decided_by, Some(denier));
+        assert_eq!(row.deny_reason.as_deref(), Some("denied mid-approve"));
+        assert!(row.want_id.is_none());
+
+        // The losing approve retracted the want it created.
+        let created = monitor.created.lock().unwrap().expect("want was created");
+        assert_eq!(*monitor.removed.lock().unwrap(), vec![created]);
+    }
+
+    /// Interposes a full competing approval inside the outer approve's
+    /// external await: the inner approval wins the status compare-and-swap
+    /// and owns the want.
+    struct ApproveDuringCreateWant {
+        pool: SqlitePool,
+        winner: UserId,
+        removed: std::sync::atomic::AtomicBool,
+    }
+
+    impl MonitorService for ApproveDuringCreateWant {
+        async fn create_want(&self, request: &MediaRequest) -> Result<WantId, AitesisError> {
+            approve_request(
+                &self.pool,
+                request.id,
+                self.winner,
+                UserRole::Admin,
+                &AlwaysValidIdentity,
+                &AlwaysCreateMonitor,
+            )
+            .await?;
+            Ok(WantId::new())
+        }
+
+        async fn remove_want(
+            &self,
+            _request: &MediaRequest,
+            _want_id: WantId,
+        ) -> Result<(), AitesisError> {
+            self.removed
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn approve_losing_to_concurrent_approve_keeps_winner_want() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let loser = UserId::new();
+        let winner = UserId::new();
+        let req = submitted_request(user_id);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        let monitor = ApproveDuringCreateWant {
+            pool: pool.clone(),
+            winner,
+            removed: std::sync::atomic::AtomicBool::new(false),
+        };
+
+        let err = approve_request(
+            &pool,
+            req_id,
+            loser,
+            UserRole::Admin,
+            &AlwaysValidIdentity,
+            &monitor,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AitesisError::StaleTransition { .. }));
+
+        // The winning approval's state and want survive intact.
+        let row = crate::repo::get_request(&pool, &req_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, RequestStatus::Monitoring);
+        assert_eq!(row.decided_by, Some(winner));
+        assert!(row.want_id.is_some());
+        assert!(
+            !monitor.removed.load(std::sync::atomic::Ordering::SeqCst),
+            "a want owned by the winning approval must not be retracted"
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_losing_to_concurrent_transition_surfaces_conflict() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let admin_id = UserId::new();
+        let req = submitted_request(user_id);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        // Simulate a transition committing between deny's read and its write:
+        // fetch the row first, move it, then run the stale write directly.
+        let stale_read = crate::repo::get_request(&pool, &req_id)
+            .await
+            .unwrap()
+            .unwrap();
+        approve_request(
+            &pool,
+            req_id,
+            admin_id,
+            UserRole::Admin,
+            &AlwaysValidIdentity,
+            &AlwaysCreateMonitor,
+        )
+        .await
+        .unwrap();
+
+        let err = crate::repo::update_status(
+            &pool,
+            crate::repo::UpdateStatusParams {
+                id: &req_id,
+                expected_status: stale_read.status,
+                status: RequestStatus::Denied,
+                decided_by: Some(&admin_id),
+                decided_at: Some(jiff::Timestamp::now()),
+                deny_reason: Some("stale deny"),
+                want_id: None,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AitesisError::StaleTransition { .. }));
+
+        let row = crate::repo::get_request(&pool, &req_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, RequestStatus::Monitoring);
+        assert!(row.want_id.is_some());
     }
 }

--- a/crates/aitesis/src/error.rs
+++ b/crates/aitesis/src/error.rs
@@ -44,6 +44,21 @@ pub enum AitesisError {
         location: snafu::Location,
     },
 
+    /// The request row left the expected status while the operation was in
+    /// flight — a concurrent decision won and must not be overwritten.
+    #[snafu(display("stale request transition: {id} expected status {expected}, found {actual}"))]
+    StaleTransition {
+        /// Request identifier whose status moved under the caller.
+        id: String,
+        /// Status the caller observed before starting the operation.
+        expected: String,
+        /// Status found in the database when the write ran.
+        actual: String,
+        /// Source location captured when the error is constructed.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     /// A request status transition is not allowed by the workflow.
     #[snafu(display("invalid status transition: {from} -> {to}"))]
     InvalidTransition {

--- a/crates/aitesis/src/lib.rs
+++ b/crates/aitesis/src/lib.rs
@@ -94,6 +94,12 @@ pub trait RequestService: Send + Sync {
     ) -> Result<u64, AitesisError>;
 
     /// Cancels a request. Users may cancel their own; admins may cancel any.
+    ///
+    /// Errors with [`AitesisError::StaleTransition`] when the request's
+    /// status changes between the authorization read and the delete — the
+    /// concurrent decision wins and the caller must re-read before retrying.
+    ///
+    /// [`AitesisError::StaleTransition`]: crate::error::AitesisError::StaleTransition
     async fn cancel_request(
         &self,
         request_id: RequestId,
@@ -348,7 +354,10 @@ where
             .fail();
         }
 
-        repo::delete_request(&self.write, &request_id).await
+        // WHY: the delete compares-and-swaps on the status this cancel was
+        // authorized against — a decision committed after that read (an
+        // approve or deny) wins instead of being silently erased.
+        repo::delete_request(&self.write, &request_id, request.status).await
     }
 }
 
@@ -391,6 +400,14 @@ mod tests {
         async fn create_want(&self, _request: &MediaRequest) -> Result<WantId, AitesisError> {
             Ok(WantId::new())
         }
+
+        async fn remove_want(
+            &self,
+            _request: &MediaRequest,
+            _want_id: WantId,
+        ) -> Result<(), AitesisError> {
+            Ok(())
+        }
     }
 
     struct RejectingIdentity;
@@ -415,6 +432,14 @@ mod tests {
                 detail: "injected create_want failure".to_string(),
             }
             .fail()
+        }
+
+        async fn remove_want(
+            &self,
+            _request: &MediaRequest,
+            _want_id: WantId,
+        ) -> Result<(), AitesisError> {
+            Ok(())
         }
     }
 
@@ -651,6 +676,73 @@ mod tests {
 
         let err = svc.cancel_request(req.id, bob).await.unwrap_err();
         assert!(matches!(err, AitesisError::InsufficientPermission { .. }));
+    }
+
+    /// Interposes a concurrent deny inside cancel's role-lookup await, making
+    /// the cancel-vs-deny race deterministic: the deny commits after cancel
+    /// authorized against the row it read but before the delete runs.
+    struct DenyDuringRoleLookup {
+        pool: SqlitePool,
+        request_id: themelion::RequestId,
+        denier: UserId,
+    }
+
+    impl UserRoleProvider for DenyDuringRoleLookup {
+        async fn role_of(&self, _user_id: UserId) -> Result<UserRole, AitesisError> {
+            crate::repo::update_status(
+                &self.pool,
+                crate::repo::UpdateStatusParams {
+                    id: &self.request_id,
+                    expected_status: RequestStatus::Submitted,
+                    status: RequestStatus::Denied,
+                    decided_by: Some(&self.denier),
+                    decided_at: Some(jiff::Timestamp::now()),
+                    deny_reason: Some("denied mid-cancel"),
+                    want_id: None,
+                },
+            )
+            .await?;
+            Ok(UserRole::Member)
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_losing_to_concurrent_deny_keeps_denial() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let owner = UserId::new();
+        let denier = UserId::new();
+        let req = raw_request(owner);
+        let req_id = req.id;
+        crate::repo::insert_request(&pool, &req).await.unwrap();
+
+        let svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            default_config(),
+            DenyDuringRoleLookup {
+                pool: pool.clone(),
+                request_id: req_id,
+                denier,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+
+        let err = svc.cancel_request(req_id, owner).await.unwrap_err();
+        assert!(
+            matches!(err, AitesisError::StaleTransition { .. }),
+            "stale cancel must surface the conflict, got: {err:?}"
+        );
+
+        // The denial that won the race survives — not erased by the cancel.
+        let row = crate::repo::get_request(&pool, &req_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, RequestStatus::Denied);
+        assert_eq!(row.decided_by, Some(denier));
+        assert_eq!(row.deny_reason.as_deref(), Some("denied mid-cancel"));
     }
 
     fn raw_request(user_id: UserId) -> MediaRequest {
@@ -1141,6 +1233,7 @@ mod tests {
             &pool,
             crate::repo::UpdateStatusParams {
                 id: &req.id,
+                expected_status: RequestStatus::Monitoring,
                 status: RequestStatus::Fulfilled,
                 decided_by: None,
                 decided_at: None,

--- a/crates/aitesis/src/repo.rs
+++ b/crates/aitesis/src/repo.rs
@@ -170,6 +170,9 @@ pub async fn get_request(
 pub struct UpdateStatusParams<'a> {
     /// Request row to update.
     pub id: &'a RequestId,
+    /// Status the caller observed before deciding on this transition; the
+    /// update applies only while the row still holds it.
+    pub expected_status: RequestStatus,
     /// New request status.
     pub status: RequestStatus,
     /// Optional administrator or actor that made the decision.
@@ -183,22 +186,37 @@ pub struct UpdateStatusParams<'a> {
 }
 
 /// Updates status and decision metadata for a request row.
+///
+/// Compare-and-swap: the UPDATE applies only while the row still holds
+/// `expected_status`. Approval flows await external work (identity
+/// resolution, want creation) between reading a request and persisting its
+/// transition, and no transaction can span those awaits — without the status
+/// predicate, a concurrent decision committed inside that window is silently
+/// overwritten (an admin deny clobbered back to Monitoring by a slower
+/// approve).
+///
+/// Errors with [`AitesisError::StaleTransition`] when the row exists in a
+/// different status, or [`AitesisError::RequestNotFound`] when it is gone.
+///
+/// [`AitesisError::StaleTransition`]: crate::error::AitesisError::StaleTransition
+/// [`AitesisError::RequestNotFound`]: crate::error::AitesisError::RequestNotFound
 pub async fn update_status(
     pool: &SqlitePool,
     params: UpdateStatusParams<'_>,
 ) -> Result<(), crate::error::AitesisError> {
     let UpdateStatusParams {
         id,
+        expected_status,
         status,
         decided_by,
         decided_at,
         deny_reason,
         want_id,
     } = params;
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE requests
          SET status = ?, decided_by = ?, decided_at = ?, deny_reason = ?, want_id = ?
-         WHERE id = ?",
+         WHERE id = ? AND status = ?",
     )
     .bind(status.as_str())
     .bind(decided_by.map(|uid| uid.as_bytes().to_vec()))
@@ -206,25 +224,59 @@ pub async fn update_status(
     .bind(deny_reason)
     .bind(want_id.map(|wid| wid.as_bytes().to_vec()))
     .bind(id.as_bytes().as_slice())
+    .bind(expected_status.as_str())
     .execute(pool)
     .await
     .context(DbQuerySnafu { table: "requests" })
     .context(DatabaseSnafu)?;
+
+    if result.rows_affected() == 0 {
+        return Err(cas_failure_error(pool, id, expected_status).await);
+    }
     Ok(())
 }
 
-/// Deletes a request row by ID.
+/// Deletes a request row by ID, guarded on the status the caller observed.
+///
+/// Compare-and-swap for the same reason as [`update_status`]: cancellation
+/// authorizes against the status it read, and a concurrent decision committed
+/// after that read must not be erased by a stale cancel.
 pub async fn delete_request(
     pool: &SqlitePool,
     id: &RequestId,
+    expected_status: RequestStatus,
 ) -> Result<(), crate::error::AitesisError> {
-    sqlx::query("DELETE FROM requests WHERE id = ?")
+    let result = sqlx::query("DELETE FROM requests WHERE id = ? AND status = ?")
         .bind(id.as_bytes().as_slice())
+        .bind(expected_status.as_str())
         .execute(pool)
         .await
         .context(DbQuerySnafu { table: "requests" })
         .context(DatabaseSnafu)?;
+
+    if result.rows_affected() == 0 {
+        return Err(cas_failure_error(pool, id, expected_status).await);
+    }
     Ok(())
+}
+
+// WHY: a zero-row CAS means the row moved or vanished — the re-read turns
+// that into a precise error (stale vs missing) instead of a blind conflict.
+async fn cas_failure_error(
+    pool: &SqlitePool,
+    id: &RequestId,
+    expected: RequestStatus,
+) -> crate::error::AitesisError {
+    match get_request(pool, id).await {
+        Ok(Some(row)) => crate::error::StaleTransitionSnafu {
+            id: id.to_string(),
+            expected: expected.as_str().to_string(),
+            actual: row.status.as_str().to_string(),
+        }
+        .build(),
+        Ok(None) => crate::error::RequestNotFoundSnafu { id: id.to_string() }.build(),
+        Err(error) => error,
+    }
 }
 
 /// Upper bound a single page may request, regardless of caller input.
@@ -507,6 +559,7 @@ mod tests {
             &pool,
             UpdateStatusParams {
                 id: &req_id,
+                expected_status: RequestStatus::Submitted,
                 status: RequestStatus::Approved,
                 decided_by: Some(&admin_id),
                 decided_at: Some(now),
@@ -523,6 +576,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_status_with_stale_expectation_errors_and_leaves_row() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let admin_id = UserId::new();
+        let req = make_request(user_id, RequestStatus::Denied);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        let err = update_status(
+            &pool,
+            UpdateStatusParams {
+                id: &req_id,
+                expected_status: RequestStatus::Submitted,
+                status: RequestStatus::Monitoring,
+                decided_by: Some(&admin_id),
+                decided_at: Some(jiff::Timestamp::now()),
+                deny_reason: None,
+                want_id: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            crate::error::AitesisError::StaleTransition { .. }
+        ));
+        let fetched = get_request(&pool, &req_id).await.unwrap().unwrap();
+        assert_eq!(fetched.status, RequestStatus::Denied);
+        assert!(fetched.decided_by.is_none());
+    }
+
+    #[tokio::test]
+    async fn update_status_on_missing_row_errors_not_found() {
+        let pool = setup().await;
+        let req_id = RequestId::new();
+
+        let err = update_status(
+            &pool,
+            UpdateStatusParams {
+                id: &req_id,
+                expected_status: RequestStatus::Submitted,
+                status: RequestStatus::Denied,
+                decided_by: None,
+                decided_at: None,
+                deny_reason: None,
+                want_id: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            crate::error::AitesisError::RequestNotFound { .. }
+        ));
+    }
+
+    #[tokio::test]
     async fn delete_request_removes_row() {
         let pool = setup().await;
         let user_id = UserId::new();
@@ -530,10 +642,32 @@ mod tests {
         let req_id = req.id;
         insert_request(&pool, &req).await.unwrap();
 
-        delete_request(&pool, &req_id).await.unwrap();
+        delete_request(&pool, &req_id, RequestStatus::Submitted)
+            .await
+            .unwrap();
 
         let result = get_request(&pool, &req_id).await.unwrap();
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_request_with_stale_expectation_errors_and_leaves_row() {
+        let pool = setup().await;
+        let user_id = UserId::new();
+        let req = make_request(user_id, RequestStatus::Denied);
+        let req_id = req.id;
+        insert_request(&pool, &req).await.unwrap();
+
+        let err = delete_request(&pool, &req_id, RequestStatus::Submitted)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            crate::error::AitesisError::StaleTransition { .. }
+        ));
+        let fetched = get_request(&pool, &req_id).await.unwrap().unwrap();
+        assert_eq!(fetched.status, RequestStatus::Denied);
     }
 
     #[tokio::test]

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -545,6 +545,20 @@ impl MonitorService for RequestMonitor {
         })?;
         Ok(themelion::WantId::from_uuid(stored_uuid))
     }
+
+    // WHY: compensation for an approval that lost the request-status
+    // compare-and-swap — the want must not outlive the refused request.
+    // delete_want treats a missing row as success, satisfying the trait's
+    // idempotency invariant.
+    async fn remove_want(
+        &self,
+        _request: &aitesis::MediaRequest,
+        want_id: themelion::WantId,
+    ) -> Result<(), aitesis::AitesisError> {
+        apotheke::repo::want::delete_want(&self.db.write, want_id.as_bytes())
+            .await
+            .context(aitesis::error::DatabaseSnafu)
+    }
 }
 
 fn request_media_types(media_type: themelion::MediaType) -> Option<(&'static str, &'static str)> {

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -334,6 +334,14 @@ impl MonitorService for MockRequestMonitor {
     ) -> Result<themelion::WantId, aitesis::AitesisError> {
         Ok(themelion::WantId::new())
     }
+
+    async fn remove_want(
+        &self,
+        _request: &aitesis::MediaRequest,
+        _want_id: themelion::WantId,
+    ) -> Result<(), aitesis::AitesisError> {
+        Ok(())
+    }
 }
 
 // ── Test helpers ─────────────────────────────────────────────────────────────

--- a/crates/paroche/src/error.rs
+++ b/crates/paroche/src/error.rs
@@ -27,6 +27,8 @@ pub enum ParocheError {
     Unauthorized,
     #[snafu(display("access forbidden"))]
     Forbidden,
+    #[snafu(display("conflict: {message}"))]
+    Conflict { message: String },
     #[snafu(display("validation error: {message}"))]
     Validation { message: String },
     #[snafu(display("rate limited"))]
@@ -50,6 +52,7 @@ impl IntoResponse for ParocheError {
                 (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", self.to_string())
             }
             ParocheError::Forbidden => (StatusCode::FORBIDDEN, "FORBIDDEN", self.to_string()),
+            ParocheError::Conflict { .. } => (StatusCode::CONFLICT, "CONFLICT", self.to_string()),
             ParocheError::Validation { .. } => (
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "VALIDATION_ERROR",
@@ -143,6 +146,16 @@ mod tests {
         let (status, body) = status_and_body(ParocheError::Forbidden).await;
         assert_eq!(status, StatusCode::FORBIDDEN);
         assert_eq!(body["code"], "FORBIDDEN");
+    }
+
+    #[tokio::test]
+    async fn conflict_returns_409() {
+        let (status, body) = status_and_body(ParocheError::Conflict {
+            message: "status changed concurrently".to_string(),
+        })
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body["code"], "CONFLICT");
     }
 
     #[tokio::test]

--- a/crates/paroche/src/routes/request.rs
+++ b/crates/paroche/src/routes/request.rs
@@ -93,6 +93,11 @@ fn map_request_service_error(error: RequestServiceError) -> ParocheError {
             | aitesis::AitesisError::InvalidTransition { .. } => ParocheError::Validation {
                 message: error.to_string(),
             },
+            // WHY: a lost optimistic-concurrency race is retryable after a
+            // re-read — 409, not a validation failure.
+            aitesis::AitesisError::StaleTransition { .. } => ParocheError::Conflict {
+                message: error.to_string(),
+            },
             aitesis::AitesisError::InsufficientPermission { .. } => ParocheError::Forbidden,
             aitesis::AitesisError::Database { source, .. } => ParocheError::Database { source },
             _ => ParocheError::Internal,
@@ -473,6 +478,14 @@ mod tests {
         ) -> Result<WantId, aitesis::AitesisError> {
             Ok(WantId::new())
         }
+
+        async fn remove_want(
+            &self,
+            _request: &aitesis::MediaRequest,
+            _want_id: WantId,
+        ) -> Result<(), aitesis::AitesisError> {
+            Ok(())
+        }
     }
 
     async fn get_request_status(
@@ -747,5 +760,17 @@ mod tests {
             "an admin may read any request"
         );
         Ok(())
+    }
+
+    #[test]
+    fn stale_transition_maps_to_conflict() {
+        let error = aitesis::error::StaleTransitionSnafu {
+            id: "req-test".to_string(),
+            expected: "submitted".to_string(),
+            actual: "denied".to_string(),
+        }
+        .build();
+        let mapped = map_request_service_error(RequestServiceError::Domain(error));
+        assert!(matches!(mapped, ParocheError::Conflict { .. }));
     }
 }


### PR DESCRIPTION
Closes a HIGH lost-update race (deep-audit): `approve`/`deny`/`cancel_request` read status, then do external identity/create_want awaits, then wrote status with no expected-status guard — so a deny committing during an approve's awaits was silently clobbered (the system would acquire media an admin denied).

Fix is optimistic concurrency (a transaction cannot span the network awaits):
- `update_status`/`delete_request` are now compare-and-swap (`WHERE id=? AND status=?` on the status read at entry); a zero-row result returns `AitesisError::StaleTransition` instead of reporting success.
- The status write is the commit point, ordered LAST. If `create_want` already ran and the CAS then loses, the leaked want is retracted (`retract_lost_want`); the only residual is a crash inside that window (documented).
- `StaleTransition` maps to a 409 at the API boundary.

Gate green; deterministic race tests (approve-loses-to-deny retracts want + keeps denial; deny/cancel-lose variants; CAS units; 409 mapping).

Closes #525
