### PR TITLE
feat(exousia): live JWT secret/TTL via config reload with immediate rotation (#529 step 3)

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -808,9 +808,12 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     let (event_tx, _event_rx) = create_event_bus(boot_config.aggelia.buffer_size);
 
     // 6. Create auth service
+    // WHY: a Section (not the frozen boot_config) — #529 step 3 makes JWT
+    // secret/TTL live: rotation invalidates outstanding bearers immediately,
+    // sessions (opaque refresh tokens) survive.
     let auth = Arc::new(ExousiaServiceImpl::new(
         db.clone(),
-        boot_config.exousia.clone(),
+        config_handle.section(|c| &c.exousia),
     ));
 
     // 7. First-run admin setup
@@ -1071,6 +1074,18 @@ fn log_reload_outcome(outcome: &ReloadOutcome) {
         tracing::info!(
             applied = ?outcome.applied,
             "configuration reloaded — {n} live change(s) applied"
+        );
+    }
+    // WHY: jwt_secret rotation is a distinct security event from an ordinary
+    // live-config change — it kills every outstanding bearer immediately (no
+    // dual-secret grace, operator-locked semantics, #529 step 3).
+    if outcome
+        .applied
+        .iter()
+        .any(|path| path == "exousia.jwt_secret")
+    {
+        tracing::warn!(
+            "exousia.jwt_secret rotated — all outstanding access tokens are now invalid"
         );
     }
     if !outcome.restart_pending.is_empty() {

--- a/crates/archon/src/startup.rs
+++ b/crates/archon/src/startup.rs
@@ -108,7 +108,7 @@ mod tests {
         let db = Arc::new(db);
         let auth = Arc::new(ExousiaServiceImpl::new(
             db.clone(),
-            horismos::ExousiaConfig::default(),
+            horismos::Section::fixed(horismos::ExousiaConfig::default()),
         ));
 
         let mut out = Vec::new();

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -14,7 +14,9 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use ergasia::{DownloadProgress, DownloadState, ErgasiaError, ExtractionResult};
 use exousia::{AuthService, CreateUserRequest, ExousiaServiceImpl, UserRole};
-use horismos::{AitesisConfig, Config, ConfigHandle, ExousiaConfig};
+use horismos::{
+    AitesisConfig, Config, ConfigHandle, ConfigManager, ConfigOverrides, ExousiaConfig, Section,
+};
 use paroche::state::{
     AppState, DynQueueManager, DynRequestService, DynSearchService, RequestServiceFut, ServiceFut,
 };
@@ -383,7 +385,10 @@ async fn test_state_with_queue(
         refresh_token_ttl_days: 30,
         jwt_secret: "test-secret-that-is-long-enough-for-hs256".to_string(),
     };
-    let auth = Arc::new(ExousiaServiceImpl::new(pools.clone(), exousia_config));
+    let auth = Arc::new(ExousiaServiceImpl::new(
+        pools.clone(),
+        Section::fixed(exousia_config),
+    ));
     let import = paroche::state::make_import_service(|| async { Ok(vec![]) });
     let mut state = AppState::with_stubs(pools, config, event_tx, auth.clone(), import);
     state.search = Arc::new(MockSearchService);
@@ -1005,6 +1010,60 @@ async fn remove_wanted_returns_no_content() -> Result<(), TestError> {
 }
 
 // ── Auth enforcement tests ───────────────────────────────────────────────────
+
+// WHY: #529 step 3 archon-level regression — proves the immediate-rotation
+// contract through the full paroche router (not just exousia's own
+// middleware unit tests). A bearer minted before a `jwt_secret` rotation
+// authenticates before the reload and gets 401/UNAUTHORIZED on the very next
+// request after it, mirroring `config_handle.section(|c| &c.exousia)` wiring
+// in serve.rs.
+#[tokio::test]
+async fn rotated_jwt_secret_returns_401_unauthorized_immediately() -> Result<(), TestError> {
+    let (mut state, _auth, _pool) = test_state().await?;
+
+    let mut config = Config::default();
+    config.exousia.jwt_secret = "pre-rotation-secret-that-is-long-enough!!".to_string();
+    let (manager, handle) = ConfigManager::new(
+        config,
+        std::path::PathBuf::from("unused.toml"),
+        ConfigOverrides::default(),
+    );
+    let auth = Arc::new(ExousiaServiceImpl::new(
+        state.db.clone(),
+        handle.section(|c| &c.exousia),
+    ));
+    state.auth = auth.clone();
+
+    let token = admin_token(&auth).await?;
+    let app = build_app(state);
+
+    let (status, _) = get_queue_snapshot(&app, &token).await?;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "token must authenticate before rotation"
+    );
+
+    let mut rotated = Config::default();
+    rotated.exousia.jwt_secret = "post-rotation-secret-that-is-long-enough!!".to_string();
+    manager.replace(rotated)?;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/downloads")
+                .header("Authorization", auth_header(&token))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let json = body_json(resp).await?;
+    assert_eq!(
+        json["code"], "UNAUTHORIZED",
+        "rotated-out token must fail as invalid, not TOKEN_EXPIRED"
+    );
+    Ok(())
+}
 
 #[tokio::test]
 async fn unauthenticated_requests_return_401() -> Result<(), TestError> {

--- a/crates/exousia/src/lib.rs
+++ b/crates/exousia/src/lib.rs
@@ -49,7 +49,7 @@ mod tests {
 
     use apotheke::DbPools;
     use apotheke::migrate::MIGRATOR;
-    use horismos::ExousiaConfig;
+    use horismos::{Config, ConfigManager, ConfigOverrides, ExousiaConfig, Section};
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
     use rand::Rng;
     use sqlx::SqlitePool;
@@ -72,7 +72,37 @@ mod tests {
             refresh_token_ttl_days: 30,
             jwt_secret: "test-secret-that-is-long-enough-for-hs256".to_string(),
         };
-        Arc::new(ExousiaServiceImpl::new(pools, config))
+        Arc::new(ExousiaServiceImpl::new(pools, Section::fixed(config)))
+    }
+
+    /// A `Config` with a valid `jwt_secret` and everything else defaulted —
+    /// mirrors horismos's own `valid_config()` test helper (handle.rs).
+    fn config_with_secret(secret: &str) -> Config {
+        let mut config = Config::default();
+        config.exousia.jwt_secret = secret.to_string();
+        config
+    }
+
+    /// A service backed by a LIVE `Section` (not `Section::fixed`) plus the
+    /// `ConfigManager` that drives it — the lever the rotation tests use to
+    /// mirror step 2's live-handle test pattern (`ConfigManager::replace`).
+    async fn setup_live(secret: &str) -> (Arc<ExousiaServiceImpl>, ConfigManager) {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let pools = Arc::new(DbPools {
+            read: pool.clone(),
+            write: pool,
+        });
+        let (manager, handle) = ConfigManager::new(
+            config_with_secret(secret),
+            std::path::PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+        let service = Arc::new(ExousiaServiceImpl::new(
+            pools,
+            handle.section(|c| &c.exousia),
+        ));
+        (service, manager)
     }
 
     async fn create_test_user(service: &Arc<ExousiaServiceImpl>) -> User {
@@ -125,6 +155,96 @@ mod tests {
         assert!(matches!(err, ExousiaError::TokenInvalid { .. }));
     }
 
+    // ── #529 step 3: live JWT secret / TTL, immediate rotation ───────────────
+
+    const OLD_SECRET: &str = "old-secret-that-is-long-enough-for-hs256!!!!";
+    const NEW_SECRET: &str = "new-secret-that-is-long-enough-for-hs256!!!!";
+
+    #[tokio::test]
+    async fn rotation_invalidates_old_access_token_immediately() {
+        let (service, manager) = setup_live(OLD_SECRET).await;
+        create_test_user(&service).await;
+        let pair = service.login("testuser", "password123").await.unwrap();
+        // Sanity: valid before rotation.
+        service.validate_bearer(&pair.access_token).await.unwrap();
+
+        manager.replace(config_with_secret(NEW_SECRET)).unwrap();
+
+        let err = service
+            .validate_bearer(&pair.access_token)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, ExousiaError::TokenInvalid { .. }),
+            "rotated-out token must be TokenInvalid (signature mismatch), not TokenExpired: {err:?}"
+        );
+
+        // A fresh login mints and verifies under the new secret with no
+        // dual-secret grace window.
+        let new_pair = service.login("testuser", "password123").await.unwrap();
+        let authenticated = service
+            .validate_bearer(&new_pair.access_token)
+            .await
+            .unwrap();
+        assert_eq!(authenticated.role, UserRole::Member);
+    }
+
+    #[tokio::test]
+    async fn refresh_across_rotation_mints_under_new_secret_and_keeps_session() {
+        let (service, manager) = setup_live(OLD_SECRET).await;
+        create_test_user(&service).await;
+        let pair = service.login("testuser", "password123").await.unwrap();
+
+        manager.replace(config_with_secret(NEW_SECRET)).unwrap();
+
+        // WHY: refresh tokens are opaque sha256-hashed DB rows, not signed
+        // with jwt_secret — the session survives rotation intact.
+        let refreshed = service.refresh(&pair.refresh_token).await.unwrap();
+        crate::jwt::validate_token(&refreshed.access_token, NEW_SECRET.as_bytes())
+            .expect("post-rotation mint must verify under the new secret");
+        let under_old_secret =
+            crate::jwt::validate_token(&refreshed.access_token, OLD_SECRET.as_bytes());
+        assert!(
+            under_old_secret.is_err(),
+            "post-rotation mint must NOT verify under the retired secret"
+        );
+    }
+
+    #[tokio::test]
+    async fn ttl_change_affects_only_the_next_mint() {
+        let (service, manager) = setup_live(OLD_SECRET).await;
+        create_test_user(&service).await;
+
+        let pair = service.login("testuser", "password123").await.unwrap();
+        let exp_before = crate::jwt::validate_token(&pair.access_token, OLD_SECRET.as_bytes())
+            .unwrap()
+            .exp;
+
+        let mut shorter_ttl = config_with_secret(OLD_SECRET);
+        shorter_ttl.exousia.access_token_ttl_secs = 60;
+        manager.replace(shorter_ttl).unwrap();
+
+        // The already-minted token's baked-in exp is untouched by the reload
+        // — no retroactive expiry.
+        let exp_after_reload =
+            crate::jwt::validate_token(&pair.access_token, OLD_SECRET.as_bytes())
+                .unwrap()
+                .exp;
+        assert_eq!(
+            exp_after_reload, exp_before,
+            "a TTL reload must not retroactively change an already-minted exp"
+        );
+
+        let pair2 = service.login("testuser", "password123").await.unwrap();
+        let exp2 = crate::jwt::validate_token(&pair2.access_token, OLD_SECRET.as_bytes())
+            .unwrap()
+            .exp;
+        assert!(
+            exp2 < exp_before,
+            "a mint after the reload must reflect the shortened TTL"
+        );
+    }
+
     #[tokio::test]
     async fn refresh_concurrent_double_use_returns_one_success() {
         // WHY: max_connections(1) mirrors the production write pool and keeps
@@ -144,7 +264,7 @@ mod tests {
             refresh_token_ttl_days: 30,
             jwt_secret: "test-secret-that-is-long-enough-for-hs256".to_string(),
         };
-        let service = Arc::new(ExousiaServiceImpl::new(pools, config));
+        let service = Arc::new(ExousiaServiceImpl::new(pools, Section::fixed(config)));
         create_test_user(&service).await;
         let pair = service.login("testuser", "password123").await.unwrap();
         let (r1, r2) = tokio::join!(

--- a/crates/exousia/src/middleware.rs
+++ b/crates/exousia/src/middleware.rs
@@ -167,7 +167,7 @@ mod tests {
     use axum::Router;
     use axum::body::Body;
     use axum::routing::get;
-    use horismos::ExousiaConfig;
+    use horismos::{Config, ConfigManager, ConfigOverrides, ExousiaConfig, Section};
     use http::{Request, StatusCode};
     use sqlx::SqlitePool;
     use tower::ServiceExt;
@@ -191,7 +191,7 @@ mod tests {
             refresh_token_ttl_days: 30,
             jwt_secret: TEST_JWT_SECRET.to_string(),
         };
-        Arc::new(ExousiaServiceImpl::new(pools, config))
+        Arc::new(ExousiaServiceImpl::new(pools, Section::fixed(config)))
     }
 
     async fn make_user_and_token(
@@ -440,6 +440,54 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         let json = body_json(response).await;
         assert_eq!(json["code"], "UNAUTHORIZED");
+    }
+
+    // WHY: proves #529's immediate-rotation contract through the actual
+    // middleware path — a bearer minted before a `jwt_secret` rotation must
+    // 401 with `UNAUTHORIZED` (not `TOKEN_EXPIRED`) on the very next request,
+    // with no dual-secret grace window.
+    #[tokio::test]
+    async fn rotated_secret_returns_401_unauthorized_not_expired() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let pools = Arc::new(DbPools {
+            read: pool.clone(),
+            write: pool,
+        });
+        let mut config = Config::default();
+        config.exousia.jwt_secret = TEST_JWT_SECRET.to_string();
+        let (manager, handle) = ConfigManager::new(
+            config,
+            std::path::PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+        let service = Arc::new(ExousiaServiceImpl::new(
+            pools,
+            handle.section(|c| &c.exousia),
+        ));
+
+        let (_, token) = make_user_and_token(&service, "mallory", UserRole::Member).await;
+
+        let mut rotated = Config::default();
+        rotated.exousia.jwt_secret = "rotated-secret-that-is-long-enough-for-hs256!!".to_string();
+        manager.replace(rotated).unwrap();
+
+        let response = app(service)
+            .oneshot(
+                Request::builder()
+                    .uri("/auth")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let json = body_json(response).await;
+        assert_eq!(
+            json["code"], "UNAUTHORIZED",
+            "rotated-out token must fail as invalid, not surface as TOKEN_EXPIRED"
+        );
     }
 
     #[tokio::test]

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use apotheke::DbPools;
 use apotheke::repo::user as db;
-use horismos::ExousiaConfig;
+use horismos::{ExousiaConfig, Section};
 use rand::Rng;
 use sha2::{Digest, Sha256};
 use snafu::ResultExt;
@@ -23,11 +23,11 @@ const MIN_PASSWORD_CHARS: usize = 8;
 
 pub struct ExousiaServiceImpl {
     pools: Arc<DbPools>,
-    config: ExousiaConfig,
+    config: Section<ExousiaConfig>,
 }
 
 impl ExousiaServiceImpl {
-    pub fn new(pools: Arc<DbPools>, config: ExousiaConfig) -> Self {
+    pub fn new(pools: Arc<DbPools>, config: Section<ExousiaConfig>) -> Self {
         Self { pools, config }
     }
 
@@ -238,6 +238,9 @@ const SENTINEL_PASSWORD_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$rCzKZ0rnCdm
 
 impl AuthService for ExousiaServiceImpl {
     async fn login(&self, username: &str, password: &str) -> Result<TokenPair, ExousiaError> {
+        // INVARIANT: one snapshot for the whole operation — a mid-rotation
+        // login must not mint with secret A and TTL B (torn-config hazard).
+        let cfg = self.config.get();
         // WHY: cap argon2 input before any hashing work — an oversized password
         // is rejected in constant, bounded time (CPU-DoS guard).
         if password.len() > MAX_PASSWORD_BYTES {
@@ -265,15 +268,12 @@ impl AuthService for ExousiaServiceImpl {
             tracing::warn!(user_id = %user.id.into_uuid(), "login attempt on inactive account");
             return Err(InvalidCredentialsSnafu.build());
         }
-        let access_token = jwt::create_access_token(
-            &user,
-            self.config.jwt_secret.as_bytes(),
-            self.config.access_token_ttl_secs,
-        )?;
+        let access_token =
+            jwt::create_access_token(&user, cfg.jwt_secret.as_bytes(), cfg.access_token_ttl_secs)?;
         let (refresh_token, token_hash) = generate_refresh_token();
         let token_id = uuid::Uuid::now_v7().as_bytes().to_vec();
         let now = now_iso();
-        let expires_at = add_days_to_iso_now(self.config.refresh_token_ttl_days);
+        let expires_at = add_days_to_iso_now(cfg.refresh_token_ttl_days);
         let refresh_row = db::RefreshToken {
             id: token_id,
             user_id: user_id_to_bytes(user.id),
@@ -298,6 +298,8 @@ impl AuthService for ExousiaServiceImpl {
     // on the write pool. A concurrent refresh of the same token blocks at begin,
     // then observes revoked = 1 and fails — a refresh token can be used once.
     async fn refresh(&self, refresh_token: &str) -> Result<TokenPair, ExousiaError> {
+        // INVARIANT: one snapshot for the whole operation — see `login`.
+        let cfg = self.config.get();
         let token_hash = sha256_hex(refresh_token.as_bytes());
         let mut tx = apotheke::begin_immediate(&self.pools.write)
             .await
@@ -348,11 +350,8 @@ impl AuthService for ExousiaServiceImpl {
         db::revoke_refresh_token(&mut *tx, &row.id)
             .await
             .context(DatabaseSnafu)?;
-        let access_token = jwt::create_access_token(
-            &user,
-            self.config.jwt_secret.as_bytes(),
-            self.config.access_token_ttl_secs,
-        )?;
+        let access_token =
+            jwt::create_access_token(&user, cfg.jwt_secret.as_bytes(), cfg.access_token_ttl_secs)?;
         let (new_refresh_token, new_hash) = generate_refresh_token();
         let token_id = uuid::Uuid::now_v7().as_bytes().to_vec();
         let new_row = db::RefreshToken {
@@ -360,7 +359,7 @@ impl AuthService for ExousiaServiceImpl {
             user_id: row.user_id,
             token_hash: new_hash,
             created_at: now_iso(),
-            expires_at: add_days_to_iso_now(self.config.refresh_token_ttl_days),
+            expires_at: add_days_to_iso_now(cfg.refresh_token_ttl_days),
             revoked: 0,
         };
         db::insert_refresh_token(&mut *tx, &new_row)
@@ -390,7 +389,11 @@ impl AuthService for ExousiaServiceImpl {
     // role and is_active come from the live user row so revocation and role
     // demotion take effect within the token's lifetime, matching validate_api_key.
     async fn validate_bearer(&self, token: &str) -> Result<AuthenticatedUser, ExousiaError> {
-        let claims = jwt::validate_token(token, self.config.jwt_secret.as_bytes())?;
+        // INVARIANT: one snapshot for the whole operation — see `login`. Live
+        // read means a rotated secret invalidates every in-flight bearer
+        // signed under the old one immediately (no dual-secret grace).
+        let cfg = self.config.get();
+        let claims = jwt::validate_token(token, cfg.jwt_secret.as_bytes())?;
         let uuid = uuid::Uuid::parse_str(&claims.sub).map_err(|_| ExousiaError::TokenInvalid {
             error: "invalid sub claim".to_string(),
             location: snafu::location!(),
@@ -636,7 +639,7 @@ mod tests {
             refresh_token_ttl_days: 30,
             jwt_secret: "test-secret-that-is-long-enough-for-hs256".to_string(),
         };
-        ExousiaServiceImpl::new(pools, config)
+        ExousiaServiceImpl::new(pools, Section::fixed(config))
     }
 
     async fn create_member(service: &ExousiaServiceImpl, username: &str, password: &str) -> User {

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -77,7 +77,7 @@ pub mod test_helpers {
     use apotheke::migrate::MIGRATOR;
     use exousia::user::{CreateUserRequest, UserRole};
     use exousia::{AuthService, ExousiaServiceImpl};
-    use horismos::{Config, ConfigHandle, ExousiaConfig};
+    use horismos::{Config, ConfigHandle, ExousiaConfig, Section};
     use sqlx::SqlitePool;
     use themelion::create_event_bus;
 
@@ -103,7 +103,10 @@ pub mod test_helpers {
             refresh_token_ttl_days: 30,
             jwt_secret: "test-secret-that-is-long-enough-for-hs256".to_string(),
         };
-        let auth = Arc::new(ExousiaServiceImpl::new(pools.clone(), exousia_config));
+        let auth = Arc::new(ExousiaServiceImpl::new(
+            pools.clone(),
+            Section::fixed(exousia_config),
+        ));
 
         let import = crate::state::make_import_service(|| async { Ok(vec![]) });
 


### PR DESCRIPTION
Step 3 of the #529 reactive-config migration — live JWT with **immediate rotation** (operator-locked semantics).

`ExousiaServiceImpl` stored a frozen `ExousiaConfig` captured at construction, so a `jwt_secret` or TTL change via SIGHUP had no effect until restart. It now holds `horismos::Section<ExousiaConfig>` and takes exactly one `self.config.get()` snapshot at the top of each operation (`login`, `refresh`, `validate_bearer`), using that single snapshot for both the secret and the TTLs — a torn-config guard so a mid-rotation login can never mint with secret A but TTL B.

**Rotation semantics (immediate, no dual-secret grace):**
- Rotate `exousia.jwt_secret` (secrets.toml or `HARMONIA__EXOUSIA__JWT_SECRET`) + SIGHUP. Reload validation still enforces ≥32 bytes / non-placeholder, so an invalid rotation is rejected atomically and the old secret stays in force.
- **Verification is live**: `validate_bearer` checks HS256 against the *current* secret, so every in-flight access token signed with the old secret fails immediately → `TokenInvalid` → HTTP 401 `UNAUTHORIZED`. This is deliberate — rotating a compromised secret must kill outstanding bearers at once.
- **Sessions survive**: refresh tokens are opaque random values (sha256-hashed in the DB, not signed with `jwt_secret`), so the refresh transaction still verifies and mints the next access token under the new secret. A client that refreshes on 401 recovers without re-login.
- **TTL changes are mint-forward**: `exp` is baked into claims at mint; a TTL change affects only tokens/refresh-rows created after the reload. Already-issued expirations are honored.
- A reload whose applied paths include `exousia.jwt_secret` logs `warn!("exousia.jwt_secret rotated — all outstanding access tokens are now invalid")`.

Production wiring passes `config_handle.section(|c| &c.exousia)`; all 10 test/static constructors use `Section::fixed(...)`.

Client-contract follow-up (out of scope): clients that auto-refresh only on `TOKEN_EXPIRED` will treat a rotation's `UNAUTHORIZED` as logout — the desktop/theatron 401 handling should refresh on any 401 with a valid refresh token. Tracked separately.

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings`), nextest 1969 passed, deny, lint (0/0). 5 new tests (all on a live `ConfigManager`/`Section` pair): old-token-invalidated-immediately, refresh-across-rotation, TTL-mint-forward, middleware 401-UNAUTHORIZED, and a full-router archon integration test. `Gate-Passed` stamped.

Refs #529
