### PR TITLE
fix(ergasia,exousia): ref-count shared torrent_ids and constant-time login miss-path (#536, #540)

### DIFF
--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
 use horismos::ErgasiaConfig;
 use librqbit::api::TorrentIdOrHash;
 use librqbit::{
@@ -47,6 +48,12 @@ pub struct TorrentSession {
     pub policy: SeedingPolicy,
     pub seed_tracker: Arc<DashMap<DownloadId, SeedHandle>>,
     torrent_map: DashMap<DownloadId, usize>,
+    // WHY: librqbit can return AlreadyManaged for a duplicate info-hash, so
+    // two DownloadIds may end up mapped to the same torrent_id. This reverse
+    // ref count is the source of truth for whether delete_torrent may reach
+    // into librqbit, or must only drop its own mapping entry — see
+    // acquire_torrent_ref / release_torrent_ref.
+    torrent_refcounts: DashMap<usize, usize>,
     map_path: PathBuf,
     persist_lock: tokio::sync::Mutex<()>,
 }
@@ -104,6 +111,7 @@ impl TorrentSession {
             policy,
             seed_tracker: Arc::new(DashMap::new()),
             torrent_map: DashMap::new(),
+            torrent_refcounts: DashMap::new(),
             map_path: PathBuf::from(&config.session_state_path).join(TORRENT_MAP_FILE),
             persist_lock: tokio::sync::Mutex::new(()),
         };
@@ -158,6 +166,7 @@ impl TorrentSession {
             AddTorrentResponse::Added(id, handle)
             | AddTorrentResponse::AlreadyManaged(id, handle) => {
                 self.torrent_map.insert(download_id, id);
+                self.acquire_torrent_ref(id);
                 if let Err(persist_err) = self.persist_torrent_map().await {
                     // WHY: fail loudly but non-destructively — the mapping is
                     // rolled back so the caller sees a consistent failure, while
@@ -165,6 +174,7 @@ impl TorrentSession {
                     // may belong to another download, so deleting it here could
                     // destroy live data).
                     self.torrent_map.remove(&download_id);
+                    self.release_torrent_ref(id);
                     return Err(persist_err);
                 }
                 Ok((id, handle))
@@ -218,14 +228,23 @@ impl TorrentSession {
             .remove(&download_id)
             .ok_or_else(|| TorrentNotFoundSnafu { download_id }.build())?;
 
-        if let Err(e) = self
-            .session
-            .delete(TorrentIdOrHash::Id(torrent_id), false)
-            .await
+        // WHY: librqbit dedups a duplicate info-hash onto one torrent_id shared
+        // by two DownloadIds (AlreadyManaged) — only the last DownloadId still
+        // referencing torrent_id may delete it from librqbit; an earlier
+        // caller just drops its own mapping entry and leaves the torrent live.
+        let last_ref = self.release_torrent_ref(torrent_id);
+
+        if last_ref
+            && let Err(e) = self
+                .session
+                .delete(TorrentIdOrHash::Id(torrent_id), false)
+                .await
         {
-            // WHY: the torrent still exists in librqbit — restore the mapping
-            // so the caller can retry instead of orphaning it.
+            // WHY: the torrent still exists in librqbit — restore the
+            // mapping and its ref so the caller can retry instead of
+            // orphaning it.
             self.torrent_map.insert(download_id, torrent_id);
+            self.acquire_torrent_ref(torrent_id);
             return Err(DeleteActionSnafu {
                 download_id,
                 error: e.to_string(),
@@ -235,6 +254,35 @@ impl TorrentSession {
 
         self.persist_torrent_map().await?;
         Ok(())
+    }
+
+    fn acquire_torrent_ref(&self, torrent_id: usize) {
+        *self.torrent_refcounts.entry(torrent_id).or_insert(0) += 1;
+    }
+
+    // Decrements the ref count for `torrent_id` and reports whether this was
+    // the last reference — i.e. whether the caller may now delete it from
+    // librqbit.
+    // INVARIANT: entry() holds the shard lock for `torrent_id` across the
+    // whole read-modify-write, so two concurrent releases for the same
+    // torrent_id can never both observe "last reference".
+    fn release_torrent_ref(&self, torrent_id: usize) -> bool {
+        match self.torrent_refcounts.entry(torrent_id) {
+            Entry::Occupied(mut e) => {
+                *e.get_mut() -= 1;
+                if *e.get() == 0 {
+                    e.remove();
+                    true
+                } else {
+                    false
+                }
+            }
+            // WHY: an untracked torrent_id has no evidence of another owner
+            // (e.g. a mapping inserted directly without acquire_torrent_ref)
+            // — fail toward attempting the real delete rather than silently
+            // orphaning it.
+            Entry::Vacant(_) => true,
+        }
     }
 
     async fn reconcile_persisted_torrents(&self) -> Result<(), ErgasiaError> {
@@ -249,6 +297,7 @@ impl TorrentSession {
                 .is_some()
             {
                 self.torrent_map.insert(entry.download_id, entry.torrent_id);
+                self.acquire_torrent_ref(entry.torrent_id);
                 restored += 1;
             } else {
                 tracing::warn!(
@@ -518,6 +567,58 @@ mod tests {
             matches!(loser, Err(ErgasiaError::TorrentNotFound { .. })),
             "loser must see TorrentNotFound, got {loser:?}"
         );
+        session.session.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn shared_torrent_id_survives_first_owners_delete() {
+        let _guard = SESSION_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path(), 24551);
+        let download_a = DownloadId::new();
+        let download_b = DownloadId::new();
+        let torrent_bytes = minimal_torrent_bytes("shared.bin");
+
+        let session = TorrentSession::new(&config).await.unwrap();
+        let (id_a, _) = session
+            .add_torrent_from_bytes(download_a, torrent_bytes.clone())
+            .await
+            .unwrap();
+        let (id_b, _) = session
+            .add_torrent_from_bytes(download_b, torrent_bytes)
+            .await
+            .unwrap();
+        assert_eq!(
+            id_a, id_b,
+            "duplicate info-hash must dedup onto one torrent_id (AlreadyManaged)"
+        );
+
+        session.delete_torrent(download_a).await.unwrap();
+
+        assert!(
+            session.get_stats(download_b).is_ok(),
+            "download_b must still resolve after download_a's delete"
+        );
+        assert!(
+            session.session.get(TorrentIdOrHash::Id(id_b)).is_some(),
+            "the shared torrent must not be deleted from librqbit while \
+             download_b still references it"
+        );
+
+        session.delete_torrent(download_b).await.unwrap();
+
+        assert!(
+            matches!(
+                session.get_stats(download_b),
+                Err(ErgasiaError::TorrentNotFound { .. })
+            ),
+            "download_b must be gone after its own delete"
+        );
+        assert!(
+            session.session.get(TorrentIdOrHash::Id(id_b)).is_none(),
+            "the shared torrent must be deleted once the last owner deletes it"
+        );
+
         session.session.stop().await;
     }
 

--- a/crates/exousia/src/password.rs
+++ b/crates/exousia/src/password.rs
@@ -15,7 +15,20 @@ pub fn hash_password(password: &str) -> Result<String, ExousiaError> {
         })
 }
 
+// WHY: test-only call spy so login()'s constant-time miss-paths can prove
+// they actually exercised an Argon2id verify, without any counting overhead
+// in the production binary. Thread-local: each #[tokio::test] runs its async
+// body on its own dedicated OS thread under the default current-thread
+// runtime, so counts never leak across concurrently running tests.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static VERIFY_CALL_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 pub fn verify_password(password: &str, hash: &str) -> Result<bool, ExousiaError> {
+    #[cfg(test)]
+    VERIFY_CALL_COUNT.with(|count| count.set(count.get() + 1));
+
     let parsed = PasswordHash::new(hash).map_err(|e| ExousiaError::PasswordHash {
         error: e.to_string(),
         location: snafu::location!(),

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -228,6 +228,14 @@ fn db_user_to_domain(u: db::User) -> Option<User> {
     })
 }
 
+// WHY: a fixed, precomputed Argon2id PHC hash with no corresponding real
+// account. login()'s username-miss path verifies the caller's password
+// against this sentinel instead of skipping straight to an error, so a
+// non-existent username costs the same Argon2id work (and wall-clock time)
+// as a real wrong-password verify — otherwise response latency alone
+// distinguishes existing from non-existing usernames (CWE-203 enumeration).
+const SENTINEL_PASSWORD_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$rCzKZ0rnCdm3pdE/YBMRJQ$3ddRg+rFxifluJSSSHl4wlaCVLzmVbRe1uZmGtKrQEI";
+
 impl AuthService for ExousiaServiceImpl {
     async fn login(&self, username: &str, password: &str) -> Result<TokenPair, ExousiaError> {
         // WHY: cap argon2 input before any hashing work — an oversized password
@@ -238,18 +246,21 @@ impl AuthService for ExousiaServiceImpl {
         let row = db::get_user_by_username(&self.pools.read, username)
             .await
             .context(DatabaseSnafu)?;
-        let row = row.ok_or_else(|| ExousiaError::InvalidCredentials {
-            location: snafu::location!(),
-        })?;
-        let user = db_user_to_domain(row).ok_or_else(|| ExousiaError::InvalidCredentials {
-            location: snafu::location!(),
-        })?;
-        // WHY: verify the password BEFORE the is_active check and return the same
-        // InvalidCredentials for inactive accounts — a distinct error (or skipped
-        // hash-verify cost) would leak which usernames exist but are deactivated.
-        if !password::verify_password(password, &user.password_hash)? {
-            return Err(InvalidCredentialsSnafu.build());
-        }
+        let candidate = row.and_then(db_user_to_domain);
+        // WHY: verify against the real hash when the user exists, otherwise
+        // against the fixed sentinel hash — both branches run exactly one
+        // Argon2id verify, so a non-existent (or too-corrupt-to-convert)
+        // username costs the same wall-clock time as a real wrong-password
+        // attempt (CWE-203 username-enumeration guard). Verifying BEFORE the
+        // is_active check keeps inactive accounts indistinguishable too.
+        let stored_hash = candidate
+            .as_ref()
+            .map_or(SENTINEL_PASSWORD_HASH, |user| user.password_hash.as_str());
+        let password_ok = password::verify_password(password, stored_hash)?;
+        let user = match candidate {
+            Some(user) if password_ok => user,
+            _ => return Err(InvalidCredentialsSnafu.build()),
+        };
         if !user.is_active {
             tracing::warn!(user_id = %user.id.into_uuid(), "login attempt on inactive account");
             return Err(InvalidCredentialsSnafu.build());
@@ -721,6 +732,64 @@ mod tests {
             unknown,
             Err(ExousiaError::InvalidCredentials { .. })
         ));
+    }
+
+    #[test]
+    fn sentinel_password_hash_constant_is_valid_and_never_matches() {
+        // WHY: guards the constant itself — a malformed PHC string would make
+        // verify_password return Err before doing any Argon2 work, silently
+        // breaking the constant-time guarantee the sentinel verify exists for.
+        let result = password::verify_password("anything", SENTINEL_PASSWORD_HASH);
+        assert!(
+            result.is_ok(),
+            "SENTINEL_PASSWORD_HASH must parse as a valid PHC string"
+        );
+        assert!(
+            !result.unwrap(),
+            "SENTINEL_PASSWORD_HASH must never match a real login attempt"
+        );
+    }
+
+    // WHY: proves the username-enumeration fix — both miss-paths must run an
+    // Argon2id verify (equal work), not just return early on one of them.
+    #[tokio::test]
+    async fn login_unknown_username_still_performs_argon2_verify() {
+        let service = setup().await;
+        create_member(&service, "alice", "password123").await;
+
+        let before = password::VERIFY_CALL_COUNT.with(std::cell::Cell::get);
+        let result = service.login("no-such-user", "whatever-password").await;
+        let after = password::VERIFY_CALL_COUNT.with(std::cell::Cell::get);
+
+        assert!(matches!(
+            result,
+            Err(ExousiaError::InvalidCredentials { .. })
+        ));
+        assert_eq!(
+            after - before,
+            1,
+            "unknown-username login must exercise exactly one sentinel-hash Argon2 verify"
+        );
+    }
+
+    #[tokio::test]
+    async fn login_wrong_password_for_existing_user_performs_argon2_verify() {
+        let service = setup().await;
+        create_member(&service, "alice", "password123").await;
+
+        let before = password::VERIFY_CALL_COUNT.with(std::cell::Cell::get);
+        let result = service.login("alice", "wrong-password").await;
+        let after = password::VERIFY_CALL_COUNT.with(std::cell::Cell::get);
+
+        assert!(matches!(
+            result,
+            Err(ExousiaError::InvalidCredentials { .. })
+        ));
+        assert_eq!(
+            after - before,
+            1,
+            "wrong-password login must exercise exactly one real-hash Argon2 verify"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Two verified fixes from the 2026-07-03 deep-audit workflow (adversarially verified + Opus-judged).

**#536 — deleting one download destroyed a sibling's live torrent (ergasia).** librqbit dedups a duplicate info-hash onto one `torrent_id` (returns `AlreadyManaged`), so two `DownloadId`s could map to the same `torrent_id`; `delete_torrent` then unconditionally called `session.delete()` on that shared id, destroying the other download's still-live torrent until a restart reconcile pruned it. Added a `torrent_refcounts: DashMap<usize, usize>` reverse index: `acquire_torrent_ref` on every mapping insert (add, delete-failure restore, reconcile-from-disk), `release_torrent_ref` on delete. `session.delete()` now runs only when the ref count hits zero; an earlier owner just drops its own mapping entry and leaves the torrent live. The decrement-and-test runs entirely inside DashMap's `Entry` shard lock, so two concurrent releases for one `torrent_id` can never both observe "last reference". Regression test (`multi_thread`) registers two DownloadIds onto one torrent_id, deletes the first, asserts the second's stats still resolve and the librqbit torrent is still present, then deletes the second and asserts it's gone.

**#540 — login timing side-channel enabled username enumeration (exousia, SECURITY / CWE-203).** `login()` returned `InvalidCredentials` immediately on a username miss but ran a full Argon2id verify when the username existed, so response latency alone distinguished existing from non-existing accounts. Fixed by routing both branches through a single `verify_password` call: against the real hash when the row exists, otherwise against a fixed precomputed Argon2id sentinel hash (default `m=19456,t=2,p=1` params matching `hash_password`), so a non-existent (or too-corrupt-to-convert) username costs the same Argon2id work and wall-clock time as a real wrong-password attempt. The verify runs before the `is_active` check, keeping inactive accounts indistinguishable too. A `#[cfg(test)]` thread-local verify-call spy proves both miss-paths exercise exactly one Argon2id verify; a third test guards that the sentinel constant parses as valid PHC and never matches.

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings`), nextest 1919 passed, deny, kanon lint (0/0/0). Two gate iterations fixed a `collapsible_if`, a `deprecated-term` lint, and a `no-silent-result-swallow` at root (not suppressed). `Gate-Passed` trailer stamped.

Closes #536
Closes #540
