### PR TITLE
feat(horismos): reactive config core (#529 step 1)

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -9,7 +9,7 @@ use epignosis::ProviderBackedResolver;
 use epignosis::resolver::ProviderCredentials;
 use ergasia::TorrentSession;
 use exousia::ExousiaServiceImpl;
-use horismos::ConfigManager;
+use horismos::{ConfigManager, ConfigOverrides};
 use kathodos::ScannerManager;
 use komide::FeedSchedulerService;
 use komide::scheduler::FeedScheduler;
@@ -755,7 +755,12 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
 
     // 3. Set up ConfigManager for hot-reload
     let config_path = args.config.clone();
-    let (config_manager, _config_handle) = ConfigManager::new(config.clone(), config_path);
+    let overrides = ConfigOverrides {
+        listen_addr: args.listen.clone(),
+        port: args.port,
+    };
+    let (config_manager, _config_handle) =
+        ConfigManager::new(config.clone(), config_path, overrides);
 
     // SIGHUP handler for config reload
     let manager_for_reload = config_manager.clone();
@@ -777,8 +782,8 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
                 // spawn_blocking keeps it off the async worker thread.
                 let manager = manager_for_reload.clone();
                 match tokio::task::spawn_blocking(move || manager.reload()).await {
-                    Ok(Ok(reload_warnings)) => {
-                        for w in reload_warnings {
+                    Ok(Ok(outcome)) => {
+                        for w in outcome.warnings {
                             tracing::warn!(field = %w.field, "config reload: {}", w.message);
                         }
                         tracing::info!("configuration reloaded");

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -1,47 +1,138 @@
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+use snafu::{OptionExt, ResultExt};
+
 use crate::Config;
+use crate::error::{HorismosError, MergePathSnafu, MergeRoundTripSnafu};
 
 // WHY: pure data — change record for config diff reporting.
 pub struct ConfigChange {
-    pub field: String,
+    pub path: String,
     pub requires_restart: bool,
 }
 
-const RESTART_REQUIRED: &[&str] = &["database", "exousia"];
+// NOTE: path PREFIXES — a changed leaf is restart-class when its dotted path
+// starts with any entry. `database.` (trailing dot) covers the whole section.
+// `exousia` is deliberately absent: auth config goes live in a later step.
+const RESTART_REQUIRED: &[&str] = &[
+    "database.",
+    "aggelia.buffer_size",
+    "ergasia.download_dir",
+    "ergasia.session_state_path",
+    "ergasia.listen_port_range",
+    "ergasia.peer_connect_timeout_seconds",
+];
 
-/// Compare two configs and return a list of changed top-level sections.
+fn requires_restart(path: &str) -> bool {
+    RESTART_REQUIRED
+        .iter()
+        .any(|prefix| path.starts_with(prefix))
+}
+
+/// Compare two configs and return the changed leaves as dotted paths
+/// (e.g. `paroche.port`, `taxis.libraries.music.path`), sorted.
 pub fn diff_config(old: &Config, new: &Config) -> Vec<ConfigChange> {
     let old_val = serde_json::to_value(old).unwrap_or_default(); // WHY: serde_json::to_value on a statically-typed Config struct cannot fail
     let new_val = serde_json::to_value(new).unwrap_or_default(); // WHY: serde_json::to_value on a statically-typed Config struct cannot fail
 
-    let mut changes = Vec::new();
+    let mut paths = Vec::new();
+    diff_value("", &old_val, &new_val, &mut paths);
+    paths
+        .into_iter()
+        .map(|path| ConfigChange {
+            requires_restart: requires_restart(&path),
+            path,
+        })
+        .collect()
+}
 
-    if let (Some(old_map), Some(new_map)) = (old_val.as_object(), new_val.as_object()) {
-        let all_keys: std::collections::HashSet<&String> =
-            old_map.keys().chain(new_map.keys()).collect();
-
-        for key in all_keys {
-            if old_map.get(key) != new_map.get(key) {
-                changes.push(ConfigChange {
-                    field: key.clone(),
-                    requires_restart: RESTART_REQUIRED.contains(&key.as_str()),
-                });
+// NOTE: arrays are atomic leaves (`ergasia.listen_port_range` reports one
+// path, not per-index paths). A subtree appearing or disappearing (e.g. an
+// Option section flipping None <-> Some) reports the subtree path itself.
+// Map keys containing '.' would produce ambiguous dotted paths, but no
+// restart-class prefix covers a dynamic-key map (taxis), so the held-back
+// copy never walks one.
+fn diff_value(path: &str, old: &Value, new: &Value, out: &mut Vec<String>) {
+    match (old, new) {
+        (Value::Object(old_map), Value::Object(new_map)) => {
+            let keys: BTreeSet<&String> = old_map.keys().chain(new_map.keys()).collect();
+            for key in keys {
+                let child = if path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{path}.{key}")
+                };
+                diff_value(
+                    &child,
+                    old_map.get(key).unwrap_or(&Value::Null),
+                    new_map.get(key).unwrap_or(&Value::Null),
+                    out,
+                );
+            }
+        }
+        _ => {
+            if old != new {
+                out.push(path.to_string());
             }
         }
     }
+}
 
-    changes
+/// Produce the new EFFECTIVE config from the old effective config and the new
+/// on-disk config: every restart-class changed leaf keeps its OLD (effective)
+/// value; every other leaf takes the new value. Generic over the config shape
+/// — leaves are copied through the serde_json tree, no per-field code.
+pub(crate) fn held_back_merge(old: &Config, new: &Config) -> Result<Config, HorismosError> {
+    let old_val = serde_json::to_value(old).context(MergeRoundTripSnafu)?;
+    let mut new_val = serde_json::to_value(new).context(MergeRoundTripSnafu)?;
+
+    let mut changed = Vec::new();
+    diff_value("", &old_val, &new_val, &mut changed);
+    for path in changed.iter().filter(|p| requires_restart(p)) {
+        copy_leaf(&old_val, &mut new_val, path)?;
+    }
+
+    serde_json::from_value(new_val).context(MergeRoundTripSnafu)
+}
+
+// INVARIANT: both trees serialize from the same statically-typed Config, so a
+// path the diff found exists in both; a miss surfaces as MergePath rather
+// than silently dropping the held-back guarantee.
+fn copy_leaf(from: &Value, to: &mut Value, path: &str) -> Result<(), HorismosError> {
+    let mut from_cur = from;
+    let mut to_cur = to;
+    let mut segments = path.split('.').peekable();
+    while let Some(segment) = segments.next() {
+        let from_next = from_cur.get(segment).context(MergePathSnafu { path })?;
+        let to_next = to_cur.get_mut(segment).context(MergePathSnafu { path })?;
+        if segments.peek().is_none() {
+            *to_next = from_next.clone();
+            return Ok(());
+        }
+        from_cur = from_next;
+        to_cur = to_next;
+    }
+    MergePathSnafu { path }.fail()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::Config;
+    use crate::subsystems::LibraryConfig;
 
     fn base_config() -> Config {
         let mut c = Config::default();
         c.exousia.jwt_secret = "a-very-long-secret-key-that-is-at-least-32-bytes-long".into();
         c
     }
+
+    fn paths(changes: &[ConfigChange]) -> Vec<&str> {
+        changes.iter().map(|c| c.path.as_str()).collect()
+    }
+
+    // ── diff_config: leaf paths ───────────────────────────────────────────────
 
     #[test]
     fn identical_configs_return_no_changes() {
@@ -50,54 +141,141 @@ mod tests {
     }
 
     #[test]
-    fn changed_paroche_returns_non_restart_change() {
+    fn changed_paroche_port_returns_leaf_path_non_restart() {
         let old = base_config();
         let mut new = base_config();
         new.paroche.port = 9090;
 
         let changes = diff_config(&old, &new);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].field, "paroche");
+        assert_eq!(paths(&changes), vec!["paroche.port"]);
         assert!(!changes[0].requires_restart);
     }
 
     #[test]
-    fn changed_database_returns_restart_required() {
+    fn changed_database_path_returns_restart_required() {
         let old = base_config();
         let mut new = base_config();
         new.database.db_path = std::path::PathBuf::from("/new/path/harmonia.db");
 
         let changes = diff_config(&old, &new);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].field, "database");
+        assert_eq!(paths(&changes), vec!["database.db_path"]);
         assert!(changes[0].requires_restart);
     }
 
     #[test]
-    fn changed_exousia_returns_restart_required() {
+    fn changed_exousia_is_not_restart_class() {
         let old = base_config();
         let mut new = base_config();
         new.exousia.jwt_secret = "another-very-long-secret-key-that-is-32-bytes-plus".into();
 
         let changes = diff_config(&old, &new);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].field, "exousia");
+        assert_eq!(paths(&changes), vec!["exousia.jwt_secret"]);
+        assert!(!changes[0].requires_restart);
+    }
+
+    #[test]
+    fn nested_library_change_returns_dotted_leaf_path() {
+        let mut old = base_config();
+        old.taxis.libraries.insert(
+            "music".to_string(),
+            LibraryConfig {
+                path: std::path::PathBuf::from("/data/music"),
+                ..LibraryConfig::default()
+            },
+        );
+        let mut new = base_config();
+        new.taxis.libraries.insert(
+            "music".to_string(),
+            LibraryConfig {
+                path: std::path::PathBuf::from("/mnt/music"),
+                ..LibraryConfig::default()
+            },
+        );
+
+        let changes = diff_config(&old, &new);
+        assert_eq!(paths(&changes), vec!["taxis.libraries.music.path"]);
+        assert!(!changes[0].requires_restart);
+    }
+
+    #[test]
+    fn added_library_reports_subtree_path() {
+        let old = base_config();
+        let mut new = base_config();
+        new.taxis.libraries.insert(
+            "music".to_string(),
+            LibraryConfig {
+                path: std::path::PathBuf::from("/data/music"),
+                ..LibraryConfig::default()
+            },
+        );
+
+        let changes = diff_config(&old, &new);
+        assert_eq!(paths(&changes), vec!["taxis.libraries.music"]);
+    }
+
+    #[test]
+    fn changed_listen_port_range_is_one_restart_leaf() {
+        let old = base_config();
+        let mut new = base_config();
+        new.ergasia.listen_port_range = [7000, 7009];
+
+        let changes = diff_config(&old, &new);
+        assert_eq!(paths(&changes), vec!["ergasia.listen_port_range"]);
         assert!(changes[0].requires_restart);
     }
 
     #[test]
-    fn multiple_changed_sections_return_multiple_entries() {
+    fn multiple_changed_leaves_return_multiple_entries() {
         let old = base_config();
         let mut new = base_config();
         new.paroche.port = 9090;
         new.kritike.scan_interval_hours = 12;
 
         let changes = diff_config(&old, &new);
-        assert_eq!(changes.len(), 2);
-        let fields: std::collections::HashSet<&str> =
-            changes.iter().map(|c| c.field.as_str()).collect();
-        assert!(fields.contains("paroche"));
-        assert!(fields.contains("kritike"));
+        assert_eq!(
+            paths(&changes),
+            vec!["kritike.scan_interval_hours", "paroche.port"]
+        );
         assert!(changes.iter().all(|c| !c.requires_restart));
+    }
+
+    // ── held_back_merge ───────────────────────────────────────────────────────
+
+    #[test]
+    fn merge_holds_back_restart_leaf_and_applies_live_leaf() {
+        let old = base_config();
+        let mut new = base_config();
+        new.database.db_path = std::path::PathBuf::from("/new/harmonia.db");
+        new.paroche.port = 9090;
+
+        let effective = held_back_merge(&old, &new).unwrap();
+        assert_eq!(effective.database.db_path, old.database.db_path);
+        assert_eq!(effective.paroche.port, 9090);
+    }
+
+    #[test]
+    fn merge_without_restart_changes_equals_new() {
+        let old = base_config();
+        let mut new = base_config();
+        new.paroche.port = 9090;
+        new.kritike.scan_interval_hours = 12;
+
+        let effective = held_back_merge(&old, &new).unwrap();
+        assert!(diff_config(&effective, &new).is_empty());
+    }
+
+    #[test]
+    fn merge_holds_back_every_leaf_under_database_prefix() {
+        let old = base_config();
+        let mut new = base_config();
+        new.database.db_path = std::path::PathBuf::from("/new/harmonia.db");
+        new.database.write_pool_max = 8;
+
+        let effective = held_back_merge(&old, &new).unwrap();
+        assert_eq!(effective.database.db_path, old.database.db_path);
+        assert_eq!(
+            effective.database.write_pool_max,
+            old.database.write_pool_max
+        );
     }
 }

--- a/crates/horismos/src/error.rs
+++ b/crates/horismos/src/error.rs
@@ -18,4 +18,18 @@ pub enum HorismosError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    #[snafu(display("configuration merge round-trip failed: {source}"))]
+    MergeRoundTrip {
+        source: serde_json::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("configuration merge failed: path '{path}' missing from config tree"))]
+    MergePath {
+        path: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }

--- a/crates/horismos/src/handle.rs
+++ b/crates/horismos/src/handle.rs
@@ -4,66 +4,163 @@ use std::sync::Arc;
 use tokio::sync::watch;
 
 use crate::config::Config;
-use crate::diff::diff_config;
-use crate::validation::ValidationWarning;
+use crate::diff::{diff_config, held_back_merge};
+use crate::validation::{ValidationWarning, validate_config};
 use crate::{HorismosError, load_config};
 
+/// CLI-level overrides pinned for the lifetime of the process. Re-applied to
+/// the config after EVERY load so a reload cannot silently un-pin them.
+#[derive(Debug, Clone, Default)]
+pub struct ConfigOverrides {
+    pub listen_addr: Option<String>,
+    pub port: Option<u16>,
+}
+
+impl ConfigOverrides {
+    fn apply(&self, config: &mut Config) {
+        if let Some(listen_addr) = &self.listen_addr {
+            config.paroche.listen_addr = listen_addr.clone();
+        }
+        if let Some(port) = self.port {
+            config.paroche.port = port;
+        }
+    }
+}
+
+/// Result of a reload/replace. `applied` and `restart_pending` are dotted
+/// leaf paths (e.g. `paroche.port`); restart-class leaves are held back from
+/// the published config and listed in `restart_pending` until the process
+/// restarts or the file reverts.
+#[derive(Debug)]
+pub struct ReloadOutcome {
+    pub warnings: Vec<ValidationWarning>,
+    pub applied: Vec<String>,
+    pub restart_pending: Vec<String>,
+}
+
+impl ReloadOutcome {
+    /// True when nothing changed relative to the effective config.
+    pub fn is_unchanged(&self) -> bool {
+        self.applied.is_empty() && self.restart_pending.is_empty()
+    }
+
+    /// True when at least one change is held back pending a restart.
+    pub fn needs_restart(&self) -> bool {
+        !self.restart_pending.is_empty()
+    }
+}
+
 /// A shared handle to the live configuration. Subsystems hold a `ConfigHandle`
-/// and call `.current()` for the current config or `.subscribe()` to react to changes.
+/// and call `.current()` for the current config, `.section()` for a typed live
+/// sub-view, or `.subscribe()` to react to changes.
 #[derive(Clone)]
 pub struct ConfigHandle {
     rx: watch::Receiver<Arc<Config>>,
+    pending_rx: watch::Receiver<Vec<String>>,
 }
 
 /// The owner side — held by archon to push config updates.
 #[derive(Clone)]
 pub struct ConfigManager {
     tx: Arc<watch::Sender<Arc<Config>>>,
+    pending_tx: Arc<watch::Sender<Vec<String>>>,
     config_path: PathBuf,
+    overrides: ConfigOverrides,
 }
 
 impl ConfigManager {
-    pub fn new(initial: Config, config_path: PathBuf) -> (Self, ConfigHandle) {
+    pub fn new(
+        initial: Config,
+        config_path: PathBuf,
+        overrides: ConfigOverrides,
+    ) -> (Self, ConfigHandle) {
+        let mut initial = initial;
+        overrides.apply(&mut initial);
         let (tx, rx) = watch::channel(Arc::new(initial));
+        let (pending_tx, pending_rx) = watch::channel(Vec::new());
         let manager = Self {
             tx: Arc::new(tx),
+            pending_tx: Arc::new(pending_tx),
             config_path,
+            overrides,
         };
-        (manager, ConfigHandle { rx })
+        (manager, ConfigHandle { rx, pending_rx })
     }
 
-    /// Re-read config from disk, validate, and broadcast if changed.
+    /// Re-read config from disk, re-apply overrides, and publish the merged
+    /// effective config. Restart-class changed leaves are held back (the
+    /// published config keeps their effective values) and reported in
+    /// `restart_pending`.
     ///
-    /// Returns validation warnings. Errors are returned to the caller rather than
-    /// crashing — the current config remains active on failure.
+    /// Errors are returned to the caller rather than crashing — the current
+    /// config remains active on failure.
     ///
     /// WARNING: performs blocking file I/O (figment reads the TOML from disk).
     /// Callers on an async runtime must dispatch through
     /// `tokio::task::spawn_blocking` to avoid stalling a worker thread.
-    pub fn reload(&self) -> Result<Vec<ValidationWarning>, HorismosError> {
+    pub fn reload(&self) -> Result<ReloadOutcome, HorismosError> {
         let (new_config, warnings) = load_config(Some(&self.config_path))?;
+        self.publish(new_config, warnings)
+    }
+
+    /// Publish a programmatic config through the same override + held-back
+    /// pipeline as `reload`. Validates the incoming config first.
+    pub fn replace(&self, new: Config) -> Result<ReloadOutcome, HorismosError> {
+        let warnings = validate_config(&new)?;
+        self.publish(new, warnings)
+    }
+
+    fn publish(
+        &self,
+        mut new_config: Config,
+        warnings: Vec<ValidationWarning>,
+    ) -> Result<ReloadOutcome, HorismosError> {
+        self.overrides.apply(&mut new_config);
 
         let current = self.tx.borrow().clone();
         let changes = diff_config(&current, &new_config);
 
-        if changes.is_empty() {
-            tracing::info!("SIGHUP: config unchanged");
-            return Ok(warnings);
-        }
-
-        for change in &changes {
+        let mut applied = Vec::new();
+        let mut restart_pending = Vec::new();
+        for change in changes {
             if change.requires_restart {
                 tracing::warn!(
-                    field = %change.field,
-                    "SIGHUP: field changed but requires restart to take effect",
+                    field = %change.path,
+                    "config: change held back — restart required to take effect",
                 );
+                restart_pending.push(change.path);
             } else {
-                tracing::info!(field = %change.field, "SIGHUP: field updated");
+                tracing::info!(field = %change.path, "config: field updated");
+                applied.push(change.path);
             }
         }
 
-        self.tx.send_replace(Arc::new(new_config));
-        Ok(warnings)
+        if applied.is_empty() {
+            tracing::info!("config: no live changes to apply");
+        } else {
+            // INVARIANT: `current()` always reflects what is actually in
+            // effect — restart-class changed leaves are reverted to their
+            // effective values before the new config is published.
+            let effective = held_back_merge(&current, &new_config)?;
+            self.tx.send_replace(Arc::new(effective));
+        }
+
+        // NOTE: restart-pending is derived (file-vs-effective) on every
+        // publish, so reverting the change on disk clears it.
+        self.pending_tx.send_if_modified(|pending| {
+            if *pending == restart_pending {
+                false
+            } else {
+                pending.clone_from(&restart_pending);
+                true
+            }
+        });
+
+        Ok(ReloadOutcome {
+            warnings,
+            applied,
+            restart_pending,
+        })
     }
 }
 
@@ -72,15 +169,78 @@ impl ConfigHandle {
     // .await point blocks the reload writer; `current()` returns an owned
     // Arc snapshot with no lifetime hazard at the cost of one Arc clone.
 
-    /// Get a cloned Arc of the current config.
+    /// Get a cloned Arc of the current effective config.
     pub fn current(&self) -> Arc<Config> {
         self.rx.borrow().clone()
     }
 
     /// Subscribe to config changes. The returned receiver marks itself changed
-    /// whenever a new config is broadcast.
+    /// whenever a new effective config is broadcast.
     pub fn subscribe(&self) -> watch::Receiver<Arc<Config>> {
         self.rx.clone()
+    }
+
+    /// Typed live sub-view of one config section.
+    ///
+    /// Consumption idiom: read once per operation (`let cfg = section.get();`)
+    /// and use that snapshot for the whole operation — consistency within an
+    /// op, liveness across ops.
+    pub fn section<T: Clone>(&self, project: fn(&Config) -> &T) -> Section<T> {
+        Section {
+            inner: SectionInner::Live {
+                rx: self.rx.clone(),
+                project,
+            },
+        }
+    }
+
+    /// Dotted leaf paths changed on disk but held back pending a restart.
+    pub fn restart_pending(&self) -> Vec<String> {
+        self.pending_rx.borrow().clone()
+    }
+
+    /// A handle serving a fixed config (tests / static wiring). The senders
+    /// are dropped; `current()` and `section()` keep serving the last value.
+    pub fn fixed(config: Config) -> ConfigHandle {
+        let (_, rx) = watch::channel(Arc::new(config));
+        let (_, pending_rx) = watch::channel(Vec::new());
+        ConfigHandle { rx, pending_rx }
+    }
+}
+
+/// A typed view of one config section.
+///
+/// Consumption idiom: `get()` returns an OWNED clone (sections are small).
+/// Read once per operation and use that snapshot throughout — consistency
+/// within an op, liveness across ops. No guard is ever held across an .await.
+#[derive(Clone)]
+pub struct Section<T> {
+    inner: SectionInner<T>,
+}
+
+#[derive(Clone)]
+enum SectionInner<T> {
+    Live {
+        rx: watch::Receiver<Arc<Config>>,
+        project: fn(&Config) -> &T,
+    },
+    Fixed(Arc<T>),
+}
+
+impl<T: Clone> Section<T> {
+    /// Owned snapshot of the current section value.
+    pub fn get(&self) -> T {
+        match &self.inner {
+            SectionInner::Live { rx, project } => project(&rx.borrow()).clone(),
+            SectionInner::Fixed(value) => (**value).clone(),
+        }
+    }
+
+    /// A section pinned to a static value (tests / non-live wiring).
+    pub fn fixed(value: T) -> Self {
+        Self {
+            inner: SectionInner::Fixed(Arc::new(value)),
+        }
     }
 }
 
@@ -99,6 +259,18 @@ mod tests {
         format!("[exousia]\njwt_secret = \"{VALID_JWT}\"\n\n[paroche]\nport = {port}\n")
     }
 
+    fn toml_with_port_and_db(port: u16, db_path: &str) -> String {
+        format!(
+            "[exousia]\njwt_secret = \"{VALID_JWT}\"\n\n[paroche]\nport = {port}\n\n[database]\ndb_path = \"{db_path}\"\n"
+        )
+    }
+
+    fn valid_config() -> Config {
+        let mut config = Config::default();
+        config.exousia.jwt_secret = VALID_JWT.into();
+        config
+    }
+
     #[allow(
         clippy::result_large_err,
         reason = "figment::Jail::expect_with requires figment::Result; this lint is version-dependent"
@@ -114,39 +286,110 @@ mod tests {
 
     #[test]
     fn new_creates_manager_and_handle_with_initial_config() {
-        let mut config = Config::default();
-        config.exousia.jwt_secret = VALID_JWT.into();
+        let mut config = valid_config();
         config.paroche.port = 9191;
 
-        let (_, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
+        let (_, handle) = ConfigManager::new(
+            config,
+            PathBuf::from("harmonia.toml"),
+            ConfigOverrides::default(),
+        );
         assert_eq!(handle.current().paroche.port, 9191);
+        assert!(handle.restart_pending().is_empty());
+    }
+
+    #[test]
+    fn new_applies_overrides_to_initial_config() {
+        let config = valid_config();
+        let overrides = ConfigOverrides {
+            listen_addr: Some("127.0.0.1".to_string()),
+            port: Some(9999),
+        };
+
+        let (_, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"), overrides);
+        assert_eq!(handle.current().paroche.port, 9999);
+        assert_eq!(handle.current().paroche.listen_addr, "127.0.0.1");
     }
 
     // ── ConfigHandle accessors ────────────────────────────────────────────────
 
     #[test]
     fn current_returns_cloned_arc() {
-        let mut config = Config::default();
-        config.exousia.jwt_secret = VALID_JWT.into();
+        let config = valid_config();
 
-        let (_, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
+        let (_, handle) = ConfigManager::new(
+            config,
+            PathBuf::from("harmonia.toml"),
+            ConfigOverrides::default(),
+        );
         let a = handle.current();
         let b = handle.current();
         assert_eq!(a.paroche.port, b.paroche.port);
     }
 
+    #[test]
+    fn fixed_handle_serves_config_via_current_and_section() {
+        let mut config = valid_config();
+        config.paroche.port = 9393;
+
+        let handle = ConfigHandle::fixed(config);
+        assert_eq!(handle.current().paroche.port, 9393);
+
+        let section = handle.section(|c| &c.paroche);
+        assert_eq!(section.get().port, 9393);
+        assert!(handle.restart_pending().is_empty());
+    }
+
+    // ── Section ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn section_get_returns_current_value_and_tracks_replace() {
+        let config = valid_config();
+        let (manager, handle) = ConfigManager::new(
+            config,
+            PathBuf::from("harmonia.toml"),
+            ConfigOverrides::default(),
+        );
+        let section = handle.section(|c| &c.paroche);
+        assert_eq!(section.get().port, 8096);
+
+        let mut changed = valid_config();
+        changed.paroche.port = 9090;
+        manager.replace(changed).unwrap();
+
+        assert_eq!(section.get().port, 9090);
+    }
+
+    #[test]
+    fn section_fixed_serves_pinned_value() {
+        let mut config = valid_config();
+        config.paroche.port = 4242;
+
+        let section = Section::fixed(config.paroche.clone());
+        assert_eq!(section.get().port, 4242);
+        assert_eq!(section.get().listen_addr, config.paroche.listen_addr);
+    }
+
     // ── ConfigManager::reload ─────────────────────────────────────────────────
 
     #[test]
-    fn reload_with_unchanged_file_returns_no_warnings() {
+    fn reload_with_unchanged_file_returns_empty_outcome() {
         with_jail(|jail| {
             jail.create_file("harmonia.toml", &toml_with_port(8096))
                 .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
-            let (manager, _) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
+            let (manager, _) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
 
-            let warnings = manager.reload().unwrap();
-            assert!(warnings.is_empty());
+            let outcome = manager.reload().unwrap();
+            assert!(outcome.warnings.is_empty());
+            assert!(outcome.applied.is_empty());
+            assert!(outcome.restart_pending.is_empty());
+            assert!(outcome.is_unchanged());
+            assert!(!outcome.needs_restart());
         });
     }
 
@@ -156,42 +399,147 @@ mod tests {
             jail.create_file("harmonia.toml", &toml_with_port(8096))
                 .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
-            let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
+            let (manager, handle) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
 
             jail.create_file("harmonia.toml", &toml_with_port(9090))
                 .unwrap();
-            manager.reload().unwrap();
+            let outcome = manager.reload().unwrap();
 
             assert_eq!(handle.current().paroche.port, 9090);
+            assert_eq!(outcome.applied, vec!["paroche.port"]);
+            assert!(outcome.restart_pending.is_empty());
         });
     }
 
     #[test]
-    fn reload_with_changed_database_path_updates_config() {
+    fn reload_holds_back_database_change_and_applies_live_change() {
         with_jail(|jail| {
-            jail.create_file(
-                "harmonia.toml",
-                &format!(
-                    "[exousia]\njwt_secret = \"{VALID_JWT}\"\n\n[database]\ndb_path = \"/tmp/harmonia.db\"\n"
-                ),
-            )
-            .unwrap();
+            jail.create_file("harmonia.toml", &toml_with_port_and_db(8096, "/tmp/a.db"))
+                .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
-            let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
+            let (manager, handle) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
 
-            jail.create_file(
-                "harmonia.toml",
-                &format!(
-                    "[exousia]\njwt_secret = \"{VALID_JWT}\"\n\n[database]\ndb_path = \"/tmp/harmonia2.db\"\n"
-                ),
-            )
-            .unwrap();
-            manager.reload().unwrap();
+            jail.create_file("harmonia.toml", &toml_with_port_and_db(9090, "/tmp/b.db"))
+                .unwrap();
+            let outcome = manager.reload().unwrap();
 
+            let current = handle.current();
+            assert_eq!(current.paroche.port, 9090);
+            assert_eq!(current.database.db_path, PathBuf::from("/tmp/a.db"));
+            assert_eq!(outcome.applied, vec!["paroche.port"]);
+            assert_eq!(outcome.restart_pending, vec!["database.db_path"]);
+            assert!(outcome.needs_restart());
+            assert!(!outcome.is_unchanged());
+            assert_eq!(handle.restart_pending(), vec!["database.db_path"]);
+        });
+    }
+
+    #[test]
+    fn restart_only_change_does_not_wake_subscribers() {
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port_and_db(8096, "/tmp/a.db"))
+                .unwrap();
+            let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
+            let (manager, handle) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
+            let rx = handle.subscribe();
+
+            jail.create_file("harmonia.toml", &toml_with_port_and_db(8096, "/tmp/b.db"))
+                .unwrap();
+            let outcome = manager.reload().unwrap();
+
+            assert!(outcome.applied.is_empty());
+            assert_eq!(outcome.restart_pending, vec!["database.db_path"]);
+            assert!(!rx.has_changed().unwrap());
             assert_eq!(
                 handle.current().database.db_path,
-                PathBuf::from("/tmp/harmonia2.db")
+                PathBuf::from("/tmp/a.db")
             );
+        });
+    }
+
+    #[test]
+    fn restart_pending_clears_when_file_reverted() {
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port_and_db(8096, "/tmp/a.db"))
+                .unwrap();
+            let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
+            let (manager, handle) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
+
+            jail.create_file("harmonia.toml", &toml_with_port_and_db(8096, "/tmp/b.db"))
+                .unwrap();
+            manager.reload().unwrap();
+            assert_eq!(handle.restart_pending(), vec!["database.db_path"]);
+
+            jail.create_file("harmonia.toml", &toml_with_port_and_db(8096, "/tmp/a.db"))
+                .unwrap();
+            let outcome = manager.reload().unwrap();
+            assert!(outcome.restart_pending.is_empty());
+            assert!(handle.restart_pending().is_empty());
+        });
+    }
+
+    #[test]
+    fn restart_pending_persists_across_reload_with_unchanged_file() {
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port_and_db(8096, "/tmp/a.db"))
+                .unwrap();
+            let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
+            let (manager, handle) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
+
+            jail.create_file("harmonia.toml", &toml_with_port_and_db(8096, "/tmp/b.db"))
+                .unwrap();
+            manager.reload().unwrap();
+
+            let outcome = manager.reload().unwrap();
+            assert_eq!(outcome.restart_pending, vec!["database.db_path"]);
+            assert_eq!(handle.restart_pending(), vec!["database.db_path"]);
+            assert_eq!(
+                handle.current().database.db_path,
+                PathBuf::from("/tmp/a.db")
+            );
+        });
+    }
+
+    #[test]
+    fn overrides_are_reapplied_after_reload() {
+        with_jail(|jail| {
+            jail.create_file("harmonia.toml", &toml_with_port(8096))
+                .unwrap();
+            let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
+            let overrides = ConfigOverrides {
+                listen_addr: None,
+                port: Some(9999),
+            };
+            let (manager, handle) =
+                ConfigManager::new(config, PathBuf::from("harmonia.toml"), overrides);
+            assert_eq!(handle.current().paroche.port, 9999);
+
+            jail.create_file("harmonia.toml", &toml_with_port(9090))
+                .unwrap();
+            let outcome = manager.reload().unwrap();
+
+            assert_eq!(handle.current().paroche.port, 9999);
+            assert!(outcome.applied.is_empty());
         });
     }
 
@@ -201,7 +549,11 @@ mod tests {
             jail.create_file("harmonia.toml", &toml_with_port(8096))
                 .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
-            let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
+            let (manager, handle) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
 
             // Remove jwt_secret — validation will reject it
             jail.create_file("harmonia.toml", "[paroche]\nport = 9090\n")
@@ -219,7 +571,11 @@ mod tests {
             jail.create_file("harmonia.toml", &toml_with_port(8096))
                 .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
-            let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
+            let (manager, handle) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
 
             let mut rx1 = handle.subscribe();
             let mut rx2 = handle.subscribe();
@@ -235,6 +591,61 @@ mod tests {
         });
     }
 
+    // ── ConfigManager::replace ────────────────────────────────────────────────
+
+    #[test]
+    fn replace_applies_held_back_logic() {
+        let mut config = valid_config();
+        config.database.db_path = PathBuf::from("/tmp/a.db");
+        let (manager, handle) = ConfigManager::new(
+            config,
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+
+        let mut changed = valid_config();
+        changed.database.db_path = PathBuf::from("/tmp/b.db");
+        changed.paroche.port = 9090;
+        let outcome = manager.replace(changed).unwrap();
+
+        let current = handle.current();
+        assert_eq!(current.database.db_path, PathBuf::from("/tmp/a.db"));
+        assert_eq!(current.paroche.port, 9090);
+        assert_eq!(outcome.applied, vec!["paroche.port"]);
+        assert_eq!(outcome.restart_pending, vec!["database.db_path"]);
+    }
+
+    #[test]
+    fn replace_reapplies_overrides() {
+        let config = valid_config();
+        let overrides = ConfigOverrides {
+            listen_addr: None,
+            port: Some(9999),
+        };
+        let (manager, handle) = ConfigManager::new(config, PathBuf::from("unused.toml"), overrides);
+
+        let mut changed = valid_config();
+        changed.paroche.port = 9090;
+        manager.replace(changed).unwrap();
+
+        assert_eq!(handle.current().paroche.port, 9999);
+    }
+
+    #[test]
+    fn replace_rejects_invalid_config() {
+        let config = valid_config();
+        let (manager, handle) = ConfigManager::new(
+            config,
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+
+        let mut invalid = valid_config();
+        invalid.exousia.jwt_secret = "tooshort".into();
+        assert!(manager.replace(invalid).is_err());
+        assert_eq!(handle.current().exousia.jwt_secret, VALID_JWT);
+    }
+
     // ── ConfigHandle::subscribe ───────────────────────────────────────────────
 
     #[test]
@@ -243,7 +654,11 @@ mod tests {
             jail.create_file("harmonia.toml", &toml_with_port(8096))
                 .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
-            let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
+            let (manager, handle) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
             let mut rx = handle.subscribe();
 
             jail.create_file("harmonia.toml", &toml_with_port(9090))
@@ -261,7 +676,11 @@ mod tests {
             jail.create_file("harmonia.toml", &toml_with_port(8096))
                 .unwrap();
             let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
-            let (manager, handle) = ConfigManager::new(config, PathBuf::from("harmonia.toml"));
+            let (manager, handle) = ConfigManager::new(
+                config,
+                PathBuf::from("harmonia.toml"),
+                ConfigOverrides::default(),
+            );
             let rx = handle.subscribe();
 
             // File unchanged — reload should be a no-op

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -13,7 +13,7 @@ pub use diff::{ConfigChange, diff_config};
 pub use error::HorismosError;
 use figment::Figment;
 use figment::providers::{Env, Format, Serialized, Toml};
-pub use handle::{ConfigHandle, ConfigManager};
+pub use handle::{ConfigHandle, ConfigManager, ConfigOverrides, ReloadOutcome, Section};
 use snafu::ResultExt;
 pub use subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,


### PR DESCRIPTION
Step 1 of #529 (reactive config). Foundation only — no consumer behavior changes yet.

Adds to horismos: a recursive leaf-path config diff (dotted paths), a prefix-based `RESTART_REQUIRED` list, a generic serde_json held-back merge (restart-class changed leaves keep their in-effect value so `current()` always reflects reality), `ReloadOutcome` (applied vs restart_pending paths), `ConfigOverrides` re-applied after every disk load (fixes a latent trap where reload would un-pin `--listen`/`--port`), `ConfigManager::replace`, a typed live `Section<T>` sub-view, `restart_pending()`, and `ConfigHandle::fixed`.

Subsequent steps migrate each subsystem off the frozen `Arc<Config>` snapshot onto these primitives.

Refs #529.
