### PR TITLE
feat(zetesis,syntaxis,ergasia,horismos): live acquisition config + seed-threshold restart reclass (#529 step 7)

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -29,6 +29,7 @@ use tokio::signal::unix::SignalKind;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info};
+use zetesis::CardigannRegistry;
 use zetesis::SearchIndexerService;
 use zetesis::cf_bypass::CloudflareProxy;
 use zetesis::cf_bypass::byparr::ByparrProxy;
@@ -645,7 +646,10 @@ async fn subtitle_target(
 /// that Syntaxis expects for dispatching downloads.
 struct SessionEngine {
     session: Arc<TorrentSession>,
-    extraction_limits: ergasia::ExtractionLimits,
+    // WHY: a `Section` (not a frozen `ExtractionLimits`) — #529 step 7 makes
+    // `ergasia.max_extraction_depth`/`max_decompression_ratio` live: `extract`
+    // builds fresh limits FROM a snapshot taken per call.
+    extraction_config: horismos::Section<horismos::ErgasiaConfig>,
 }
 
 impl ergasia::DownloadEngine for SessionEngine {
@@ -702,7 +706,8 @@ impl ergasia::DownloadEngine for SessionEngine {
         download_path: &std::path::Path,
         output_dir: &std::path::Path,
     ) -> Result<Option<ergasia::ExtractionResult>, ergasia::ErgasiaError> {
-        ergasia::extract_archives(download_path, output_dir, self.extraction_limits).await
+        let limits = ergasia::ExtractionLimits::from(&self.extraction_config.get());
+        ergasia::extract_archives(download_path, output_dir, limits).await
     }
 }
 
@@ -885,16 +890,28 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
 
     // Layer 0: Zetesis (indexer protocol)
     let cf_proxy = build_cf_proxy(&boot_config.zetesis)?;
+    // WHY: a `Section` (not the frozen boot_config) — #529 step 7 makes the
+    // per-op fields live; the zetesis supervisor below handles the
+    // remaining LIVE-B mechanisms (rate limiter, cf proxy, cardigann).
     let zetesis = Arc::new(SearchIndexerService::new(
         db.read.clone(),
         db.write.clone(),
         cf_proxy,
-        boot_config.zetesis.clone(),
+        config_handle.section(|c| &c.zetesis),
         event_tx.clone(),
     ));
     info!(
         cloudflare_bypass = boot_config.zetesis.cloudflare_bypass_enabled,
         "zetesis (indexer search) initialized"
+    );
+    let zetesis_supervisor = tokio::spawn(
+        run_zetesis_supervisor(
+            Arc::clone(&zetesis),
+            boot_config.zetesis.clone(),
+            config_handle.clone(),
+            shutdown_token.child_token(),
+        )
+        .instrument(tracing::info_span!("zetesis_supervisor")),
     );
 
     // Layer 1: Ergasia (download execution)
@@ -906,9 +923,11 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     info!("ergasia (download engine) initialized");
 
     // Layer 2: Syntaxis (queue orchestration, depends on ergasia)
+    // WHY: a `Section` (not the frozen boot_config) — #529 step 7 makes
+    // `ergasia.max_extraction_depth`/`max_decompression_ratio` live.
     let engine_adapter = Arc::new(SessionEngine {
         session: Arc::clone(&ergasia_session),
-        extraction_limits: ergasia::ExtractionLimits::from(&boot_config.ergasia),
+        extraction_config: config_handle.section(|c| &c.ergasia),
     });
     let syntaxis_svc = Arc::new(
         DownloadQueue::new(
@@ -922,6 +941,17 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     );
     let syntaxis_handle = syntaxis_svc.start(event_tx.subscribe(), shutdown_token.child_token());
     info!("syntaxis (download queue) initialized  -  event listener started");
+    // WHY: `retry_count`/`retry_backoff_base_seconds`/the `SlotAllocator`
+    // limits go live via `DownloadQueue::update_config` (#529 step 7) — a
+    // `syntaxis.*` change is applied in place, never rebuilt.
+    let syntaxis_supervisor = tokio::spawn(
+        run_syntaxis_supervisor(
+            Arc::clone(&syntaxis_svc),
+            config_handle.clone(),
+            shutdown_token.child_token(),
+        )
+        .instrument(tracing::info_span!("syntaxis_supervisor")),
+    );
 
     // Layer 4: Syndesmos (external integrations  -  Plex, Last.fm, Tidal)
     let syndesmos_svc = Arc::new(build_syndesmos(&boot_config, &event_tx, db.read.clone()));
@@ -1049,6 +1079,16 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // Wait for the syntaxis event listener to drain (layer 2, after layer 4)
     if let Err(e) = syntaxis_handle.await {
         tracing::warn!(error = %e, "syntaxis event listener panicked during shutdown");
+    }
+
+    // #529 step 7: the zetesis and syntaxis LIVE-B supervisors exit on the
+    // same shutdown_token child their construction site was handed; joining
+    // them here is symmetric with the step-6 rebuild supervisors below.
+    if let Err(e) = syntaxis_supervisor.await {
+        tracing::warn!(error = %e, "syntaxis supervisor panicked during shutdown");
+    }
+    if let Err(e) = zetesis_supervisor.await {
+        tracing::warn!(error = %e, "zetesis supervisor panicked during shutdown");
     }
 
     // Shutdown core subsystems (reverse of startup) — the #529 step 6
@@ -1610,6 +1650,141 @@ async fn run_feed_supervisor(
     }
 }
 
+// ── Acquisition-live supervisors (#529 step 7) ──────────────────────────────
+//
+// Unlike the rebuild-class supervisors above, zetesis and syntaxis need no
+// teardown/rebuild: their per-op fields already go live through a `Section`,
+// and their remaining LIVE-B mechanisms (rate limiter, cf proxy, cardigann
+// registry, `SlotAllocator` limits) are updated IN PLACE behind swappable
+// interior mutability — the service instance itself never changes identity.
+
+/// Runs the `syntaxis.*` live-limit supervisor: on a section change it calls
+/// `DownloadQueue::update_config`, which replaces the stored config (making
+/// `retry_count`/`retry_backoff_base_seconds` reads live) and updates the
+/// `SlotAllocator`'s concurrency limits in place. A decrease below the
+/// current in-flight count simply stops new dispatch until in-flight drains
+/// below the new cap — nothing already dispatched is cancelled.
+async fn run_syntaxis_supervisor(
+    queue: Arc<DownloadQueue<SessionEngine>>,
+    config: horismos::ConfigHandle,
+    shutdown: CancellationToken,
+) {
+    let mut watcher = config.watch_section(|c| &c.syntaxis);
+    loop {
+        let changed = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            changed = watcher.changed() => changed,
+        };
+        let Some(new_cfg) = changed else {
+            shutdown.cancelled().await;
+            break;
+        };
+
+        tracing::info!(
+            subsystem = "syntaxis",
+            "syntaxis config changed  -  updating live limits"
+        );
+        queue.update_config(new_cfg).await;
+    }
+}
+
+/// Runs the zetesis LIVE-B mechanisms (per-indexer rate limits, Cloudflare
+/// bypass proxy, Cardigann definitions registry) under a section watcher.
+/// The per-op fields (`max_concurrent_searches`, `search_timeout_seconds`,
+/// `max_response_body_bytes`, `request_timeout_secs`) need no supervisor
+/// action — `SearchIndexerService` already reads them live through its own
+/// `Section`.
+async fn run_zetesis_supervisor(
+    service: Arc<SearchIndexerService>,
+    initial: horismos::SearchSubsystemConfig,
+    config: horismos::ConfigHandle,
+    shutdown: CancellationToken,
+) {
+    let mut watcher = config.watch_section(|c| &c.zetesis);
+    let mut current = initial;
+
+    loop {
+        let changed = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            changed = watcher.changed() => changed,
+        };
+        let Some(new) = changed else {
+            shutdown.cancelled().await;
+            break;
+        };
+
+        if new.per_indexer_rate_limit_requests != current.per_indexer_rate_limit_requests
+            || new.per_indexer_rate_limit_window_seconds
+                != current.per_indexer_rate_limit_window_seconds
+        {
+            tracing::info!(
+                subsystem = "zetesis",
+                "rate limit config changed  -  reconfiguring live"
+            );
+            service
+                .reconfigure_rate_limiter(
+                    new.per_indexer_rate_limit_requests,
+                    std::time::Duration::from_secs(new.per_indexer_rate_limit_window_seconds),
+                )
+                .await;
+        }
+
+        if new.cloudflare_bypass_enabled != current.cloudflare_bypass_enabled
+            || new.cf_proxy_url != current.cf_proxy_url
+            || new.cf_proxy_timeout_seconds != current.cf_proxy_timeout_seconds
+        {
+            tracing::info!(
+                subsystem = "zetesis",
+                "cloudflare bypass config changed  -  rebuilding proxy"
+            );
+            match build_cf_proxy(&new) {
+                Ok(proxy) => service.set_cf_proxy(proxy),
+                Err(e) => tracing::error!(
+                    subsystem = "zetesis",
+                    error = %e,
+                    "cf proxy rebuild failed  -  keeping the previous proxy"
+                ),
+            }
+        }
+
+        if new.cardigann_definitions_dir != current.cardigann_definitions_dir {
+            tracing::info!(
+                subsystem = "zetesis",
+                "cardigann_definitions_dir changed  -  reloading registry"
+            );
+            // WHY: `CardigannRegistry::load` never hard-fails (a broken
+            // definition file or unreadable dir is logged and skipped
+            // internally) — the one failure mode this can preflight is the
+            // directory itself being unreadable, checked here so a typo'd
+            // path cannot silently blank out a working registry. An
+            // existing-but-empty directory is NOT a failure — that is the
+            // same state boot accepts.
+            match &new.cardigann_definitions_dir {
+                Some(dir) if std::fs::metadata(dir).is_err() => {
+                    tracing::error!(
+                        subsystem = "zetesis",
+                        dir = %dir.display(),
+                        "cardigann_definitions_dir is not readable  -  keeping the previous registry"
+                    );
+                }
+                _ => {
+                    let registry = CardigannRegistry::load(Arc::new(new.clone()));
+                    tracing::info!(
+                        subsystem = "zetesis",
+                        count = registry.len(),
+                        "cardigann registry reloaded"
+                    );
+                    service.set_cardigann_registry(Arc::new(registry));
+                }
+            }
+        }
+
+        current = new;
+    }
+}
+
 // ── Syndesmos construction ──────────────────────────────────────────────────
 
 fn build_syndesmos(
@@ -2148,7 +2323,7 @@ mod search_adapter_tests {
             pool.clone(),
             pool,
             Arc::new(zetesis::cf_bypass::noop::NoProxy),
-            horismos::SearchSubsystemConfig::default(),
+            horismos::Section::fixed(horismos::SearchSubsystemConfig::default()),
             event_tx,
         );
         let adapter = SearchAdapter(Arc::new(service));

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -22,6 +22,11 @@ const RESTART_REQUIRED: &[&str] = &[
     "ergasia.session_state_path",
     "ergasia.listen_port_range",
     "ergasia.peer_connect_timeout_seconds",
+    // #529 step 7: frozen into librqbit's `SeedingPolicy` at session build with
+    // no reconfigure API — holding these back keeps `current()` honest (a
+    // reload would otherwise "apply" a value with zero live effect).
+    "ergasia.seed_ratio_threshold",
+    "ergasia.seed_time_threshold_hours",
 ];
 
 fn requires_restart(path: &str) -> bool {
@@ -225,6 +230,28 @@ mod tests {
     }
 
     #[test]
+    fn changed_seed_ratio_threshold_is_restart_class() {
+        let old = base_config();
+        let mut new = base_config();
+        new.ergasia.seed_ratio_threshold = 2.5;
+
+        let changes = diff_config(&old, &new);
+        assert_eq!(paths(&changes), vec!["ergasia.seed_ratio_threshold"]);
+        assert!(changes[0].requires_restart);
+    }
+
+    #[test]
+    fn changed_seed_time_threshold_hours_is_restart_class() {
+        let old = base_config();
+        let mut new = base_config();
+        new.ergasia.seed_time_threshold_hours = 200;
+
+        let changes = diff_config(&old, &new);
+        assert_eq!(paths(&changes), vec!["ergasia.seed_time_threshold_hours"]);
+        assert!(changes[0].requires_restart);
+    }
+
+    #[test]
     fn multiple_changed_leaves_return_multiple_entries() {
         let old = base_config();
         let mut new = base_config();
@@ -277,5 +304,25 @@ mod tests {
             effective.database.write_pool_max,
             old.database.write_pool_max
         );
+    }
+
+    #[test]
+    fn merge_holds_back_seed_threshold_changes() {
+        let old = base_config();
+        let mut new = base_config();
+        new.ergasia.seed_ratio_threshold = 3.0;
+        new.ergasia.seed_time_threshold_hours = 999;
+        new.paroche.port = 9090;
+
+        let effective = held_back_merge(&old, &new).unwrap();
+        assert_eq!(
+            effective.ergasia.seed_ratio_threshold,
+            old.ergasia.seed_ratio_threshold
+        );
+        assert_eq!(
+            effective.ergasia.seed_time_threshold_hours,
+            old.ergasia.seed_time_threshold_hours
+        );
+        assert_eq!(effective.paroche.port, 9090);
     }
 }

--- a/crates/horismos/src/handle.rs
+++ b/crates/horismos/src/handle.rs
@@ -664,6 +664,40 @@ mod tests {
         assert_eq!(outcome.restart_pending, vec!["database.db_path"]);
     }
 
+    // #529 step 7: seed thresholds are frozen into librqbit's `SeedingPolicy`
+    // at session build with no reconfigure API — a reload must hold them back
+    // exactly like the database prefix, not silently "apply" a value with
+    // zero live effect.
+    #[test]
+    fn replace_holds_back_seed_threshold_changes() {
+        let config = valid_config();
+        let (manager, handle) = ConfigManager::new(
+            config,
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+
+        let mut changed = valid_config();
+        changed.ergasia.seed_ratio_threshold = 3.0;
+        changed.ergasia.seed_time_threshold_hours = 999;
+        changed.paroche.port = 9090;
+        let outcome = manager.replace(changed).unwrap();
+
+        let current = handle.current();
+        assert_eq!(current.ergasia.seed_ratio_threshold, 1.0);
+        assert_eq!(current.ergasia.seed_time_threshold_hours, 72);
+        assert_eq!(current.paroche.port, 9090);
+        assert_eq!(
+            outcome.restart_pending,
+            vec![
+                "ergasia.seed_ratio_threshold",
+                "ergasia.seed_time_threshold_hours"
+            ]
+        );
+        assert_eq!(outcome.applied, vec!["paroche.port"]);
+        assert!(outcome.needs_restart());
+    }
+
     #[test]
     fn replace_reapplies_overrides() {
         let config = valid_config();

--- a/crates/syntaxis/src/dispatch.rs
+++ b/crates/syntaxis/src/dispatch.rs
@@ -92,6 +92,25 @@ impl SlotAllocator {
         self.active_total < self.max_concurrent
     }
 
+    /// Updates the concurrency limits in place — the #529 step-7 live-config
+    /// mechanism (`DownloadQueue::update_config`). Active-download counts are
+    /// left untouched: a decrease takes effect purely by making
+    /// `has_slot`/`global_slot_available` return `false` until in-flight
+    /// naturally drains below the new cap — nothing already dispatched is
+    /// evicted.
+    pub(crate) fn set_limits(&mut self, max_concurrent: usize, max_per_tracker: usize) {
+        self.max_concurrent = max_concurrent;
+        self.max_per_tracker = max_per_tracker;
+    }
+
+    /// The live per-tracker limit — the single source of truth
+    /// `next_dispatchable` reads FROM (heals the split-brain where
+    /// `has_slot`'s check and a second frozen `SyntaxisConfig` copy could
+    /// disagree the moment config became mutable).
+    pub(crate) fn max_per_tracker(&self) -> usize {
+        self.max_per_tracker
+    }
+
     /// Returns a snapshot of per-tracker active counts for use in closures
     /// that cannot hold a reference to `self`.
     pub(crate) fn per_tracker_snapshot(&self) -> HashMap<i64, usize> {
@@ -202,5 +221,50 @@ mod tests {
         // Releasing when nothing is active should not panic
         allocator.release(DownloadProtocol::Torrent, Some(1));
         assert_eq!(allocator.active_total(), 0);
+    }
+
+    // ── #529 step 7: SlotAllocator::set_limits ──────────────────────────────
+
+    #[test]
+    fn set_limits_raises_max_per_tracker_and_unblocks_has_slot() {
+        let mut allocator = SlotAllocator::new(5, 1);
+        allocator.acquire(&torrent_item(Some(1)));
+        assert!(!allocator.has_slot(&torrent_item(Some(1))));
+
+        allocator.set_limits(5, 3);
+
+        assert_eq!(allocator.max_per_tracker(), 3);
+        assert!(allocator.has_slot(&torrent_item(Some(1))));
+    }
+
+    #[test]
+    fn set_limits_decrease_below_active_blocks_new_dispatch_without_evicting() {
+        let mut allocator = SlotAllocator::new(5, 5);
+        allocator.acquire(&torrent_item(Some(1)));
+        allocator.acquire(&torrent_item(Some(2)));
+        assert_eq!(allocator.active_total(), 2);
+
+        allocator.set_limits(1, 5);
+        assert!(
+            !allocator.global_slot_available(),
+            "over the new cap  -  no new dispatch"
+        );
+        assert_eq!(
+            allocator.active_total(),
+            2,
+            "in-flight downloads are never evicted by a limit decrease"
+        );
+
+        allocator.release(DownloadProtocol::Torrent, Some(1));
+        assert!(
+            !allocator.global_slot_available(),
+            "still at the new cap after only one of two drains"
+        );
+
+        allocator.release(DownloadProtocol::Torrent, Some(2));
+        assert!(
+            allocator.global_slot_available(),
+            "below the new cap  -  dispatch resumes"
+        );
     }
 }

--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -179,6 +179,27 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
         })
     }
 
