### PR TITLE
fix(deps): replace opus with opusic-c to build Opus under modern CMake

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -24,9 +24,6 @@ ignore = [
     # paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis.
     # review-by: 2026-10-01
     "RUSTSEC-2024-0436",
-    # audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available.
-    # review-by: 2026-10-01
-    "RUSTSEC-2026-0150",
     # quick-xml < 0.41 quadratic-attribute DoS. The direct indexer-XML parser (zetesis) is on 0.41; the remaining 0.37.5 is transitively pinned by feed-rs (RSS/podcast) and librqbit-upnp (LAN UPnP), neither of which yet targets 0.41. No safe upgrade until upstream bumps.
     # review-by: 2026-10-01
     "RUSTSEC-2026-0194",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
  "cpal",
  "ebur128",
  "lofty",
- "opus",
+ "opusic-c",
  "rand 0.10.1",
  "rstest",
  "rubato",
@@ -479,17 +479,6 @@ checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
 dependencies = [
  "audio-core",
  "num-traits",
-]
-
-[[package]]
-name = "audiopus_sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
-dependencies = [
- "cmake",
- "log",
- "pkg-config",
 ]
 
 [[package]]
@@ -3736,12 +3725,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "opus"
-version = "0.3.1"
+name = "opusic-c"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
+checksum = "89f8e9c909466f15e60277212cc4fec082c68a5e1c9f6e373eee716fec2fed47"
 dependencies = [
- "audiopus_sys",
+ "opusic-sys",
+]
+
+[[package]]
+name = "opusic-sys"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2804e694ef0de3b4cbb254de565053b7cb48d3398df7fd60c6c62bed40c5372a"
+dependencies = [
+ "cmake",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ lofty           = "=0.24.0"
 
 # ── Audio decoding ─────────────────────────────────────────────────────────────
 symphonia       = { version = "0.6", features = ["all"] }
-opus            = "0.3"
+opusic-c        = "1.6"
 rubato          = "3.0"
 ebur128         = "0.1"
 

--- a/crates/akouo-core/Cargo.toml
+++ b/crates/akouo-core/Cargo.toml
@@ -14,7 +14,7 @@ native-output = ["cpal"]
 [dependencies]
 # Audio decode
 symphonia.workspace = true
-opus.workspace = true
+opusic-c.workspace = true
 lofty.workspace = true
 
 # Audio processing

--- a/crates/akouo-core/src/decode/opus.rs
+++ b/crates/akouo-core/src/decode/opus.rs
@@ -1,6 +1,6 @@
-// P1-03: OpusDecoder  -  FFI bridge wrapping libopus via the `opus` crate.
+// P1-03: OpusDecoder  -  FFI bridge wrapping libopus via the `opusic-c` crate.
 //
-// Symphonia's OGG demuxer extracts raw Opus packets; `opus::Decoder` decodes them.
+// Symphonia's OGG demuxer extracts raw Opus packets; `opusic_c::Decoder` decodes them.
 // When Symphonia's native Opus decoder reaches production readiness (PR #398), this
 // bridge can be removed without API change  -  it implements the same SyncAudioDecoder
 // trait.
@@ -26,13 +26,13 @@ const OPUS_MAX_FRAME_SAMPLES: usize = 5_760;
 /// All I/O is synchronous (std file reads); the decoder implements `SyncAudioDecoder`
 /// and is driven on a dedicated decode thread by `blocking::BlockingDecoder`.
 pub struct OpusDecoder {
-    decoder: opus::Decoder,
+    decoder: opusic_c::Decoder,
     format_reader: Box<dyn FormatReader + 'static>,
     track_id: u32,
     params: StreamParams,
     gapless: Option<GaplessInfo>,
     time_base: TimeBase,
-    /// Pre-allocated f32 output FROM `opus::Decoder::decode_float` (interleaved channels).
+    /// Pre-allocated f32 output FROM `opusic_c::Decoder::decode_float_to_slice` (interleaved channels).
     decode_buf: Box<[f32]>,
     /// Widened f64 copy for the internal pipeline.
     output_buf: Box<[f64]>,
@@ -76,17 +76,16 @@ impl OpusDecoder {
         let channels = codec_params.channels.map(|c| c.count() as u16).unwrap_or(2);
 
         let opus_channels = if channels == 1 {
-            opus::Channels::Mono
+            opusic_c::Channels::Mono
         } else {
-            opus::Channels::Stereo
+            opusic_c::Channels::Stereo
         };
 
-        let decoder = opus::Decoder::new(OPUS_SAMPLE_RATE, opus_channels).map_err(|e| {
-            DecodeError::OpusDecode {
-                message: format!("failed to initialise libopus decoder: {e}"),
+        let decoder = opusic_c::Decoder::new(opus_channels, opusic_c::SampleRate::Hz48000)
+            .map_err(|e| DecodeError::OpusDecode {
+                message: format!("failed to initialise libopus decoder: {e:?}"),
                 location: snafu::Location::new(file!(), line!(), column!()),
-            }
-        })?;
+            })?;
 
         let time_base = track_time_base
             .or_else(|| TimeBase::try_from_recip(OPUS_SAMPLE_RATE))
@@ -152,9 +151,9 @@ impl OpusDecoder {
             // An empty slice triggers Opus Packet Loss Concealment (PLC).
             let n_samples_per_channel = self
                 .decoder
-                .decode_float(packet.data.as_ref(), &mut self.decode_buf, false)
+                .decode_float_to_slice(packet.data.as_ref(), &mut self.decode_buf, false)
                 .map_err(|e| DecodeError::OpusDecode {
-                    message: format!("decode_float failed: {e}"),
+                    message: format!("decode_float failed: {e:?}"),
                     location: snafu::Location::new(file!(), line!(), column!()),
                 })?;
 
@@ -194,16 +193,15 @@ impl OpusDecoder {
 
         // Recreate decoder to clear internal state after seek.
         let opus_channels = if self.params.channels == 1 {
-            opus::Channels::Mono
+            opusic_c::Channels::Mono
         } else {
-            opus::Channels::Stereo
+            opusic_c::Channels::Stereo
         };
-        self.decoder = opus::Decoder::new(OPUS_SAMPLE_RATE, opus_channels).map_err(|e| {
-            DecodeError::OpusDecode {
-                message: format!("decoder reset after seek failed: {e}"),
+        self.decoder = opusic_c::Decoder::new(opus_channels, opusic_c::SampleRate::Hz48000)
+            .map_err(|e| DecodeError::OpusDecode {
+                message: format!("decoder reset after seek failed: {e:?}"),
                 location: snafu::Location::new(file!(), line!(), column!()),
-            }
-        })?;
+            })?;
 
         let secs = self
             .time_base
@@ -286,10 +284,12 @@ mod tests {
 
     #[test]
     fn opus_plc_decode_produces_concealment_audio() {
-        // Passing an empty slice to decode_float triggers Opus Packet Loss Concealment.
-        let mut dec = opus::Decoder::new(48_000, opus::Channels::Stereo).unwrap();
+        // Passing an empty slice to decode_float_to_slice triggers Opus Packet Loss Concealment.
+        let mut dec =
+            opusic_c::Decoder::new(opusic_c::Channels::Stereo, opusic_c::SampleRate::Hz48000)
+                .unwrap();
         let mut buf = vec![0.0f32; OPUS_MAX_FRAME_SAMPLES * 2];
-        let result = dec.decode_float(&[], &mut buf, false);
+        let result = dec.decode_float_to_slice(&[], &mut buf, false);
         assert!(result.is_ok(), "PLC decode must not error: {result:?}");
         assert!(result.unwrap() > 0, "PLC must produce samples");
     }

--- a/deny.toml
+++ b/deny.toml
@@ -40,10 +40,6 @@ id = "RUSTSEC-2024-0436"
 reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis. review-by: 2026-10-01"
 
 [[advisories.ignore]]
-id = "RUSTSEC-2026-0150"
-reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available. review-by: 2026-10-01"
-
-[[advisories.ignore]]
 id = "RUSTSEC-2026-0194"
 reason = "quick-xml < 0.41 quadratic-attribute DoS. The direct indexer-XML parser (zetesis) is on 0.41; the remaining 0.37.5 is transitively pinned by feed-rs (RSS/podcast) and librqbit-upnp (LAN UPnP), neither of which yet targets 0.41. No safe upgrade until upstream bumps. review-by: 2026-10-01"
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -27,10 +27,6 @@ id = "RUSTSEC-2024-0436"
 reason = "paste unmaintained (dtolnay archived) — transitive dep via lofty/taxis. review-by: 2026-10-01"
 
 [[IgnoredVulns]]
-id = "RUSTSEC-2026-0150"
-reason = "audiopus_sys unmaintained via opus/akouo-core; no safe upgrade available. review-by: 2026-10-01"
-
-[[IgnoredVulns]]
 id = "RUSTSEC-2026-0194"
 reason = "quick-xml < 0.41 quadratic-attribute DoS. The direct indexer-XML parser (zetesis) is on 0.41; the remaining 0.37.5 is transitively pinned by feed-rs (RSS/podcast) and librqbit-upnp (LAN UPnP), neither of which yet targets 0.41. No safe upgrade until upstream bumps. review-by: 2026-10-01"
 


### PR DESCRIPTION
Fixes #565 — the release macOS (aarch64-apple-darwin) build failed because `audiopus_sys 0.2.2` (transitively via `opus 0.3.1`) vendors Opus with a `cmake_minimum_required(3.1)` CMakeLists that CMake 4.x rejects.

No version bump could fix it (opus 0.3.1 is the latest release; its audiopus_sys backend is unmaintained since 2021; symphonia has no native Opus decoder). Replaced the binding: `opus 0.3` → `opusic-c 1.6` (backend `opusic-sys 0.7.3`, vendored libopus 1.6.1 with `cmake_minimum_required(3.16)` — CMake-4.x-clean; actively maintained, BSD-3, 495K downloads). `decode/opus.rs` migrated 1:1 (decode_float → decode_float_to_slice, typed SampleRate, PLC/reset-on-seek preserved). Removed the now-obsolete audiopus_sys RUSTSEC ignore + regenerated audit/osv config.

Gate green (1909 tests; 8 opus decode tests incl. PLC). The CMake root cause is proven fixed on Linux (metis runs the same CMake 4.x); the release macOS build is being verified on this branch.

Closes #565
