### PR TITLE
fix(horismos,apotheke,kritike,kathodos,prostheke): reject 0-limits, wire tuning fields, enforce OpenSubtitles rate limit (#528, #551, #554)

### DIFF
--- a/crates/apotheke/src/pools.rs
+++ b/crates/apotheke/src/pools.rs
@@ -27,15 +27,32 @@ pub async fn commit_tx(tx: Transaction<'static, Sqlite>) -> Result<(), DbError> 
     tx.commit().await.context(TransactionSnafu)
 }
 
-pub async fn init_pools(db_path: &str) -> Result<DbPools, DbError> {
+/// Opens the read/write SQLite pools.
+///
+/// `read_pool_size` sizes the read pool; `0` auto-detects FROM
+/// `available_parallelism` (the documented sentinel on
+/// `horismos::DatabaseConfig::read_pool_size`). `write_pool_max` sizes the
+/// write pool directly — callers are expected to reject `0` upstream (see
+/// `horismos` validation); it is clamped here too as a defense-in-depth floor,
+/// since `max_connections(0)` would leave every write `.acquire()` blocked
+/// forever, the same hang class `taxis.scan_concurrency` had.
+pub async fn init_pools(
+    db_path: &str,
+    read_pool_size: u32,
+    write_pool_max: u32,
+) -> Result<DbPools, DbError> {
     let base_opts = SqliteConnectOptions::new()
         .filename(db_path)
         .journal_mode(SqliteJournalMode::Wal)
         .synchronous(SqliteSynchronous::Normal)
         .foreign_keys(true);
 
+    // WARNING: SQLite WAL allows only one writer to hold the lock at a time;
+    // sqlx's default 5s busy_timeout serializes contenders past a single
+    // connection. `write_pool_max` lets an operator raise the queue depth;
+    // it defaults to 1 (a single physical connection) unless configured.
     let write = SqlitePoolOptions::new()
-        .max_connections(1) // CRITICAL: single writer  -  SQLite WAL constraint
+        .max_connections(write_pool_max.max(1))
         .connect_with(base_opts.clone().create_if_missing(true))
         .await
         .context(PoolInitSnafu)?;
@@ -51,17 +68,59 @@ pub async fn init_pools(db_path: &str) -> Result<DbPools, DbError> {
 
     run_migrations(&write).await?;
 
-    let read_pool_size = std::thread::available_parallelism()
-        .map(|n| n.get() as u32)
-        .unwrap_or(4)
-        .max(2);
+    let read_pool_size = if read_pool_size == 0 {
+        std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(4)
+            .max(2)
+    } else {
+        read_pool_size
+    };
+    let read_min_connections = read_pool_size.min(2);
 
     let read = SqlitePoolOptions::new()
         .max_connections(read_pool_size)
-        .min_connections(2)
+        .min_connections(read_min_connections)
         .connect_with(base_opts.read_only(true))
         .await
         .context(PoolInitSnafu)?;
 
     Ok(DbPools { read, write })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn init_pools_honors_configured_pool_sizes() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let pools = init_pools(db_path.to_str().unwrap(), 3, 2).await.unwrap();
+
+        assert_eq!(pools.read.options().get_max_connections(), 3);
+        assert_eq!(pools.write.options().get_max_connections(), 2);
+    }
+
+    #[tokio::test]
+    async fn init_pools_zero_read_pool_size_auto_detects() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let pools = init_pools(db_path.to_str().unwrap(), 0, 1).await.unwrap();
+
+        let expected = std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(4)
+            .max(2);
+        assert_eq!(pools.read.options().get_max_connections(), expected);
+    }
+
+    #[tokio::test]
+    async fn init_pools_clamps_zero_write_pool_max_to_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let pools = init_pools(db_path.to_str().unwrap(), 0, 0).await.unwrap();
+
+        assert_eq!(pools.write.options().get_max_connections(), 1);
+    }
 }

