### PR TITLE
fix(archon): guard migrate slices, cap QUIC admission, reset backoff, fix underrun warning

### DIFF
--- a/crates/archon/src/migrate.rs
+++ b/crates/archon/src/migrate.rs
@@ -554,7 +554,10 @@ fn parse_track_stem(stem: &str) -> (Option<u32>, String) {
 /// - `"20240315 - Title"` → `(Some("2024-03-15"), "Title")`
 /// - `"Episode Title"` → `(None, "Episode Title")`
 fn parse_date_stem(stem: &str) -> (Option<String>, String) {
-    if stem.len() >= 10 && looks_like_iso_date(&stem[..10]) {
+    // INVARIANT: byte-length checks alone don't guarantee `stem[..10]`/`stem[10..]`
+    // land on a char boundary — a multibyte UTF-8 char straddling offset 10 (or 8
+    // below) would panic on the slice; `is_char_boundary` guards each cut.
+    if stem.len() >= 10 && stem.is_char_boundary(10) && looks_like_iso_date(&stem[..10]) {
         let rest = stem[10..]
             .strip_prefix(" - ")
             .or_else(|| stem[10..].strip_prefix(' '))
@@ -563,7 +566,8 @@ fn parse_date_stem(stem: &str) -> (Option<String>, String) {
         return (Some(stem[..10].to_string()), sanitize_owned(title));
     }
 
-    if stem.len() >= 8 && stem[..8].chars().all(|c| c.is_ascii_digit()) {
+    if stem.len() >= 8 && stem.is_char_boundary(8) && stem[..8].chars().all(|c| c.is_ascii_digit())
+    {
         let formatted = format!("{}-{}-{}", &stem[..4], &stem[4..6], &stem[6..8]);
         let rest = stem[8..]
             .strip_prefix(" - ")
@@ -790,6 +794,32 @@ mod tests {
         let (date, title) = parse_date_stem("Episode Title");
         assert!(date.is_none());
         assert_eq!(title, "Episode Title");
+    }
+
+    #[test]
+    fn parse_date_stem_multibyte_char_at_boundary_does_not_panic() {
+        // "1234A6789" is 9 ASCII bytes, then a 2-byte 'é' starting at byte
+        // offset 9 — it straddles the byte-10 cut the ISO-date branch slices
+        // at. Pre-fix, `&stem[..10]` panicked on the non-boundary index. The
+        // embedded 'A' also fails the compact-date branch's all-digit check,
+        // so both branches decline cleanly and this falls through to None.
+        let stem = "1234A6789é - Title";
+        assert!(!stem.is_char_boundary(10));
+        let (date, title) = parse_date_stem(stem);
+        assert!(date.is_none());
+        assert_eq!(title, sanitize_owned(stem));
+    }
+
+    #[test]
+    fn parse_date_stem_multibyte_char_at_compact_boundary_does_not_panic() {
+        // "1234567" is 7 ASCII bytes, then a 2-byte 'é' starting at byte
+        // offset 7 — it straddles the byte-8 cut the compact-date branch
+        // slices at. Pre-fix, `&stem[..8]` panicked on the non-boundary index.
+        let stem = "1234567é9 - Title";
+        assert!(!stem.is_char_boundary(8));
+        let (date, title) = parse_date_stem(stem);
+        assert!(date.is_none());
+        assert_eq!(title, sanitize_owned(stem));
     }
 
     #[test]

--- a/crates/archon/src/render/runner.rs
+++ b/crates/archon/src/render/runner.rs
@@ -128,6 +128,7 @@ pub async fn run_renderer_loop(args: RunnerArgs) -> Result<(), RenderError> {
             &config,
             dsp_tx.subscribe(),
             shutdown.child_token(),
+            &mut backoff,
         )
         .await
         {
@@ -164,6 +165,7 @@ async fn connect_and_run(
     config: &RendererConfig,
     dsp_rx: watch::Receiver<akouo_core::DspConfig>,
     shutdown: CancellationToken,
+    backoff: &mut ExponentialBackoff,
 ) -> Result<(), RenderError> {
     let mut endpoint =
         quinn::Endpoint::client(SocketAddr::from(([0, 0, 0, 0], 0))).map_err(|e| {
@@ -216,6 +218,10 @@ async fn connect_and_run(
         channels = accept.channels,
         "session established"
     );
+    // WHY: a negotiated session is proof the connection is healthy again — a
+    // renderer that ran for days before a transient blip must retry at
+    // initial_backoff_ms, not the ratcheted max from unrelated past failures.
+    backoff.reset();
 
     let mut pipeline = RenderPipeline::new(config, dsp_rx)?;
     let status = Arc::new(StatusReporter::new());
@@ -479,7 +485,6 @@ impl ExponentialBackoff {
         delay
     }
 
-    #[cfg_attr(not(test), expect(dead_code))]
     fn reset(&mut self) {
         self.current_ms = self.initial_ms;
     }
@@ -693,10 +698,18 @@ mod connect_and_run_tests {
         let config = RendererConfig::default();
         let (_dsp_tx, dsp_rx) = watch::channel(config.dsp_config());
         let shutdown = CancellationToken::new();
+        let mut backoff = ExponentialBackoff::new(1000, 30000);
 
         let result = tokio::time::timeout(
             Duration::from_secs(10),
-            connect_and_run(&args, &client_config, &config, dsp_rx, shutdown),
+            connect_and_run(
+                &args,
+                &client_config,
+                &config,
+                dsp_rx,
+                shutdown,
+                &mut backoff,
+            ),
         )
         .await
         .expect("connect_and_run must not hang on a failed audio task");
@@ -708,6 +721,60 @@ mod connect_and_run_tests {
             "a failed audio task must propagate so the reconnect backoff engages"
         );
     }
+
+    // ── #547: a healthy session resets the reconnect backoff ───────────────
+
+    #[tokio::test]
+    async fn connect_and_run_resets_backoff_after_successful_session_negotiation() {
+        let (addr, fingerprint, _cert_dir) = spawn_poisoned_audio_server("key-547").await;
+
+        let args = RunnerArgs {
+            server_addr: addr,
+            name: "test-renderer".to_string(),
+            config_path: None,
+            server_fingerprint: fingerprint.clone(),
+            api_key: "key-547".to_string(),
+        };
+        let client_config = tls::build_client_config(&fingerprint).expect("client config");
+        let config = RendererConfig::default();
+        let (_dsp_tx, dsp_rx) = watch::channel(config.dsp_config());
+        let shutdown = CancellationToken::new();
+
+        // Simulate prior transient failures having ratcheted the backoff well
+        // past its initial delay.
+        let mut backoff = ExponentialBackoff::new(1000, 30000);
+        backoff.next_delay();
+        backoff.next_delay();
+        assert_eq!(backoff.next_delay(), Duration::from_millis(4000));
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            connect_and_run(
+                &args,
+                &client_config,
+                &config,
+                dsp_rx,
+                shutdown,
+                &mut backoff,
+            ),
+        )
+        .await
+        .expect("connect_and_run must not hang on a failed audio task");
+        assert!(
+            result.is_err(),
+            "the poisoned audio stream still fails this connection attempt"
+        );
+
+        // The session negotiated successfully before the poisoned audio
+        // stream failed — pre-fix, the ratcheted delay would carry over
+        // (8000ms next); post-fix it must be back at the initial delay.
+        assert_eq!(
+            backoff.next_delay(),
+            Duration::from_millis(1000),
+            "a successful session must reset the backoff for the next transient failure"
+        );
+    }
+
     #[tokio::test(start_paused = true)]
     async fn reap_task_aborts_a_wedged_task_and_returns() {
         use std::sync::Arc;

--- a/crates/archon/src/render/server.rs
+++ b/crates/archon/src/render/server.rs
@@ -3,9 +3,9 @@
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, warn};
 
@@ -128,12 +128,28 @@ impl paroche::state::DynRendererRegistry for RendererRegistry {
     }
 }
 
+/// Renderer QUIC server admission/auth tuning, threaded from
+/// `ParocheConfig`'s `renderer_*` fields (see `crate::serve`'s call site).
+/// Bundled to keep `start_renderer_server` under the workspace's
+/// too-many-arguments lint threshold.
+pub struct RendererServerLimits {
+    /// Shared secret renderers must present when registering over QUIC.
+    /// Leaving it unset rejects every renderer registration (fail closed).
+    pub renderer_api_key: Option<String>,
+    /// Maximum concurrent renderer connections/tasks admitted before the
+    /// pre-auth SessionInit handshake; excess connections are refused.
+    pub max_connections: usize,
+    /// Deadline for a connecting renderer to complete the pre-auth
+    /// SessionInit handshake (control-stream accept + read).
+    pub session_init_timeout: Duration,
+}
+
 pub async fn start_renderer_server(
     listen_addr: SocketAddr,
     cert_dir: &Path,
     registry: Arc<RendererRegistry>,
     shutdown: CancellationToken,
-    renderer_api_key: Option<String>,
+    limits: RendererServerLimits,
 ) -> Result<(), RenderError> {
     let server_config = tls::load_or_generate_server_config(cert_dir)?;
     let endpoint = quinn::Endpoint::server(server_config, listen_addr).map_err(|e| {
@@ -143,14 +159,26 @@ pub async fn start_renderer_server(
         }
     })?;
 
-    if renderer_api_key.as_deref().is_none_or(str::is_empty) {
+    if limits.renderer_api_key.as_deref().is_none_or(str::is_empty) {
         warn!(
             "paroche.renderer_api_key not configured; rejecting every renderer registration \
              until a key is SET"
         );
     }
 
-    info!(addr = %listen_addr, "renderer QUIC server listening");
+    info!(
+        addr = %listen_addr,
+        max_connections = limits.max_connections,
+        "renderer QUIC server listening"
+    );
+
+    // INVARIANT: bounds concurrent renderer connections/tasks server-wide —
+    // mirrors syndesis::ServerConfig::max_sessions, the sibling QUIC admission
+    // surface in this workspace. A permit is held for the connection's full
+    // handling lifetime (see below), not just the pre-auth handshake, so an
+    // unauthenticated peer that completes TLS then stalls (bounded separately
+    // by session_init_timeout) still counts against the cap.
+    let admission = Arc::new(Semaphore::new(limits.max_connections));
 
     loop {
         let incoming = tokio::select! {
@@ -162,14 +190,30 @@ pub async fn start_renderer_server(
             },
         };
 
+        let (incoming, permit) = match try_admit(incoming, &admission, limits.max_connections) {
+            Some(pair) => pair,
+            None => continue,
+        };
+
         let registry = Arc::clone(&registry);
-        let expected_api_key = renderer_api_key.clone();
+        let expected_api_key = limits.renderer_api_key.clone();
         let ct = shutdown.child_token();
+        let session_init_timeout = limits.session_init_timeout;
 
         tokio::spawn(
             async move {
-                if let Err(e) =
-                    handle_renderer_connection(incoming, registry, expected_api_key, ct).await
+                // WHY: held until this task ends (success, error, or panic
+                // unwind) so the admission cap always reflects live
+                // connections, not just ones still in the pre-auth handshake.
+                let _permit = permit;
+                if let Err(e) = handle_renderer_connection(
+                    incoming,
+                    registry,
+                    expected_api_key,
+                    ct,
+                    session_init_timeout,
+                )
+                .await
                 {
                     warn!(error = %e, "renderer connection handler failed");
                 }
@@ -183,32 +227,52 @@ pub async fn start_renderer_server(
     Ok(())
 }
 
+/// Attempts to admit a freshly-accepted (pre-handshake) connection under the
+/// concurrency cap. Refuses and returns `None` when the cap is reached,
+/// spending no TLS work — mirrors `syndesis::StreamServer`'s session cap.
+fn try_admit(
+    incoming: quinn::Incoming,
+    admission: &Arc<Semaphore>,
+    max_connections: usize,
+) -> Option<(quinn::Incoming, tokio::sync::OwnedSemaphorePermit)> {
+    match Arc::clone(admission).try_acquire_owned() {
+        Ok(permit) => Some((incoming, permit)),
+        Err(_) => {
+            warn!(
+                max_connections,
+                "refusing renderer connection: admission cap reached"
+            );
+            incoming.refuse();
+            None
+        }
+    }
+}
+
 async fn handle_renderer_connection(
     incoming: quinn::Incoming,
     registry: Arc<RendererRegistry>,
     expected_api_key: Option<String>,
     shutdown: CancellationToken,
+    session_init_timeout: Duration,
 ) -> Result<(), RenderError> {
     let connection = incoming.await?;
     let remote = connection.remote_address();
     info!(remote = %remote, "renderer connected");
 
-    // Accept bidirectional control stream.
-    let (mut ctrl_send, mut ctrl_recv) = connection.accept_bi().await?;
-
-    // Read SessionInit.
-    let (msg_type, payload) = protocol::recv_message(&mut ctrl_recv).await?;
-    if msg_type != MSG_SESSION_INIT {
-        return Err(RenderError::Protocol {
-            message: format!("expected SessionInit (0x01), got 0x{msg_type:02x}"),
-            location: snafu::location!(),
-        });
-    }
-    let init: SessionInit =
-        serde_json::from_slice(&payload).map_err(|e| RenderError::Protocol {
-            message: e.to_string(),
-            location: snafu::location!(),
-        })?;
+    // INVARIANT: bounds the whole pre-auth handshake (control-stream accept +
+    // SessionInit read) so a peer that completes TLS then never sends
+    // SessionInit cannot hold the connection — and its admission-cap slot —
+    // open indefinitely.
+    let (mut ctrl_send, mut ctrl_recv, init) =
+        tokio::time::timeout(session_init_timeout, accept_session_init(&connection))
+            .await
+            .map_err(|_| RenderError::Connection {
+                message: format!(
+                    "renderer {remote} did not complete SessionInit within \
+                     {session_init_timeout:?}"
+                ),
+                location: snafu::location!(),
+            })??;
     validate_session_init(&init)?;
     info!(name = %init.name, version = init.protocol_version, "session init received");
 
@@ -276,6 +340,29 @@ async fn handle_renderer_connection(
     );
 
     result
+}
+
+/// Accepts the control bidirectional stream and reads/parses the SessionInit
+/// frame. Callers wrap this in a deadline — see `handle_renderer_connection`
+/// — since it runs entirely on the unauthenticated pre-auth path.
+async fn accept_session_init(
+    connection: &quinn::Connection,
+) -> Result<(quinn::SendStream, quinn::RecvStream, SessionInit), RenderError> {
+    let (ctrl_send, mut ctrl_recv) = connection.accept_bi().await?;
+
+    let (msg_type, payload) = protocol::recv_message(&mut ctrl_recv).await?;
+    if msg_type != MSG_SESSION_INIT {
+        return Err(RenderError::Protocol {
+            message: format!("expected SessionInit (0x01), got 0x{msg_type:02x}"),
+            location: snafu::location!(),
+        });
+    }
+    let init: SessionInit =
+        serde_json::from_slice(&payload).map_err(|e| RenderError::Protocol {
+            message: e.to_string(),
+            location: snafu::location!(),
+        })?;
+    Ok((ctrl_send, ctrl_recv, init))
 }
 
 /// Removes the session's registry entry on drop, covering panic unwinds.
@@ -584,6 +671,13 @@ mod handshake_tests {
     }
 
     async fn spawn_test_server(expected_key: Option<&str>) -> TestServer {
+        spawn_test_server_with_timeout(expected_key, Duration::from_secs(5)).await
+    }
+
+    async fn spawn_test_server_with_timeout(
+        expected_key: Option<&str>,
+        session_init_timeout: Duration,
+    ) -> TestServer {
         let cert_dir = tempfile::TempDir::new().expect("tempdir");
         let server_config =
             tls::load_or_generate_server_config(cert_dir.path()).expect("server config");
@@ -609,7 +703,7 @@ mod handshake_tests {
                 tokio::spawn(async move {
                     // WHY: rejection surfaces as Err by design; tests assert via
                     // the client result and registry contents
-                    handle_renderer_connection(incoming, registry, key, ct)
+                    handle_renderer_connection(incoming, registry, key, ct, session_init_timeout)
                         .await
                         .ok();
                 });
@@ -744,6 +838,80 @@ mod handshake_tests {
         assert!(
             cleaned,
             "a dropped connection must not leave a registry entry behind"
+        );
+    }
+
+    // ── #546: pre-auth admission is bounded ─────────────────────────────────
+
+    #[tokio::test]
+    async fn stalled_peer_is_dropped_after_session_init_timeout() {
+        let server =
+            spawn_test_server_with_timeout(Some("key-123"), Duration::from_millis(200)).await;
+
+        let client_config = tls::build_client_config(&server.fingerprint).expect("client config");
+        let mut endpoint = quinn::Endpoint::client("127.0.0.1:0".parse().expect("loopback addr"))
+            .expect("client endpoint");
+        endpoint.set_default_client_config(client_config);
+
+        let connection = endpoint
+            .connect(server.addr, "harmonia")
+            .expect("connect")
+            .await
+            .expect("QUIC handshake completes");
+
+        // Deliberately never opens the control stream or sends SessionInit —
+        // pre-fix, the server would hold this connection (and task) open
+        // indefinitely.
+        let closed = tokio::time::timeout(Duration::from_secs(5), connection.closed()).await;
+        assert!(
+            closed.is_ok(),
+            "the server must drop a peer that never completes SessionInit \
+             instead of holding the connection open indefinitely"
+        );
+        assert!(server.registry.list().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn admission_cap_refuses_beyond_max_connections() {
+        let cert_dir = tempfile::TempDir::new().expect("tempdir");
+        let server_config =
+            tls::load_or_generate_server_config(cert_dir.path()).expect("server config");
+        let endpoint =
+            quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().expect("loopback addr"))
+                .expect("server endpoint");
+        let addr = endpoint.local_addr().expect("local addr");
+        let cert_der = std::fs::read(cert_dir.path().join("server.der")).expect("read cert");
+        let fingerprint = hex_fingerprint(&cert_der);
+
+        let admission = Arc::new(Semaphore::new(1));
+
+        let client_config = tls::build_client_config(&fingerprint).expect("client config");
+        let mut client = quinn::Endpoint::client("127.0.0.1:0".parse().expect("loopback addr"))
+            .expect("client endpoint");
+        client.set_default_client_config(client_config);
+
+        // Two peers dial before either Incoming is admitted, so the second is
+        // guaranteed to still be pending when the server accepts it below.
+        // WHY: fire-and-forget — the test only cares that the server sees the
+        // initial packet, not that either handshake completes.
+        let connecting1 = client.connect(addr, "harmonia").expect("client1 connect");
+        tokio::spawn(async move {
+            connecting1.await.ok();
+        });
+        let connecting2 = client.connect(addr, "harmonia").expect("client2 connect");
+        tokio::spawn(async move {
+            connecting2.await.ok();
+        });
+
+        let incoming1 = endpoint.accept().await.expect("first incoming");
+        let admitted1 = try_admit(incoming1, &admission, 1);
+        assert!(admitted1.is_some(), "first connection fits under the cap");
+
+        let incoming2 = endpoint.accept().await.expect("second incoming");
+        let admitted2 = try_admit(incoming2, &admission, 1);
+        assert!(
+            admitted2.is_none(),
+            "a connection beyond max_connections must be refused"
         );
     }
 }

--- a/crates/archon/src/render/status.rs
+++ b/crates/archon/src/render/status.rs
@@ -10,6 +10,9 @@ pub struct StatusReporter {
     latency_ms: AtomicU64,
     device_state: Mutex<DeviceState>,
     underrun_count: AtomicU64,
+    /// Underrun count as of the last `report()` call, so a fresh climb can be
+    /// detected against the previous report rather than the current value.
+    last_reported_underrun_count: AtomicU64,
 }
 
 impl Default for StatusReporter {
@@ -25,6 +28,10 @@ impl StatusReporter {
             latency_ms: AtomicU64::new(0.0f64.to_bits()),
             device_state: Mutex::new(DeviceState::Opening),
             underrun_count: AtomicU64::new(0),
+            // WHY: u64::MAX is the "no prior report" sentinel — the first report
+            // establishes the baseline (current > MAX is always false) rather than
+            // warning on a count that already existed before observation began.
+            last_reported_underrun_count: AtomicU64::new(u64::MAX),
         }
     }
 
@@ -56,12 +63,23 @@ impl StatusReporter {
             .unwrap_or_else(|e| e.into_inner())
             .clone();
         let underrun_count = self.underrun_count.load(Ordering::Acquire);
+        // INVARIANT: compare against the PREVIOUS report's count, not another
+        // load of the same atomic — two loads of `underrun_count` back-to-back
+        // are equal by construction (nothing else writes it in between), which
+        // silently defeated this warning regardless of how high the count climbed.
+        let previous_underrun_count = self
+            .last_reported_underrun_count
+            .swap(underrun_count, Ordering::AcqRel);
 
         if latency_ms > 200.0 {
             tracing::warn!(latency_ms, "high renderer latency");
         }
-        if underrun_count > 0 && underrun_count != self.underrun_count.load(Ordering::Relaxed) {
-            tracing::warn!(underrun_count, "audio underruns detected");
+        if underrun_count > previous_underrun_count {
+            tracing::warn!(
+                underrun_count,
+                previous_underrun_count,
+                "audio underruns detected"
+            );
         }
 
         StatusReport {
@@ -116,6 +134,78 @@ mod tests {
         assert_eq!(
             reporter.report().device_state,
             DeviceState::Error("test".into())
+        );
+    }
+
+    // ── #553: underrun warning compares against the PREVIOUS report ────────
+
+    #[derive(Clone)]
+    struct VecWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for VecWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for VecWriter {
+        type Writer = VecWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn captured_log(run: impl FnOnce()) -> String {
+        let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(VecWriter(std::sync::Arc::clone(&buf)))
+            .without_time()
+            .with_ansi(false)
+            .finish();
+        tracing::subscriber::with_default(subscriber, run);
+        String::from_utf8(buf.lock().unwrap_or_else(|e| e.into_inner()).clone())
+            .expect("log output is valid utf8")
+    }
+
+    #[test]
+    fn underrun_warning_does_not_fire_when_count_is_unchanged() {
+        let reporter = StatusReporter::new();
+        reporter.update_underrun_count(2);
+
+        let log = captured_log(|| {
+            let _ = reporter.report();
+            let _ = reporter.report();
+        });
+
+        assert_eq!(
+            log.matches("audio underruns detected").count(),
+            0,
+            "an unchanged count across reports must not warn"
+        );
+    }
+
+    #[test]
+    fn underrun_warning_fires_on_increase_since_last_report() {
+        let reporter = StatusReporter::new();
+
+        let log = captured_log(|| {
+            let _ = reporter.report(); // count 0 -> 0, no warning
+            reporter.update_underrun_count(3);
+            let _ = reporter.report(); // count 0 -> 3, warns
+            let _ = reporter.report(); // count 3 -> 3, no warning
+        });
+
+        assert_eq!(
+            log.matches("audio underruns detected").count(),
+            1,
+            "the warning must fire exactly once, on the report where the count climbed"
         );
     }
 }

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use aitesis::{IdentityValidator, MonitorService, RequestService, UserRoleProvider};
 use apotheke::init_pools;
@@ -942,7 +943,13 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         &config.paroche.listen_addr,
         crate::render::server::DEFAULT_QUIC_PORT,
     )?;
-    let renderer_api_key = config.paroche.renderer_api_key.clone();
+    let renderer_limits = crate::render::server::RendererServerLimits {
+        renderer_api_key: config.paroche.renderer_api_key.clone(),
+        max_connections: config.paroche.renderer_max_connections,
+        session_init_timeout: Duration::from_secs(
+            config.paroche.renderer_session_init_timeout_secs,
+        ),
+    };
     let renderer_registry_for_quic = Arc::clone(&renderer_registry);
     let renderer_shutdown = shutdown_token.child_token();
     tokio::spawn(
@@ -952,7 +959,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
                 &renderer_cert_dir,
                 renderer_registry_for_quic,
                 renderer_shutdown,
-                renderer_api_key,
+                renderer_limits,
             )
             .await
             {

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -65,6 +65,14 @@ pub struct ParocheConfig {
     /// server beyond a trusted network can close the abuse surface here.
     #[serde(default = "default_true")]
     pub kosync_registration_enabled: bool,
+    /// Maximum concurrent renderer QUIC connections/tasks admitted before the
+    /// pre-auth SessionInit handshake; excess connections are refused. Bounds
+    /// server-side task/memory growth from an unauthenticated peer flood.
+    pub renderer_max_connections: usize,
+    /// Deadline (seconds) for a connecting renderer to complete the pre-auth
+    /// SessionInit handshake (control-stream accept + read); a peer that
+    /// stalls past this is dropped rather than held open indefinitely.
+    pub renderer_session_init_timeout_secs: u64,
 }
 
 fn default_true() -> bool {
@@ -87,6 +95,11 @@ impl std::fmt::Debug for ParocheConfig {
                 "kosync_registration_enabled",
                 &self.kosync_registration_enabled,
             )
+            .field("renderer_max_connections", &self.renderer_max_connections)
+            .field(
+                "renderer_session_init_timeout_secs",
+                &self.renderer_session_init_timeout_secs,
+            )
             .finish()
     }
 }
@@ -101,6 +114,10 @@ impl Default for ParocheConfig {
             opds_page_size: 50,
             renderer_api_key: None,
             kosync_registration_enabled: true,
+            // WHY: mirrors syndesis::ServerConfig::max_sessions' default — the
+            // sibling QUIC admission surface in this workspace.
+            renderer_max_connections: 32,
+            renderer_session_init_timeout_secs: 10,
         }
     }
 }


### PR DESCRIPTION
Four archon defects (deep-audit).

- **#545** — `parse_date_stem` sliced `&stem[..10]`/`[..8]` by byte length only; a multibyte UTF-8 char at the boundary panicked inside the spawn_blocking migration, aborting the run. Now char-boundary-guarded (returns None, no panic).
- **#546** — the QUIC render accept loop spawned one task per connection with no cap and no pre-auth deadline on 0.0.0.0. Now bounded by a `Semaphore` (`max_connections`, refuses beyond it) with the permit held for the connection lifetime, and a `session_init_timeout` drops peers that never send SessionInit.
- **#547** — the reconnect `ExponentialBackoff` ratcheted to max for the process lifetime; it now `reset()`s after a successful session negotiation, so a healthy renderer restores initial backoff for the next transient blip.
- **#553** — the underrun warning compared the counter against a second load of itself (never fired). Now compares against a stored last-reported value; a `u64::MAX` sentinel makes the first report establish the baseline without a spurious warn.

Gate green; 8 new tests (multibyte-no-panic, admission-cap-refuses, stalled-peer-dropped, backoff-reset-on-success, underrun-fires-on-increase/not-on-unchanged).

Closes #545
Closes #546
Closes #547
Closes #553
