### PR TITLE
fix(akouo): propagate real underruns, stop audio on pause, honor buffer_size

### DIFF
--- a/crates/akouo-core/src/engine.rs
+++ b/crates/akouo-core/src/engine.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use snafu::ResultExt;
-use tokio::sync::{broadcast, mpsc, oneshot, watch};
+use tokio::sync::{Notify, broadcast, mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{Instrument, instrument, warn};
 
@@ -95,6 +95,17 @@ struct PlaybackSession {
         )
     )]
     output_error_tx: mpsc::Sender<OutputError>,
+    // WHY(#542): written by the DSP task's pause/resume-propagation wiring so the
+    // output backend's actual hardware pause state is observable; read via the
+    // test-only backend_paused() seam.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "written by the DSP task pause wiring; read via the test-only backend_paused() seam"
+        )
+    )]
+    backend_paused: Arc<AtomicBool>,
 }
 
 /// The audio engine: owns the decode → DSP → output pipeline.
@@ -111,6 +122,10 @@ pub struct Engine {
     signal_path_tx: Arc<watch::Sender<SignalPathSnapshot>>,
     event_tx: broadcast::Sender<EngineEvent>,
     session: Mutex<Option<PlaybackSession>>,
+    // WHY(#542): wakes the DSP task immediately on pause()/resume() even while it
+    // is blocked awaiting the next frame — without this, a pause landing on an
+    // empty frame channel would not be observed until the next frame arrived.
+    state_notify: Arc<Notify>,
 }
 
 // SAFETY: All fields are Send+Sync. Mutex<Option<PlaybackSession>> is Sync because
@@ -136,6 +151,7 @@ impl Engine {
             signal_path_tx: Arc::new(signal_path_tx),
             event_tx,
             session: Mutex::new(None),
+            state_notify: Arc::new(Notify::new()),
         })
     }
 
@@ -187,6 +203,9 @@ impl Engine {
         let source_for_dsp = source.clone();
         let ring_for_dsp = Arc::clone(&ring);
         let output_error_tx_for_dsp = output_error_tx.clone();
+        let state_notify_for_dsp = Arc::clone(&self.state_notify);
+        let backend_paused = Arc::new(AtomicBool::new(false));
+        let backend_paused_for_dsp = Arc::clone(&backend_paused);
 
         let AudioSource::File(ref path) = source;
         let path = path.clone();
@@ -222,6 +241,8 @@ impl Engine {
                 seek_generation_rx,
                 output_error_rx,
                 output_error_tx: output_error_tx_for_dsp,
+                state_notify: state_notify_for_dsp,
+                backend_paused: backend_paused_for_dsp,
             })
             .instrument(tracing::info_span!("dsp_task")),
         );
@@ -232,6 +253,7 @@ impl Engine {
             dsp_task,
             seek_tx,
             output_error_tx,
+            backend_paused,
         });
         drop(guard);
 
@@ -250,6 +272,10 @@ impl Engine {
         if prev.is_ok() {
             // WHY: send fails only when no receivers exist; dropping is intentional
             self.event_tx.send(EngineEvent::PlaybackPaused).ok();
+            // WHY(#542): wakes the DSP task immediately even if it is currently
+            // blocked awaiting the next frame, so the output backend is paused
+            // (true hardware stop) without waiting on frame arrival.
+            self.state_notify.notify_one();
         }
         Ok(())
     }
@@ -266,6 +292,8 @@ impl Engine {
         if prev.is_ok() {
             // WHY: send fails only when no receivers exist; dropping is intentional
             self.event_tx.send(EngineEvent::PlaybackResumed).ok();
+            // WHY(#542): symmetric wake for the resume path — see pause() above.
+            self.state_notify.notify_one();
         }
         Ok(())
     }