--- a/crates/archon/src/db.rs
+++ b/crates/archon/src/db.rs
@@ -24,9 +24,13 @@ pub(crate) async fn run_db_migrate(
     }
 
     let db_path = config.database.db_path.to_string_lossy();
-    let pools = apotheke::init_pools(&db_path)
-        .await
-        .context(DatabaseSnafu)?;
+    let pools = apotheke::init_pools(
+        &db_path,
+        config.database.read_pool_size,
+        config.database.write_pool_max,
+    )
+    .await
+    .context(DatabaseSnafu)?;
     pools.read.close().await;
     pools.write.close().await;
 

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -807,7 +807,15 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
 
     // 4. Create database pools
     let db_path = config.database.db_path.to_string_lossy();
-    let db = Arc::new(init_pools(&db_path).await.context(DatabaseSnafu)?);
+    let db = Arc::new(
+        init_pools(
+            &db_path,
+            config.database.read_pool_size,
+            config.database.write_pool_max,
+        )
+        .await
+        .context(DatabaseSnafu)?,
+    );
 
     // 5. Create Aggelia event bus
     let (event_tx, _event_rx) = create_event_bus(config.aggelia.buffer_size);
@@ -828,6 +836,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     let curation_service = Arc::new(DefaultCurationService::new(
         db.read.clone(),
         event_tx.clone(),
+        config.kritike.quality_check_concurrency,
     ));
 
     // 10. Start scanner  -  background task
@@ -1196,7 +1205,7 @@ mod service_adapter_tests {
     async fn curation_adapter_calls_live_kritike_service() {
         let pool = migrated_pool().await;
         let (event_tx, _) = create_event_bus(64);
-        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(pool, event_tx)));
+        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(pool, event_tx, 4)));
 
         let report = adapter
             .health_report()
@@ -1219,7 +1228,7 @@ mod service_adapter_tests {
     async fn curation_adapter_maps_profile_not_found() {
         let pool = migrated_pool().await;
         let (event_tx, _) = create_event_bus(64);
-        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(pool, event_tx)));
+        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(pool, event_tx, 4)));
 
         let error = adapter
             .assess_quality(

--- a/crates/archon/src/startup.rs
+++ b/crates/archon/src/startup.rs
@@ -102,7 +102,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_admin_user_creates_and_writes_password() {
         let db_file = tempfile::NamedTempFile::new().unwrap();
-        let db = apotheke::init_pools(db_file.path().to_str().unwrap())
+        let db = apotheke::init_pools(db_file.path().to_str().unwrap(), 0, 1)
             .await
             .unwrap();
         let db = Arc::new(db);

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -312,6 +312,49 @@ mod tests {
         assert!(err.to_string().contains("max_response_body_bytes"));
     }
 
+    // ── Taxis / database / kritike concurrency validation ─────────────────────
+
+    #[test]
+    fn validation_rejects_zero_scan_concurrency() {
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.taxis.scan_concurrency = 0;
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("scan_concurrency"));
+    }
+
+    #[test]
+    fn validation_accepts_nonzero_scan_concurrency() {
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.taxis.scan_concurrency = 1;
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn validation_rejects_zero_write_pool_max() {
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.database.write_pool_max = 0;
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("write_pool_max"));
+    }
+
+    #[test]
+    fn validation_accepts_zero_read_pool_size_as_auto_detect() {
+        // WHY: read_pool_size = 0 is a documented sentinel (auto-detect FROM
+        // available_parallelism), unlike write_pool_max — it must not be
+        // rejected the way the other concurrency knobs are.
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.database.read_pool_size = 0;
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn validation_rejects_zero_quality_check_concurrency() {
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.kritike.quality_check_concurrency = 0;
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("quality_check_concurrency"));
+    }
+
     #[test]
     fn validation_rejects_cf_bypass_without_proxy_url() {
         let mut config = config_with_jwt(valid_jwt_secret());

--- a/crates/horismos/src/validation.rs
+++ b/crates/horismos/src/validation.rs
@@ -65,6 +65,26 @@ fn validate_limits(config: &Config) -> Result<(), HorismosError> {
         }
         .fail();
     }
+    if config.taxis.scan_concurrency == 0 {
+        return ValidationSnafu {
+            message: "taxis.scan_concurrency must be greater than 0 — it sizes a semaphore \
+                      that library scans acquire from; 0 permits blocks the first scan forever"
+                .to_string(),
+        }
+        .fail();
+    }
+    if config.database.write_pool_max == 0 {
+        return ValidationSnafu {
+            message: "database.write_pool_max must be greater than 0".to_string(),
+        }
+        .fail();
+    }
+    if config.kritike.quality_check_concurrency == 0 {
+        return ValidationSnafu {
+            message: "kritike.quality_check_concurrency must be greater than 0".to_string(),
+        }
+        .fail();
+    }
     if config.zetesis.cloudflare_bypass_enabled
         && config
             .zetesis

--- a/crates/kathodos/src/scanner/mod.rs
+++ b/crates/kathodos/src/scanner/mod.rs
@@ -206,15 +206,58 @@ async fn run_scan_task(
             }
 
             _ = trigger_rx.recv() => {
-                run_full_scan(&cfg.library_name, &cfg.root, cfg.media_type, &event_tx, &semaphore).await;
+                if scan_yielding_to_shutdown(&cfg, &event_tx, &semaphore, &mut shutdown_rx).await.is_shutdown() {
+                    break;
+                }
             }
 
             _ = interval_timer.tick() => {
-                run_full_scan(&cfg.library_name, &cfg.root, cfg.media_type, &event_tx, &semaphore).await;
+                if scan_yielding_to_shutdown(&cfg, &event_tx, &semaphore, &mut shutdown_rx).await.is_shutdown() {
+                    break;
+                }
             }
         }
     }
     tracing::info!(library = %cfg.library_name, "scan task stopped");
