### PR TITLE
feat(horismos,archon,paroche): reactive config foundation — SectionWatcher, live paroche reads, honest SIGHUP logging (#529 step 2)

### DIFF
--- a/crates/archon/src/error.rs
+++ b/crates/archon/src/error.rs
@@ -10,6 +10,13 @@ pub enum HostError {
         location: snafu::Location,
     },
 
+    #[snafu(display("config reload task panicked: {source}"))]
+    ReloadTaskPanicked {
+        source: tokio::task::JoinError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("database error: {source}"))]
     Database {
         source: apotheke::DbError,

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -10,7 +10,7 @@ use epignosis::ProviderBackedResolver;
 use epignosis::resolver::ProviderCredentials;
 use ergasia::TorrentSession;
 use exousia::ExousiaServiceImpl;
-use horismos::{ConfigManager, ConfigOverrides};
+use horismos::{ConfigManager, ConfigOverrides, ReloadOutcome};
 use kathodos::ScannerManager;
 use komide::FeedSchedulerService;
 use komide::scheduler::FeedScheduler;
@@ -38,7 +38,7 @@ use zetesis::cf_bypass::noop::NoProxy;
 use crate::cli::ServeArgs;
 use crate::error::{
     ConfigSnafu, DatabaseSnafu, DownloadEngineSnafu, DownloadQueueSnafu, FeedSchedulerSnafu,
-    HostError, ListenAddrSnafu, ScannerSnafu, ServerSnafu,
+    HostError, ListenAddrSnafu, ReloadTaskPanickedSnafu, ScannerSnafu, ServerSnafu,
 };
 use crate::shutdown::shutdown_signal;
 use crate::startup::{ensure_admin_user, init_tracing};
@@ -760,7 +760,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         listen_addr: args.listen.clone(),
         port: args.port,
     };
-    let (config_manager, _config_handle) =
+    let (config_manager, config_handle) =
         ConfigManager::new(config.clone(), config_path, overrides);
 
     // SIGHUP handler for config reload
@@ -779,23 +779,10 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
             loop {
                 sighup.recv().await;
                 tracing::info!("SIGHUP received  -  reloading configuration");
-                // WHY: reload() does blocking file I/O (figment TOML read);
-                // spawn_blocking keeps it off the async worker thread.
-                let manager = manager_for_reload.clone();
-                match tokio::task::spawn_blocking(move || manager.reload()).await {
-                    Ok(Ok(outcome)) => {
-                        for w in outcome.warnings {
-                            tracing::warn!(field = %w.field, "config reload: {}", w.message);
-                        }
-                        tracing::info!("configuration reloaded");
-                    }
-                    Ok(Err(e)) => {
-                        tracing::error!("config reload failed: {e}  -  keeping current config");
-                    }
+                match reload_config(manager_for_reload.clone()).await {
+                    Ok(outcome) => log_reload_outcome(&outcome),
                     Err(e) => {
-                        tracing::error!(
-                            "config reload task panicked: {e}  -  keeping current config"
-                        );
+                        tracing::error!("config reload failed: {e}  -  keeping current config");
                     }
                 }
             }
@@ -803,32 +790,35 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         .instrument(tracing::info_span!("sighup_handler")),
     );
 
-    let config = Arc::new(config);
+    let boot_config = Arc::new(config);
 
     // 4. Create database pools
-    let db_path = config.database.db_path.to_string_lossy();
+    let db_path = boot_config.database.db_path.to_string_lossy();
     let db = Arc::new(
         init_pools(
             &db_path,
-            config.database.read_pool_size,
-            config.database.write_pool_max,
+            boot_config.database.read_pool_size,
+            boot_config.database.write_pool_max,
         )
         .await
         .context(DatabaseSnafu)?,
     );
 
     // 5. Create Aggelia event bus
-    let (event_tx, _event_rx) = create_event_bus(config.aggelia.buffer_size);
+    let (event_tx, _event_rx) = create_event_bus(boot_config.aggelia.buffer_size);
 
     // 6. Create auth service
-    let auth = Arc::new(ExousiaServiceImpl::new(db.clone(), config.exousia.clone()));
+    let auth = Arc::new(ExousiaServiceImpl::new(
+        db.clone(),
+        boot_config.exousia.clone(),
+    ));
 
     // 7. First-run admin setup
     ensure_admin_user(&auth, &db, out).await?;
 
     // 8. Create metadata resolver
     let metadata_service = Arc::new(ProviderBackedResolver::new(
-        config.epignosis.clone(),
+        boot_config.epignosis.clone(),
         ProviderCredentials::default(),
     ));
 
