### PR TITLE
feat(themelion,archon): live renderer QUIC api-key/timeout/admission via LiveGate (#529 step 4)

### DIFF
--- a/crates/archon/src/render/server.rs
+++ b/crates/archon/src/render/server.rs
@@ -5,7 +5,9 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use tokio::sync::{RwLock, Semaphore};
+use horismos::{ParocheConfig, Section};
+use themelion::{GateGuard, LiveGate};
+use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, warn};
 
@@ -128,28 +130,12 @@ impl paroche::state::DynRendererRegistry for RendererRegistry {
     }
 }
 
-/// Renderer QUIC server admission/auth tuning, threaded from
-/// `ParocheConfig`'s `renderer_*` fields (see `crate::serve`'s call site).
-/// Bundled to keep `start_renderer_server` under the workspace's
-/// too-many-arguments lint threshold.
-pub struct RendererServerLimits {
-    /// Shared secret renderers must present when registering over QUIC.
-    /// Leaving it unset rejects every renderer registration (fail closed).
-    pub renderer_api_key: Option<String>,
-    /// Maximum concurrent renderer connections/tasks admitted before the
-    /// pre-auth SessionInit handshake; excess connections are refused.
-    pub max_connections: usize,
-    /// Deadline for a connecting renderer to complete the pre-auth
-    /// SessionInit handshake (control-stream accept + read).
-    pub session_init_timeout: Duration,
-}
-
 pub async fn start_renderer_server(
     listen_addr: SocketAddr,
     cert_dir: &Path,
     registry: Arc<RendererRegistry>,
     shutdown: CancellationToken,
-    limits: RendererServerLimits,
+    section: Section<ParocheConfig>,
 ) -> Result<(), RenderError> {
     let server_config = tls::load_or_generate_server_config(cert_dir)?;
     let endpoint = quinn::Endpoint::server(server_config, listen_addr).map_err(|e| {
@@ -159,7 +145,8 @@ pub async fn start_renderer_server(
         }
     })?;
 
-    if limits.renderer_api_key.as_deref().is_none_or(str::is_empty) {
+    let boot = section.get();
+    if boot.renderer_api_key.as_deref().is_none_or(str::is_empty) {
         warn!(
             "paroche.renderer_api_key not configured; rejecting every renderer registration \
              until a key is SET"
@@ -168,17 +155,21 @@ pub async fn start_renderer_server(
 
     info!(
         addr = %listen_addr,
-        max_connections = limits.max_connections,
+        max_connections = boot.renderer_max_connections,
         "renderer QUIC server listening"
     );
 
     // INVARIANT: bounds concurrent renderer connections/tasks server-wide —
     // mirrors syndesis::ServerConfig::max_sessions, the sibling QUIC admission
-    // surface in this workspace. A permit is held for the connection's full
+    // surface in this workspace. A guard is held for the connection's full
     // handling lifetime (see below), not just the pre-auth handshake, so an
     // unauthenticated peer that completes TLS then stalls (bounded separately
-    // by session_init_timeout) still counts against the cap.
-    let admission = Arc::new(Semaphore::new(limits.max_connections));
+    // by session_init_timeout) still counts against the cap. Unlike the
+    // fixed `Semaphore` this replaces, the cap is read LIVE from `section` on
+    // every admission attempt: a reload changes it without rebuilding the
+    // gate. A LOWERED cap applies to new admissions only — live connections
+    // are never force-closed on a cap decrease.
+    let admission = Arc::new(LiveGate::new());
 
     loop {
         let incoming = tokio::select! {
@@ -190,30 +181,24 @@ pub async fn start_renderer_server(
             },
         };
 
-        let (incoming, permit) = match try_admit(incoming, &admission, limits.max_connections) {
+        let max_connections = section.get().renderer_max_connections;
+        let (incoming, guard) = match try_admit(incoming, &admission, max_connections) {
             Some(pair) => pair,
             None => continue,
         };
 
         let registry = Arc::clone(&registry);
-        let expected_api_key = limits.renderer_api_key.clone();
+        let conn_section = section.clone();
         let ct = shutdown.child_token();
-        let session_init_timeout = limits.session_init_timeout;
 
         tokio::spawn(
             async move {
                 // WHY: held until this task ends (success, error, or panic
                 // unwind) so the admission cap always reflects live
                 // connections, not just ones still in the pre-auth handshake.
-                let _permit = permit;
-                if let Err(e) = handle_renderer_connection(
-                    incoming,
-                    registry,
-                    expected_api_key,
-                    ct,
-                    session_init_timeout,
-                )
-                .await
+                let _guard = guard;
+                if let Err(e) =
+                    handle_renderer_connection(incoming, registry, conn_section, ct).await
                 {
                     warn!(error = %e, "renderer connection handler failed");
                 }
@@ -232,12 +217,12 @@ pub async fn start_renderer_server(
 /// spending no TLS work — mirrors `syndesis::StreamServer`'s session cap.
 fn try_admit(
     incoming: quinn::Incoming,
-    admission: &Arc<Semaphore>,
+    admission: &Arc<LiveGate>,
     max_connections: usize,
-) -> Option<(quinn::Incoming, tokio::sync::OwnedSemaphorePermit)> {
-    match Arc::clone(admission).try_acquire_owned() {
-        Ok(permit) => Some((incoming, permit)),
-        Err(_) => {
+) -> Option<(quinn::Incoming, GateGuard)> {
+    match admission.try_enter(max_connections) {
+        Some(guard) => Some((incoming, guard)),
+        None => {
             warn!(
                 max_connections,
                 "refusing renderer connection: admission cap reached"
@@ -251,13 +236,20 @@ fn try_admit(
 async fn handle_renderer_connection(
     incoming: quinn::Incoming,
     registry: Arc<RendererRegistry>,
-    expected_api_key: Option<String>,
+    section: Section<ParocheConfig>,
     shutdown: CancellationToken,
-    session_init_timeout: Duration,
 ) -> Result<(), RenderError> {
     let connection = incoming.await?;
     let remote = connection.remote_address();
     info!(remote = %remote, "renderer connected");
+
+    // WHY: ONE snapshot for the whole handshake — the timeout deadline below
+    // and the api key checked against it further down both come from this
+    // same read, so a reload racing this connection cannot mix an old
+    // timeout with a new key (the #529 single-op-snapshot invariant:
+    // handle.rs's documented `Section::get()` idiom, one read per operation).
+    let cfg = section.get();
+    let session_init_timeout = Duration::from_secs(cfg.renderer_session_init_timeout_secs);
 
     // INVARIANT: bounds the whole pre-auth handshake (control-stream accept +
     // SessionInit read) so a peer that completes TLS then never sends
@@ -277,8 +269,13 @@ async fn handle_renderer_connection(
     info!(name = %init.name, version = init.protocol_version, "session init received");
 
     // INVARIANT: no session state (session_id, registry entry, streams) exists
-    // before this guard passes; unauthenticated peers cannot register.
-    if !api_key_matches(expected_api_key.as_deref(), &init.api_key) {
+    // before this guard passes; unauthenticated peers cannot register. A
+    // rotated key affects NEW registrations only — this check uses the
+    // snapshot taken above at connection-accept time, so an in-progress
+    // handshake is judged consistently even if a reload lands mid-handshake;
+    // established sessions (past this point) are never re-challenged or
+    // evicted by a later rotation.
+    if !api_key_matches(cfg.renderer_api_key.as_deref(), &init.api_key) {
         warn!(remote = %remote, name = %init.name, "renderer authentication failed; rejecting");
         connection.close(CLOSE_CODE_AUTH_FAILURE.into(), b"authentication failed");
         return UnauthorizedSnafu { name: init.name }.fail();
@@ -641,14 +638,24 @@ mod tests {
 mod handshake_tests {
     use std::time::Duration;
 
+    use horismos::{Config, ConfigManager, ConfigOverrides};
+
     use super::*;
     use crate::render::protocol::PROTOCOL_VERSION;
+
+    /// Generous default so tests that don't care about the admission cap
+    /// never trip it.
+    const DEFAULT_TEST_MAX_CONNECTIONS: usize = 100;
 
     struct TestServer {
         addr: SocketAddr,
         fingerprint: String,
         registry: Arc<RendererRegistry>,
         shutdown: CancellationToken,
+        /// Owner side of the live config driving this server — tests call
+        /// `.replace(...)` to exercise a reload (rotation, cap change) the
+        /// exact way `archon::serve`'s SIGHUP path does.
+        manager: ConfigManager,
         _cert_dir: tempfile::TempDir,
     }
 
@@ -670,6 +677,36 @@ mod handshake_tests {
             })
     }
 
+    fn renderer_test_jwt_secret() -> &'static str {
+        "renderer-test-secret-that-is-at-least-32-bytes-long"
+    }
+
+    /// A full, otherwise-valid `Config` with only the renderer-relevant
+    /// `paroche` fields and `exousia.jwt_secret` set — `ConfigManager::replace`
+    /// validates the WHOLE config on every call, so every config a test
+    /// publishes must clear validation, not just the fields under test.
+    fn renderer_test_config(
+        api_key: Option<&str>,
+        max_connections: usize,
+        session_init_timeout: Duration,
+    ) -> Config {
+        let mut config = Config::default();
+        config.exousia.jwt_secret = renderer_test_jwt_secret().to_string();
+        config.paroche.renderer_api_key = api_key.map(str::to_string);
+        config.paroche.renderer_max_connections = max_connections;
+        config.paroche.renderer_session_init_timeout_secs = session_init_timeout.as_secs();
+        config
+    }
+
+    /// Reserves an ephemeral UDP port on loopback and releases it immediately
+    /// — `start_renderer_server` binds its own `quinn::Endpoint` internally
+    /// and never reports the address it chose, so tests must pick the port
+    /// themselves to know where to dial the client.
+    fn free_udp_addr() -> SocketAddr {
+        let socket = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind ephemeral udp port");
+        socket.local_addr().expect("local addr")
+    }
+
     async fn spawn_test_server(expected_key: Option<&str>) -> TestServer {
         spawn_test_server_with_timeout(expected_key, Duration::from_secs(5)).await
     }
@@ -678,36 +715,62 @@ mod handshake_tests {
         expected_key: Option<&str>,
         session_init_timeout: Duration,
     ) -> TestServer {
+        spawn_test_server_with_config(
+            expected_key,
+            DEFAULT_TEST_MAX_CONNECTIONS,
+            session_init_timeout,
+        )
+        .await
+    }
+
+    /// Full harness: spawns the REAL `start_renderer_server` (not a
+    /// hand-rolled stand-in), driven by a real `ConfigManager`/`Section`
+    /// pair — every test in this module, including the pre-#529 ones,
+    /// exercises the exact production admission + per-connection-read path.
+    async fn spawn_test_server_with_config(
+        expected_key: Option<&str>,
+        max_connections: usize,
+        session_init_timeout: Duration,
+    ) -> TestServer {
         let cert_dir = tempfile::TempDir::new().expect("tempdir");
+        // WHY: materialize the persisted cert up front so the fingerprint is
+        // known before `start_renderer_server` (re)loads the SAME cert file
+        // (`load_or_generate_server_config` loads existing material rather
+        // than regenerating it).
         let server_config =
             tls::load_or_generate_server_config(cert_dir.path()).expect("server config");
+        drop(server_config);
         let cert_der = std::fs::read(cert_dir.path().join("server.der")).expect("read cert");
         let fingerprint = hex_fingerprint(&cert_der);
 
-        let endpoint =
-            quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().expect("loopback addr"))
-                .expect("server endpoint");
-        let addr = endpoint.local_addr().expect("local addr");
+        let config = renderer_test_config(expected_key, max_connections, session_init_timeout);
+        let (manager, handle) = ConfigManager::new(
+            config,
+            std::path::PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+        let section = handle.section(|c| &c.paroche);
 
         let registry = Arc::new(RendererRegistry::new());
         let shutdown = CancellationToken::new();
-        let expected: Option<String> = expected_key.map(str::to_string);
-        let registry_task = Arc::clone(&registry);
-        let shutdown_task = shutdown.clone();
+        let addr = free_udp_addr();
 
+        let server_registry = Arc::clone(&registry);
+        let server_shutdown = shutdown.clone();
+        let cert_dir_path = cert_dir.path().to_path_buf();
         tokio::spawn(async move {
-            while let Some(incoming) = endpoint.accept().await {
-                let registry = Arc::clone(&registry_task);
-                let key = expected.clone();
-                let ct = shutdown_task.child_token();
-                tokio::spawn(async move {
-                    // WHY: rejection surfaces as Err by design; tests assert via
-                    // the client result and registry contents
-                    handle_renderer_connection(incoming, registry, key, ct, session_init_timeout)
-                        .await
-                        .ok();
-                });
-            }
+            // WHY: server-side failure surfaces as Err by design (e.g. on
+            // cancellation); tests assert via the client result and
+            // registry contents, not this task's outcome.
+            start_renderer_server(
+                addr,
+                &cert_dir_path,
+                server_registry,
+                server_shutdown,
+                section,
+            )
+            .await
+            .ok();
         });
 
         TestServer {
@@ -715,6 +778,7 @@ mod handshake_tests {
             fingerprint,
             registry,
             shutdown,
+            manager,
             _cert_dir: cert_dir,
         }
     }
@@ -752,6 +816,88 @@ mod handshake_tests {
                 message: "timed out waiting for server response".into(),
                 location: snafu::location!(),
             })?
+    }
+
+    /// A live renderer session held open by the test. Its existence keeps the
+    /// server-side session — and therefore its `LiveGate` admission guard —
+    /// alive; dropping it closes the QUIC connection, which the server
+    /// observes as a disconnect (freeing the slot and removing the registry
+    /// entry). `client_handshake` above deliberately does NOT hold its
+    /// connection, so it is unsuitable for the persistence assertions below.
+    struct HeldSession {
+        // WHY: every one of these must stay alive to keep the session up.
+        // Dropping the endpoint or connection tears down QUIC; dropping the
+        // control SendStream finishes the stream, which the server's
+        // `read_status_loop` sees as a clean disconnect and ends the session.
+        _endpoint: quinn::Endpoint,
+        _connection: quinn::Connection,
+        _ctrl_send: quinn::SendStream,
+        _ctrl_recv: quinn::RecvStream,
+    }
+
+    /// Connects, completes SessionInit, and RETURNS the live streams/connection
+    /// so the caller keeps the session (and its server-side admission slot)
+    /// alive for the duration of the test. Contrast `client_handshake`, which
+    /// drops everything on return.
+    async fn client_connect_and_hold(
+        server: &TestServer,
+        pin: &str,
+        api_key: &str,
+    ) -> Result<(HeldSession, u8, Vec<u8>), RenderError> {
+        let client_config = tls::build_client_config(pin)?;
+        let mut endpoint = quinn::Endpoint::client("127.0.0.1:0".parse().expect("loopback addr"))
+            .expect("client endpoint");
+        endpoint.set_default_client_config(client_config);
+
+        let connection = endpoint
+            .connect(server.addr, "harmonia")
+            .map_err(|e| RenderError::Connection {
+                message: e.to_string(),
+                location: snafu::location!(),
+            })?
+            .await?;
+
+        let (mut send, mut recv) = connection.open_bi().await?;
+        let init = SessionInit {
+            name: "test-renderer".into(),
+            protocol_version: PROTOCOL_VERSION,
+            api_key: api_key.to_string(),
+        };
+        let payload = serde_json::to_vec(&init).expect("serialize init");
+        protocol::send_message(&mut send, MSG_SESSION_INIT, &payload).await?;
+
+        let (msg_type, body) =
+            tokio::time::timeout(Duration::from_secs(5), protocol::recv_message(&mut recv))
+                .await
+                .map_err(|_| RenderError::Connection {
+                    message: "timed out waiting for server response".into(),
+                    location: snafu::location!(),
+                })??;
+
+        Ok((
+            HeldSession {
+                _endpoint: endpoint,
+                _connection: connection,
+                _ctrl_send: send,
+                _ctrl_recv: recv,
+            },
+            msg_type,
+            body,
+        ))
+    }
+
+    /// Polls until the registry reaches `expected` entries (bounded), then
+    /// asserts. Registry insertion happens AFTER SessionAccept is sent, so a
+    /// held session is not necessarily listed the instant its handshake
+    /// returns — this closes that race without masking a genuine miscount.
+    async fn assert_registry_len(server: &TestServer, expected: usize, context: &str) {
+        for _ in 0..100 {
+            if server.registry.list().await.len() == expected {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(server.registry.list().await.len(), expected, "{context}");
     }
 
     #[tokio::test]
@@ -883,7 +1029,7 @@ mod handshake_tests {
         let cert_der = std::fs::read(cert_dir.path().join("server.der")).expect("read cert");
         let fingerprint = hex_fingerprint(&cert_der);
 
-        let admission = Arc::new(Semaphore::new(1));
+        let admission = Arc::new(LiveGate::new());
 
         let client_config = tls::build_client_config(&fingerprint).expect("client config");
         let mut client = quinn::Endpoint::client("127.0.0.1:0".parse().expect("loopback addr"))
@@ -913,5 +1059,134 @@ mod handshake_tests {
             admitted2.is_none(),
             "a connection beyond max_connections must be refused"
         );
+    }
+
+    // ── #529 step 4: renderer_api_key / renderer_max_connections go live ───
+
+    #[tokio::test]
+    async fn rotating_api_key_rejects_old_accepts_new_keeps_prior_session() {
+        let server = spawn_test_server(Some("old-key")).await;
+
+        // Hold the pre-rotation session open for the whole test — the
+        // established connection is what a later rotation must NOT disturb.
+        let (prior, msg_type, _) = client_connect_and_hold(&server, &server.fingerprint, "old-key")
+            .await
+            .expect("pre-rotation handshake with the original key succeeds");
+        assert_eq!(msg_type, MSG_SESSION_ACCEPT);
+        assert_registry_len(&server, 1, "pre-rotation session must be registered").await;
+
+        let rotated = renderer_test_config(
+            Some("new-key"),
+            DEFAULT_TEST_MAX_CONNECTIONS,
+            Duration::from_secs(5),
+        );
+        server
+            .manager
+            .replace(rotated)
+            .expect("replace applies the rotated key");
+
+        let old_key_result = client_connect_and_hold(&server, &server.fingerprint, "old-key").await;
+        assert!(
+            old_key_result.is_err(),
+            "a NEW registration with the OLD key must be rejected after rotation"
+        );
+
+        let (_new, msg_type_new, _) =
+            client_connect_and_hold(&server, &server.fingerprint, "new-key")
+                .await
+                .expect("a NEW registration with the rotated key must succeed");
+        assert_eq!(msg_type_new, MSG_SESSION_ACCEPT);
+
+        // Rotation affects new registrations only — the pre-rotation session
+        // is never re-challenged or evicted.
+        assert_registry_len(
+            &server,
+            2,
+            "the pre-rotation session must still be registered alongside the new one",
+        )
+        .await;
+
+        // Keep `prior` alive until here so the survival assertion is genuine.
+        drop(prior);
+    }
+
+    #[tokio::test]
+    async fn lowering_max_connections_refuses_new_while_existing_survive() {
+        let server =
+            spawn_test_server_with_config(Some("key-123"), 2, Duration::from_secs(5)).await;
+
+        let (s1, msg_type_a, _) = client_connect_and_hold(&server, &server.fingerprint, "key-123")
+            .await
+            .expect("first connection admitted under a cap of 2");
+        assert_eq!(msg_type_a, MSG_SESSION_ACCEPT);
+        let (s2, msg_type_b, _) = client_connect_and_hold(&server, &server.fingerprint, "key-123")
+            .await
+            .expect("second connection admitted under a cap of 2");
+        assert_eq!(msg_type_b, MSG_SESSION_ACCEPT);
+        assert_registry_len(&server, 2, "both pre-lowering sessions must register").await;
+
+        let lowered = renderer_test_config(Some("key-123"), 1, Duration::from_secs(5));
+        server
+            .manager
+            .replace(lowered)
+            .expect("replace applies the lowered cap");
+
+        // Both slots are still held, so the live cap of 1 refuses this new
+        // connection — a LOWERED cap applies to new admissions only.
+        let refused = client_connect_and_hold(&server, &server.fingerprint, "key-123").await;
+        assert!(
+            refused.is_err(),
+            "a new connection beyond the lowered cap must be refused"
+        );
+
+        assert_registry_len(
+            &server,
+            2,
+            "existing sessions must survive a cap decrease — never force-closed",
+        )
+        .await;
+
+        drop((s1, s2));
+    }
+
+    #[tokio::test]
+    async fn raising_max_connections_admits_a_new_connection() {
+        let server =
+            spawn_test_server_with_config(Some("key-123"), 1, Duration::from_secs(5)).await;
+
+        let (s1, msg_type, _) = client_connect_and_hold(&server, &server.fingerprint, "key-123")
+            .await
+            .expect("first connection admitted under a cap of 1");
+        assert_eq!(msg_type, MSG_SESSION_ACCEPT);
+        assert_registry_len(&server, 1, "the first session must be registered").await;
+
+        // The first slot is still held, so at the original cap of 1 a second
+        // connection is refused.
+        let refused_at_old_cap =
+            client_connect_and_hold(&server, &server.fingerprint, "key-123").await;
+        assert!(
+            refused_at_old_cap.is_err(),
+            "a second connection at the original cap of 1 must be refused"
+        );
+
+        let raised = renderer_test_config(Some("key-123"), 2, Duration::from_secs(5));
+        server
+            .manager
+            .replace(raised)
+            .expect("replace applies the raised cap");
+
+        let (_s2, msg_type_second, _) =
+            client_connect_and_hold(&server, &server.fingerprint, "key-123")
+                .await
+                .expect("a new connection must be admitted once the cap is raised");
+        assert_eq!(msg_type_second, MSG_SESSION_ACCEPT);
+        assert_registry_len(
+            &server,
+            2,
+            "both sessions must be registered after the raise",
+        )
+        .await;
+
+        drop(s1);
     }
 }

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
 
 use aitesis::{IdentityValidator, MonitorService, RequestService, UserRoleProvider};
 use apotheke::init_pools;
@@ -765,6 +764,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
 
     // SIGHUP handler for config reload
     let manager_for_reload = config_manager.clone();
+    let handle_for_reload = config_handle.clone();
     tokio::spawn(
         async move {
             let mut sighup = match tokio::signal::unix::signal(SignalKind::hangup()) {
@@ -780,7 +780,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
                 sighup.recv().await;
                 tracing::info!("SIGHUP received  -  reloading configuration");
                 match reload_config(manager_for_reload.clone()).await {
-                    Ok(outcome) => log_reload_outcome(&outcome),
+                    Ok(outcome) => log_reload_outcome(&outcome, &handle_for_reload),
                     Err(e) => {
                         tracing::error!("config reload failed: {e}  -  keeping current config");
                     }
@@ -956,13 +956,11 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         &boot_config.paroche.listen_addr,
         crate::render::server::DEFAULT_QUIC_PORT,
     )?;
-    let renderer_limits = crate::render::server::RendererServerLimits {
-        renderer_api_key: boot_config.paroche.renderer_api_key.clone(),
-        max_connections: boot_config.paroche.renderer_max_connections,
-        session_init_timeout: Duration::from_secs(
-            boot_config.paroche.renderer_session_init_timeout_secs,
-        ),
-    };
+    // WHY: a Section (not the frozen boot_config) — #529 step 4 makes the
+    // renderer's api key / admission cap / handshake timeout live: a reload
+    // is read fresh per admission attempt and per connection-accept, no
+    // process restart or renderer-server rebuild required.
+    let renderer_section = config_handle.section(|c| &c.paroche);
     let renderer_registry_for_quic = Arc::clone(&renderer_registry);
     let renderer_shutdown = shutdown_token.child_token();
     tokio::spawn(
@@ -972,7 +970,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
                 &renderer_cert_dir,
                 renderer_registry_for_quic,
                 renderer_shutdown,
-                renderer_limits,
+                renderer_section,
             )
             .await
             {
@@ -1064,8 +1062,10 @@ pub(crate) async fn reload_config(manager: ConfigManager) -> Result<ReloadOutcom
 }
 
 /// Logs a `ReloadOutcome` honestly: live changes actually applied, changes
-/// held back pending a restart, or neither.
-fn log_reload_outcome(outcome: &ReloadOutcome) {
+/// held back until a restart, or neither. `config` supplies the post-publish
+/// effective value for change-specific logging (e.g. detecting a cleared
+/// renderer key) — `ReloadOutcome` itself carries only dotted paths, not values.
+fn log_reload_outcome(outcome: &ReloadOutcome, config: &horismos::ConfigHandle) {
     for w in &outcome.warnings {
         tracing::warn!(field = %w.field, "config reload: {}", w.message);
     }
@@ -1086,6 +1086,29 @@ fn log_reload_outcome(outcome: &ReloadOutcome) {
     {
         tracing::warn!(
             "exousia.jwt_secret rotated — all outstanding access tokens are now invalid"
+        );
+    }
+    // WHY: a reload that CLEARS the renderer key must reproduce the
+    // boot-time fail-closed heads-up (render/server.rs's
+    // `renderer_api_key not configured` warn) — an operator who blanks the
+    // key deserves the same signal immediately, not a slow discovery via a
+    // stream of per-connection auth-failure warnings later (#529 step 4).
+    // A rotation to a DIFFERENT non-empty key needs no extra warn — new
+    // registrations simply start using it.
+    if outcome
+        .applied
+        .iter()
+        .any(|path| path == "paroche.renderer_api_key")
+        && config
+            .current()
+            .paroche
+            .renderer_api_key
+            .as_deref()
+            .is_none_or(str::is_empty)
+    {
+        tracing::warn!(
+            "paroche.renderer_api_key not configured; rejecting every renderer registration \
+             until a key is SET"
         );
     }
     if !outcome.restart_pending.is_empty() {

--- a/crates/themelion/src/gate.rs
+++ b/crates/themelion/src/gate.rs
@@ -1,0 +1,240 @@
+// Reusable concurrency admission gate whose limit is supplied live per call.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::sync::Notify;
+
+/// An admission gate whose limit is read fresh on every call instead of
+/// fixed at construction (contrast `tokio::sync::Semaphore`, whose permit
+/// count is set once). Callers thread a live limit — typically a
+/// `horismos::Section<T>::get()` read, or a plain `usize` — through
+/// `try_enter`/`enter` so a config reload changes admission without
+/// rebuilding the gate. `themelion` takes no dependency on `horismos` to
+/// support this: the limit arrives as a plain `usize` or closure, never a
+/// config type.
+pub struct LiveGate {
+    in_flight: AtomicUsize,
+    notify: Notify,
+}
+
+impl Default for LiveGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LiveGate {
+    pub fn new() -> Self {
+        Self {
+            in_flight: AtomicUsize::new(0),
+            notify: Notify::new(),
+        }
+    }
+
+    /// Number of currently-admitted (not yet dropped) guards.
+    pub fn in_flight(&self) -> usize {
+        self.in_flight.load(Ordering::Acquire)
+    }
+
+    /// Admission-refusal entry: `Some(guard)` when `in_flight < limit` at the
+    /// moment of the call, `None` otherwise. Never blocks; a refused call
+    /// never increments the counter.
+    ///
+    /// INVARIANT: the check-and-increment is one atomic operation
+    /// (`fetch_update`'s internal CAS retry loop), so two concurrent callers
+    /// racing at `in_flight == limit - 1` cannot both observe success —
+    /// exactly one wins the last slot and the other is refused.
+    pub fn try_enter(self: &Arc<Self>, limit: usize) -> Option<GateGuard> {
+        self.in_flight
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < limit).then_some(current + 1)
+            })
+            .ok()
+            .map(|_| GateGuard {
+                gate: Arc::clone(self),
+            })
+    }
+
+    /// Wait-until-below entry: on every attempt (including every wake),
+    /// `limit()` is re-read before re-checking admission — so a config
+    /// reload that raises or lowers the effective cap is observed by the
+    /// next admission decision without rebuilding the gate.
+    ///
+    /// WAKE ORDERING (the subtle bit): a raised limit is only re-evaluated
+    /// when this waiter is woken, and the only wake source is a `GateGuard`
+    /// drop (`notify_waiters()`). A limit raise with no subsequent guard
+    /// drop leaves an already-parked waiter parked — there is no dedicated
+    /// `poke()` to force a re-check out of band, by design (the gate stays a
+    /// two-method primitive). Every real caller of `enter` (concurrency
+    /// admission under ongoing traffic) pairs a raise with request traffic
+    /// that drops guards continuously, so the window is not observable in
+    /// practice; a caller with wholly idle traffic across a raise can force
+    /// a re-check by taking and immediately dropping one extra `try_enter`.
+    ///
+    /// SAFETY (no missed wakeup): `self.notify.notified()` is constructed
+    /// BEFORE `try_enter` is (re)attempted on each loop iteration. Per
+    /// `tokio::sync::Notify`'s documented idiom, a `notify_waiters()` call
+    /// that races between our failed `try_enter` and our `.await` on
+    /// `notified` is still observed — the `Notified` future captures the
+    /// notify generation at construction time, not at first poll, so it
+    /// cannot miss a `notify_waiters()` that happens after it was created.
+    pub async fn enter(self: &Arc<Self>, limit: impl Fn() -> usize) -> GateGuard {
+        loop {
+            let notified = self.notify.notified();
+            if let Some(guard) = self.try_enter(limit()) {
+                return guard;
+            }
+            notified.await;
+        }
+    }
+}
+
+/// Held while admitted through `LiveGate::try_enter`/`enter`. Dropping
+/// releases the slot and wakes any `enter` waiters to re-check the
+/// (possibly-changed) limit.
+pub struct GateGuard {
+    gate: Arc<LiveGate>,
+}
+
+impl Drop for GateGuard {
+    fn drop(&mut self) {
+        // INVARIANT: exactly one decrement per admitted guard — `try_enter`
+        // increments exactly once per `Some` it returns, `GateGuard` is not
+        // `Clone`, and `Drop` runs exactly once per value, so this fires
+        // exactly once per admission.
+        self.gate.in_flight.fetch_sub(1, Ordering::AcqRel);
+        self.gate.notify.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn try_enter_two_concurrent_at_limit_one_exactly_one_succeeds() {
+        let gate = Arc::new(LiveGate::new());
+        let first = gate.try_enter(1);
+        let second = gate.try_enter(1);
+
+        assert!(first.is_some(), "first entry under the limit must succeed");
+        assert!(
+            second.is_none(),
+            "second entry at the limit must be refused"
+        );
+        assert_eq!(gate.in_flight(), 1);
+    }
+
+    #[test]
+    fn try_enter_refuses_without_incrementing_when_at_limit() {
+        let gate = Arc::new(LiveGate::new());
+        let _held = gate.try_enter(1).expect("first entry admitted");
+
+        assert!(gate.try_enter(1).is_none());
+        assert_eq!(
+            gate.in_flight(),
+            1,
+            "a refused try_enter must not increment the counter"
+        );
+    }
+
+    #[test]
+    fn guard_drop_lets_next_try_enter_succeed() {
+        let gate = Arc::new(LiveGate::new());
+        let held = gate.try_enter(1).expect("first entry admitted");
+        assert!(gate.try_enter(1).is_none());
+
+        drop(held);
+
+        assert!(
+            gate.try_enter(1).is_some(),
+            "dropping the only guard must free the slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn enter_blocks_at_limit_then_admits_after_a_drop() {
+        let gate = Arc::new(LiveGate::new());
+        let held = gate.try_enter(1).expect("first entry admitted");
+
+        let waiter_gate = Arc::clone(&gate);
+        let waiter = tokio::spawn(async move { waiter_gate.enter(|| 1).await });
+
+        // Bounded window: while the only slot stays held, the waiter must
+        // never report done (no over-admission).
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            assert!(
+                !waiter.is_finished(),
+                "waiter must not be admitted while the sole slot is held"
+            );
+        }
+
+        drop(held);
+
+        let admitted = tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter must be admitted once the guard drops")
+            .expect("waiter task must not panic");
+        assert_eq!(gate.in_flight(), 1);
+        drop(admitted);
+        assert_eq!(gate.in_flight(), 0);
+    }
+
+    #[tokio::test]
+    async fn raised_limit_admits_a_previously_blocked_waiter_after_a_guard_drop() {
+        let gate = Arc::new(LiveGate::new());
+        let limit = Arc::new(AtomicUsize::new(1));
+
+        let held = gate.try_enter(1).expect("first entry admitted at limit 1");
+
+        let waiter_gate = Arc::clone(&gate);
+        let waiter_limit = Arc::clone(&limit);
+        let waiter = tokio::spawn(async move {
+            waiter_gate
+                .enter(|| waiter_limit.load(Ordering::Acquire))
+                .await
+        });
+
+        // While the limit is still 1 and the sole slot is held, the waiter
+        // must stay blocked — this also holds regardless of the raise
+        // below, since it is checked strictly before the raise happens.
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            assert!(
+                !waiter.is_finished(),
+                "waiter must not admit under the old limit"
+            );
+        }
+
+        // Raise the limit. `held` is still held (in_flight == 1); a fresh
+        // try_enter can now admit a SECOND concurrent guard at the raised
+        // cap — this is only possible because the raise took effect, proving
+        // it is live (not a one-shot construction-time value).
+        limit.store(2, Ordering::Release);
+        let second = gate
+            .try_enter(2)
+            .expect("raised limit admits a second concurrent guard");
+        assert_eq!(gate.in_flight(), 2);
+
+        // Drop the SECOND guard — not the guard the waiter is parked behind —
+        // to prove ANY guard drop, not a specific one, wakes the waiter to
+        // re-check the raised limit.
+        drop(second);
+
+        let admitted = tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter must be admitted once the raised limit is (re)checked on drop")
+            .expect("waiter task must not panic");
+
+        // `held` (the original guard) and the admitted waiter now coexist —
+        // impossible under the original limit of 1.
+        assert_eq!(gate.in_flight(), 2);
+        drop(held);
+        drop(admitted);
+        assert_eq!(gate.in_flight(), 0);
+    }
+}

--- a/crates/themelion/src/lib.rs
+++ b/crates/themelion/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod aggelia;
 pub mod error;
+pub mod gate;
 pub mod ids;
 pub mod media;
 
 pub use aggelia::{EventReceiver, EventSender, HarmoniaEvent, create_event_bus};
 pub use error::CommonError;
+pub use gate::{GateGuard, LiveGate};
 pub use ids::{
     ApiKeyId, DownloadId, EpisodeId, FeedId, HaveId, MediaId, QueryId, RegistryId, ReleaseId,
     RequestId, UserId, WantId,


### PR DESCRIPTION
Step 4 of the #529 reactive-config migration — renderer QUIC api-key, handshake timeout, and admission cap now read config live.

**New primitive `themelion::LiveGate`** (`crates/themelion/src/gate.rs`): an admission gate whose limit is supplied live per call instead of fixed at construction (contrast `Semaphore`). `try_enter(limit)` is admission-refusal via an atomic `fetch_update` check-and-increment (two concurrent callers racing at `limit-1` can't both win); `enter(limit_fn)` is wait-until-below, re-reading `limit()` on every wake. `GateGuard::drop` decrements once and `notify_waiters()`. themelion takes no horismos dependency — the limit arrives as a plain `usize`/closure. This is the reusable gate kritike's concurrency bound (step 8) will also use.

**Renderer server** (`crates/archon/src/render/server.rs`): the frozen `RendererServerLimits` is gone; `start_renderer_server` takes `Section<ParocheConfig>`. Admission reads `section.get().renderer_max_connections` live at each accept via `LiveGate::try_enter`, so a cap change takes effect on the next admission (a decrease applies to new connections only — live sessions drain naturally, never force-closed). `handle_renderer_connection` takes exactly one `section.get()` snapshot at connection-accept time for both the handshake timeout and the api-key check — a reload racing a connection can't mix an old timeout with a new key (the #529 single-op-snapshot invariant). A rotated `renderer_api_key` affects new registrations only; established sessions are not re-challenged or evicted (eviction is a separate feature, not faked). A `None`/empty key stays fail-closed, and a reload that clears a previously-set key re-emits the "renderer api key not set" warning.

Tests spawn the real `start_renderer_server` driven by a live `ConfigManager`/`Section`: rotating the key rejects a new registration with the old key, accepts the new key, and keeps a held pre-rotation session; lowering the cap below the live count refuses the next connection while existing held sessions survive; raising it admits a new one. A `HeldSession` harness keeps QUIC connections (and thus their admission guards) alive so the persistence assertions are genuine. LiveGate has its own unit tests (concurrent refusal, drop-frees-slot, blocked-then-admitted, raised-limit-admits-after-drop).

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings`), nextest 1977 passed, deny, kanon lint (0/0). `Gate-Passed` stamped.

Refs #529
