### PR TITLE
fix(apotheke): guard want.rs and play_history single-row writes

### DIFF
--- a/crates/apotheke/src/repo/play_history/mod.rs
+++ b/crates/apotheke/src/repo/play_history/mod.rs
@@ -211,7 +211,7 @@ pub async fn end_session(
     id: SessionId,
     outcome: &SessionOutcome,
 ) -> Result<(), DbError> {
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE play_sessions
          SET ended_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
              duration_ms = ?,
@@ -228,7 +228,11 @@ pub async fn end_session(
     .context(QuerySnafu {
         table: "play_sessions",
     })?;
-    Ok(())
+    super::require_affected(
+        result,
+        "play_sessions",
+        super::id_hex(id.as_bytes().as_ref()),
+    )
 }
 
 pub async fn get_active_sessions(
@@ -263,14 +267,18 @@ pub async fn mark_scrobble_eligible(
     pool: &SqlitePool,
     session_id: SessionId,
 ) -> Result<(), DbError> {
-    sqlx::query("UPDATE play_sessions SET scrobble_eligible = 1 WHERE id = ?")
+    let result = sqlx::query("UPDATE play_sessions SET scrobble_eligible = 1 WHERE id = ?")
         .bind(session_id.as_bytes().as_ref())
         .execute(pool)
         .await
         .context(QuerySnafu {
             table: "play_sessions",
         })?;
-    Ok(())
+    super::require_affected(
+        result,
+        "play_sessions",
+        super::id_hex(session_id.as_bytes().as_ref()),
+    )
 }
 
 pub async fn get_pending_scrobbles(
@@ -299,7 +307,7 @@ pub async fn mark_scrobbled(
     session_id: SessionId,
     service: &str,
 ) -> Result<(), DbError> {
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE play_sessions
          SET scrobbled_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
              scrobble_service = ?
@@ -312,7 +320,11 @@ pub async fn mark_scrobbled(
     .context(QuerySnafu {
         table: "play_sessions",
     })?;
-    Ok(())
+    super::require_affected(
+        result,
+        "play_sessions",
+        super::id_hex(session_id.as_bytes().as_ref()),
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/apotheke/src/repo/play_history/tests.rs
+++ b/crates/apotheke/src/repo/play_history/tests.rs
@@ -202,6 +202,23 @@ async fn get_active_sessions_excludes_ended() {
 // -----------------------------------------------------------------------
 
 #[tokio::test]
+async fn end_session_nonexistent_returns_not_found() {
+    let pool = setup().await;
+    let err = end_session(
+        &pool,
+        SessionId::new(),
+        &SessionOutcome {
+            duration_ms: 1_000,
+            completed: false,
+            percent_heard: None,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, DbError::NotFound { .. }));
+}
+
+#[tokio::test]
 async fn mark_scrobble_eligible_sets_flag() {
     let pool = setup().await;
     let user_id = make_user_id();

--- a/crates/apotheke/src/repo/want.rs
+++ b/crates/apotheke/src/repo/want.rs
@@ -195,14 +195,14 @@ pub async fn update_want_status(
     status: &str,
     fulfilled_at: Option<&str>,
 ) -> Result<(), DbError> {
-    sqlx::query("UPDATE wants SET status = ?, fulfilled_at = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE wants SET status = ?, fulfilled_at = ? WHERE id = ?")
         .bind(status)
         .bind(fulfilled_at)
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "wants" })?;
-    Ok(())
+    super::require_affected(result, "wants", super::id_hex(id))
 }
 
 /// Lists the non-null `source_ref` values of all wants from the given source.
@@ -223,12 +223,12 @@ pub async fn list_want_source_refs(
 }
 
 pub async fn delete_want(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
-    sqlx::query("DELETE FROM wants WHERE id = ?")
+    let result = sqlx::query("DELETE FROM wants WHERE id = ?")
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "wants" })?;
-    Ok(())
+    super::require_affected(result, "wants", super::id_hex(id))
 }
 
 // --- releases ---
@@ -295,23 +295,24 @@ pub async fn update_release(
     grabbed_at: Option<&str>,
     rejected_reason: Option<&str>,
 ) -> Result<(), DbError> {
-    sqlx::query("UPDATE releases SET grabbed_at = ?, rejected_reason = ? WHERE id = ?")
-        .bind(grabbed_at)
-        .bind(rejected_reason)
-        .bind(id)
-        .execute(pool)
-        .await
-        .context(QuerySnafu { table: "releases" })?;
-    Ok(())
+    let result =
+        sqlx::query("UPDATE releases SET grabbed_at = ?, rejected_reason = ? WHERE id = ?")
+            .bind(grabbed_at)
+            .bind(rejected_reason)
+            .bind(id)
+            .execute(pool)
+            .await
+            .context(QuerySnafu { table: "releases" })?;
+    super::require_affected(result, "releases", super::id_hex(id))
 }
 
 pub async fn delete_release(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
-    sqlx::query("DELETE FROM releases WHERE id = ?")
+    let result = sqlx::query("DELETE FROM releases WHERE id = ?")
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "releases" })?;
-    Ok(())
+    super::require_affected(result, "releases", super::id_hex(id))
 }
 
 // --- haves ---
@@ -365,22 +366,22 @@ pub async fn list_haves_for_want(pool: &SqlitePool, want_id: &[u8]) -> Result<Ve
 }
 
 pub async fn update_have_status(pool: &SqlitePool, id: &[u8], status: &str) -> Result<(), DbError> {
-    sqlx::query("UPDATE haves SET status = ? WHERE id = ?")
+    let result = sqlx::query("UPDATE haves SET status = ? WHERE id = ?")
         .bind(status)
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "haves" })?;
-    Ok(())
+    super::require_affected(result, "haves", super::id_hex(id))
 }
 
 pub async fn delete_have(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
-    sqlx::query("DELETE FROM haves WHERE id = ?")
+    let result = sqlx::query("DELETE FROM haves WHERE id = ?")
         .bind(id)
         .execute(pool)
         .await
         .context(QuerySnafu { table: "haves" })?;
-    Ok(())
+    super::require_affected(result, "haves", super::id_hex(id))
 }
 
 #[cfg(test)]