@@ -375,6 +403,17 @@ impl Engine {
         guard
             .as_ref()
             .is_some_and(|session| session.output_error_tx.try_send(error).is_ok())
+    }
+
+    /// Test seam: whether the output backend has actually been paused (#542) —
+    /// distinct FROM the engine's own `STATE_PAUSED`, which only reflects intent
+    /// until the DSP task propagates it to the hardware stream.
+    #[cfg(test)]
+    fn backend_paused(&self) -> bool {
+        let guard = self.session.lock().unwrap_or_else(|e| e.into_inner());
+        guard
+            .as_ref()
+            .is_some_and(|session| session.backend_paused.load(Ordering::Relaxed))
     }
 }
 
@@ -552,6 +591,8 @@ struct DspTaskParams {
     seek_generation_rx: watch::Receiver<u64>,
     output_error_rx: mpsc::Receiver<OutputError>,
     output_error_tx: mpsc::Sender<OutputError>,
+    state_notify: Arc<Notify>,
+    backend_paused: Arc<AtomicBool>,
 }
 
 async fn dsp_task_fn(params: DspTaskParams) {
@@ -568,9 +609,11 @@ async fn dsp_task_fn(params: DspTaskParams) {
         seek_generation_rx,
         mut output_error_rx,
         output_error_tx,
+        state_notify,
+        backend_paused,
     } = params;
     #[cfg(not(feature = "native-output"))]
-    let _ = (&engine_config, &output_error_tx);
+    let _ = (&engine_config, &output_error_tx, &backend_paused);
 
     let mut dsp = DspPipeline::new(initial_dsp_config, dsp_config_rx);
     let mut output_opened = false;
@@ -590,8 +633,43 @@ async fn dsp_task_fn(params: DspTaskParams) {
         }
 
         if state.load(Ordering::Relaxed) == STATE_PAUSED {
+            #[cfg(feature = "native-output")]
+            if !backend_paused.load(Ordering::Relaxed)
+                && let Some(b) = backend.as_mut()
+            {
+                use crate::output::OutputBackend;
+                // WHY(#542): stop the hardware stream immediately — otherwise
+                // cpal keeps popping already-buffered ring samples and audio
+                // continues audibly for up to ring_buffer_capacity (~0.7s)
+                // after pause() returns.
+                if let Err(e) = b.pause().await {
+                    // WHY: send fails only when no receivers exist; dropping is intentional
+                    event_tx
+                        .send(EngineEvent::Error {
+                            message: e.to_string(),
+                        })
+                        .ok();
+                }
+                backend_paused.store(true, Ordering::Relaxed);
+            }
             tokio::time::sleep(Duration::from_millis(5)).await;
             continue;
+        }
+
+        #[cfg(feature = "native-output")]
+        if backend_paused.load(Ordering::Relaxed)
+            && let Some(b) = backend.as_mut()
+        {
+            use crate::output::OutputBackend;
+            if let Err(e) = b.start().await {
+                // WHY: send fails only when no receivers exist; dropping is intentional
+                event_tx
+                    .send(EngineEvent::Error {
+                        message: e.to_string(),
+                    })
+                    .ok();
+            }
+            backend_paused.store(false, Ordering::Relaxed);
         }
 
         // WHY(#404): the select surfaces asynchronous output-stream errors while
@@ -610,6 +688,13 @@ async fn dsp_task_fn(params: DspTaskParams) {
                 };
                 report_output_error(&e, &state, &event_tx);
                 break;
+            }
+            () = state_notify.notified() => {
+                // WHY(#542): a pause can land while this select is blocked
+                // awaiting the next frame (e.g. decode is also paused and the
+                // frame channel is drained); wake immediately so the
+                // pause/resume propagation above runs without delay.
+                continue;
             }
         };
 