+    /// Replaces the live config: `retry_count`/`retry_backoff_base_seconds`
+    /// reads go live immediately, and the `SlotAllocator`'s concurrency
+    /// limits are updated in place. A decrease below the current in-flight
+    /// count is never enforced by cancelling in-flight work — dispatch
+    /// simply stops accepting new work until in-flight drains below the new
+    /// cap. Any additional headroom from an INCREASE is filled immediately
+    /// via a backlog dispatch pass, mirroring startup recovery.
+    ///
+    /// Called by archon's syntaxis supervisor on a `syntaxis.*` config
+    /// change (#529 step 7).
+    pub async fn update_config(&self, new: SyntaxisConfig) {
+        {
+            let mut inner = self.inner.lock().await;
+            inner
+                .allocator
+                .set_limits(new.max_concurrent_downloads, new.max_per_tracker);
+            inner.config = new;
+        }
+        Self::dispatch_backlog(&self.inner, &self.engine, &self.pool).await;
+    }
+
     /// Launches the event-listener task that processes `DownloadCompleted` and
     /// `DownloadFailed` events from the Ergasia broadcast bus.
     ///
@@ -822,7 +843,10 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
             return None;
         }
 
-        let max_per_tracker = inner.config.max_per_tracker;
+        // WHY: reads FROM the allocator (the live, supervisor-updated value),
+        // not `inner.config.max_per_tracker` — a second frozen copy would
+        // reopen the #529 step-7 split-brain `update_config` heals.
+        let max_per_tracker = inner.allocator.max_per_tracker();
         // WHY: Snapshot tracker counts before mutably borrowing the queue.
         // The closure passed to dequeue_eligible cannot hold a reference into
         // `inner` while `inner.queue` is mutably borrowed.