@@ -836,11 +826,11 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     let curation_service = Arc::new(DefaultCurationService::new(
         db.read.clone(),
         event_tx.clone(),
-        config.kritike.quality_check_concurrency,
+        boot_config.kritike.quality_check_concurrency,
     ));
 
     // 10. Start scanner  -  background task
-    let scanner = ScannerManager::start(&config.taxis, event_tx.clone())
+    let scanner = ScannerManager::start(&boot_config.taxis, event_tx.clone())
         .await
         .context(ScannerSnafu)?;
 
@@ -852,7 +842,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // wedging that feed's poll task.
     let komide_client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(
-            config.komide.fetch_timeout_secs,
+            boot_config.komide.fetch_timeout_secs,
         ))
         .build()
         .unwrap_or_default(); // WHY: reqwest::Client::default() is a valid fallback; build fails only with invalid TLS config
@@ -863,11 +853,11 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         },
         event_tx.clone(),
         komide_client,
-        config.komide.clone(),
+        boot_config.komide.clone(),
     ));
     let feed_scheduler = FeedScheduler::start(
         komide_service,
-        config.komide.clone(),
+        boot_config.komide.clone(),
         apotheke::DbPools {
             read: db.read.clone(),
             write: db.write.clone(),
@@ -877,29 +867,29 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     .context(FeedSchedulerSnafu)?;
 
     // ── Pre-flight: acquisition config validation ─────────────────────────
-    validate_download_dir(&config)?;
+    validate_download_dir(&boot_config)?;
 
     // ── Acquisition subsystem startup ───────────────────────────────────────
 
     let shutdown_token = CancellationToken::new();
 
     // Layer 0: Zetesis (indexer protocol)
-    let cf_proxy = build_cf_proxy(&config.zetesis)?;
+    let cf_proxy = build_cf_proxy(&boot_config.zetesis)?;
     let zetesis = Arc::new(SearchIndexerService::new(
         db.read.clone(),
         db.write.clone(),
         cf_proxy,
-        config.zetesis.clone(),
+        boot_config.zetesis.clone(),
         event_tx.clone(),
     ));
     info!(
-        cloudflare_bypass = config.zetesis.cloudflare_bypass_enabled,
+        cloudflare_bypass = boot_config.zetesis.cloudflare_bypass_enabled,
         "zetesis (indexer search) initialized"
     );
 
     // Layer 1: Ergasia (download execution)
     let ergasia_session = Arc::new(
-        TorrentSession::new(&config.ergasia)
+        TorrentSession::new(&boot_config.ergasia)
             .await
             .context(DownloadEngineSnafu)?,
     );
@@ -908,14 +898,14 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // Layer 2: Syntaxis (queue orchestration, depends on ergasia)
     let engine_adapter = Arc::new(SessionEngine {
         session: Arc::clone(&ergasia_session),
-        extraction_limits: ergasia::ExtractionLimits::from(&config.ergasia),
+        extraction_limits: ergasia::ExtractionLimits::from(&boot_config.ergasia),
     });
     let syntaxis_svc = Arc::new(
         DownloadQueue::new(
             db.write.clone(),
             engine_adapter,
             Arc::new(StubImportService),
-            config.syntaxis.clone(),
+            boot_config.syntaxis.clone(),
         )
         .await
         .context(DownloadQueueSnafu)?,
@@ -924,7 +914,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     info!("syntaxis (download queue) initialized  -  event listener started");
 
     // Layer 4: Syndesmos (external integrations  -  Plex, Last.fm, Tidal)
-    let syndesmos_svc = Arc::new(build_syndesmos(&config, &event_tx, db.read.clone()));
+    let syndesmos_svc = Arc::new(build_syndesmos(&boot_config, &event_tx, db.read.clone()));
     let syndesmos_handle = spawn_syndesmos_handler(
         Arc::clone(&syndesmos_svc),
         event_tx.subscribe(),
@@ -933,11 +923,11 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     info!("syndesmos (external integrations) initialized  -  event listener started");
 
     // Layer 4: Prostheke (subtitle management)
-    let providers = Provider::default_providers(config.prostheke.opensubtitles.clone());
+    let providers = Provider::default_providers(boot_config.prostheke.opensubtitles.clone());
     let prostheke_svc = Arc::new(SubtitleManager::new(
         db.read.clone(),
         db.write.clone(),
-        config.prostheke.clone(),
+        boot_config.prostheke.clone(),
         providers,
         event_tx.clone(),
     ));
@@ -947,7 +937,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     let request_service = Arc::new(aitesis::AitesisServiceImpl::new(
         db.read.clone(),
         db.write.clone(),
-        config.aitesis.clone(),
+        boot_config.aitesis.clone(),
         RequestRoleProvider { db: db.clone() },
         RequestIdentityValidator,
         RequestMonitor { db: db.clone() },
@@ -960,14 +950,14 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     let renderer_registry = Arc::new(crate::render::RendererRegistry::new());
     let renderer_cert_dir = crate::paths::dirs_config_path().join("certs");
     let renderer_addr = resolve_listen_addr(
-        &config.paroche.listen_addr,
+        &boot_config.paroche.listen_addr,
         crate::render::server::DEFAULT_QUIC_PORT,
     )?;
     let renderer_limits = crate::render::server::RendererServerLimits {
-        renderer_api_key: config.paroche.renderer_api_key.clone(),
-        max_connections: config.paroche.renderer_max_connections,
+        renderer_api_key: boot_config.paroche.renderer_api_key.clone(),
+        max_connections: boot_config.paroche.renderer_max_connections,
         session_init_timeout: Duration::from_secs(
-            config.paroche.renderer_session_init_timeout_secs,
+            boot_config.paroche.renderer_session_init_timeout_secs,
         ),
     };
     let renderer_registry_for_quic = Arc::clone(&renderer_registry);
@@ -1000,7 +990,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // 13. Build HTTP router
     let state = AppState {
         db,
-        config: config.clone(),
+        config: config_handle,
         event_tx,
         auth,
         import,
@@ -1017,7 +1007,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     let router = paroche::build_router(state);
 
     // 14. Bind + serve
-    let addr = resolve_listen_addr(&config.paroche.listen_addr, config.paroche.port)?;
+    let addr = resolve_listen_addr(&boot_config.paroche.listen_addr, boot_config.paroche.port)?;
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .context(ServerSnafu)?;
@@ -1051,6 +1041,48 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
 
     info!("shutdown complete");
     Ok(())
+}
+
+// ── Config reload (SIGHUP) ───────────────────────────────────────────────────
+
+/// Re-reads and re-publishes configuration through `manager`.
+///
+/// Extracted from the SIGHUP handler so tests can drive a reload without
+/// sending a real signal, asserting on the returned `ReloadOutcome` directly
+/// rather than scraping log output.
+///
+/// WHY: `ConfigManager::reload()` does blocking file I/O (figment TOML
+/// read); `spawn_blocking` keeps it off the async worker thread.
+pub(crate) async fn reload_config(manager: ConfigManager) -> Result<ReloadOutcome, HostError> {
+    tokio::task::spawn_blocking(move || manager.reload())
+        .await
+        .context(ReloadTaskPanickedSnafu)?
+        .context(ConfigSnafu)
+}
+
+/// Logs a `ReloadOutcome` honestly: live changes actually applied, changes
+/// held back pending a restart, or neither.
+fn log_reload_outcome(outcome: &ReloadOutcome) {
+    for w in &outcome.warnings {
+        tracing::warn!(field = %w.field, "config reload: {}", w.message);
+    }
+    if !outcome.applied.is_empty() {
+        let n = outcome.applied.len();
+        tracing::info!(
+            applied = ?outcome.applied,
+            "configuration reloaded — {n} live change(s) applied"
+        );
+    }
+    if !outcome.restart_pending.is_empty() {
+        let n = outcome.restart_pending.len();
+        tracing::warn!(
+            pending = ?outcome.restart_pending,
+            "config reload: {n} change(s) require restart and were held back"
+        );
+    }
+    if outcome.is_unchanged() {
+        tracing::info!("configuration reloaded — no changes");
+    }
 }
 
 // ── Syndesmos construction ──────────────────────────────────────────────────
@@ -2036,5 +2068,70 @@ mod tests {
             .expect_err("missing media cannot be searched for subtitles");
 
         assert!(matches!(error, ServiceError::NotFound));
+    }
+
+    // ── reload_config ────────────────────────────────────────────────────────
+
+    fn reload_test_toml(port: u16, db_path: &std::path::Path) -> String {
+        format!(
+            "[exousia]\njwt_secret = \"test-secret-that-is-long-enough-for-hs256\"\n\n[paroche]\nport = {port}\n\n[database]\ndb_path = \"{}\"\n",
+            db_path.display()
+        )
+    }
+
+    #[tokio::test]
+    async fn reload_config_reports_applied_and_restart_pending() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("harmonia.toml");
+        let db_a = dir.path().join("a.db");
+        let db_b = dir.path().join("b.db");
+
+        std::fs::write(&config_path, reload_test_toml(8096, &db_a)).expect("write initial config");
+        let (initial_config, _warnings) =
+            horismos::load_config(Some(config_path.as_path())).expect("load initial config");
+        let (manager, _handle) = ConfigManager::new(
+            initial_config,
+            config_path.clone(),
+            ConfigOverrides::default(),
+        );
+
+        // A LIVE change (paroche.port) alongside a RESTART-class change
+        // (database.db_path) in the same reload — the outcome must report
+        // both correctly rather than collapsing to one bucket.
+        std::fs::write(&config_path, reload_test_toml(9090, &db_b)).expect("write changed config");
+
+        let outcome = reload_config(manager)
+            .await
+            .expect("reload_config succeeds");
+
+        assert_eq!(outcome.applied, vec!["paroche.port".to_string()]);
+        assert_eq!(
+            outcome.restart_pending,
+            vec!["database.db_path".to_string()]
+        );
+        assert!(outcome.needs_restart());
+        assert!(!outcome.is_unchanged());
+    }
+
+    #[tokio::test]
+    async fn reload_config_reports_unchanged_when_file_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("harmonia.toml");
+        let db_a = dir.path().join("a.db");
+
+        std::fs::write(&config_path, reload_test_toml(8096, &db_a)).expect("write initial config");
+        let (initial_config, _warnings) =
+            horismos::load_config(Some(config_path.as_path())).expect("load initial config");
+        let (manager, _handle) =
+            ConfigManager::new(initial_config, config_path, ConfigOverrides::default());
+
+        let outcome = reload_config(manager)
+            .await
+            .expect("reload_config succeeds");
+
+        assert!(outcome.applied.is_empty());
+        assert!(outcome.restart_pending.is_empty());
+        assert!(outcome.is_unchanged());
+        assert!(!outcome.needs_restart());
     }
 }

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -14,7 +14,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use ergasia::{DownloadProgress, DownloadState, ErgasiaError, ExtractionResult};
 use exousia::{AuthService, CreateUserRequest, ExousiaServiceImpl, UserRole};
-use horismos::{AitesisConfig, Config, ExousiaConfig};
+use horismos::{AitesisConfig, Config, ConfigHandle, ExousiaConfig};
 use paroche::state::{
     AppState, DynQueueManager, DynRequestService, DynSearchService, RequestServiceFut, ServiceFut,
 };
@@ -370,7 +370,7 @@ async fn test_state_with_queue(
         read: pool.clone(),
         write: pool.clone(),
     });
-    let config = Arc::new(Config {
+    let config = ConfigHandle::fixed(Config {
         aitesis: AitesisConfig {
             auto_approve_admins: false,
             ..AitesisConfig::default()
@@ -411,7 +411,7 @@ async fn test_state_with_queue(
         aitesis::AitesisServiceImpl::new(
             pool.clone(),
             pool.clone(),
-            state.config.aitesis.clone(),
+            state.config.current().aitesis.clone(),
             MockRequestRoles { pool: pool.clone() },
             MockRequestIdentity,
             MockRequestMonitor,

--- a/crates/horismos/Cargo.toml
+++ b/crates/horismos/Cargo.toml
@@ -19,7 +19,7 @@ tracing.workspace = true
 rstest.workspace = true
 tempfile = "3"
 figment = { workspace = true, features = ["toml", "env", "test"] }
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [lints]
 workspace = true

--- a/crates/horismos/src/config.rs
+++ b/crates/horismos/src/config.rs
@@ -6,7 +6,7 @@ use crate::subsystems::{
     SyndesisConfig, SyndesmosConfig, SyntaxisConfig, TaxisConfig,
 };
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]

--- a/crates/horismos/src/handle.rs
+++ b/crates/horismos/src/handle.rs
@@ -194,6 +194,23 @@ impl ConfigHandle {
         }
     }
 
+    /// Change-detection watcher over one config section.
+    ///
+    /// Unlike `section()`, this is consumed by a long-lived supervisor task
+    /// (`.changed().await` in a loop) rather than read per-operation — the
+    /// primitive every REBUILD/LIVE-B consumer builds on.
+    pub fn watch_section<T: Clone + PartialEq>(
+        &self,
+        project: fn(&Config) -> &T,
+    ) -> SectionWatcher<T> {
+        let last = project(&self.rx.borrow()).clone();
+        SectionWatcher {
+            rx: self.rx.clone(),
+            project,
+            last,
+        }
+    }
+
     /// Dotted leaf paths changed on disk but held back pending a restart.
     pub fn restart_pending(&self) -> Vec<String> {
         self.pending_rx.borrow().clone()
@@ -240,6 +257,38 @@ impl<T: Clone> Section<T> {
     pub fn fixed(value: T) -> Self {
         Self {
             inner: SectionInner::Fixed(Arc::new(value)),
+        }
+    }
+}
+
+/// Change-detection watcher over one config section, built by
+/// `ConfigHandle::watch_section`.
+///
+/// Consumption idiom: `.changed().await` in a supervisor loop — it yields
+/// only when the projected section actually differs from the last-seen
+/// value (a publish that touches a different section is not a wakeup), and
+/// returns `None` once the `ConfigManager` (and every clone) is dropped —
+/// the supervisor's exit signal.
+pub struct SectionWatcher<T> {
+    rx: watch::Receiver<Arc<Config>>,
+    project: fn(&Config) -> &T,
+    last: T,
+}
+
+impl<T: Clone + PartialEq> SectionWatcher<T> {
+    /// Waits for the next publish that changes this section's projected
+    /// value, returning the new value. Returns `None` when the sender side
+    /// is dropped and no further changes can ever arrive.
+    pub async fn changed(&mut self) -> Option<T> {
+        loop {
+            if self.rx.changed().await.is_err() {
+                return None;
+            }
+            let next = (self.project)(&self.rx.borrow_and_update()).clone();
+            if next != self.last {
+                self.last = next.clone();
+                return Some(next);
+            }
         }
     }
 }
@@ -688,5 +737,52 @@ mod tests {
 
             assert!(!rx.has_changed().unwrap());
         });
+    }
+
+    // ── ConfigHandle::watch_section ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn watch_section_yields_only_on_its_section_change() {
+        let config = valid_config();
+        let (manager, handle) = ConfigManager::new(
+            config,
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+        let mut watcher = handle.watch_section(|c| &c.paroche);
+
+        // A publish that changes a DIFFERENT section must not surface as a
+        // distinct wakeup with a stale/unrelated value.
+        let mut changed = valid_config();
+        changed.exousia.access_token_ttl_secs = 1234;
+        manager.replace(changed.clone()).unwrap();
+
+        // A publish that changes the watched section wakes it with the new
+        // projected value.
+        changed.paroche.port = 9191;
+        manager.replace(changed).unwrap();
+
+        let seen = tokio::time::timeout(std::time::Duration::from_secs(1), watcher.changed())
+            .await
+            .expect("watcher did not wake for a section change")
+            .expect("watcher returned None while the manager is alive");
+        assert_eq!(seen.port, 9191);
+    }
+
+    #[tokio::test]
+    async fn watch_section_returns_none_when_manager_dropped() {
+        let config = valid_config();
+        let (manager, handle) = ConfigManager::new(
+            config,
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+        let mut watcher = handle.watch_section(|c| &c.paroche);
+        drop(manager);
+
+        let seen = tokio::time::timeout(std::time::Duration::from_secs(1), watcher.changed())
+            .await
+            .expect("watcher did not resolve after the manager was dropped");
+        assert!(seen.is_none());
     }
 }

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct DatabaseConfig {
     pub db_path: PathBuf,
@@ -21,7 +21,7 @@ impl Default for DatabaseConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ExousiaConfig {
     pub access_token_ttl_secs: u64,
@@ -48,7 +48,7 @@ impl Default for ExousiaConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ParocheConfig {
     pub listen_addr: String,
@@ -142,7 +142,7 @@ pub enum MediaType {
     Book,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct LibraryConfig {
     pub path: PathBuf,
@@ -166,7 +166,7 @@ impl Default for LibraryConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default, deny_unknown_fields)]
 pub struct TaxisConfig {
     pub libraries: HashMap<String, LibraryConfig>,
@@ -189,7 +189,7 @@ impl Default for TaxisConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct EpignosisConfig {
     pub cache_ttl_secs: u64,
@@ -223,7 +223,7 @@ impl Default for EpignosisConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct KritikeConfig {
     pub scan_interval_hours: u64,
@@ -239,7 +239,7 @@ impl Default for KritikeConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct AggeliaConfig {
     pub buffer_size: usize,
@@ -255,7 +255,7 @@ impl Default for AggeliaConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct SearchSubsystemConfig {
     pub request_timeout_secs: u64,
@@ -299,14 +299,14 @@ impl Default for SearchSubsystemConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TrackerSeedPolicy {
     pub ratio_threshold: f64,
     pub time_threshold_hours: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ErgasiaConfig {
     pub download_dir: PathBuf,
@@ -348,7 +348,7 @@ impl Default for ErgasiaConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct SyntaxisConfig {
     pub max_concurrent_downloads: usize,
@@ -370,7 +370,7 @@ impl Default for SyntaxisConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct OpenSubtitlesConfig {
     pub api_key: String,
@@ -411,7 +411,7 @@ impl Default for OpenSubtitlesConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ProsthekeConfig {
     /// BCP 47 language tags in preference ORDER, e.g. `["en", "fr"]`.
@@ -435,7 +435,7 @@ impl Default for ProsthekeConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct KomideConfig {
     /// Poll interval for podcast feeds in minutes.
@@ -484,7 +484,7 @@ impl Default for KomideConfig {
 
 // ── External API integration (Syndesmos) ──────────────────────────────────────
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct PlexConfig {
     /// Base URL of the Plex Media Server, e.g. `http://localhost:32400`.
@@ -504,7 +504,7 @@ impl std::fmt::Debug for PlexConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct LastfmConfig {
     pub api_key: String,
@@ -522,7 +522,7 @@ impl std::fmt::Debug for LastfmConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TidalConfig {
     pub client_id: String,
@@ -557,7 +557,7 @@ impl Default for TidalConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct SyndesmosConfig {
     /// Plex integration  -  `None` disables Plex notify and collection management.
@@ -584,7 +584,7 @@ impl Default for SyndesmosConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct SyndesisConfig {
     /// Maximum frames a renderer's jitter buffer holds before evicting the
@@ -604,7 +604,7 @@ impl Default for SyndesisConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct AitesisConfig {
     /// Maximum number of Submitted + Approved + Monitoring requests per user.

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -77,7 +77,7 @@ pub mod test_helpers {
     use apotheke::migrate::MIGRATOR;
     use exousia::user::{CreateUserRequest, UserRole};
     use exousia::{AuthService, ExousiaServiceImpl};
-    use horismos::{Config, ExousiaConfig};
+    use horismos::{Config, ConfigHandle, ExousiaConfig};
     use sqlx::SqlitePool;
     use themelion::create_event_bus;
 
@@ -95,7 +95,7 @@ pub mod test_helpers {
             read: pool.clone(),
             write: pool,
         });
-        let config = Arc::new(Config::default());
+        let config = ConfigHandle::fixed(Config::default());
         let (event_tx, _) = create_event_bus(64);
 
         let exousia_config = ExousiaConfig {

--- a/crates/paroche/src/opds/catalog/mod.rs
+++ b/crates/paroche/src/opds/catalog/mod.rs
@@ -273,7 +273,7 @@ pub async fn books_v2(
 ) -> Result<OpdsV2Response, ParocheError> {
     let page = pq.page.max(1);
     // INVARIANT: opds_page_size is a config usize (default 50); all as-casts here are safe
-    let page_size_usize = state.config.paroche.opds_page_size;
+    let page_size_usize = state.config.current().paroche.opds_page_size;
     let page_size = page_size_usize as i64;
     let offset = ((page - 1) * page_size_usize as u64) as i64;
 
@@ -317,7 +317,7 @@ pub async fn comics_v2(
 ) -> Result<OpdsV2Response, ParocheError> {
     let page = pq.page.max(1);
     // INVARIANT: opds_page_size is a config usize (default 50); all as-casts here are safe
-    let page_size_usize = state.config.paroche.opds_page_size;
+    let page_size_usize = state.config.current().paroche.opds_page_size;
     let page_size = page_size_usize as i64;
     let offset = ((page - 1) * page_size_usize as u64) as i64;
 
@@ -427,7 +427,7 @@ pub async fn shelf_v2(
         "new-arrivals" => {
             let page = pq.page.max(1);
             // INVARIANT: opds_page_size is a config usize (default 50); all as-casts here are safe
-            let page_size_usize = state.config.paroche.opds_page_size;
+            let page_size_usize = state.config.current().paroche.opds_page_size;
             let page_size = page_size_usize as i64;
             let offset = ((page - 1) * page_size_usize as u64) as i64;
 
@@ -470,7 +470,7 @@ pub async fn shelf_v2(
         "series" => {
             let page = pq.page.max(1);
             // INVARIANT: opds_page_size is a config usize (default 50); all as-casts here are safe
-            let page_size_usize = state.config.paroche.opds_page_size;
+            let page_size_usize = state.config.current().paroche.opds_page_size;
             let page_size = page_size_usize as i64;
             let offset = ((page - 1) * page_size_usize as u64) as i64;
 
@@ -513,7 +513,7 @@ pub async fn shelf_v2(
         "authors" => {
             let page = pq.page.max(1);
             // INVARIANT: opds_page_size is a config usize (default 50); all as-casts here are safe
-            let page_size_usize = state.config.paroche.opds_page_size;
+            let page_size_usize = state.config.current().paroche.opds_page_size;
             let page_size = page_size_usize as i64;
             let offset = ((page - 1) * page_size_usize as u64) as i64;
 
@@ -636,7 +636,7 @@ pub async fn books_v1(
 ) -> Result<OpdsV1Response, ParocheError> {
     let page = pq.page.max(1);
     // INVARIANT: opds_page_size is a config usize (default 50); all as-casts here are safe
-    let page_size_usize = state.config.paroche.opds_page_size;
+    let page_size_usize = state.config.current().paroche.opds_page_size;
     let page_size = page_size_usize as i64;
     let offset = ((page - 1) * page_size_usize as u64) as i64;
     let now = chrono_now_pub();
@@ -687,7 +687,7 @@ pub async fn comics_v1(
 ) -> Result<OpdsV1Response, ParocheError> {
     let page = pq.page.max(1);
     // INVARIANT: opds_page_size is a config usize (default 50); all as-casts here are safe
-    let page_size_usize = state.config.paroche.opds_page_size;
+    let page_size_usize = state.config.current().paroche.opds_page_size;
     let page_size = page_size_usize as i64;
     let offset = ((page - 1) * page_size_usize as u64) as i64;
     let now = chrono_now_pub();

--- a/crates/paroche/src/opds/search.rs
+++ b/crates/paroche/src/opds/search.rs
@@ -21,7 +21,8 @@ pub async fn search_v2(
     Query(sq): Query<SearchQuery>,
 ) -> Result<OpdsV2Response, ParocheError> {
     let query = sq.q.as_deref().unwrap_or("").trim().to_string();
-    let page_size = state.config.paroche.opds_page_size as i64; // INVARIANT: opds_page_size is a config usize (default 50); i64 overflow impossible
+    let cfg = state.config.current();
+    let page_size = cfg.paroche.opds_page_size as i64; // INVARIANT: opds_page_size is a config usize (default 50); i64 overflow impossible
 
     let books = apotheke::repo::book::search_books(&state.db.read, &query, page_size, 0).await?;
     let comics = apotheke::repo::comic::search_comics(&state.db.read, &query, page_size, 0).await?;
@@ -57,7 +58,8 @@ pub async fn search_v1(
     Query(sq): Query<SearchQuery>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     if let Some(query) = sq.q.as_deref().map(str::trim).filter(|q| !q.is_empty()) {
-        let page_size = state.config.paroche.opds_page_size as i64; // INVARIANT: opds_page_size is a config usize (default 50); i64 overflow impossible
+        let cfg = state.config.current();
+        let page_size = cfg.paroche.opds_page_size as i64; // INVARIANT: opds_page_size is a config usize (default 50); i64 overflow impossible
         let now = chrono_now_pub();
 
         let books = apotheke::repo::book::search_books(&state.db.read, query, page_size, 0).await?;

--- a/crates/paroche/src/routes/kosync.rs
+++ b/crates/paroche/src/routes/kosync.rs
@@ -103,7 +103,7 @@ async fn create_user(
     // WHY: KOReader self-registration is protocol behavior, but unlimited
     // anonymous account creation is an abuse surface — operators can close
     // it via config once their readers are enrolled.
-    if !state.config.paroche.kosync_registration_enabled {
+    if !state.config.current().paroche.kosync_registration_enabled {
         return Err(ParocheError::Forbidden);
     }
 
@@ -315,6 +315,7 @@ pub fn kosync_routes() -> axum::Router<AppState> {
 mod tests {
     use axum::body::to_bytes;
     use axum::http::{Request, StatusCode};
+    use horismos::{Config, ConfigManager, ConfigOverrides};
     use tower::ServiceExt;
 
     use super::*;
@@ -372,33 +373,67 @@ mod tests {
         assert_eq!(parsed["username"], "reader1");
     }
 
+    // WHY: this is the step's regression proof for the frozen-Arc failure
+    // mode #529 fixes — the router is built ONCE from a LIVE handle, then
+    // `ConfigManager::replace` flips `kosync_registration_enabled` with no
+    // router rebuild, and the very next request observes it.
     #[tokio::test]
-    async fn create_user_rejected_when_registration_disabled() {
+    async fn registration_toggle_is_live_without_router_rebuild() {
         let (mut state, _) = test_state().await;
-        let mut config = (*state.config).clone();
-        config.paroche.kosync_registration_enabled = false;
-        state.config = std::sync::Arc::new(config);
+        let mut config = Config::default();
+        config.exousia.jwt_secret = "test-secret-that-is-long-enough-for-hs256".to_string();
+        let (manager, handle) = ConfigManager::new(
+            config,
+            std::path::PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+        state.config = handle;
         let app = super::super::super::build_router(state);
 
-        let create_body = serde_json::json!({
-            "username": "reader6",
-            "password": "mypassword"
-        });
-        let resp = app
+        let create_body = |username: &str| {
+            serde_json::json!({
+                "username": username,
+                "password": "mypassword"
+            })
+        };
+
+        // Registration is enabled by default — the first create succeeds.
+        let allowed_resp = app
+            .clone()
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/kosync/users/create")
                     .header("content-type", "application/json")
                     .body(axum::body::Body::from(
-                        serde_json::to_string(&create_body).unwrap(),
+                        serde_json::to_string(&create_body("reader6")).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(allowed_resp.status(), StatusCode::CREATED);
+
+        let mut disabled = Config::default();
+        disabled.exousia.jwt_secret = "test-secret-that-is-long-enough-for-hs256".to_string();
+        disabled.paroche.kosync_registration_enabled = false;
+        manager.replace(disabled).unwrap();
+
+        let rejected_resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/kosync/users/create")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        serde_json::to_string(&create_body("reader7")).unwrap(),
                     ))
                     .unwrap(),
             )
             .await
             .unwrap();
 
-        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(rejected_resp.status(), StatusCode::FORBIDDEN);
     }
 
     #[test]

--- a/crates/paroche/src/routes/system.rs
+++ b/crates/paroche/src/routes/system.rs
@@ -18,7 +18,7 @@ pub async fn config(
     State(state): State<AppState>,
     _admin: RequireAdmin,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
-    let cfg = &state.config;
+    let cfg = state.config.current();
     Ok((
         StatusCode::OK,
         Json(json!({
@@ -27,7 +27,8 @@ pub async fn config(
                 "listen_addr": cfg.paroche.listen_addr,
                 "stream_buffer_kb": cfg.paroche.stream_buffer_kb,
                 "opds_page_size": cfg.paroche.opds_page_size,
-            }
+            },
+            "restart_pending": state.config.restart_pending(),
         })),
     ))
 }

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use apotheke::DbPools;
 use axum::extract::FromRef;
 use exousia::ExousiaServiceImpl;
-use horismos::Config;
+use horismos::ConfigHandle;
 use themelion::EventSender;
 
 type ImportQueueFut = Pin<
@@ -403,7 +403,7 @@ impl DynRendererRegistry for NullRendererRegistry {
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<DbPools>,
-    pub config: Arc<Config>,
+    pub config: ConfigHandle,
     pub event_tx: EventSender,
     pub auth: Arc<ExousiaServiceImpl>,
     pub import: Arc<dyn DynImportService>,
@@ -428,7 +428,7 @@ impl AppState {
     /// Build a new AppState with stub service impls for testing.
     pub fn with_stubs(
         db: Arc<DbPools>,
-        config: Arc<Config>,
+        config: ConfigHandle,
         event_tx: EventSender,
         auth: Arc<ExousiaServiceImpl>,
         import: Arc<dyn DynImportService>,


### PR DESCRIPTION
Step 2 of the #529 reactive-config migration — the foundation the remaining steps build on. Fixes the core defect (SIGHUP reload was a silent no-op: `run_serve` discarded the `ConfigHandle` and built every subsystem from a frozen `Arc` snapshot, so reloads broadcast to zero subscribers) for the HTTP-handler class, and lands the reusable change-detection primitive + honest reload reporting.

**horismos** — `PartialEq` derived on `Config` and all 21 subsystem structs. New `ConfigHandle::watch_section(project) -> SectionWatcher<T>`: `SectionWatcher::changed()` awaits the next publish that changes *its* projected section (value-driven via `borrow_and_update` + `!= last`, so unrelated-section publishes don't wake it), returning `None` when the sender drops (the supervisor-exit signal). This is the primitive every later REBUILD/LIVE-B consumer will use.

**archon** — `run_serve` keeps the `ConfigHandle` (was dropped into `_`) and wires it into `AppState`; the frozen construction snapshot is renamed `boot_config`. The SIGHUP handler now reports honestly via extracted `reload_config()` + `log_reload_outcome()`: live changes applied → `info!(applied = …)`, changes held back → `warn!(pending = …, "restart required")`, nothing changed → `info!("no changes")` — no more "configuration reloaded" success log over a no-op. New `HostError::ReloadTaskPanicked` cleanly separates a `spawn_blocking` join panic from a reload/validation error (HorismosError context-selectors are `pub(crate)`, so archon owns its side).

**paroche** — `AppState.config: Arc<Config>` → `ConfigHandle`; every read site (opds catalog + search, kosync, system diagnostics) migrated to `state.config.current()` with **one snapshot per operation** (torn-config guard). The admin `/api/system/config` payload gains `restart_pending`. The test-only Arc-rebuild in kosync is replaced with a real `ConfigManager::replace(...)` regression test proving a `kosync_registration_enabled` flip flips the route 403↔200 on the next request **without a router rebuild** — the exact frozen-Arc failure mode #529 describes.

Live/restart classification, JWT rotation, QUIC/HTTP endpoint rebind, and the rebuild-class supervisors follow in steps 3-9 (design in kanon planning). This step is independently correct and gateable.

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings`), nextest 1964 passed, deny, kanon lint (0/0). New tests: SectionWatcher (change-only + drop), paroche live-flip, reload-outcome reporting. `Gate-Passed` trailer stamped.

Refs #529