@@ -670,9 +755,14 @@ async fn dsp_task_fn(params: DspTaskParams) {
                 use crate::output::{AudioDataCallback, OutputBackend, OutputParams};
                 let ring_cb = Arc::clone(&ring);
                 let callback: AudioDataCallback = Box::new(move |buf: &mut [f64]| {
-                    if !ring_cb.pop_frame(buf) {
+                    // WHY(#541): the return value is the single source of truth the
+                    // cpal backend uses to count a genuine (ring-empty) underrun —
+                    // the raw cpal callback can no longer see the ring directly.
+                    let popped = ring_cb.pop_frame(buf);
+                    if !popped {
                         buf.fill(0.0);
                     }
+                    popped
                 });
                 let params = OutputParams {
                     sample_rate: frame.sample_rate,
@@ -682,6 +772,9 @@ async fn dsp_task_fn(params: DspTaskParams) {
                     needs_resample: false,
                     source_sample_rate: frame.sample_rate,
                     quality_tier: QualityTier::Lossless,
+                    // WHY(#543): honors the configured buffer_size instead of
+                    // always requesting the platform default.
+                    buffer_size: engine_config.output.buffer_size.clone(),
                 };
                 let mut b = crate::output::cpal::CpalOutputBackend::new();
                 match b
@@ -1135,6 +1228,56 @@ mod tests {
         engine.stop().await.unwrap();
     }
 
+    // --- #542: pause() must propagate to the output backend (true hardware stop),
+    // not just flip the state atomic while cpal keeps draining the ring ---
+
+    #[tokio::test]
+    #[ignore = "requires audio hardware — see #542"]
+    async fn engine_pause_stops_output_backend() {
+        let engine = Engine::new(EngineConfig::default()).unwrap();
+        let mut events = engine.subscribe_events();
+        let wav = make_wav(2, 44100, 5.0);
+
+        engine
+            .play(AudioSource::File(wav.path().to_path_buf()))
+            .unwrap();
+
+        // Wait for the output device to actually open: SignalPathChanged is
+        // published once the DSP task reaches the post-open snapshot.
+        loop {
+            let evt = timeout(Duration::from_secs(5), events.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            if matches!(evt, EngineEvent::SignalPathChanged(_)) {
+                break;
+            }
+        }
+
+        assert!(
+            !engine.backend_paused(),
+            "backend must not be paused before pause() is called"
+        );
+
+        engine.pause().unwrap();
+        // Give the DSP task a moment to observe the notify wake and call
+        // the backend's pause().
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            engine.backend_paused(),
+            "backend must be paused (true hardware stop) after Engine::pause()"
+        );
+
+        engine.resume().unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !engine.backend_paused(),
+            "backend must be resumed after Engine::resume()"
+        );
+
+        engine.stop().await.unwrap();
+    }
+
     #[tokio::test]
     async fn engine_signal_path_stream_returns_receiver() {
         let engine = Engine::new(EngineConfig::default()).unwrap();
@@ -1441,6 +1584,8 @@ mod tests {
             seek_generation_rx,
             output_error_rx,
             output_error_tx,
+            state_notify: Arc::new(Notify::new()),
+            backend_paused: Arc::new(AtomicBool::new(false)),
         }));
 
         frame_tx

--- a/crates/akouo-core/src/output/cpal.rs
+++ b/crates/akouo-core/src/output/cpal.rs
@@ -2,12 +2,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use tracing::warn;
+use tracing::{error, warn};
 
 // WHY: quantization lives in dsp::volume — a second local implementation
 // drifted to an asymmetric formula (-1.0 mapped to i32::MIN here but
 // -2_147_483_647 in the DSP path), so the output stage shares the one
 // canonical symmetric-scale quantizer family.
+use crate::config::BufferSize;
 use crate::dsp::volume::{quantize_i16, quantize_i32};
 use crate::error::OutputError;
 #[cfg(target_os = "linux")]
@@ -170,7 +171,7 @@ impl OutputBackend for CpalOutputBackend {
         let device = resolve_device(&self.host, device_id)?;
         let device_name = device_name(&device).unwrap_or_else(|_| "<unknown>".into());
 
-        let (stream_config, sample_format) =
+        let (stream_config, sample_format, supported_buffer_size) =
             find_stream_config(&device, &params).map_err(|e| OutputError::DeviceOpen {
                 device: device_name.clone(),
                 message: e.to_string(),
@@ -179,15 +180,21 @@ impl OutputBackend for CpalOutputBackend {
         let pipewire_rate_forced = force_pipewire_rate(params.sample_rate)?;
 
         let channels = usize::from(params.channels);
-        // Pre-allocate f64 working buffer large enough for any callback invocation.
-        // Fixed buffer size is requested; 8 192 samples covers 4 096 stereo frames.
-        const MAX_SAMPLES: usize = 8192;
-        let mut f64_buf = vec![0.0f64; MAX_SAMPLES];
+        // WHY(#543): sized FROM the negotiated buffer_size (or the device's
+        // reported max period when Default) instead of a fixed 8 192-sample
+        // guess — a device requesting more per callback than the guess would
+        // otherwise silently truncate real audio.
+        let mut f64_buf =
+            vec![
+                0.0f64;
+                scratch_buffer_samples(&params.buffer_size, supported_buffer_size, channels)
+            ];
         let mut callback = data_callback;
         // Fresh stream, fresh counter.
         self.underruns.store(0, Ordering::Relaxed);
         let underruns_rt = Arc::clone(&self.underruns);
 
+        let error_tx_rt = error_tx.clone();
         let error_cb = make_stream_error_callback(device_name.clone(), error_tx);
 
         let stream = match device.build_output_stream_raw(
@@ -195,17 +202,19 @@ impl OutputBackend for CpalOutputBackend {
             sample_format,
             move |data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {
                 let n_samples = data.len();
-                // Use the pre-allocated buffer; if callback asks for more than we have
-                // (shouldn't happen with fixed buffer), fill the rest with silence.
-                let fill = n_samples.min(f64_buf.len());
-                callback(&mut f64_buf[..fill]);
-
-                // Track underruns: cpal asked for more samples than we could provide
-                if fill < n_samples {
-                    underruns_rt.fetch_add(1, Ordering::Relaxed);
+                match pull_samples(n_samples, &mut f64_buf, &mut callback, &underruns_rt) {
+                    Ok(samples) => write_to_data(data, samples, n_samples, channels),
+                    Err(message) => {
+                        // WHY(#543): a scratch buffer sized below the negotiated
+                        // device period must never silently truncate real audio —
+                        // emit silence for this callback and surface the defect.
+                        error!("{message}");
+                        error_tx_rt
+                            .try_send(OutputError::StreamError { message })
+                            .ok();
+                        write_to_data(data, &[], n_samples, channels);
+                    }
                 }
-
-                write_to_data(data, &f64_buf[..fill], n_samples, channels);
             },
             error_cb,
             None,
@@ -393,11 +402,23 @@ fn reset_pipewire_rate() -> Result<(), OutputError> {
 
 /// Finds the best matching cpal `StreamConfig` and `SampleFormat` for the requested params.
 ///
-/// Format preference (highest quality first): F32 > I32 > I16.
+/// Format preference (highest quality first): F32 > I32 > I16. Honors
+/// `params.buffer_size` (#543) instead of always requesting
+/// `cpal::BufferSize::Default`; a `Fixed` request is validated against the
+/// matched config's supported range before being handed to cpal. Also returns
+/// the matched config's `SupportedBufferSize` so the caller can size its
+/// scratch buffer FROM the negotiated period.
 fn find_stream_config(
     device: &cpal::Device,
     params: &OutputParams,
-) -> Result<(cpal::StreamConfig, cpal::SampleFormat), OutputError> {
+) -> Result<
+    (
+        cpal::StreamConfig,
+        cpal::SampleFormat,
+        cpal::SupportedBufferSize,
+    ),
+    OutputError,
+> {
     let supported: Vec<_> = device
         .supported_output_configs()
         .map_err(|e| OutputError::StreamError {
@@ -434,13 +455,105 @@ fn find_stream_config(
         })?;
 
     let sample_format = best.sample_format();
+    let supported_buffer_size = *best.buffer_size();
+
+    let buffer_size = match params.buffer_size {
+        BufferSize::Default => cpal::BufferSize::Default,
+        BufferSize::Fixed(frames) => {
+            validate_fixed_buffer_size(frames, supported_buffer_size)?;
+            cpal::BufferSize::Fixed(frames)
+        }
+    };
+
     let config = cpal::StreamConfig {
         channels: params.channels,
         sample_rate: params.sample_rate,
-        buffer_size: cpal::BufferSize::Default,
+        buffer_size,
     };
 
-    Ok((config, sample_format))
+    Ok((config, sample_format, supported_buffer_size))
+}
+
+/// Validates a requested `BufferSize::Fixed` frame count against the device's
+/// supported range. `Unknown` (device reports no range) passes through — cpal
+/// itself rejects an unsupportable value when the stream is built.
+///
+/// Pure so the #543 validation logic is unit-testable without a real device.
+fn validate_fixed_buffer_size(
+    requested: cpal::FrameCount,
+    supported: cpal::SupportedBufferSize,
+) -> Result<(), OutputError> {
+    if let cpal::SupportedBufferSize::Range { min, max } = supported
+        && !(min..=max).contains(&requested)
+    {
+        return Err(OutputError::FormatUnsupported {
+            message: format!(
+                "requested fixed buffer size {requested} frames outside device-supported range {min}..={max}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Fallback per-callback frame budget when the device reports no buffer-size
+/// range (`SupportedBufferSize::Unknown`) and the caller requested the default
+/// buffer size — matches the scratch buffer's previous fixed allocation.
+const DEFAULT_SCRATCH_FRAMES: usize = 4096;
+
+/// Floor on the scratch buffer so a degenerate (zero-channel) negotiation
+/// never leaves a too-small buffer.
+const MIN_SCRATCH_SAMPLES: usize = 512;
+
+/// Ceiling on the scratch buffer regardless of what the device reports — guards
+/// against a driver advertising an unreasonable `SupportedBufferSize::Range.max`.
+const MAX_SCRATCH_SAMPLES: usize = 1 << 20;
+
+/// Computes the scratch-buffer sample capacity (across all channels) needed to
+/// service one callback without truncation (#543).
+///
+/// Pure so the sizing logic is unit-testable without a real device.
+fn scratch_buffer_samples(
+    buffer_size: &BufferSize,
+    supported: cpal::SupportedBufferSize,
+    channels: usize,
+) -> usize {
+    let frames = match (buffer_size, supported) {
+        (BufferSize::Fixed(frames), _) => *frames as usize,
+        (BufferSize::Default, cpal::SupportedBufferSize::Range { max, .. }) => max as usize,
+        (BufferSize::Default, cpal::SupportedBufferSize::Unknown) => DEFAULT_SCRATCH_FRAMES,
+    };
+    frames
+        .saturating_mul(channels)
+        .clamp(MIN_SCRATCH_SAMPLES, MAX_SCRATCH_SAMPLES)
+}
+
+/// Pulls one callback's worth of samples FROM `callback` into `f64_buf[..n_samples]`.
+///
+/// Tracks a genuine underrun in `underruns` whenever `callback` reports it could
+/// not supply real audio (the ring buffer was empty) — this is the single source
+/// of truth for underruns (#541); a callback that fills the buffer with real
+/// audio never increments the counter, regardless of `n_samples`.
+///
+/// Returns `Err` when `n_samples` exceeds the pre-allocated scratch buffer — a
+/// buffer-sizing defect (#543) that must be surfaced, never silently truncated.
+fn pull_samples<'a>(
+    n_samples: usize,
+    f64_buf: &'a mut [f64],
+    callback: &mut dyn FnMut(&mut [f64]) -> bool,
+    underruns: &AtomicU64,
+) -> Result<&'a [f64], String> {
+    if n_samples > f64_buf.len() {
+        return Err(format!(
+            "audio callback requested {n_samples} samples, exceeding the {}-sample negotiated scratch buffer",
+            f64_buf.len()
+        ));
+    }
+
+    let filled = callback(&mut f64_buf[..n_samples]);
+    if !filled {
+        underruns.fetch_add(1, Ordering::Relaxed);
+    }
+    Ok(&f64_buf[..n_samples])
 }
 
 /// Writes quantized f64 samples INTO the cpal output buffer.
@@ -560,5 +673,107 @@ mod tests {
     fn quantize_i16_clips() {
         assert_eq!(quantize_i16(2.0), i16::MAX);
         assert_eq!(quantize_i16(-2.0), -i16::MAX);
+    }
+
+    // --- #541: real (ring-empty) underruns must be counted, not near-unreachable
+    // "cpal asked for more than the fixed scratch buffer" cases ---
+
+    #[test]
+    fn pull_samples_increments_underrun_on_empty_ring() {
+        let underruns = AtomicU64::new(0);
+        let mut buf = vec![0.0f64; 8];
+        let mut cb = |b: &mut [f64]| -> bool {
+            b.fill(0.0);
+            false // simulates pop_frame() returning false (ring empty)
+        };
+
+        let result = pull_samples(4, &mut buf, &mut cb, &underruns);
+
+        assert!(result.is_ok());
+        assert_eq!(underruns.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn pull_samples_no_underrun_when_callback_supplies_real_audio() {
+        let underruns = AtomicU64::new(0);
+        let mut buf = vec![0.0f64; 8];
+        let mut cb = |b: &mut [f64]| -> bool {
+            b.fill(1.0);
+            true
+        };
+
+        let result = pull_samples(4, &mut buf, &mut cb, &underruns);
+
+        assert!(result.is_ok());
+        assert_eq!(underruns.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn pull_samples_errors_without_counting_underrun_when_buffer_too_small() {
+        let underruns = AtomicU64::new(0);
+        let mut buf = vec![0.0f64; 4];
+        let mut cb = |_: &mut [f64]| -> bool { true };
+
+        let result = pull_samples(8, &mut buf, &mut cb, &underruns);
+
+        assert!(result.is_err());
+        // WHY: a buffer-sizing defect (#543) is a distinct failure mode FROM a
+        // genuine ring-empty underrun (#541) — never conflate the two counters.
+        assert_eq!(underruns.load(Ordering::Relaxed), 0);
+    }
+
+    // --- #543: buffer_size must be honored, never silently truncated ---
+
+    #[test]
+    fn validate_fixed_buffer_size_accepts_in_range() {
+        let supported = cpal::SupportedBufferSize::Range { min: 64, max: 4096 };
+        assert!(validate_fixed_buffer_size(1024, supported).is_ok());
+    }
+
+    #[test]
+    fn validate_fixed_buffer_size_rejects_out_of_range() {
+        let supported = cpal::SupportedBufferSize::Range { min: 64, max: 4096 };
+        assert!(validate_fixed_buffer_size(8192, supported).is_err());
+    }
+
+    #[test]
+    fn validate_fixed_buffer_size_passes_through_unknown() {
+        assert!(validate_fixed_buffer_size(99_999, cpal::SupportedBufferSize::Unknown).is_ok());
+    }
+
+    #[test]
+    fn scratch_buffer_samples_uses_fixed_request_regardless_of_supported() {
+        let n = scratch_buffer_samples(
+            &BufferSize::Fixed(2048),
+            cpal::SupportedBufferSize::Range { min: 64, max: 512 },
+            2,
+        );
+        assert_eq!(n, 2048 * 2);
+    }
+
+    #[test]
+    fn scratch_buffer_samples_default_uses_device_max() {
+        let n = scratch_buffer_samples(
+            &BufferSize::Default,
+            cpal::SupportedBufferSize::Range {
+                min: 64,
+                max: 16_384,
+            },
+            2,
+        );
+        assert_eq!(n, 16_384 * 2);
+    }
+
+    #[test]
+    fn scratch_buffer_samples_default_unknown_uses_fallback() {
+        let n = scratch_buffer_samples(&BufferSize::Default, cpal::SupportedBufferSize::Unknown, 2);
+        assert_eq!(n, DEFAULT_SCRATCH_FRAMES * 2);
+    }
+
+    #[test]
+    fn scratch_buffer_samples_never_below_floor() {
+        let n =
+            scratch_buffer_samples(&BufferSize::Fixed(1), cpal::SupportedBufferSize::Unknown, 1);
+        assert!(n >= MIN_SCRATCH_SAMPLES);
     }
 }

--- a/crates/akouo-core/src/output/format.rs
+++ b/crates/akouo-core/src/output/format.rs
@@ -85,6 +85,7 @@ pub fn negotiate_format(
         needs_resample,
         source_sample_rate: stream_params.sample_rate,
         quality_tier,
+        buffer_size: config.buffer_size.clone(),
     })
 }
 

--- a/crates/akouo-core/src/output/mod.rs
+++ b/crates/akouo-core/src/output/mod.rs
@@ -5,12 +5,17 @@ pub mod format;
 pub mod pipewire;
 pub mod resample;
 
+use crate::config::BufferSize;
 use crate::error::OutputError;
 use crate::signal_path::QualityTier;
 
 /// Callback type supplied to `OutputBackend::open`. Called by the audio backend whenever
 /// it needs samples; must fill the provided buffer within the real-time deadline.
-pub type AudioDataCallback = Box<dyn FnMut(&mut [f64]) + Send + 'static>;
+///
+/// Returns `true` when the buffer was filled with real audio, `false` when the
+/// caller fell back to silence (e.g. the source ring buffer was empty) — this is
+/// the single source of truth backends use to count genuine underruns (#541).
+pub type AudioDataCallback = Box<dyn FnMut(&mut [f64]) -> bool + Send + 'static>;
 
 /// Newtype for audio device identifiers.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -64,6 +69,9 @@ pub struct OutputParams {
     pub source_sample_rate: u32,
     /// Signal quality tier after output negotiation.
     pub quality_tier: QualityTier,
+    /// Requested hardware buffer size (see #543); backends honor `Fixed` instead
+    /// of always requesting their platform default.
+    pub buffer_size: BufferSize,
 }
 
 /// Abstraction over platform audio backends (cpal, AAudio, CoreAudio, WASAPI).

--- a/crates/archon/src/render/pipeline.rs
+++ b/crates/archon/src/render/pipeline.rs
@@ -133,10 +133,12 @@ impl RenderPipeline {
         let ring_cb = Arc::clone(&self.ring);
         let underrun_cb = Arc::clone(&self.underrun_count);
         let callback: AudioDataCallback = Box::new(move |buf: &mut [f64]| {
-            if !ring_cb.pop_frame(buf) {
+            let popped = ring_cb.pop_frame(buf);
+            if !popped {
                 buf.fill(0.0);
                 underrun_cb.fetch_add(1, Ordering::Relaxed);
             }
+            popped
         });
 
         let params = OutputParams {
@@ -147,6 +149,9 @@ impl RenderPipeline {
             needs_resample: false,
             source_sample_rate: sample_rate,
             quality_tier: QualityTier::Lossless,
+            // WHY: the renderer has no per-track buffer-size override today;
+            // Default preserves this crate's existing negotiation behavior (#543).
+            buffer_size: akouo_core::BufferSize::default(),
         };
 
         if let Ok(devices) = self.backend.available_devices() {


### PR DESCRIPTION
Three audio-output defects (deep-audit).

- **#541** — the underrun counter only tracked a near-unreachable oversized-callback case; genuine ring-empty dropouts (pop_frame() false) are now the single source of truth and increment the counter.
- **#542** — Engine::pause() now stops the output backend and a Notify wakes the DSP task immediately, so audio stops at once instead of playing the ~0.7s already buffered in the ring.
- **#543** — the callback scratch buffer is sized from the negotiated buffer_size (or the device max period), and a Fixed buffer_size out of range errors clearly — no more silent truncation at sample 8192.

Gate green; new tests for underrun-on-empty-ring, pause-stops-backend, and buffer-size validation.

Closes #541
Closes #542
Closes #543
