### PR TITLE
fix(akouo-core): decode >2-channel Opus via multistream instead of collapsing to stereo (#544)

### DIFF
--- a/crates/akouo-core/src/decode/opus.rs
+++ b/crates/akouo-core/src/decode/opus.rs
@@ -1,6 +1,8 @@
 // P1-03: OpusDecoder  -  FFI bridge wrapping libopus via the `opusic-c` crate.
 //
-// Symphonia's OGG demuxer extracts raw Opus packets; `opusic_c::Decoder` decodes them.
+// Symphonia's OGG demuxer extracts raw Opus packets; libopus decodes them  -
+// `opusic_c::Decoder` for mono/stereo streams, `opusic_c::multistream::Decoder` for
+// mapping-family-1 multichannel streams (RFC 7845 §5.1.1.2).
 // When Symphonia's native Opus decoder reaches production readiness (PR #398), this
 // bridge can be removed without API change  -  it implements the same SyncAudioDecoder
 // trait.
@@ -21,21 +23,253 @@ const OPUS_SAMPLE_RATE: u32 = 48_000;
 /// Maximum Opus frame size: 120 ms at 48 kHz per channel.
 const OPUS_MAX_FRAME_SAMPLES: usize = 5_760;
 
+/// Maximum channel count for mapping family 1 (RFC 7845 §5.1.1.2, Vorbis channel order).
+const OPUS_MAX_MAPPED_CHANNELS: usize = 8;
+
 /// Opus FFI decoder. Demuxes OGG via Symphonia, decodes packets via libopus.
 ///
 /// All I/O is synchronous (std file reads); the decoder implements `SyncAudioDecoder`
 /// and is driven on a dedicated decode thread by `blocking::BlockingDecoder`.
 pub struct OpusDecoder {
-    decoder: opusic_c::Decoder,
+    decoder: OpusInner,
     format_reader: Box<dyn FormatReader + 'static>,
     track_id: u32,
     params: StreamParams,
     gapless: Option<GaplessInfo>,
     time_base: TimeBase,
-    /// Pre-allocated f32 output FROM `opusic_c::Decoder::decode_float_to_slice` (interleaved channels).
+    /// Pre-allocated f32 output FROM libopus float decode (interleaved channels).
     decode_buf: Box<[f32]>,
     /// Widened f64 copy for the internal pipeline.
     output_buf: Box<[f64]>,
+}
+
+/// Channel configuration resolved FROM the OpusHead identification header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ChannelLayout {
+    /// Mapping family 0: single elementary stream, mono or stereo.
+    Single(opusic_c::Channels),
+    /// Mapping family 1: multiple elementary streams with an explicit channel-mapping table.
+    Multi {
+        channels: u8,
+        streams: u8,
+        coupled_streams: u8,
+        /// Channel-mapping table; only the first `channels` entries are meaningful.
+        mapping: [u8; OPUS_MAX_MAPPED_CHANNELS],
+    },
+}
+
+impl ChannelLayout {
+    fn channel_count(&self) -> u16 {
+        match self {
+            Self::Single(opusic_c::Channels::Mono) => 1,
+            Self::Single(opusic_c::Channels::Stereo) => 2,
+            Self::Multi { channels, .. } => u16::from(*channels),
+        }
+    }
+}
+
+/// Newtype over `opusic_c::multistream::Decoder` carrying the `Send` impl upstream omits.
+struct MultiDecoder(opusic_c::multistream::Decoder);
+
+// SAFETY: `multistream::Decoder` uniquely owns its heap-allocated libopus state
+// (`mem::Unique`), which has no thread affinity, and every method takes `&mut self`.
+// opusic-c marks the structurally identical `Decoder`, `Encoder`, and
+// `multistream::Encoder` as `Send`; the missing impl here is an upstream omission.
+unsafe impl Send for MultiDecoder {}
+
+/// libopus decoder behind a common decode/reset surface for both stream layouts.
+enum OpusInner {
+    Single(opusic_c::Decoder),
+    Multi(MultiDecoder),
+}
+
+impl OpusInner {
+    fn new(layout: &ChannelLayout) -> Result<Self, DecodeError> {
+        match layout {
+            ChannelLayout::Single(channels) => {
+                opusic_c::Decoder::new(*channels, opusic_c::SampleRate::Hz48000)
+                    .map(Self::Single)
+                    .map_err(|e| DecodeError::OpusDecode {
+                        message: format!("failed to initialise libopus decoder: {e:?}"),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    })
+            }
+            ChannelLayout::Multi {
+                channels,
+                streams,
+                coupled_streams,
+                mapping,
+            } => new_multistream(*channels, *streams, *coupled_streams, mapping)
+                .map(|decoder| Self::Multi(MultiDecoder(decoder))),
+        }
+    }
+
+    fn decode_float_to_slice(
+        &mut self,
+        input: &[u8],
+        output: &mut [f32],
+        decode_fec: bool,
+    ) -> Result<usize, opusic_c::ErrorCode> {
+        match self {
+            Self::Single(decoder) => decoder.decode_float_to_slice(input, output, decode_fec),
+            Self::Multi(decoder) => decoder.0.decode_float_to_slice(input, output, decode_fec),
+        }
+    }
+
+    /// Resets decoder state to initial (libopus `OPUS_RESET_STATE`).
+    fn reset(&mut self) -> Result<(), opusic_c::ErrorCode> {
+        match self {
+            Self::Single(decoder) => decoder.reset(),
+            Self::Multi(decoder) => decoder.0.reset(),
+        }
+    }
+}
+
+/// Constructs a multistream decoder for `channels` I/O channels.
+fn new_multistream(
+    channels: u8,
+    streams: u8,
+    coupled_streams: u8,
+    mapping: &[u8; OPUS_MAX_MAPPED_CHANNELS],
+) -> Result<opusic_c::multistream::Decoder, DecodeError> {
+    fn build<const CH: usize>(
+        streams: u8,
+        coupled_streams: u8,
+        mapping: &[u8; OPUS_MAX_MAPPED_CHANNELS],
+    ) -> Result<opusic_c::multistream::Decoder, DecodeError> {
+        let mut table = [0u8; CH];
+        table.copy_from_slice(&mapping[..CH]);
+        let config = opusic_c::multistream::Config::<CH>::try_new(streams, coupled_streams, table)
+            .ok_or_else(|| DecodeError::OpusDecode {
+                message: format!(
+                    "invalid Opus channel mapping: {streams} streams, {coupled_streams} coupled, {CH} channels"
+                ),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        opusic_c::multistream::Decoder::new(config, opusic_c::SampleRate::Hz48000).map_err(|e| {
+            DecodeError::OpusDecode {
+                message: format!("failed to initialise libopus multistream decoder: {e:?}"),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            }
+        })
+    }
+
+    // WHY: `multistream::Config` is const-generic over the channel count, so each
+    // family-1 count (1..=8) needs its own monomorphisation.
+    match channels {
+        1 => build::<1>(streams, coupled_streams, mapping),
+        2 => build::<2>(streams, coupled_streams, mapping),
+        3 => build::<3>(streams, coupled_streams, mapping),
+        4 => build::<4>(streams, coupled_streams, mapping),
+        5 => build::<5>(streams, coupled_streams, mapping),
+        6 => build::<6>(streams, coupled_streams, mapping),
+        7 => build::<7>(streams, coupled_streams, mapping),
+        8 => build::<8>(streams, coupled_streams, mapping),
+        // INVARIANT: resolve_channel_layout only produces Multi for 1..=8 channels.
+        _ => Err(unsupported_layout(u16::from(channels), Some(1))),
+    }
+}
+
+/// Fields of the OpusHead identification header needed for decoder construction.
+///
+/// All containers Symphonia routes here (OGG, Matroska/WebM, MP4 dOps) normalise
+/// `extra_data` to this magic-prefixed layout. Only single-byte fields are read, so
+/// the OGG (little-endian) vs MP4 (big-endian) multi-byte field difference is moot.
+struct OpusHead {
+    channels: u8,
+    mapping_family: u8,
+    /// Present only when `mapping_family != 0` and the table fits family 1's bounds.
+    table: Option<MappingTable>,
+}
+
+struct MappingTable {
+    streams: u8,
+    coupled_streams: u8,
+    mapping: [u8; OPUS_MAX_MAPPED_CHANNELS],
+}
+
+fn parse_opus_head(extra_data: &[u8]) -> Option<OpusHead> {
+    const MAGIC: &[u8; 8] = b"OpusHead";
+    const CHANNELS_OFFSET: usize = 9;
+    const FAMILY_OFFSET: usize = 18;
+    const STREAMS_OFFSET: usize = 19;
+    const COUPLED_OFFSET: usize = 20;
+    const TABLE_OFFSET: usize = 21;
+
+    if extra_data.len() <= FAMILY_OFFSET || !extra_data.starts_with(MAGIC) {
+        return None;
+    }
+
+    let channels = extra_data[CHANNELS_OFFSET];
+    let mapping_family = extra_data[FAMILY_OFFSET];
+
+    let table_len = usize::from(channels);
+    let table = if mapping_family == 0
+        || table_len > OPUS_MAX_MAPPED_CHANNELS
+        || extra_data.len() < TABLE_OFFSET + table_len
+    {
+        None
+    } else {
+        let mut mapping = [0u8; OPUS_MAX_MAPPED_CHANNELS];
+        mapping[..table_len].copy_from_slice(&extra_data[TABLE_OFFSET..TABLE_OFFSET + table_len]);
+        Some(MappingTable {
+            streams: extra_data[STREAMS_OFFSET],
+            coupled_streams: extra_data[COUPLED_OFFSET],
+            mapping,
+        })
+    };
+
+    Some(OpusHead {
+        channels,
+        mapping_family,
+        table,
+    })
+}
+
+/// Resolves the decoder channel layout FROM the identification header.
+///
+/// WHY(#544): the layout must reflect the stream's TRUE channel count. Collapsing >2
+/// channels to stereo configured libopus for 2 channels while `total` used the real
+/// count  -  fabricating extra-channel audio FROM stale buffer bytes and desyncing
+/// every downstream per-channel DSP stage. Unsupported layouts fail loudly instead.
+fn resolve_channel_layout(
+    fallback_channels: u16,
+    extra_data: Option<&[u8]>,
+) -> Result<ChannelLayout, DecodeError> {
+    match extra_data.and_then(parse_opus_head) {
+        Some(head) => match (head.mapping_family, head.channels) {
+            (0, 1) => Ok(ChannelLayout::Single(opusic_c::Channels::Mono)),
+            (0, 2) => Ok(ChannelLayout::Single(opusic_c::Channels::Stereo)),
+            (1, channels @ 1..=8) => match head.table {
+                Some(table) => Ok(ChannelLayout::Multi {
+                    channels,
+                    streams: table.streams,
+                    coupled_streams: table.coupled_streams,
+                    mapping: table.mapping,
+                }),
+                None => Err(unsupported_layout(u16::from(channels), Some(1))),
+            },
+            (family, channels) => Err(unsupported_layout(u16::from(channels), Some(family))),
+        },
+        // NOTE: without an OpusHead there is no channel-mapping table, so only the
+        // implicit mono/stereo layouts of mapping family 0 are decodable.
+        None => match fallback_channels {
+            1 => Ok(ChannelLayout::Single(opusic_c::Channels::Mono)),
+            2 => Ok(ChannelLayout::Single(opusic_c::Channels::Stereo)),
+            channels => Err(unsupported_layout(channels, None)),
+        },
+    }
+}
+
+fn unsupported_layout(channels: u16, mapping_family: Option<u8>) -> DecodeError {
+    let label = match mapping_family {
+        Some(family) => format!("Opus ({channels} channels, mapping family {family})"),
+        None => format!("Opus ({channels} channels, no identification header)"),
+    };
+    DecodeError::UnsupportedCodec {
+        codec: Codec::Other(label),
+        location: snafu::Location::new(file!(), line!(), column!()),
+    }
 }
 
 impl OpusDecoder {
@@ -73,19 +307,13 @@ impl OpusDecoder {
             .cloned()
             .unwrap_or_default();
 
-        let channels = codec_params.channels.map(|c| c.count() as u16).unwrap_or(2);
+        let demuxed_channels = codec_params.channels.map(|c| c.count() as u16).unwrap_or(2);
 
-        let opus_channels = if channels == 1 {
-            opusic_c::Channels::Mono
-        } else {
-            opusic_c::Channels::Stereo
-        };
-
-        let decoder = opusic_c::Decoder::new(opus_channels, opusic_c::SampleRate::Hz48000)
-            .map_err(|e| DecodeError::OpusDecode {
-                message: format!("failed to initialise libopus decoder: {e:?}"),
-                location: snafu::Location::new(file!(), line!(), column!()),
-            })?;
+        let layout = resolve_channel_layout(demuxed_channels, codec_params.extra_data.as_deref())?;
+        // INVARIANT: `channels` matches the libopus decoder configuration  -  the
+        // interleaved sample math in decode_next_packet depends on this.
+        let channels = layout.channel_count();
+        let decoder = OpusInner::new(&layout)?;
 
         let time_base = track_time_base
             .or_else(|| TimeBase::try_from_recip(OPUS_SAMPLE_RATE))
@@ -191,17 +419,13 @@ impl OpusDecoder {
                 location: snafu::Location::new(file!(), line!(), column!()),
             })?;
 
-        // Recreate decoder to clear internal state after seek.
-        let opus_channels = if self.params.channels == 1 {
-            opusic_c::Channels::Mono
-        } else {
-            opusic_c::Channels::Stereo
-        };
-        self.decoder = opusic_c::Decoder::new(opus_channels, opusic_c::SampleRate::Hz48000)
-            .map_err(|e| DecodeError::OpusDecode {
-                message: format!("decoder reset after seek failed: {e:?}"),
-                location: snafu::Location::new(file!(), line!(), column!()),
-            })?;
+        // WHY(#544): reset in place (`OPUS_RESET_STATE`) clears post-seek decoder state
+        // without re-deriving the channel layout  -  the old rebuild duplicated layout
+        // logic here and silently collapsed >2-channel streams to stereo.
+        self.decoder.reset().map_err(|e| DecodeError::OpusDecode {
+            message: format!("decoder reset after seek failed: {e:?}"),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
 
         let secs = self
             .time_base
@@ -292,5 +516,134 @@ mod tests {
         let result = dec.decode_float_to_slice(&[], &mut buf, false);
         assert!(result.is_ok(), "PLC decode must not error: {result:?}");
         assert!(result.unwrap() > 0, "PLC must produce samples");
+    }
+
+    // --- #544: >2-channel streams must never be collapsed to a stereo decoder ---
+
+    /// RFC 7845 5.1 mapping: 4 streams, 2 coupled, Vorbis order [FL FC FR RL RR LFE].
+    const SURROUND_5_1_TABLE: [u8; 8] = [4, 2, 0, 4, 1, 2, 3, 5];
+
+    /// Builds a synthetic OpusHead identification header. `table` carries
+    /// `[streams, coupled, mapping...]` and must be empty for mapping family 0.
+    fn opus_head_bytes(channels: u8, family: u8, table: &[u8]) -> Vec<u8> {
+        let mut head = Vec::new();
+        head.extend_from_slice(b"OpusHead");
+        head.push(1); // version
+        head.push(channels);
+        head.extend_from_slice(&312u16.to_le_bytes()); // pre-skip
+        head.extend_from_slice(&48_000u32.to_le_bytes()); // input sample rate
+        head.extend_from_slice(&0u16.to_le_bytes()); // output gain
+        head.push(family);
+        head.extend_from_slice(table);
+        head
+    }
+
+    #[test]
+    fn parse_opus_head_reads_family1_mapping_table() {
+        let head = parse_opus_head(&opus_head_bytes(6, 1, &SURROUND_5_1_TABLE[..8])).unwrap();
+        assert_eq!(head.channels, 6);
+        assert_eq!(head.mapping_family, 1);
+        let table = head.table.unwrap();
+        assert_eq!(table.streams, 4);
+        assert_eq!(table.coupled_streams, 2);
+        assert_eq!(&table.mapping[..6], &[0, 4, 1, 2, 3, 5]);
+    }
+
+    #[test]
+    fn parse_opus_head_rejects_bad_magic_and_truncation() {
+        let mut bad_magic = opus_head_bytes(2, 0, &[]);
+        bad_magic[0] = b'X';
+        assert!(parse_opus_head(&bad_magic).is_none());
+        assert!(parse_opus_head(&opus_head_bytes(2, 0, &[])[..12]).is_none());
+    }
+
+    #[test]
+    fn resolve_5_1_family1_yields_multistream_layout() {
+        let head = opus_head_bytes(6, 1, &SURROUND_5_1_TABLE[..8]);
+        let layout = resolve_channel_layout(6, Some(&head)).unwrap();
+        assert_eq!(layout.channel_count(), 6, "true channel count must survive");
+        assert!(
+            matches!(
+                layout,
+                ChannelLayout::Multi {
+                    channels: 6,
+                    streams: 4,
+                    coupled_streams: 2,
+                    ..
+                }
+            ),
+            "5.1 must resolve to a multistream layout, got {layout:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_family0_mono_and_stereo_use_single_decoder() {
+        let mono = resolve_channel_layout(1, Some(&opus_head_bytes(1, 0, &[]))).unwrap();
+        assert_eq!(mono, ChannelLayout::Single(opusic_c::Channels::Mono));
+        let stereo = resolve_channel_layout(2, Some(&opus_head_bytes(2, 0, &[]))).unwrap();
+        assert_eq!(stereo, ChannelLayout::Single(opusic_c::Channels::Stereo));
+        // No identification header: the demuxed channel count alone drives the layout.
+        let fallback = resolve_channel_layout(2, None).unwrap();
+        assert_eq!(fallback, ChannelLayout::Single(opusic_c::Channels::Stereo));
+    }
+
+    #[test]
+    fn resolve_rejects_multichannel_without_mapping_table() {
+        // 6 channels but no OpusHead: no mapping table exists, so constructing a
+        // decoder must fail loudly instead of collapsing to stereo.
+        let err = resolve_channel_layout(6, None).unwrap_err();
+        assert!(
+            matches!(err, DecodeError::UnsupportedCodec { .. }),
+            "expected UnsupportedCodec, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_family0_multichannel() {
+        // Mapping family 0 is defined only for 1-2 channels (RFC 7845 §5.1.1.1).
+        let err = resolve_channel_layout(6, Some(&opus_head_bytes(6, 0, &[]))).unwrap_err();
+        assert!(matches!(err, DecodeError::UnsupportedCodec { .. }));
+    }
+
+    #[test]
+    fn resolve_rejects_reserved_mapping_family() {
+        let head = opus_head_bytes(6, 255, &SURROUND_5_1_TABLE[..8]);
+        let err = resolve_channel_layout(6, Some(&head)).unwrap_err();
+        assert!(matches!(err, DecodeError::UnsupportedCodec { .. }));
+    }
+
+    #[test]
+    fn multistream_5_1_round_trip_decodes_six_channels() {
+        const CHANNELS: usize = 6;
+        const FRAME_SAMPLES: usize = 960; // 20 ms at 48 kHz
+
+        // Encode one genuine 6-channel frame with the libopus multistream encoder.
+        let mapping = [0u8, 4, 1, 2, 3, 5];
+        let config = opusic_c::multistream::Config::<CHANNELS>::try_new(4, 2, mapping).unwrap();
+        let mut encoder = opusic_c::multistream::Encoder::new(
+            config,
+            opusic_c::SampleRate::Hz48000,
+            opusic_c::Application::Audio,
+        )
+        .unwrap();
+        let mut pcm = vec![0.0f32; FRAME_SAMPLES * CHANNELS];
+        for (i, sample) in pcm.iter_mut().enumerate() {
+            *sample = (i % 480) as f32 / 4_800.0 - 0.05;
+        }
+        let mut packet = vec![0u8; 4_000];
+        let packet_len = encoder.encode_float_to_slice(&pcm, &mut packet).unwrap();
+
+        // The decoder constructed FROM a 5.1 OpusHead must decode the full frame.
+        let head = opus_head_bytes(6, 1, &SURROUND_5_1_TABLE[..8]);
+        let layout = resolve_channel_layout(6, Some(&head)).unwrap();
+        let mut decoder = OpusInner::new(&layout).unwrap();
+        let mut out = vec![0.0f32; OPUS_MAX_FRAME_SAMPLES * CHANNELS];
+        let decoded = decoder
+            .decode_float_to_slice(&packet[..packet_len], &mut out, false)
+            .unwrap();
+        assert_eq!(
+            decoded, FRAME_SAMPLES,
+            "6-channel packet must decode a full frame per channel"
+        );
     }
 }


### PR DESCRIPTION
Verified decode-correctness fix from the 2026-07-03 deep-audit workflow (adversarially verified + Opus-judged).

**#544 — >2-channel Opus streams were collapsed to stereo.** `opus_channels` was forced to `Mono`/`Stereo` at both decoder construction and post-seek reset, while `total = n_samples × channels` used the source's TRUE (possibly >2) channel count. A >2-channel Opus stream therefore either errored on every packet (libopus configured stereo) or fabricated extra-channel audio from stale `decode_buf` bytes, desyncing every downstream per-channel DSP stage — a silently-wrong-audio bug.

**Fix — decode multichannel correctly (opusic-c exposes a multistream decoder).** Verified against the installed crate source: `opusic_c::multistream::Decoder` (libopus `OpusMSDecoder`) and `multistream::Config<CH>` (RFC-7845 stream/coupled/mapping validation) are available. The fix resolves the real channel layout from the `OpusHead` identification header (which Symphonia forwards via `AudioCodecParameters.extra_data` for OGG/MP4-dOps/Matroska):

- mono/stereo family-0 streams keep the existing `opusic_c::Decoder`;
- mapping-family-1 streams (≤8 channels) decode through `multistream::Decoder` with the correct channel-mapping table;
- genuinely-undecodable layouts — reserved mapping families, family-0 with >2 channels, family-1 >8ch, and >2 channels with **no** `OpusHead` (no mapping table exists) — return `DecodeError::UnsupportedCodec` (the WavPack idiom) instead of collapsing.

The seek path now resets decoder state in place (`OPUS_RESET_STATE`) instead of rebuilding, removing the duplicated collapse logic. `channels` flows from the resolved layout's true count, with an `INVARIANT` tag tying it to the interleaved-sample math.

**Note for reviewers:** adds one `unsafe impl Send for MultiDecoder` — `opusic-c` marks the structurally-identical `Decoder`/`Encoder`/`multistream::Encoder` as `Send` but omits it on `multistream::Decoder`; the decoder is exclusively-owned heap state (`&mut self`-only, no thread affinity), so the transfer is sound. `parse_opus_head` is bounds-checked on all offsets and never panics on malformed `extra_data`.

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings --all-targets`), nextest 1923 passed, deny, lint (0 errors). 13 opus-module tests (7 pre-existing + 6 new), including a real libopus 5.1 encode→decode round-trip proving six channels decode a full frame each. `Gate-Passed` trailer stamped.

Closes #544