+}
+
+/// Outcome of racing a full scan against shutdown.
+enum ScanOutcome {
+    Completed,
+    ShutdownRequested,
+}
+
+impl ScanOutcome {
+    fn is_shutdown(&self) -> bool {
+        matches!(self, ScanOutcome::ShutdownRequested)
+    }
+}
+
+/// Runs a full scan but abandons waiting for it the instant shutdown is
+/// requested.
+///
+/// WHY: `run_full_scan` awaits a semaphore permit then a blocking directory
+/// walk — either can run long. Without this race, awaiting it directly inside
+/// the outer `select!` arm hides the loop FROM the shutdown branch for the
+/// scan's whole duration, so a slow/stuck scan wedges `ScannerManager::shutdown`.
+/// Racing here means shutdown is observed immediately; the abandoned scan
+/// future is dropped at its current await point (the semaphore permit is
+/// released, or the `spawn_blocking` handle is detached to finish on its own).
+async fn scan_yielding_to_shutdown(
+    cfg: &ScanTaskConfig,
+    event_tx: &EventSender,
+    semaphore: &Arc<Semaphore>,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> ScanOutcome {
+    tokio::select! {
+        biased;
+
+        _ = shutdown_rx.changed() => ScanOutcome::ShutdownRequested,
+
+        () = run_full_scan(&cfg.library_name, &cfg.root, cfg.media_type, event_tx, semaphore) => {
+            ScanOutcome::Completed
+        }
+    }
 }
 
 async fn run_full_scan(
@@ -294,5 +337,36 @@ mod tests {
             got_scan_completed,
             "expected LibraryScanCompleted event with items_added >= 1"
         );
+    }
+
+    /// A scan starved of a semaphore permit (simulating one already in
+    /// progress) must not block shutdown FROM being observed.
+    #[tokio::test]
+    async fn scan_yields_to_shutdown_when_stuck_on_a_starved_semaphore() {
+        let dir = TempDir::new().unwrap();
+        let semaphore = Arc::new(Semaphore::new(1));
+        // Hold the only permit for the whole test — the scan below can never
+        // acquire one and would hang FROM `walk_library`'s `.acquire()` alone.
+        let _held = semaphore.clone().try_acquire_owned().unwrap();
+
+        let cfg = ScanTaskConfig {
+            library_name: "test".to_string(),
+            root: dir.path().to_path_buf(),
+            media_type: MediaType::Music,
+            interval: Duration::from_secs(9999),
+        };
+        let (tx, _rx) = create_event_bus(64);
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+        let scan_future = scan_yielding_to_shutdown(&cfg, &tx, &semaphore, &mut shutdown_rx);
+        tokio::pin!(scan_future);
+
+        shutdown_tx.send(true).unwrap();
+
+        let outcome = tokio::time::timeout(Duration::from_secs(1), scan_future)
+            .await
+            .expect("scan_yielding_to_shutdown must return promptly on shutdown, not hang");
+
+        assert!(outcome.is_shutdown());
     }
 }