@@ -487,6 +488,22 @@ mod tests {
         let pool = setup().await;
         let results = list_wants(&pool, 10, 0).await.unwrap();
         assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_want_status_nonexistent_returns_not_found() {
+        let pool = setup().await;
+        let err = update_want_status(&pool, &make_id(), "fulfilled", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DbError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn delete_want_nonexistent_returns_not_found() {
+        let pool = setup().await;
+        let err = delete_want(&pool, &make_id()).await.unwrap_err();
+        assert!(matches!(err, DbError::NotFound { .. }));
     }
 
     fn make_sourced_want(profile_id: i64, source: Option<&str>, source_ref: Option<&str>) -> Want {

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -548,16 +548,19 @@ impl MonitorService for RequestMonitor {
 
     // WHY: compensation for an approval that lost the request-status
     // compare-and-swap — the want must not outlive the refused request.
-    // delete_want treats a missing row as success, satisfying the trait's
-    // idempotency invariant.
+    // delete_want now returns NotFound on a zero-row match, but the trait's
+    // idempotency invariant requires retracting an already-absent want to be a
+    // no-op success, so NotFound is mapped to Ok here (a normal caller still
+    // gets the stricter NotFound).
     async fn remove_want(
         &self,
         _request: &aitesis::MediaRequest,
         want_id: themelion::WantId,
     ) -> Result<(), aitesis::AitesisError> {
-        apotheke::repo::want::delete_want(&self.db.write, want_id.as_bytes())
-            .await
-            .context(aitesis::error::DatabaseSnafu)
+        match apotheke::repo::want::delete_want(&self.db.write, want_id.as_bytes()).await {
+            Ok(()) | Err(apotheke::DbError::NotFound { .. }) => Ok(()),
+            Err(source) => Err(source).context(aitesis::error::DatabaseSnafu),
+        }
     }
 }
 


### PR DESCRIPTION
Two write-guard-consistency gaps the 29a97cc sweep missed (deep-audit).

- **#538** — 6 single-row-by-id mutators in `apotheke/src/repo/want.rs` (update/delete want, release, have) now route through `require_affected`, returning `NotFound` on a zero-row match instead of a silent `Ok(())`. Bulk writes untouched.
- **#552** — the 3 single-row-by-SessionId updates in `play_history` (end_session, mark_scrobble_eligible, mark_scrobbled) likewise.

Reconciled with #560: `archon::remove_want` (lost-approval want retraction) now maps `NotFound → Ok`, preserving its documented idempotency invariant now that `delete_want` is strict; normal callers still get `NotFound`.

Gate green (1875 tests); `*_nonexistent_returns_not_found` tests added.

Closes #538
Closes #552