@@ -2882,5 +2906,89 @@ mod tests {
                 .is_none(),
             "the cancelled row must stay deleted"
         );
+    }
+
+    // ── #529 step 7: DownloadQueue::update_config live limits ───────────────
+
+    #[tokio::test]
+    async fn update_config_raises_limit_and_dispatches_backlog() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(1, 3, 0)).await;
+
+        let first = make_item(DownloadProtocol::Torrent, 2);
+        let second = make_item(DownloadProtocol::Torrent, 2);
+        svc.enqueue(first).await.unwrap();
+        svc.enqueue(second).await.unwrap();
+
+        // max_concurrent_downloads = 1  -  only the first item gets a slot.
+        tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        settle_until(|| queued_len_sync(&svc) == 1 && active_total_sync(&svc) == 1).await;
+
+        svc.update_config(test_config(2, 3, 0)).await;
+
+        // The raised limit must immediately dispatch the queued second item
+        // FROM the same config-change call, not wait on unrelated activity.
+        let (dl_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(active_contains(&svc, dl_id).await);
+        assert_eq!(queued_len(&svc).await, 0);
+        assert_eq!(active_total(&svc).await, 2);
+    }
+
+    #[tokio::test]
+    async fn update_config_decrease_stops_new_dispatch_without_cancelling_in_flight() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 3, 0)).await;
+
+        let first = make_item(DownloadProtocol::Torrent, 2);
+        let second = make_item(DownloadProtocol::Torrent, 2);
+        svc.enqueue(first).await.unwrap();
+        svc.enqueue(second).await.unwrap();
+
+        for _ in 0..2 {
+            tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        }
+        assert_eq!(active_total(&svc).await, 2);
+
+        svc.update_config(test_config(1, 3, 0)).await;
+        assert_eq!(
+            active_total(&svc).await,
+            2,
+            "a config decrease must never cancel in-flight downloads"
+        );
+
+        let third = make_item(DownloadProtocol::Torrent, 2);
+        svc.enqueue(third).await.unwrap();
+        settle_until(|| queued_len_sync(&svc) == 1).await;
+        assert!(
+            tokio::time::timeout(tokio::time::Duration::from_millis(100), started_rx.recv())
+                .await
+                .is_err(),
+            "no new dispatch may occur while active_total is at/over the decreased cap"
+        );
+    }
+
+    fn queued_len_sync(svc: &DownloadQueue<MockEngine>) -> usize {
+        svc.inner
+            .try_lock()
+            .map(|inner| inner.queue.len())
+            .unwrap_or(usize::MAX)
+    }
+
+    fn active_total_sync(svc: &DownloadQueue<MockEngine>) -> usize {
+        svc.inner
+            .try_lock()
+            .map(|inner| inner.allocator.active_total())
+            .unwrap_or(usize::MAX)
     }
 }