--- a/crates/kritike/src/error.rs
+++ b/crates/kritike/src/error.rs
@@ -25,4 +25,10 @@ pub enum KritikeError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    #[snafu(display("quality-check concurrency limiter closed"))]
+    ConcurrencyLimiterClosed {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }

--- a/crates/kritike/src/lib.rs
+++ b/crates/kritike/src/lib.rs
@@ -5,14 +5,19 @@ pub mod health;
 pub mod profile;
 pub mod upgrade;
 
+use std::sync::Arc;
+
 pub use assessment::{QualityAssessment, QualityMetadata};
 pub use error::KritikeError;
 pub use format_score::QualityScore;
 pub use health::{HealthReport, TypeHealthReport};
 use sqlx::SqlitePool;
 use themelion::{EventSender, HarmoniaEvent, HaveId, MediaId, MediaType, QualityProfile};
+use tokio::sync::Semaphore;
 use tracing::instrument;
 pub use upgrade::UpgradeDecision;
+
+use crate::error::ConcurrencyLimiterClosedSnafu;
 
 #[expect(
     async_fn_in_trait,
@@ -40,11 +45,23 @@ pub trait CurationService: Send + Sync {
 pub struct DefaultCurationService {
     pool: SqlitePool,
     events: EventSender,
+    /// Bounds concurrent `assess_quality` calls to
+    /// `KritikeConfig::quality_check_concurrency`.
+    quality_check_semaphore: Arc<Semaphore>,
 }
 
 impl DefaultCurationService {
-    pub fn new(pool: SqlitePool, events: EventSender) -> Self {
-        Self { pool, events }
+    /// `quality_check_concurrency` is clamped to at least 1 as
+    /// defense-in-depth — a 0-permit semaphore would block every quality
+    /// check forever, the same hang class `taxis.scan_concurrency` had.
+    /// Callers are expected to reject `0` upstream (see `horismos`
+    /// validation).
+    pub fn new(pool: SqlitePool, events: EventSender, quality_check_concurrency: usize) -> Self {
+        Self {
+            pool,
+            events,
+            quality_check_semaphore: Arc::new(Semaphore::new(quality_check_concurrency.max(1))),
+        }
     }
 }
 
@@ -55,6 +72,11 @@ impl CurationService for DefaultCurationService {
         media_type: MediaType,
         item_metadata: &QualityMetadata,
     ) -> Result<QualityAssessment, KritikeError> {
+        let _permit = self
+            .quality_check_semaphore
+            .acquire()
+            .await
+            .map_err(|_| ConcurrencyLimiterClosedSnafu.build())?;
         assessment::assess(&self.pool, media_type, item_metadata).await
     }
 
@@ -82,5 +104,71 @@ impl CurationService for DefaultCurationService {
     #[instrument(skip(self))]
     async fn health_report(&self) -> Result<HealthReport, KritikeError> {
         health::generate(&self.pool).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use themelion::create_event_bus;
+
+    use super::*;
+
+    // WHY: no schema needed — none of these tests reach a real query
+    // (the concurrency-limit tests inspect the semaphore directly; the
+    // exhausted-permit test times out before `assessment::assess` runs).
+    async fn unmigrated_pool() -> SqlitePool {
+        SqlitePool::connect("sqlite::memory:").await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn quality_check_semaphore_matches_configured_concurrency() {
+        let (events, _rx) = create_event_bus(8);
+        let service = DefaultCurationService::new(unmigrated_pool().await, events, 3);
+        assert_eq!(service.quality_check_semaphore.available_permits(), 3);
+    }
+
+    #[tokio::test]
+    async fn zero_quality_check_concurrency_clamps_to_one() {
+        let (events, _rx) = create_event_bus(8);
+        let service = DefaultCurationService::new(unmigrated_pool().await, events, 0);
+        assert_eq!(service.quality_check_semaphore.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn assess_quality_blocks_when_concurrency_limit_is_exhausted() {
+        let (events, _rx) = create_event_bus(8);
+        let service = DefaultCurationService::new(unmigrated_pool().await, events, 1);
+
+        // Hold the only permit externally — simulates a quality check already
+        // in flight FROM another caller.
+        let _held = service
+            .quality_check_semaphore
+            .clone()
+            .try_acquire_owned()
+            .unwrap();
+
+        let metadata = QualityMetadata {
+            format: "FLAC_24BIT".to_string(),
+            custom_format_score: 0,
+            profile_id: 1,
+            codec: None,
+            bit_depth: None,
+            sample_rate: None,
+            file_size: None,
+            channels: None,
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            service.assess_quality(MediaType::Music, &metadata),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "assess_quality must block on the exhausted concurrency semaphore, not bypass it"
+        );
     }
 }

--- a/crates/prostheke/Cargo.toml
+++ b/crates/prostheke/Cargo.toml
@@ -24,8 +24,11 @@ jiff.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
+
+[dev-dependencies.tokio]
+workspace = true
+features = ["rt-multi-thread", "macros", "test-util"]
 
 [lints]
 workspace = true

--- a/crates/prostheke/src/lib.rs
+++ b/crates/prostheke/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod events;
 pub mod language;
 pub mod providers;
+pub mod rate_limit;
 pub mod repo;
 pub mod search;
 pub mod timing;

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -14,6 +14,7 @@ use crate::error::{
     ProviderDownSnafu,
 };
 use crate::providers::SubtitleProvider;
+use crate::rate_limit::RateLimiter;
 use crate::types::{SubtitleMatch, SubtitleProviderId};
 
 const BASE_URL: &str = "https://api.opensubtitles.com/api/v1";
@@ -79,6 +80,10 @@ pub struct OpenSubtitlesProvider {
     config: Option<OpenSubtitlesConfig>,
     client: reqwest::Client,
     base_url: String,
+    /// Bounds requests to `OpenSubtitlesConfig::rate_limit_per_second`.
+    /// `None` when unconfigured — `search`/`download` return before ever
+    /// reaching a network call in that case, so no limiter is needed.
+    rate_limiter: Option<RateLimiter>,
 }
 
 impl OpenSubtitlesProvider {
@@ -88,10 +93,21 @@ impl OpenSubtitlesProvider {
             .user_agent(USER_AGENT)
             .build()
             .unwrap_or_default(); // WHY: reqwest::Client::default() is a valid fallback; build fails only with invalid TLS config
+        let rate_limiter = config
+            .as_ref()
+            .map(|c| RateLimiter::new(c.rate_limit_per_second));
         Self {
             config,
             client,
             base_url: BASE_URL.to_string(),
+            rate_limiter,
+        }
+    }
+
+    /// Waits for the configured request budget before an OpenSubtitles API call.
+    async fn throttle(&self) {
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.acquire().await;
         }
     }
 
@@ -290,6 +306,7 @@ impl SubtitleProvider for OpenSubtitlesProvider {
             params.push(("moviehash", hash.to_string()));
         }
 
+        self.throttle().await;
         let response = self
             .client
             .get(format!("{}/subtitles", self.base_url))
@@ -371,6 +388,7 @@ impl SubtitleProvider for OpenSubtitlesProvider {
             })?;
 
         let download_req = serde_json::json!({ "file_id": file_id });
+        self.throttle().await;
         let dl_resp = self
             .client
             .post(format!("{}/download", self.base_url))
@@ -403,6 +421,7 @@ impl SubtitleProvider for OpenSubtitlesProvider {
             .config
             .as_ref()
             .map_or(DEFAULT_MAX_DOWNLOAD_BYTES, |c| c.max_download_bytes);
+        self.throttle().await;
         let response = self
             .client
             .get(download_url)
@@ -432,6 +451,35 @@ mod tests {
         };
         let provider = OpenSubtitlesProvider::new(Some(config));
         assert_eq!(provider.api_key(), Some(""));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unconfigured_provider_never_throttles() {
+        let provider = OpenSubtitlesProvider::new(None);
+        let start = tokio::time::Instant::now();
+        provider.throttle().await;
+        provider.throttle().await;
+        assert_eq!(start.elapsed(), Duration::ZERO);
+    }
+
+    /// Proves `rate_limit_per_second` is actually wired into the provider's
+    /// request path, not just parsed and ignored — mirrors
+    /// `rate_limit::tests::rapid_calls_are_throttled_to_the_configured_rate`
+    /// but goes through `OpenSubtitlesProvider::new` + `throttle()`.
+    #[tokio::test(start_paused = true)]
+    async fn configured_provider_throttles_to_the_configured_rate() {
+        let provider = OpenSubtitlesProvider::new(Some(OpenSubtitlesConfig {
+            api_key: "key".to_string(),
+            rate_limit_per_second: 5, // 200ms interval
+            ..OpenSubtitlesConfig::default()
+        }));
+        let start = tokio::time::Instant::now();
+
+        for _ in 0..5 {
+            provider.throttle().await;
+        }
+
+        assert_eq!(start.elapsed(), Duration::from_millis(800));
     }
 
     #[test]

--- a/crates/prostheke/src/rate_limit.rs
+++ b/crates/prostheke/src/rate_limit.rs
@@ -1,0 +1,83 @@
+//! Token-bucket rate limiter bounding request throughput to a subtitle provider.
+
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+
+/// Spaces calls to at most `requests_per_second`, allowing a burst of one
+/// immediately after construction (or after an idle gap) before throttling
+/// kicks in.
+///
+/// WHY: mirrors `epignosis::rate_limit::ProviderQueue`'s spacing approach (the
+/// existing per-provider metadata rate limiter in this workspace), but tracks
+/// the next eligible slot directly instead of a background task + channel —
+/// construction must stay runtime-agnostic, since `OpenSubtitlesProvider::new`
+/// is exercised FROM plain (non-`tokio::test`) unit tests.
+pub struct RateLimiter {
+    interval: Duration,
+    next_slot: Mutex<Instant>,
+}
+
+impl RateLimiter {
+    pub fn new(requests_per_second: u32) -> Self {
+        // WHY: 0 has no documented "unlimited" meaning for this field —
+        // clamp rather than let the interval computation divide by zero or
+        // degenerate into a permanently-stuck limiter.
+        let requests_per_second = requests_per_second.max(1);
+        let interval = Duration::from_secs(1) / requests_per_second;
+        Self {
+            interval,
+            next_slot: Mutex::new(Instant::now()),
+        }
+    }
+
+    /// Blocks until the next slot in the configured rate is available.
+    pub async fn acquire(&self) {
+        let wait_until = {
+            let mut next_slot = self.next_slot.lock().await;
+            let now = Instant::now();
+            let slot = if *next_slot > now { *next_slot } else { now };
+            *next_slot = slot + self.interval;
+            slot
+        };
+        tokio::time::sleep_until(wait_until).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn first_call_is_not_throttled() {
+        let limiter = RateLimiter::new(5);
+        let start = Instant::now();
+        limiter.acquire().await;
+        assert_eq!(start.elapsed(), Duration::ZERO);
+    }
+
+    /// 5 req/s → 200ms interval. The first call is free (burst of one); each
+    /// of the next 4 is spaced by one interval.
+    ///
+    /// WHY `start_paused`: runs the limiter's `tokio::time::sleep_until` on
+    /// the mock clock, so the schedule is exact logical time — no wall-clock
+    /// slack, no flake under load.
+    #[tokio::test(start_paused = true)]
+    async fn rapid_calls_are_throttled_to_the_configured_rate() {
+        let limiter = RateLimiter::new(5);
+        let start = Instant::now();
+
+        for _ in 0..5 {
+            limiter.acquire().await;
+        }
+
+        assert_eq!(start.elapsed(), Duration::from_millis(800));
+    }
+
+    #[tokio::test]
+    async fn zero_rate_clamps_to_one_request_per_second() {
+        let limiter = RateLimiter::new(0);
+        assert_eq!(limiter.interval, Duration::from_secs(1));
+    }
+}


### PR DESCRIPTION
Three verified config-safety defects from the 2026-07-03 deep-audit workflow (adversarially verified + Opus-judged).

**#528 — `scan_concurrency=0` hung the scanner and could wedge shutdown (kathodos/horismos).** A 0 permitted a semaphore that library scans acquire from, blocking the first scan forever; and a stuck scan (starved on a permit or the blocking walk) blocked `run_scan_task` from ever observing shutdown, wedging `ScannerManager::shutdown`. Fixed on both axes: `horismos` validation now rejects `taxis.scan_concurrency == 0` (consistent with every other non-auto limit knob — only `read_pool_size` carries a documented `0=auto` sentinel), and the trigger/interval scan arms now run through `scan_yielding_to_shutdown`, a `biased` `select!` of `run_full_scan` against `shutdown_rx.changed()`, so shutdown is observed mid-scan and the task exits promptly. Regression test starves the semaphore and asserts the scan yields to shutdown within 1s.

**#551 — DatabaseConfig/KritikeConfig tuning fields were silently ignored.** `read_pool_size`, `write_pool_max`, and `quality_check_concurrency` were config knobs that reached no consumer. `apotheke::init_pools` now takes `read_pool_size` (0 = auto-detect from `available_parallelism`, its documented sentinel; floor 2) and `write_pool_max` (sizes the write pool; `.max(1)` defense-in-depth); `horismos` rejects `write_pool_max == 0`. `kritike::DefaultCurationService::new` takes `quality_check_concurrency` and bounds `assess_quality` behind a `Semaphore` (clamped ≥1), with a new `KritikeError::ConcurrencyLimiterClosed`; `horismos` rejects `quality_check_concurrency == 0`. All call sites (`serve.rs`, `db.rs`, `startup.rs`) updated.

**#554 — OpenSubtitles `rate_limit_per_second` was never enforced (prostheke).** Added a runtime-agnostic token-bucket `RateLimiter` (next-slot tracking; mirrors epignosis's `ProviderQueue` spacing without a background task/channel so `OpenSubtitlesProvider::new` stays constructible from plain non-tokio tests), throttling before every network request in `search`/`download`; the limiter is `None` when unconfigured and those paths short-circuit before any network call. Test asserts 5 rapid calls throttle to exactly 800ms on the mock clock.

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings`), nextest 1932 passed, deny, kanon lint (0/0). Three first-pass lint findings fixed at root (not suppressed): a false-positive migration-checksum (reworked a kritike test to an unmigrated in-memory pool), a TOML inline-table-too-long (expanded to a `[dev-dependencies.tokio]` block), and a `std-mutex-in-async` (RateLimiter now uses `tokio::sync::Mutex`). `Gate-Passed` trailer stamped.

Closes #528
Closes #551
Closes #554
