### PR TITLE
fix(zetesis): correct regexp-filter group semantics and rate-limit embargo accrual (#531, #533)

### DIFF
--- a/crates/zetesis/src/client/cardigann/filters.rs
+++ b/crates/zetesis/src/client/cardigann/filters.rs
@@ -90,9 +90,21 @@ fn apply_one(value: String, spec: &FilterSpec, now: &Zoned) -> Result<String, St
                 .captures(&value)
                 .ok_or_else(|| format!("regexp {pattern:?} did not match {value:?}"))?;
             // WHY: Cardigann yields the first capture group; a group-less
-            // pattern falls back to the whole match.
-            let m = caps.get(1).or_else(|| caps.get(0));
-            Ok(m.map_or_else(String::new, |m| m.as_str().to_string()))
+            // pattern falls back to the whole match. `Captures::len()` counts
+            // group 0 plus all capture groups, so `> 1` means the pattern
+            // statically has a group 1 — in that case a non-participating
+            // group (e.g. the other arm of an alternation) yields the empty
+            // string, not the whole match, matching upstream Cardigann/Go
+            // semantics. Only a pattern with no group 1 at all falls back to
+            // the whole match.
+            let m = if caps.len() > 1 {
+                caps.get(1)
+                    .map_or_else(String::new, |m| m.as_str().to_string())
+            } else {
+                caps.get(0)
+                    .map_or_else(String::new, |m| m.as_str().to_string())
+            };
+            Ok(m)
         }
         "re_replace" => {
             let re = Regex::new(arg(0)?).map_err(|e| format!("re_replace: {e}"))?;
@@ -314,6 +326,25 @@ mod tests {
     fn regexp_without_groups_returns_whole_match() {
         assert_eq!(
             run("abc123def", &[spec("regexp", &[r"\d+"])]).unwrap(),
+            "123"
+        );
+    }
+
+    #[test]
+    fn regexp_non_participating_group_returns_empty() {
+        // WHY: group 1 exists in the pattern but the "abc" arm of the
+        // alternation matched instead — upstream Cardigann/Go semantics
+        // yield the empty string here, not the whole match.
+        assert_eq!(
+            run("abc", &[spec("regexp", &[r"(?:(\d+)|abc)"])]).unwrap(),
+            ""
+        );
+    }
+
+    #[test]
+    fn regexp_participating_group_returns_group_text() {
+        assert_eq!(
+            run("123", &[spec("regexp", &[r"(?:(\d+)|abc)"])]).unwrap(),
             "123"
         );
     }

--- a/crates/zetesis/src/rate_limit.rs
+++ b/crates/zetesis/src/rate_limit.rs
@@ -40,8 +40,13 @@ impl TokenBucket {
     }
 
     fn try_acquire(&mut self) -> Option<Duration> {
-        self.refill();
-
+        // WHY: refill() must not run while an embargo is active — otherwise
+        // tokens re-accumulate for the whole back-off window and fire a
+        // full-`max_tokens` burst the instant the embargo clears, risking an
+        // immediate re-429. Checking retry_after first and only refilling
+        // once the embargo has genuinely cleared (last_refill is frozen at
+        // retry_until by set_retry_after) means accrual resumes strictly
+        // after the embargo, not from whenever the last real refill ran.
         if let Some(retry_until) = self.retry_after {
             let now = Instant::now();
             if now < retry_until {
@@ -49,6 +54,8 @@ impl TokenBucket {
             }
             self.retry_after = None;
         }
+
+        self.refill();
 
         if self.tokens >= 1.0 {
             self.tokens -= 1.0;
@@ -60,7 +67,13 @@ impl TokenBucket {
     }
 
     fn set_retry_after(&mut self, duration: Duration) {
-        self.retry_after = Some(Instant::now() + duration);
+        let retry_until = Instant::now() + duration;
+        self.retry_after = Some(retry_until);
+        // WHY: freeze last_refill at retry_until (not now) so refill() only
+        // accrues tokens for time elapsed AFTER the embargo clears — without
+        // this, tokens would re-accumulate across the whole back-off window
+        // and the bucket would be full again the instant retry_after expires.
+        self.last_refill = retry_until;
         self.tokens = 0.0;
     }
 }
@@ -179,6 +192,31 @@ mod tests {
         assert!(
             elapsed >= Duration::from_millis(90),
             "expected retry-after delay, got {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn embargo_freezes_accrual_until_retry_after_clears() {
+        // refill_rate = 10 tokens / 10s = 1 token/sec.
+        let mut bucket = TokenBucket::new(10, Duration::from_secs(10));
+
+        // retry_after >= the refill window — the regime the bug fired in:
+        // an unfrozen last_refill accrues a full max_tokens burst by the
+        // time the embargo clears.
+        bucket.set_retry_after(Duration::from_secs(20));
+
+        // Advance 5s past retry_until.
+        tokio::time::advance(Duration::from_secs(25)).await;
+
+        let wait = bucket.try_acquire();
+        assert!(wait.is_none(), "expected a token once the embargo cleared");
+        // Only the 5s elapsed AFTER retry_until should have accrued (5
+        // tokens, minus the 1 just spent = 4). A full burst (the bug) would
+        // leave max_tokens - 1 = 9.
+        assert!(
+            bucket.tokens <= 4.5,
+            "expected accrual limited to post-embargo elapsed time, got {} tokens",
+            bucket.tokens
         );
     }
 }


### PR DESCRIPTION
Two verified zetesis correctness fixes from the 2026-07-03 deep-audit workflow (adversarially verified + Opus-judged).

**#531 — Cardigann `regexp` filter mishandled non-participating groups.** `caps.get(1).or_else(|| caps.get(0))` could not distinguish "pattern has no capture group 1" from "group 1 exists but did not participate in this match" (e.g. `(?:(\d+)|abc)` on `"abc"`) — both fell through to the whole match, contradicting upstream Cardigann/Go semantics, which yield the empty string for a non-participating group. Now checks `caps.len() > 1` (true iff the compiled pattern statically has a group 1): when true, return group 1's text or `""` if it did not participate; only fall back to group 0 when the pattern truly has no group. Two new tests cover the non-participating (`→ ""`) and participating (`→ "123"`) arms; the existing group-less-fallback test still passes.

**#533 — token bucket refilled during the 429 back-off window.** `try_acquire` called `refill()` unconditionally before the `retry_after` check, and `set_retry_after` zeroed tokens without freezing `last_refill` — so tokens re-accumulated across the whole embargo and the bucket fired a full `max_tokens` burst the instant a 429's `Retry-After` cleared, risking an immediate re-429. Now `try_acquire` checks the embargo first and skips `refill()` while it is active, and `set_retry_after` sets `last_refill = retry_until` so accrual resumes strictly after the embargo clears. A deterministic mock-clock test (`start_paused`, 20s embargo over a 10s window, advance 25s) asserts only the 5s of post-embargo accrual is present, not a full burst.

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings --all-targets`), nextest 1918/1918, deny, lint (0/0). `Gate-Passed` trailer stamped.

Closes #531
Closes #533