--- a/crates/zetesis/src/rate_limit.rs
+++ b/crates/zetesis/src/rate_limit.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::time::Duration;
 
 use dashmap::DashMap;
@@ -6,10 +7,15 @@ use tokio::sync::Mutex;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
+/// Per-indexer rate limiting with a live-reconfigurable ceiling.
+///
+/// `max_tokens`/`window` are atomics (not plain fields) because `reconfigure`
+/// mutates them through a shared `&self` — the same handle `search()` reads
+/// through concurrently.
 pub struct RateLimiter {
     buckets: Arc<DashMap<i64, Mutex<TokenBucket>>>,
-    max_tokens: u32,
-    window: Duration,
+    max_tokens: AtomicU32,
+    window_millis: AtomicU64,
 }
 
 struct TokenBucket {
@@ -82,9 +88,15 @@ impl RateLimiter {
     pub fn new(max_tokens: u32, window: Duration) -> Self {
         Self {
             buckets: Arc::new(DashMap::new()),
-            max_tokens,
-            window,
+            max_tokens: AtomicU32::new(max_tokens),
+            window_millis: AtomicU64::new(u64::try_from(window.as_millis()).unwrap_or(u64::MAX)),
         }
+    }
+
+    fn current_limits(&self) -> (u32, Duration) {
+        let max_tokens = self.max_tokens.load(Ordering::Relaxed);
+        let window = Duration::from_millis(self.window_millis.load(Ordering::Relaxed));
+        (max_tokens, window)
     }
 
     /// Waits for a token, racing the back-off sleep against cancellation.
@@ -95,10 +107,11 @@ impl RateLimiter {
     pub async fn acquire(&self, indexer_id: i64, ct: &CancellationToken) -> bool {
         loop {
             let wait = {
+                let (max_tokens, window) = self.current_limits();
                 let entry = self
                     .buckets
                     .entry(indexer_id)
-                    .or_insert_with(|| Mutex::new(TokenBucket::new(self.max_tokens, self.window)));
+                    .or_insert_with(|| Mutex::new(TokenBucket::new(max_tokens, window)));
                 let mut bucket = entry.value().lock().await;
                 bucket.try_acquire()
             };
@@ -118,12 +131,42 @@ impl RateLimiter {
     }
 
     pub async fn set_retry_after(&self, indexer_id: i64, duration: Duration) {
+        let (max_tokens, window) = self.current_limits();
         let entry = self
             .buckets
             .entry(indexer_id)
-            .or_insert_with(|| Mutex::new(TokenBucket::new(self.max_tokens, self.window)));
+            .or_insert_with(|| Mutex::new(TokenBucket::new(max_tokens, window)));
         let mut bucket = entry.value().lock().await;
         bucket.set_retry_after(duration);
+    }
+
+    /// Live-reconfigures the rate limit: updates the ceiling used for any
+    /// bucket created FROM here on, and updates every EXISTING bucket's
+    /// `max_tokens`/`refill_rate` in place, clamping its available token
+    /// count to the new max.
+    ///
+    /// CRITICAL: `retry_after` and `last_refill` are left UNTOUCHED — the
+    /// #533 fix (an active embargo freezes accrual until `retry_after`
+    /// clears) must survive a reconfigure. A reload must never un-embargo an
+    /// indexer that returned 429.
+    pub async fn reconfigure(&self, requests_per: u32, window: Duration) {
+        self.max_tokens.store(requests_per, Ordering::Relaxed);
+        self.window_millis.store(
+            u64::try_from(window.as_millis()).unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
+
+        let new_max = f64::from(requests_per);
+        let new_refill_rate = new_max / window.as_secs_f64();
+        for entry in self.buckets.iter() {
+            let mut bucket = entry.value().lock().await;
+            bucket.max_tokens = new_max;
+            bucket.refill_rate = new_refill_rate;
+            // WHY: clamp only — a lowered ceiling must not leave a bucket
+            // holding more tokens than the new max allows. `retry_after` and
+            // `last_refill` are untouched (see doc comment above).
+            bucket.tokens = bucket.tokens.min(new_max);
+        }
     }
 }
 
@@ -192,6 +235,85 @@ mod tests {
         assert!(
             elapsed >= Duration::from_millis(90),
             "expected retry-after delay, got {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconfigure_preserves_active_embargo() {
+        let limiter = RateLimiter::new(5, Duration::from_secs(10));
+        limiter.set_retry_after(1, Duration::from_millis(300)).await;
+
+        // A reconfigure racing the embargo must not clear it.
+        limiter.reconfigure(20, Duration::from_secs(5)).await;
+
+        let start = Instant::now();
+        assert!(limiter.acquire(1, &CancellationToken::new()).await);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(250),
+            "reconfigure must not un-embargo an indexer that returned 429, got {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconfigure_preserves_accrual_state_across_the_embargo_window() {
+        // Mirrors `embargo_freezes_accrual_until_retry_after_clears`, but with
+        // a `reconfigure` call injected mid-embargo — the #533 semantics
+        // (accrual frozen until retry_after clears) must survive it.
+        let limiter = RateLimiter::new(10, Duration::from_secs(10));
+        limiter.set_retry_after(1, Duration::from_secs(20)).await;
+
+        // Reconfigure partway through the embargo window — same ceiling, so
+        // this isolates "does reconfigure preserve last_refill/retry_after"
+        // from "does it also update the ceiling".
+        tokio::time::advance(Duration::from_secs(5)).await;
+        limiter.reconfigure(10, Duration::from_secs(10)).await;
+
+        tokio::time::advance(Duration::from_secs(20)).await;
+
+        let start = Instant::now();
+        assert!(limiter.acquire(1, &CancellationToken::new()).await);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed.is_zero(),
+            "embargo should have cleared by now, got {elapsed:?} wait"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconfigure_clamps_existing_tokens_to_lowered_max() {
+        let limiter = RateLimiter::new(10, Duration::from_secs(10));
+        // Touch the bucket once so it exists with a full 10-token bank.
+        assert!(limiter.acquire(1, &CancellationToken::new()).await);
+
+        limiter.reconfigure(2, Duration::from_secs(10)).await;
+
+        let bucket = limiter
+            .buckets
+            .get(&1)
+            .expect("bucket exists after acquire");
+        let bucket = bucket.lock().await;
+        assert!(
+            bucket.tokens <= 2.0,
+            "expected tokens clamped to the new max of 2, got {}",
+            bucket.tokens
+        );
+    }
+
+    #[tokio::test]
+    async fn reconfigure_applies_new_ceiling_to_newly_seen_indexers() {
+        let limiter = RateLimiter::new(5, Duration::from_secs(10));
+        limiter.reconfigure(1, Duration::from_millis(500)).await;
+
+        // A brand-new indexer bucket must be created with the RECONFIGURED
+        // ceiling, not the constructor's original value.
+        assert!(limiter.acquire(99, &CancellationToken::new()).await);
+        let start = Instant::now();
+        assert!(limiter.acquire(99, &CancellationToken::new()).await);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(400),
+            "expected the reconfigured (lower) ceiling to apply, got {elapsed:?}"
         );
     }
 

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -27,14 +27,38 @@ const DEFAULT_RETRY_AFTER_SECS: u64 = 60;
 /// indexer indefinitely.
 const MAX_RETRY_AFTER_SECS: u64 = 3600;
 
+/// A custom DNS resolver re-validates every resolved address at connect
+/// time, closing the DNS-rebinding TOCTOU that validate_fetch_url's
+/// pre-check alone cannot — the client re-resolves after validation, so a
+/// host that answers public then private would otherwise bypass the guard.
+fn build_http_client(request_timeout_secs: u64) -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(request_timeout_secs))
+        .dns_resolver(Arc::new(SsrfGuardResolver))
+        .build()
+        .unwrap_or_default() // WHY: reqwest::Client::default() is a valid fallback (build fails only with invalid TLS config); the validate_fetch_url pre-check still guards that path
+}
+
 pub struct SearchIndexerService {
     read_pool: SqlitePool,
     write_pool: SqlitePool,
-    cf_proxy: Arc<dyn CloudflareProxy>,
+    // WHY: swappable behind a std RwLock (never held across an .await —
+    // every read site takes the lock, clones the Arc, and drops the guard
+    // before doing anything async) so a `(cloudflare_bypass_enabled,
+    // cf_proxy_url, cf_proxy_timeout_seconds)` change can swap the live proxy
+    // without a service rebuild.
+    cf_proxy: std::sync::RwLock<Arc<dyn CloudflareProxy>>,
     rate_limiter: RateLimiter,
-    http: reqwest::Client,
-    config: SearchSubsystemConfig,
-    cardigann: CardigannRegistry,
+    // WHY: (request_timeout_secs, client) cache — rebuilt only when the live
+    // section's `request_timeout_secs` has actually changed, so most
+    // operations reuse the client's connection pool instead of paying a
+    // fresh-connect cost every call.
+    http: std::sync::RwLock<(u64, reqwest::Client)>,
+    config: horismos::Section<SearchSubsystemConfig>,
+    // WHY: swappable behind a std RwLock, same discipline as `cf_proxy` — a
+    // `cardigann_definitions_dir` change re-runs `CardigannRegistry::load`
+    // and swaps the Arc; a load failure keeps the previous registry.
+    cardigann: std::sync::RwLock<Arc<CardigannRegistry>>,
     event_tx: EventSender,
 }
 
@@ -43,39 +67,85 @@ impl SearchIndexerService {
         read_pool: SqlitePool,
         write_pool: SqlitePool,
         cf_proxy: Arc<dyn CloudflareProxy>,
-        config: SearchSubsystemConfig,
+        config: horismos::Section<SearchSubsystemConfig>,
         event_tx: EventSender,
     ) -> Self {
+        let cfg = config.get();
         let rate_limiter = RateLimiter::new(
-            config.per_indexer_rate_limit_requests,
-            Duration::from_secs(config.per_indexer_rate_limit_window_seconds),
+            cfg.per_indexer_rate_limit_requests,
+            Duration::from_secs(cfg.per_indexer_rate_limit_window_seconds),
         );
 
-        // WHY: a custom DNS resolver re-validates every resolved address at
-        // connect time, closing the DNS-rebinding TOCTOU that validate_fetch_url's
-        // pre-check alone cannot — the client re-resolves after validation, so a
-        // host that answers public then private would otherwise bypass the guard.
-        let http = reqwest::Client::builder()
-            .timeout(Duration::from_secs(config.request_timeout_secs))
-            .dns_resolver(Arc::new(SsrfGuardResolver))
-            .build()
-            .unwrap_or_default(); // WHY: reqwest::Client::default() is a valid fallback (build fails only with invalid TLS config); the validate_fetch_url pre-check still guards that path
+        let http = build_http_client(cfg.request_timeout_secs);
 
-        // WHY: definitions are read once at startup — this is the read site
-        // for `cardigann_definitions_dir`; per-search dispatch only resolves
-        // against the loaded set.
-        let cardigann = CardigannRegistry::load(Arc::new(config.clone()));
+        // WHY: definitions are read once here at construction; a live
+        // `cardigann_definitions_dir` change re-loads and swaps the registry
+        // via `set_cardigann_registry` (archon's zetesis supervisor), never
+        // re-reading this construction path.
+        let cardigann = CardigannRegistry::load(Arc::new(cfg.clone()));
 
         Self {
             read_pool,
             write_pool,
-            cf_proxy,
+            cf_proxy: std::sync::RwLock::new(cf_proxy),
             rate_limiter,
-            http,
+            http: std::sync::RwLock::new((cfg.request_timeout_secs, http)),
             config,
-            cardigann,
+            cardigann: std::sync::RwLock::new(Arc::new(cardigann)),
             event_tx,
         }
+    }
+
+    /// Swaps the live Cloudflare-bypass proxy. Called by archon's zetesis
+    /// supervisor on a `(cloudflare_bypass_enabled, cf_proxy_url,
+    /// cf_proxy_timeout_seconds)` change.
+    pub fn set_cf_proxy(&self, new: Arc<dyn CloudflareProxy>) {
+        let mut guard = self.cf_proxy.write().unwrap_or_else(|e| e.into_inner());
+        *guard = new;
+    }
+
+    /// Swaps the live Cardigann definitions registry. Called by archon's
+    /// zetesis supervisor on a `cardigann_definitions_dir` change; a load
+    /// failure is the caller's responsibility to detect — this always swaps
+    /// to whatever it is given.
+    pub fn set_cardigann_registry(&self, new: Arc<CardigannRegistry>) {
+        let mut guard = self.cardigann.write().unwrap_or_else(|e| e.into_inner());
+        *guard = new;
+    }
+
+    /// Live-reconfigures the per-indexer rate limiter. Called by archon's
+    /// zetesis supervisor on a `(per_indexer_rate_limit_requests,
+    /// per_indexer_rate_limit_window_seconds)` change; preserves every
+    /// bucket's active embargo (see `RateLimiter::reconfigure`).
+    pub async fn reconfigure_rate_limiter(&self, requests_per: u32, window: Duration) {
+        self.rate_limiter.reconfigure(requests_per, window).await;
+    }
+
+    fn cf_proxy_snapshot(&self) -> Arc<dyn CloudflareProxy> {
+        let guard = self.cf_proxy.read().unwrap_or_else(|e| e.into_inner());
+        Arc::clone(&guard)
+    }
+
+    fn cardigann_snapshot(&self) -> Arc<CardigannRegistry> {
+        let guard = self.cardigann.read().unwrap_or_else(|e| e.into_inner());
+        Arc::clone(&guard)
+    }
+
+    /// Returns a client built for `request_timeout_secs`, rebuilding (and
+    /// caching) only when the live value differs from the last build — most
+    /// operations reuse the cached client's connection pool while
+    /// `zetesis.request_timeout_secs` still goes live on the next change.
+    fn http_client(&self, request_timeout_secs: u64) -> reqwest::Client {
+        {
+            let guard = self.http.read().unwrap_or_else(|e| e.into_inner());
+            if guard.0 == request_timeout_secs {
+                return guard.1.clone();
+            }
+        }
+        let client = build_http_client(request_timeout_secs);
+        let mut guard = self.http.write().unwrap_or_else(|e| e.into_inner());
+        *guard = (request_timeout_secs, client.clone());
+        client
     }
 
     #[instrument(skip(self, ct))]
@@ -85,6 +155,10 @@ impl SearchIndexerService {
         ct: CancellationToken,
     ) -> Result<Vec<SearchResult>, SearchIndexerError> {
         let query_id = QueryId::new();
+        // WHY: one snapshot for the whole operation — a mid-search reload
+        // cannot mix an old bound from before the change with a new one FROM
+        // after it (torn-config guard).
+        let cfg = self.config.get();
 
         // Step 1: Filter eligible indexers
         let indexers = repo::get_eligible_indexers(&self.read_pool)
@@ -104,15 +178,17 @@ impl SearchIndexerService {
         );
 
         // Step 3: Parallel fan-out
-        let cf_proxy = Arc::clone(&self.cf_proxy);
-        let http = self.http.clone();
-        let timeout = Duration::from_secs(self.config.search_timeout_seconds);
-        let max_body_bytes = self.config.max_response_body_bytes;
+        let cf_proxy = self.cf_proxy_snapshot();
+        let cardigann = self.cardigann_snapshot();
+        let http = self.http_client(cfg.request_timeout_secs);
+        let timeout = Duration::from_secs(cfg.search_timeout_seconds);
+        let max_body_bytes = cfg.max_response_body_bytes;
         let rate_limiter = &self.rate_limiter;
 
         let results: Vec<SearchResult> = stream::iter(eligible)
             .map(|indexer| {
                 let cf = Arc::clone(&cf_proxy);
+                let cardigann = Arc::clone(&cardigann);
                 let h = http.clone();
                 let ct = ct.clone();
                 let q = query.clone();
@@ -127,26 +203,20 @@ impl SearchIndexerService {
                         );
                         return Vec::new();
                     }
-                    let client = match make_client(
-                        &indexer,
-                        h,
-                        cf,
-                        timeout,
-                        max_body_bytes,
-                        &self.cardigann,
-                    ) {
-                        Ok(client) => client,
-                        Err(e) => {
-                            warn!(
-                                indexer_id = indexer.id,
-                                indexer_name = %indexer.name,
-                                error = %e,
-                                "failed to construct indexer client"
-                            );
-                            self.handle_search_error(&indexer, &e).await;
-                            return Vec::new();
-                        }
-                    };
+                    let client =
+                        match make_client(&indexer, h, cf, timeout, max_body_bytes, &cardigann) {
+                            Ok(client) => client,
+                            Err(e) => {
+                                warn!(
+                                    indexer_id = indexer.id,
+                                    indexer_name = %indexer.name,
+                                    error = %e,
+                                    "failed to construct indexer client"
+                                );
+                                self.handle_search_error(&indexer, &e).await;
+                                return Vec::new();
+                            }
+                        };
                     match client.search_boxed(&q, ct).await {
                         Ok(results) => results,
                         Err(e @ SearchIndexerError::Cancelled { .. }) => {
@@ -173,7 +243,7 @@ impl SearchIndexerService {
                     }
                 }
             })
-            .buffer_unordered(self.config.max_concurrent_searches)
+            .buffer_unordered(cfg.max_concurrent_searches)
             .flat_map(stream::iter)
             .collect()
             .await;
@@ -203,14 +273,15 @@ impl SearchIndexerService {
         indexer_id: i64,
         ct: CancellationToken,
     ) -> Result<IndexerStatus, SearchIndexerError> {
+        let cfg = self.config.get();
         let indexer = self.load_indexer(indexer_id).await?;
         let client = make_client(
             &indexer,
-            self.http.clone(),
-            Arc::clone(&self.cf_proxy),
-            Duration::from_secs(self.config.request_timeout_secs),
-            self.config.max_response_body_bytes,
-            &self.cardigann,
+            self.http_client(cfg.request_timeout_secs),
+            self.cf_proxy_snapshot(),
+            Duration::from_secs(cfg.request_timeout_secs),
+            cfg.max_response_body_bytes,
+            &self.cardigann_snapshot(),
         )?;
         let status = client.test_boxed(ct).await?;
         let db_status = if status.healthy { "active" } else { "degraded" };
@@ -228,14 +299,15 @@ impl SearchIndexerService {
         indexer_id: i64,
         ct: CancellationToken,
     ) -> Result<IndexerCaps, SearchIndexerError> {
+        let cfg = self.config.get();
         let indexer = self.load_indexer(indexer_id).await?;
         let client = make_client(
             &indexer,
-            self.http.clone(),
-            Arc::clone(&self.cf_proxy),
-            Duration::from_secs(self.config.request_timeout_secs),
-            self.config.max_response_body_bytes,
-            &self.cardigann,
+            self.http_client(cfg.request_timeout_secs),
+            self.cf_proxy_snapshot(),
+            Duration::from_secs(cfg.request_timeout_secs),
+            cfg.max_response_body_bytes,
+            &self.cardigann_snapshot(),
         )?;
         let caps =
             client

--- a/crates/zetesis/src/search/tests.rs
+++ b/crates/zetesis/src/search/tests.rs
@@ -220,16 +220,23 @@ async fn make_service() -> (SearchIndexerService, SqlitePool) {
 }
 
 async fn make_service_with(config: SearchSubsystemConfig) -> (SearchIndexerService, SqlitePool) {
+    make_service_with_section(horismos::Section::fixed(config)).await
+}
+
+async fn make_service_with_section(
+    config: horismos::Section<SearchSubsystemConfig>,
+) -> (SearchIndexerService, SqlitePool) {
+    make_service_with_section_and_proxy(config, Arc::new(NoProxy)).await
+}
+
+async fn make_service_with_section_and_proxy(
+    config: horismos::Section<SearchSubsystemConfig>,
+    cf_proxy: Arc<dyn crate::cf_bypass::CloudflareProxy>,
+) -> (SearchIndexerService, SqlitePool) {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     MIGRATOR.run(&pool).await.unwrap();
     let (event_tx, _) = create_event_bus(16);
-    let service = SearchIndexerService::new(
-        pool.clone(),
-        pool.clone(),
-        Arc::new(NoProxy),
-        config,
-        event_tx,
-    );
+    let service = SearchIndexerService::new(pool.clone(), pool.clone(), cf_proxy, config, event_tx);
     (service, pool)
 }
 
@@ -617,4 +624,219 @@ async fn refresh_caps_commits_caps_categories_and_status_together() {
             (2010, "Movies/Foreign".to_string())
         ]
     );
+}
+
+// ── #529 step 7: live `Section`, cf-proxy swap ────────────────────────────
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use crate::cf_bypass::{CloudflareProxy, ProxyResponse};
+
+fn valid_horismos_config() -> horismos::Config {
+    let mut config = horismos::Config::default();
+    // WHY: validate_config rejects a short/placeholder jwt_secret; nothing
+    // else under test touches exousia.
+    config.exousia.jwt_secret = "test-secret-that-is-long-enough-for-hs256".to_string();
+    config
+}
+
+/// A TCP server that records the number of connections concurrently
+/// in-flight (peak), holds each connection briefly to create overlap
+/// opportunity, then answers with a minimal valid torznab feed.
+async fn spawn_concurrency_probe(
+    concurrent: Arc<AtomicUsize>,
+    peak: Arc<AtomicUsize>,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let handle = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let now = concurrent.fetch_add(1, Ordering::SeqCst) + 1;
+        peak.fetch_max(now, Ordering::SeqCst);
+
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            let n = stream.read(&mut chunk).await.unwrap();
+            buf.extend_from_slice(&chunk[..n]);
+            if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        // WHY: hold the connection open briefly so overlapping fan-out
+        // requests genuinely race — without this, sequential dispatch and
+        // parallel dispatch are indistinguishable at this timescale.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        concurrent.fetch_sub(1, Ordering::SeqCst);
+
+        let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel><title>Probe</title></channel>
+</rss>"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.ok();
+        stream.flush().await.ok();
+        stream.shutdown().await.ok();
+    });
+    (url, handle)
+}
+
+#[tokio::test]
+async fn replace_lowering_max_concurrent_searches_bounds_the_next_fan_out() {
+    let concurrent = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    let mut initial = valid_horismos_config();
+    initial.zetesis.max_concurrent_searches = 4;
+    let (manager, handle) = horismos::ConfigManager::new(
+        initial,
+        std::path::PathBuf::from("unused.toml"),
+        horismos::ConfigOverrides::default(),
+    );
+    let (service, pool) = make_service_with_section(handle.section(|c| &c.zetesis)).await;
+
+    let mut urls = Vec::new();
+    let mut probe_handles = Vec::new();
+    for _ in 0..3 {
+        let (url, h) = spawn_concurrency_probe(Arc::clone(&concurrent), Arc::clone(&peak)).await;
+        urls.push(url);
+        probe_handles.push(h);
+    }
+    for url in &urls {
+        seed_indexer(&pool, url).await;
+    }
+
+    // Lower the bound to 1 BEFORE the search fan-out runs.
+    let mut lowered = valid_horismos_config();
+    lowered.zetesis.max_concurrent_searches = 1;
+    manager.replace(lowered).unwrap();
+
+    service
+        .search(SearchQuery::new(), CancellationToken::new())
+        .await
+        .unwrap();
+
+    for h in probe_handles {
+        h.await.unwrap();
+    }
+
+    assert_eq!(
+        peak.load(Ordering::SeqCst),
+        1,
+        "max_concurrent_searches = 1 must serialize the fan-out across all 3 indexers"
+    );
+}
+
+struct StubCfProxy {
+    body: String,
+    calls: AtomicUsize,
+}
+
+impl CloudflareProxy for StubCfProxy {
+    fn get(
+        &self,
+        _url: &str,
+        _ct: CancellationToken,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<ProxyResponse, SearchIndexerError>> + Send + '_,
+        >,
+    > {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let body = self.body.clone();
+        Box::pin(async move {
+            Ok(ProxyResponse {
+                status: 200,
+                body,
+                cookies: Vec::new(),
+                user_agent: "stub-agent".to_string(),
+            })
+        })
+    }
+}
+
+const CF_FEED_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <title>Test Indexer</title>
+    <item>
+      <title>Test.Release.2024.FLAC</title>
+      <guid>abc123</guid>
+      <size>734003200</size>
+      <link>https://example.com/download/abc123</link>
+      <torznab:attr name="seeders" value="42"/>
+      <torznab:attr name="infohash" value="deadbeef"/>
+    </item>
+  </channel>
+</rss>"#;
+
+#[tokio::test]
+async fn cf_proxy_swap_turns_a_no_proxy_service_into_a_proxied_one() {
+    let (service, pool) = make_service_with_section_and_proxy(
+        horismos::Section::fixed(SearchSubsystemConfig {
+            cloudflare_bypass_enabled: true,
+            cf_proxy_url: Some("https://cf-proxy.example".to_string()),
+            ..SearchSubsystemConfig::default()
+        }),
+        Arc::new(NoProxy),
+    )
+    .await;
+
+    let indexer_id = repo::insert_indexer(
+        &pool,
+        InsertIndexerParams {
+            name: "CF Bypass",
+            url: "https://cf-protected.example/api",
+            protocol: "torznab",
+            api_key: None,
+            cf_bypass: true,
+            priority: 50,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Before the swap: NoProxy rejects every cf_bypass request — the search
+    // must complete with zero results and the indexer marked degraded.
+    let before = service
+        .search(SearchQuery::new(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert!(before.is_empty(), "NoProxy must produce zero results");
+    let row = repo::get_indexer(&pool, indexer_id).await.unwrap().unwrap();
+    assert_eq!(row.status, "degraded");
+
+    // Reset status so the post-swap search's outcome is unambiguous.
+    repo::update_indexer_status(&pool, indexer_id, "active")
+        .await
+        .unwrap();
+
+    let stub = Arc::new(StubCfProxy {
+        body: CF_FEED_XML.to_string(),
+        calls: AtomicUsize::new(0),
+    });
+    let proxy = Arc::clone(&stub) as Arc<dyn CloudflareProxy>;
+    service.set_cf_proxy(proxy);
+
+    let after = service
+        .search(SearchQuery::new(), CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        stub.calls.load(Ordering::SeqCst),
+        1,
+        "the stub proxy must be reached after the swap"
+    );
+    assert_eq!(after.len(), 1);
+    assert_eq!(after[0].title, "Test.Release.2024.FLAC");
+    let row = repo::get_indexer(&pool, indexer_id).await.unwrap().unwrap();
+    assert_eq!(row.status, "active");
 }


### PR DESCRIPTION
Step 7 of the #529 reactive-config migration — the acquisition subsystems (indexer search, download queue, extraction) reconfigure live, and two structurally-frozen seed thresholds are reclassified as restart-required.

**zetesis** — `SearchIndexerService` holds `Section<SearchSubsystemConfig>` and takes one `.get()` snapshot per operation (`max_concurrent_searches`, `search_timeout_seconds`, `max_response_body_bytes`, per-op client timeout go live). New `RateLimiter::reconfigure(requests, window)` updates `max_tokens`/`refill_rate` and *clamps* `tokens` to the new ceiling, but **leaves `retry_after` and `last_refill` untouched** — so a reconfigure racing an active 429 embargo cannot un-embargo the indexer or resurrect burst tokens (the #533 embargo-freeze invariant survives). The cf-proxy, cardigann registry, and HTTP client are each behind a `std::sync::RwLock<Arc<…>>` read through a sync snapshot helper that clones the `Arc` and drops the guard **before** any await (never held across `.await`); an archon `run_zetesis_supervisor` swaps the proxy/registry on the relevant config change (a cardigann load failure keeps the old registry + `error!`).

**syntaxis** — `DownloadQueue::update_config` replaces the stored config (live `retry_count`/`retry_backoff_base_seconds`) and calls `SlotAllocator::set_limits`; `next_dispatchable` now reads `allocator.max_per_tracker()`, healing the frozen-vs-live `max_per_tracker` split-brain. A cap **decrease** below the in-flight count simply stops new dispatch until it drains — in-flight downloads are never cancelled; a cap **increase** runs a backlog pass so raised capacity fills immediately. `run_syntaxis_supervisor` drives it.

**ergasia** — `SessionEngine` holds `Section<ErgasiaConfig>` and builds `ExtractionLimits` per extract call, so `max_extraction_depth`/`max_decompression_ratio` are live.

**horismos** — `ergasia.seed_ratio_threshold` and `ergasia.seed_time_threshold_hours` are added to `RESTART_REQUIRED` (frozen into the librqbit `SeedingPolicy` at session build with no reconfigure API, so a reload would otherwise "apply" them with zero effect — a step-1 honesty-invariant violation). Held back + reported on reload.

Tests (real `ConfigManager`/`Section` where a live handle is needed): rate-limiter embargo/accrual survives reconfigure (4 tests), a lowered `max_concurrent_searches` bounds the next fan-out, a cf-proxy swap proxies a previously-unproxied service, `SlotAllocator`/`update_config` decrease stops dispatch without eviction and increase dispatches backlog, and the two seed thresholds are held back on reload.

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings`), nextest 646 (5 crates) / full workspace, deny, kanon lint (0/0). `Gate-Passed` stamped.

Refs #529
