### PR TITLE
feat(epignosis,prostheke,syndesmos,kritike,aitesis): live integration-service config (#529 step 8)

### DIFF
--- a/crates/aitesis/src/lib.rs
+++ b/crates/aitesis/src/lib.rs
@@ -15,7 +15,7 @@ pub mod workflow;
 use apotheke::error::TransactionSnafu;
 pub use approval::{IdentityValidator, MonitorService, UserRoleProvider};
 pub use error::AitesisError;
-use horismos::AitesisConfig;
+use horismos::{AitesisConfig, Section};
 use snafu::ResultExt;
 use sqlx::SqlitePool;
 use themelion::{RequestId, UserId};
@@ -114,7 +114,11 @@ pub trait RequestService: Send + Sync {
 pub struct AitesisServiceImpl<R, I, M> {
     read: SqlitePool,
     write: SqlitePool,
-    config: AitesisConfig,
+    // WHY: a live `Section` (not a frozen `AitesisConfig`) — #529 step 8
+    // makes `max_pending_per_user`/`max_requests_per_day`/`auto_approve_admins`
+    // live; `submit_request` takes ONE snapshot per call (below), so a
+    // mid-submission reload cannot mix an old limit with a new one.
+    config: Section<AitesisConfig>,
     user_roles: R,
     identity: I,
     monitor: M,
@@ -130,7 +134,7 @@ where
     pub fn new(
         read: SqlitePool,
         write: SqlitePool,
-        config: AitesisConfig,
+        config: Section<AitesisConfig>,
         user_roles: R,
         identity: I,
         monitor: M,
@@ -160,7 +164,11 @@ where
     ) -> Result<MediaRequest, AitesisError> {
         let role = self.user_roles.role_of(user_id).await?;
 
-        let auto_approve = role == UserRole::Admin && self.config.auto_approve_admins;
+        // WHY: one snapshot for the whole operation — a mid-submit reload
+        // cannot mix an old `auto_approve_admins` read with a new
+        // `max_pending_per_user`/`max_requests_per_day` FROM after it.
+        let config = self.config.get();
+        let auto_approve = role == UserRole::Admin && config.auto_approve_admins;
 
         let now = jiff::Timestamp::now();
         let request = MediaRequest {
@@ -190,8 +198,8 @@ where
             &mut tx,
             &user_id,
             role,
-            self.config.max_pending_per_user,
-            self.config.max_requests_per_day,
+            config.max_pending_per_user,
+            config.max_requests_per_day,
         )
         .await?;
         repo::insert_request(&mut *tx, &request).await?;
@@ -443,8 +451,8 @@ mod tests {
         }
     }
 
-    fn default_config() -> AitesisConfig {
-        AitesisConfig::default()
+    fn default_config() -> Section<AitesisConfig> {
+        Section::fixed(AitesisConfig::default())
     }
 
     type TestService = AitesisServiceImpl<MockRoles, AlwaysValidIdentity, AlwaysCreateMonitor>;
@@ -825,11 +833,11 @@ mod tests {
         let pool = SqlitePool::connect(&url).await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
 
-        let config = AitesisConfig {
+        let config = Section::fixed(AitesisConfig {
             max_pending_per_user: 1,
             max_requests_per_day: 100,
             auto_approve_admins: false,
-        };
+        });
         let svc = Arc::new(AitesisServiceImpl::new(
             pool.clone(),
             pool.clone(),
@@ -872,11 +880,11 @@ mod tests {
     async fn member_blocked_when_pending_limit_reached() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
-        let config = AitesisConfig {
+        let config = Section::fixed(AitesisConfig {
             max_pending_per_user: 2,
             max_requests_per_day: 100,
             auto_approve_admins: true,
-        };
+        });
         let svc = AitesisServiceImpl::new(
             pool.clone(),
             pool.clone(),
@@ -903,11 +911,11 @@ mod tests {
     async fn member_blocked_when_daily_limit_reached() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
-        let config = AitesisConfig {
+        let config = Section::fixed(AitesisConfig {
             max_pending_per_user: 100,
             max_requests_per_day: 2,
             auto_approve_admins: true,
-        };
+        });
         let svc = AitesisServiceImpl::new(
             pool.clone(),
             pool.clone(),
@@ -934,13 +942,13 @@ mod tests {
     async fn admin_exempt_from_limits() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
-        let config = AitesisConfig {
+        let config = Section::fixed(AitesisConfig {
             max_pending_per_user: 1,
             max_requests_per_day: 1,
             // WHY: auto_approve disabled so requests stay in Submitted/Monitoring counts
             // would normally trigger the limit — but admin is exempt regardless.
             auto_approve_admins: false,
-        };
+        });
         let svc = AitesisServiceImpl::new(
             pool.clone(),
             pool.clone(),
@@ -1295,5 +1303,61 @@ mod tests {
         let fetched = admin_svc.get_request(req.id, admin_id).await.unwrap();
         assert_eq!(fetched.id, req.id);
         assert_eq!(fetched.user_id, alice);
+    }
+
+    // ── Live config ───────────────────────────────────────────────────────────
+
+    // #529 step 8: a `max_pending_per_user`/`max_requests_per_day` change made
+    // through a REAL `ConfigManager::replace` must be visible on the NEXT
+    // request op — no service rebuild.
+    #[tokio::test]
+    async fn limit_change_is_visible_on_next_submit_request() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+
+        let mut boot = horismos::Config::default();
+        boot.exousia.jwt_secret = "test-secret-that-is-long-enough-for-hs256".to_string();
+        boot.aitesis = AitesisConfig {
+            max_pending_per_user: 1,
+            max_requests_per_day: 100,
+            auto_approve_admins: false,
+        };
+        let (manager, handle) = horismos::ConfigManager::new(
+            boot.clone(),
+            std::path::PathBuf::from("unused.toml"),
+            horismos::ConfigOverrides::default(),
+        );
+
+        let svc = AitesisServiceImpl::new(
+            pool.clone(),
+            pool.clone(),
+            handle.section(|c| &c.aitesis),
+            MockRoles {
+                role: UserRole::Member,
+            },
+            AlwaysValidIdentity,
+            AlwaysCreateMonitor,
+        );
+        let user_id = UserId::new();
+
+        svc.submit_request(user_id, music_input()).await.unwrap();
+        let err = svc
+            .submit_request(user_id, music_input())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, AitesisError::RequestLimitExceeded { .. }),
+            "boot-time limit of 1 must reject a second pending request"
+        );
+
+        let mut raised = boot.clone();
+        raised.aitesis.max_pending_per_user = 2;
+        manager
+            .replace(raised)
+            .expect("replace applies the raised pending limit");
+
+        svc.submit_request(user_id, music_input())
+            .await
+            .expect("the raised live limit must admit a third request on the NEXT op");
     }
 }

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -92,7 +92,35 @@ fn curation_error(error: kritike::KritikeError) -> ServiceError {
     }
 }
 
-struct MetadataAdapter(Arc<ProviderBackedResolver>);
+/// Swappable behind a std `RwLock` (never held across an .await — every
+/// method snapshots via `snapshot()`, which clones the Arc and drops the
+/// guard before any async work) so a `epignosis.*` config change can rebuild
+/// the resolver and swap it in without a service rebuild (#529 step 8).
+/// In-flight resolutions already hold their own Arc clone (taken before the
+/// call's await) and finish on the OLD instance undisturbed.
+struct MetadataAdapter {
+    inner: std::sync::RwLock<Arc<ProviderBackedResolver>>,
+}
+
+impl MetadataAdapter {
+    fn new(resolver: Arc<ProviderBackedResolver>) -> Self {
+        Self {
+            inner: std::sync::RwLock::new(resolver),
+        }
+    }
+
+    fn snapshot(&self) -> Arc<ProviderBackedResolver> {
+        let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        Arc::clone(&guard)
+    }
+
+    /// Swaps the live resolver. Called by archon's epignosis supervisor
+    /// after a rebuild on an `epignosis.*` change.
+    fn set_resolver(&self, new: Arc<ProviderBackedResolver>) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        *guard = new;
+    }
+}
 
 impl DynMetadataResolver for MetadataAdapter {
     fn resolve_identity(
@@ -100,7 +128,7 @@ impl DynMetadataResolver for MetadataAdapter {
         item: epignosis::UnidentifiedItem,
     ) -> ServiceFut<epignosis::MediaIdentity> {
         use epignosis::MetadataResolver as _;
-        let service = Arc::clone(&self.0);
+        let service = self.snapshot();
         Box::pin(async move {
             service
                 .resolve_identity(&item, CancellationToken::new())
@@ -114,7 +142,7 @@ impl DynMetadataResolver for MetadataAdapter {
         identity: epignosis::MediaIdentity,
     ) -> ServiceFut<epignosis::EnrichedMetadata> {
         use epignosis::MetadataResolver as _;
-        let service = Arc::clone(&self.0);
+        let service = self.snapshot();
         Box::pin(async move {
             service
                 .enrich(&identity, CancellationToken::new())
@@ -128,7 +156,7 @@ impl DynMetadataResolver for MetadataAdapter {
         file_path: std::path::PathBuf,
     ) -> ServiceFut<epignosis::FingerprintResult> {
         use epignosis::MetadataResolver as _;
-        let service = Arc::clone(&self.0);
+        let service = self.snapshot();
         Box::pin(async move {
             service
                 .fingerprint_audio(&file_path, CancellationToken::new())
@@ -579,7 +607,32 @@ fn request_media_types(media_type: themelion::MediaType) -> Option<(&'static str
     }
 }
 
-struct ExternalAdapter(#[expect(dead_code)] Arc<ScrobbleClient>);
+/// Swappable behind a std `RwLock` (never held across an .await) so the
+/// #529 step-8 syndesmos supervisor can swap in a rebuilt client on a
+/// `syndesmos.*` change. `DynExternalIntegration` is currently marker-only
+/// (no forwarding methods) — the real consumer of `ScrobbleClient`'s
+/// behavior is the event handler task, which holds its own Arc clone
+/// directly; this field keeps `AppState`'s view in sync for when a future
+/// `DynExternalIntegration` method needs the live client.
+struct ExternalAdapter {
+    inner: std::sync::RwLock<Arc<ScrobbleClient>>,
+}
+
+impl ExternalAdapter {
+    fn new(client: Arc<ScrobbleClient>) -> Self {
+        Self {
+            inner: std::sync::RwLock::new(client),
+        }
+    }
+
+    /// Swaps the live scrobble client. Called by archon's syndesmos
+    /// supervisor after a rebuild on a `syndesmos.*` change.
+    fn set_client(&self, new: Arc<ScrobbleClient>) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        *guard = new;
+    }
+}
+
 impl DynExternalIntegration for ExternalAdapter {}
 
 struct SubtitleAdapter {
@@ -825,16 +878,25 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     ensure_admin_user(&auth, &db, out).await?;
 
     // 8. Create metadata resolver
+    // WHY: swappable behind a MetadataAdapter — #529 step 8 makes epignosis
+    // LIVE-B: an epignosis.* change rebuilds the resolver FROM the new
+    // config and swaps it; in-flight resolutions finish on the old
+    // instance, and the metadata cache resets with the rebuild (logged by
+    // the supervisor below).
     let metadata_service = Arc::new(ProviderBackedResolver::new(
         boot_config.epignosis.clone(),
         ProviderCredentials::default(),
     ));
+    let metadata_adapter = Arc::new(MetadataAdapter::new(Arc::clone(&metadata_service)));
 
     // 9. Create curation service
+    // WHY: a Section + LiveGate (not a frozen Semaphore) — #529 step 8 makes
+    // `kritike.quality_check_concurrency` live: `assess_quality` re-reads
+    // the limit on every admission decision.
     let curation_service = Arc::new(DefaultCurationService::new(
         db.read.clone(),
         event_tx.clone(),
-        boot_config.kritike.quality_check_concurrency,
+        config_handle.section(|c| &c.kritike),
     ));
 
     // WHY: created here — earlier than the "Acquisition subsystem startup"
@@ -842,6 +904,20 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // supervisors spawned by steps 10-11 can take a child token; every
     // consumer further down still gets its own child token exactly as before.
     let shutdown_token = CancellationToken::new();
+
+    // #529 step 8: epignosis is REBUILD-class — a spawned supervisor owns
+    // the live resolver FROM here; an epignosis.* config change rebuilds +
+    // swaps via MetadataAdapter (no explicit teardown — the resolver has no
+    // shutdown hook; its cache-eviction sweeper holds only a Weak reference
+    // and exits on its own once the last Arc drops).
+    let epignosis_supervisor = tokio::spawn(
+        run_epignosis_supervisor(
+            Arc::clone(&metadata_adapter),
+            config_handle.clone(),
+            shutdown_token.child_token(),
+        )
+        .instrument(tracing::info_span!("epignosis_supervisor")),
+    );
 
     // 10. Start scanner  -  background task. #529 step 6: a spawned
     // supervisor owns it FROM here — a `taxis.*` config change tears the
@@ -954,30 +1030,67 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     );
 
     // Layer 4: Syndesmos (external integrations  -  Plex, Last.fm, Tidal)
+    // WHY: REBUILD-class (#529 step 8) — a `syndesmos.*` change cancels the
+    // event handler, rebuilds the client, respawns the handler, and swaps
+    // ExternalAdapter's inner Arc. Two honest costs, logged by the
+    // supervisor: circuit breakers reset (fresh breakers), and events
+    // published between cancel and re-subscribe are lost (a bounded
+    // scrobble-loss window).
     let syndesmos_svc = Arc::new(build_syndesmos(&boot_config, &event_tx, db.read.clone()));
+    let external_adapter = Arc::new(ExternalAdapter::new(Arc::clone(&syndesmos_svc)));
+    let syndesmos_ct = shutdown_token.child_token();
     let syndesmos_handle = spawn_syndesmos_handler(
         Arc::clone(&syndesmos_svc),
         event_tx.subscribe(),
-        shutdown_token.child_token(),
+        syndesmos_ct.clone(),
+    );
+    let syndesmos_supervisor = tokio::spawn(
+        run_syndesmos_supervisor(
+            Arc::clone(&external_adapter),
+            config_handle.clone(),
+            event_tx.clone(),
+            db.read.clone(),
+            SyndesmosGeneration {
+                ct: syndesmos_ct,
+                handle: syndesmos_handle,
+            },
+            shutdown_token.child_token(),
+        )
+        .instrument(tracing::info_span!("syndesmos_supervisor")),
     );
     info!("syndesmos (external integrations) initialized  -  event listener started");
 
     // Layer 4: Prostheke (subtitle management)
+    // WHY: a Section (not the frozen boot_config) — #529 step 8 makes the
+    // per-op language/score preferences live; the prostheke supervisor below
+    // handles the provider-set LIVE-B mechanism (the OpenSubtitles rate
+    // limiter resets with the provider — logged, not silently accepted).
     let providers = Provider::default_providers(boot_config.prostheke.opensubtitles.clone());
     let prostheke_svc = Arc::new(SubtitleManager::new(
         db.read.clone(),
         db.write.clone(),
-        boot_config.prostheke.clone(),
+        config_handle.section(|c| &c.prostheke),
         providers,
         event_tx.clone(),
     ));
     info!("prostheke (subtitles) initialized");
+    let prostheke_supervisor = tokio::spawn(
+        run_prostheke_supervisor(
+            Arc::clone(&prostheke_svc),
+            config_handle.clone(),
+            shutdown_token.child_token(),
+        )
+        .instrument(tracing::info_span!("prostheke_supervisor")),
+    );
 
     // Layer 5: Aitesis (household request workflow)
+    // WHY: a Section (not the frozen boot_config) — #529 step 8 makes
+    // per-user/per-day request limits and auto-approve live; no supervisor
+    // needed — `submit_request` already reads a fresh snapshot per call.
     let request_service = Arc::new(aitesis::AitesisServiceImpl::new(
         db.read.clone(),
         db.write.clone(),
-        boot_config.aitesis.clone(),
+        config_handle.section(|c| &c.aitesis),
         RequestRoleProvider { db: db.clone() },
         RequestIdentityValidator,
         RequestMonitor { db: db.clone() },
@@ -1033,13 +1146,13 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         event_tx,
         auth,
         import,
-        metadata: Arc::new(MetadataAdapter(metadata_service)),
+        metadata: metadata_adapter,
         curation: Arc::new(CurationAdapter(curation_service)),
         search: Arc::new(SearchAdapter(zetesis)),
         download_engine: Arc::new(EngineAdapter(ergasia_session)),
         queue: Arc::new(QueueAdapter(Arc::clone(&syntaxis_svc))),
         requests: Arc::new(RequestAdapter(request_service)),
-        external: Arc::new(ExternalAdapter(syndesmos_svc)),
+        external: external_adapter,
         subtitles,
         renderers: renderer_registry,
     };
@@ -1071,9 +1184,11 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // Cancel all acquisition background tasks (syndesmos event handler, syntaxis listener)
     shutdown_token.cancel();
 
-    // Wait for syndesmos event handler to drain
-    if let Err(e) = syndesmos_handle.await {
-        tracing::warn!(error = %e, "syndesmos event handler panicked during shutdown");
+    // #529 step 8: the syndesmos supervisor now owns the event handler's
+    // full lifecycle (its own cancel + await is internal to it); joining the
+    // supervisor here replaces the old direct `syndesmos_handle.await`.
+    if let Err(e) = syndesmos_supervisor.await {
+        tracing::warn!(error = %e, "syndesmos supervisor panicked during shutdown");
     }
 
     // Wait for the syntaxis event listener to drain (layer 2, after layer 4)
@@ -1089,6 +1204,18 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     }
     if let Err(e) = zetesis_supervisor.await {
         tracing::warn!(error = %e, "zetesis supervisor panicked during shutdown");
+    }
+
+    // #529 step 8: prostheke and epignosis are REBUILD-class with no
+    // explicit teardown call (neither `SubtitleManager` nor
+    // `ProviderBackedResolver` has a shutdown hook) — joining their
+    // supervisors here just confirms they observed the same shutdown signal
+    // as everything else, symmetric with the step-6/7 supervisors.
+    if let Err(e) = prostheke_supervisor.await {
+        tracing::warn!(error = %e, "prostheke supervisor panicked during shutdown");
+    }
+    if let Err(e) = epignosis_supervisor.await {
+        tracing::warn!(error = %e, "epignosis supervisor panicked during shutdown");
     }
 
     // Shutdown core subsystems (reverse of startup) — the #529 step 6
@@ -1785,6 +1912,141 @@ async fn run_zetesis_supervisor(
     }
 }
 
+// ── Integration-service supervisors (#529 step 8) ───────────────────────────
+
+/// Runs the `epignosis.*` metadata resolver under a REBUILD-class
+/// supervisor: on a section change it builds a fresh `ProviderBackedResolver`
+/// FROM the new config and swaps it into `MetadataAdapter` — in-flight
+/// resolutions already hold their own Arc clone (taken by
+/// `MetadataAdapter::snapshot` before any await) and finish on the OLD
+/// instance undisturbed. The resolver's own metadata cache resets on every
+/// rebuild — logged, not silently accepted.
+async fn run_epignosis_supervisor(
+    adapter: Arc<MetadataAdapter>,
+    config: horismos::ConfigHandle,
+    shutdown: CancellationToken,
+) {
+    let mut watcher = config.watch_section(|c| &c.epignosis);
+    loop {
+        let changed = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            changed = watcher.changed() => changed,
+        };
+        let Some(new_cfg) = changed else {
+            shutdown.cancelled().await;
+            break;
+        };
+
+        info!("epignosis config changed — resolver rebuilt, metadata cache reset");
+        let resolver = Arc::new(ProviderBackedResolver::new(
+            new_cfg,
+            ProviderCredentials::default(),
+        ));
+        adapter.set_resolver(resolver);
+    }
+}
+
+/// Runs the `prostheke.opensubtitles` provider set under a REBUILD-class
+/// supervisor: on a subtree change (INCLUDING None↔Some presence) it rebuilds
+/// the provider list via `Provider::default_providers` and swaps it into
+/// `SubtitleManager`. The OpenSubtitles rate limiter resets with the
+/// provider — acceptable (it's a politeness limiter, not a 429 embargo) —
+/// logged, not silently accepted. The per-op language/score preferences need
+/// no supervisor action — `SubtitleManager` already reads them live through
+/// its own `Section`.
+async fn run_prostheke_supervisor(
+    manager: Arc<SubtitleManager>,
+    config: horismos::ConfigHandle,
+    shutdown: CancellationToken,
+) {
+    let mut watcher = config.watch_section(|c| &c.prostheke.opensubtitles);
+    loop {
+        let changed = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            changed = watcher.changed() => changed,
+        };
+        let Some(new_opensubtitles) = changed else {
+            shutdown.cancelled().await;
+            break;
+        };
+
+        info!(
+            subsystem = "prostheke",
+            "prostheke.opensubtitles config changed  -  rebuilding providers; \
+             OpenSubtitles rate limiter reset"
+        );
+        let providers = Provider::default_providers(new_opensubtitles);
+        manager.set_providers(providers);
+    }
+}
+
+/// One live syndesmos event-handler generation: its child cancellation token
+/// (a child of the supervisor's `shutdown`) plus the handler task itself —
+/// bundled so `run_syndesmos_supervisor` takes one argument for "the current
+/// generation" instead of two.
+struct SyndesmosGeneration {
+    ct: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+/// Runs the `syndesmos.*` external-integrations client under a REBUILD-class
+/// supervisor: on a section change it cancels the event handler's child
+/// token, awaits it, rebuilds the `ScrobbleClient` via `build_syndesmos`,
+/// respawns the handler on a fresh subscription, and swaps `ExternalAdapter`'s
+/// inner Arc. Two honest costs, logged: the circuit breakers reset (fresh
+/// breakers, `warn!`), and any event published between the cancel and the
+/// fresh subscribe is lost — broadcast receivers only see events published
+/// after they subscribe — a bounded scrobble-loss window (`warn!`).
+async fn run_syndesmos_supervisor(
+    external: Arc<ExternalAdapter>,
+    config: horismos::ConfigHandle,
+    event_tx: themelion::EventSender,
+    db: sqlx::SqlitePool,
+    mut generation: SyndesmosGeneration,
+    shutdown: CancellationToken,
+) {
+    let mut watcher = config.watch_section(|c| &c.syndesmos);
+    loop {
+        let changed = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            changed = watcher.changed() => changed,
+        };
+        let Some(_new_syndesmos) = changed else {
+            shutdown.cancelled().await;
+            break;
+        };
+
+        tracing::warn!(
+            subsystem = "syndesmos",
+            "syndesmos config changed  -  rebuilding scrobble client; circuit breakers reset"
+        );
+        generation.ct.cancel();
+        if let Err(e) = generation.handle.await {
+            tracing::warn!(error = %e, "syndesmos event handler panicked during rebuild");
+        }
+        tracing::warn!(
+            subsystem = "syndesmos",
+            "syndesmos rebuild: events published between handler cancel and resubscribe are \
+             not delivered (bounded scrobble-loss window)"
+        );
+
+        let cfg = config.current();
+        let client = Arc::new(build_syndesmos(&cfg, &event_tx, db.clone()));
+        external.set_client(Arc::clone(&client));
+        let ct = shutdown.child_token();
+        let handle = spawn_syndesmos_handler(client, event_tx.subscribe(), ct.clone());
+        generation = SyndesmosGeneration { ct, handle };
+    }
+
+    generation.ct.cancel();
+    if let Err(e) = generation.handle.await {
+        tracing::warn!(error = %e, "syndesmos event handler panicked during shutdown");
+    }
+}
+
 // ── Syndesmos construction ──────────────────────────────────────────────────
 
 fn build_syndesmos(
@@ -1940,7 +2202,14 @@ mod service_adapter_tests {
     async fn curation_adapter_calls_live_kritike_service() {
         let pool = migrated_pool().await;
         let (event_tx, _) = create_event_bus(64);
-        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(pool, event_tx, 4)));
+        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(
+            pool,
+            event_tx,
+            horismos::Section::fixed(horismos::KritikeConfig {
+                quality_check_concurrency: 4,
+                ..Default::default()
+            }),
+        )));
 
         let report = adapter
             .health_report()
@@ -1963,7 +2232,14 @@ mod service_adapter_tests {
     async fn curation_adapter_maps_profile_not_found() {
         let pool = migrated_pool().await;
         let (event_tx, _) = create_event_bus(64);
-        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(pool, event_tx, 4)));
+        let adapter = CurationAdapter(Arc::new(DefaultCurationService::new(
+            pool,
+            event_tx,
+            horismos::Section::fixed(horismos::KritikeConfig {
+                quality_check_concurrency: 4,
+                ..Default::default()
+            }),
+        )));
 
         let error = adapter
             .assess_quality(
@@ -1988,7 +2264,7 @@ mod service_adapter_tests {
 
     #[tokio::test]
     async fn metadata_adapter_calls_live_epignosis_resolver() {
-        let adapter = MetadataAdapter(Arc::new(ProviderBackedResolver::new(
+        let adapter = MetadataAdapter::new(Arc::new(ProviderBackedResolver::new(
             horismos::EpignosisConfig::default(),
             ProviderCredentials::default(),
         )));
@@ -2744,7 +3020,7 @@ mod tests {
         let service = Arc::new(SubtitleManager::new(
             pool.clone(),
             pool.clone(),
-            horismos::ProsthekeConfig::default(),
+            horismos::Section::fixed(horismos::ProsthekeConfig::default()),
             Vec::<Provider>::new(),
             event_tx,
         ));
@@ -3372,5 +3648,70 @@ mod rebuild_supervisor_tests {
             "a rebuild FROM the new config must re-page the DB and pick up the subscription"
         );
         after.shutdown();
+    }
+
+    // ── epignosis supervisor: real MetadataAdapter + real ConfigManager ────
+
+    fn epignosis_test_config() -> Config {
+        let mut config = Config::default();
+        config.exousia.jwt_secret =
+            "epignosis-supervisor-test-secret-at-least-32-bytes-long".to_string();
+        config
+    }
+
+    /// #529 step 8: a REAL `run_epignosis_supervisor`, driven by a REAL
+    /// `ConfigManager::replace`, rebuilds the resolver on an `epignosis.*`
+    /// change and swaps it into `MetadataAdapter` — proven by Arc identity
+    /// changing (the resolver has no other externally-observable state) —
+    /// and shuts down cleanly on process shutdown.
+    #[tokio::test]
+    async fn epignosis_supervisor_rebuilds_resolver_on_config_change() {
+        let config = epignosis_test_config();
+        let (manager, handle) = ConfigManager::new(
+            config.clone(),
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+
+        let initial = Arc::new(ProviderBackedResolver::new(
+            config.epignosis.clone(),
+            ProviderCredentials::default(),
+        ));
+        let adapter = Arc::new(MetadataAdapter::new(Arc::clone(&initial)));
+
+        let shutdown = CancellationToken::new();
+        let supervisor = tokio::spawn(run_epignosis_supervisor(
+            Arc::clone(&adapter),
+            handle,
+            shutdown.clone(),
+        ));
+
+        // WHY: let the supervisor's first poll run BEFORE the replace below —
+        // `watch_section`'s baseline is established at first-poll time (a
+        // clone of a never-advanced `watch::Receiver` starts "unseen," so a
+        // replace landing before the first poll would be silently folded
+        // into that baseline instead of surfacing as a change).
+        tokio::task::yield_now().await;
+
+        let mut changed = config.clone();
+        changed.epignosis.provider_timeout_secs += 5;
+        manager
+            .replace(changed)
+            .expect("replace applies the epignosis change");
+
+        // Bounded real wait for the supervisor to observe and process the
+        // change — generous relative to in-process channel/task scheduling.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let after = adapter.snapshot();
+        assert!(
+            !Arc::ptr_eq(&initial, &after),
+            "an epignosis.* change must rebuild the resolver (new Arc identity)"
+        );
+
+        shutdown.cancel();
+        supervisor
+            .await
+            .expect("epignosis supervisor joins cleanly after a live rebuild");
     }
 }

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -416,7 +416,7 @@ async fn test_state_with_queue(
         aitesis::AitesisServiceImpl::new(
             pool.clone(),
             pool.clone(),
-            state.config.current().aitesis.clone(),
+            state.config.section(|c| &c.aitesis),
             MockRequestRoles { pool: pool.clone() },
             MockRequestIdentity,
             MockRequestMonitor,

--- a/crates/kritike/src/error.rs
+++ b/crates/kritike/src/error.rs
@@ -25,10 +25,4 @@ pub enum KritikeError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
-
-    #[snafu(display("quality-check concurrency limiter closed"))]
-    ConcurrencyLimiterClosed {
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
 }

--- a/crates/kritike/src/lib.rs
+++ b/crates/kritike/src/lib.rs
@@ -11,13 +11,11 @@ pub use assessment::{QualityAssessment, QualityMetadata};
 pub use error::KritikeError;
 pub use format_score::QualityScore;
 pub use health::{HealthReport, TypeHealthReport};
+use horismos::{KritikeConfig, Section};
 use sqlx::SqlitePool;
-use themelion::{EventSender, HarmoniaEvent, HaveId, MediaId, MediaType, QualityProfile};
-use tokio::sync::Semaphore;
+use themelion::{EventSender, HarmoniaEvent, HaveId, LiveGate, MediaId, MediaType, QualityProfile};
 use tracing::instrument;
 pub use upgrade::UpgradeDecision;
-
-use crate::error::ConcurrencyLimiterClosedSnafu;
 
 #[expect(
     async_fn_in_trait,
@@ -45,22 +43,24 @@ pub trait CurationService: Send + Sync {
 pub struct DefaultCurationService {
     pool: SqlitePool,
     events: EventSender,
-    /// Bounds concurrent `assess_quality` calls to
-    /// `KritikeConfig::quality_check_concurrency`.
-    quality_check_semaphore: Arc<Semaphore>,
+    config: Section<KritikeConfig>,
+    /// Live admission gate bounding concurrent `assess_quality` calls to
+    /// `KritikeConfig::quality_check_concurrency`. Unlike a fixed
+    /// `Semaphore`, the limit is re-read on every admission decision (via
+    /// `config.get()`) — #529 step 8, `LiveGate::enter`'s first real
+    /// consumer: under quality-check traffic guards drop continuously, so
+    /// the live-limit re-read observes a config change on the next
+    /// admission.
+    quality_check_gate: Arc<LiveGate>,
 }
 
 impl DefaultCurationService {
-    /// `quality_check_concurrency` is clamped to at least 1 as
-    /// defense-in-depth — a 0-permit semaphore would block every quality
-    /// check forever, the same hang class `taxis.scan_concurrency` had.
-    /// Callers are expected to reject `0` upstream (see `horismos`
-    /// validation).
-    pub fn new(pool: SqlitePool, events: EventSender, quality_check_concurrency: usize) -> Self {
+    pub fn new(pool: SqlitePool, events: EventSender, config: Section<KritikeConfig>) -> Self {
         Self {
             pool,
             events,
-            quality_check_semaphore: Arc::new(Semaphore::new(quality_check_concurrency.max(1))),
+            config,
+            quality_check_gate: Arc::new(LiveGate::new()),
         }
     }
 }
@@ -72,11 +72,15 @@ impl CurationService for DefaultCurationService {
         media_type: MediaType,
         item_metadata: &QualityMetadata,
     ) -> Result<QualityAssessment, KritikeError> {
-        let _permit = self
-            .quality_check_semaphore
-            .acquire()
-            .await
-            .map_err(|_| ConcurrencyLimiterClosedSnafu.build())?;
+        // WHY: `.max(1)` clamps a 0-permit config as defense-in-depth — a
+        // zero limit would block every quality check forever, the same hang
+        // class `taxis.scan_concurrency` had. Callers are expected to reject
+        // `0` upstream (see `horismos` validation); this is the last line of
+        // defense.
+        let _guard = self
+            .quality_check_gate
+            .enter(|| self.config.get().quality_check_concurrency.max(1))
+            .await;
         assessment::assess(&self.pool, media_type, item_metadata).await
     }
 
@@ -109,47 +113,23 @@ impl CurationService for DefaultCurationService {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::time::Duration;
 
+    use horismos::{Config, ConfigManager, ConfigOverrides};
     use themelion::create_event_bus;
 
     use super::*;
 
     // WHY: no schema needed — none of these tests reach a real query
-    // (the concurrency-limit tests inspect the semaphore directly; the
-    // exhausted-permit test times out before `assessment::assess` runs).
+    // (the concurrency-limit tests inspect the gate directly; the
+    // exhausted-limit test times out before `assessment::assess` runs).
     async fn unmigrated_pool() -> SqlitePool {
         SqlitePool::connect("sqlite::memory:").await.unwrap()
     }
 
-    #[tokio::test]
-    async fn quality_check_semaphore_matches_configured_concurrency() {
-        let (events, _rx) = create_event_bus(8);
-        let service = DefaultCurationService::new(unmigrated_pool().await, events, 3);
-        assert_eq!(service.quality_check_semaphore.available_permits(), 3);
-    }
-
-    #[tokio::test]
-    async fn zero_quality_check_concurrency_clamps_to_one() {
-        let (events, _rx) = create_event_bus(8);
-        let service = DefaultCurationService::new(unmigrated_pool().await, events, 0);
-        assert_eq!(service.quality_check_semaphore.available_permits(), 1);
-    }
-
-    #[tokio::test]
-    async fn assess_quality_blocks_when_concurrency_limit_is_exhausted() {
-        let (events, _rx) = create_event_bus(8);
-        let service = DefaultCurationService::new(unmigrated_pool().await, events, 1);
-
-        // Hold the only permit externally — simulates a quality check already
-        // in flight FROM another caller.
-        let _held = service
-            .quality_check_semaphore
-            .clone()
-            .try_acquire_owned()
-            .unwrap();
-
-        let metadata = QualityMetadata {
+    fn metadata() -> QualityMetadata {
+        QualityMetadata {
             format: "FLAC_24BIT".to_string(),
             custom_format_score: 0,
             profile_id: 1,
@@ -158,17 +138,144 @@ mod tests {
             sample_rate: None,
             file_size: None,
             channels: None,
-        };
+        }
+    }
+
+    fn fixed_config(quality_check_concurrency: usize) -> Section<KritikeConfig> {
+        Section::fixed(KritikeConfig {
+            quality_check_concurrency,
+            ..Default::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn quality_check_gate_admits_up_to_configured_concurrency() {
+        let (events, _rx) = create_event_bus(8);
+        let service = DefaultCurationService::new(unmigrated_pool().await, events, fixed_config(3));
+
+        let a = service
+            .quality_check_gate
+            .try_enter(3)
+            .expect("first entry admitted");
+        let b = service
+            .quality_check_gate
+            .try_enter(3)
+            .expect("second entry admitted");
+        let c = service
+            .quality_check_gate
+            .try_enter(3)
+            .expect("third entry admitted");
+        assert!(
+            service.quality_check_gate.try_enter(3).is_none(),
+            "a fourth entry must be refused at concurrency 3"
+        );
+        drop((a, b, c));
+    }
+
+    #[tokio::test]
+    async fn zero_quality_check_concurrency_clamps_to_one() {
+        let (events, _rx) = create_event_bus(8);
+        let service = DefaultCurationService::new(unmigrated_pool().await, events, fixed_config(0));
+
+        // Hold the slot at the CLAMPED limit of 1 — a config of 0 must not
+        // leave every quality check blocked forever.
+        let _held = service
+            .quality_check_gate
+            .try_enter(1)
+            .expect("clamped limit of 1 admits the first entry");
 
         let result = tokio::time::timeout(
             Duration::from_millis(100),
-            service.assess_quality(MediaType::Music, &metadata),
+            service.assess_quality(MediaType::Music, &metadata()),
         )
         .await;
 
         assert!(
             result.is_err(),
-            "assess_quality must block on the exhausted concurrency semaphore, not bypass it"
+            "a zero-concurrency config must clamp to 1, not silently admit more"
         );
+    }
+
+    #[tokio::test]
+    async fn assess_quality_blocks_when_concurrency_limit_is_exhausted() {
+        let (events, _rx) = create_event_bus(8);
+        let service = DefaultCurationService::new(unmigrated_pool().await, events, fixed_config(1));
+
+        // Hold the only slot externally — simulates a quality check already
+        // in flight FROM another caller.
+        let _held = service
+            .quality_check_gate
+            .try_enter(1)
+            .expect("first entry admitted at limit 1");
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            service.assess_quality(MediaType::Music, &metadata()),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "assess_quality must block on the exhausted concurrency gate, not bypass it"
+        );
+    }
+
+    // #529 step 8: a `quality_check_concurrency` change made through a REAL
+    // `ConfigManager::replace` must be reflected on the NEXT admission
+    // decision — no service rebuild.
+    #[tokio::test]
+    async fn quality_check_concurrency_change_reflects_on_next_admission() {
+        let mut config = Config::default();
+        config.exousia.jwt_secret = "test-secret-that-is-long-enough-for-hs256".to_string();
+        config.kritike.quality_check_concurrency = 1;
+        let (manager, handle) = ConfigManager::new(
+            config.clone(),
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+        let (events, _rx) = create_event_bus(8);
+        let service = DefaultCurationService::new(
+            unmigrated_pool().await,
+            events,
+            handle.section(|c| &c.kritike),
+        );
+
+        // Hold the sole slot at the boot-time limit of 1.
+        let held = service
+            .quality_check_gate
+            .try_enter(1)
+            .expect("first entry admitted at limit 1");
+
+        let blocked = tokio::time::timeout(
+            Duration::from_millis(100),
+            service.assess_quality(MediaType::Music, &metadata()),
+        )
+        .await;
+        assert!(
+            blocked.is_err(),
+            "must block while the sole slot is held at the boot-time limit of 1"
+        );
+
+        let mut raised = config.clone();
+        raised.kritike.quality_check_concurrency = 2;
+        manager
+            .replace(raised)
+            .expect("replace applies the raised concurrency");
+
+        // `LiveGate::enter` re-reads the limit on its first `try_enter`
+        // BEFORE ever awaiting a wake — so a FRESH admission decision at the
+        // raised limit succeeds immediately, without needing the held guard
+        // to drop first.
+        let admitted = tokio::time::timeout(
+            Duration::from_millis(200),
+            service.assess_quality(MediaType::Music, &metadata()),
+        )
+        .await;
+        assert!(
+            admitted.is_ok(),
+            "a raised live limit must admit a fresh call without waiting on a guard drop"
+        );
+
+        drop(held);
     }
 }

--- a/crates/paroche/src/routes/request.rs
+++ b/crates/paroche/src/routes/request.rs
@@ -540,11 +540,11 @@ mod tests {
     #[tokio::test]
     async fn list_requests_paginates_at_the_database() -> TestResult<()> {
         let (mut state, auth) = test_state().await;
-        let config = horismos::AitesisConfig {
+        let config = horismos::Section::fixed(horismos::AitesisConfig {
             max_pending_per_user: 10,
             max_requests_per_day: 100,
             auto_approve_admins: false,
-        };
+        });
         let service = Arc::new(aitesis::AitesisServiceImpl::new(
             state.db.read.clone(),
             state.db.write.clone(),
@@ -619,11 +619,11 @@ mod tests {
     #[tokio::test]
     async fn submit_request_enforces_aitesis_pending_limit() -> TestResult<()> {
         let (mut state, auth) = test_state().await;
-        let config = horismos::AitesisConfig {
+        let config = horismos::Section::fixed(horismos::AitesisConfig {
             max_pending_per_user: 1,
             max_requests_per_day: 100,
             auto_approve_admins: false,
-        };
+        });
         let service = Arc::new(aitesis::AitesisServiceImpl::new(
             state.db.read.clone(),
             state.db.write.clone(),
@@ -662,11 +662,11 @@ mod tests {
     #[tokio::test]
     async fn get_request_is_scoped_to_owner_or_admin() -> TestResult<()> {
         let (mut state, auth) = test_state().await;
-        let config = horismos::AitesisConfig {
+        let config = horismos::Section::fixed(horismos::AitesisConfig {
             max_pending_per_user: 10,
             max_requests_per_day: 100,
             auto_approve_admins: false,
-        };
+        });
         let service = Arc::new(aitesis::AitesisServiceImpl::new(
             state.db.read.clone(),
             state.db.write.clone(),

--- a/crates/prostheke/src/lib.rs
+++ b/crates/prostheke/src/lib.rs
@@ -15,9 +15,10 @@ pub mod timing;
 pub mod types;
 
 use std::path::Path;
+use std::sync::Arc;
 
 pub use error::ProsthekeError;
-use horismos::ProsthekeConfig;
+use horismos::{ProsthekeConfig, Section};
 use themelion::{EventSender, HarmoniaEvent, MediaId, MediaType};
 use tracing::instrument;
 pub use types::{
@@ -57,8 +58,17 @@ pub trait SubtitleService: Send + Sync {
 pub struct SubtitleManager<P: SubtitleProvider = Provider> {
     read: sqlx::SqlitePool,
     write: sqlx::SqlitePool,
-    config: ProsthekeConfig,
-    providers: Vec<P>,
+    // WHY: a live `Section` (not a frozen `ProsthekeConfig`) — #529 step 8
+    // makes the per-op language/score preferences live.
+    config: Section<ProsthekeConfig>,
+    // WHY: swappable behind a std RwLock (never held across an .await — the
+    // one read site takes the lock, clones the Arc, and drops the guard
+    // before any async work) so a `prostheke.opensubtitles` subtree change
+    // can swap the live provider set without a service rebuild. Arc-wrapped
+    // (not `RwLock<Vec<P>>`) because provider variants hold non-Clone
+    // internal rate-limiter state (`OpenSubtitlesProvider`'s `RateLimiter`
+    // wraps a `tokio::sync::Mutex`).
+    providers: std::sync::RwLock<Arc<Vec<P>>>,
     event_tx: EventSender,
 }
 
@@ -66,7 +76,7 @@ impl<P: SubtitleProvider> SubtitleManager<P> {
     pub fn new(
         read: sqlx::SqlitePool,
         write: sqlx::SqlitePool,
-        config: ProsthekeConfig,
+        config: Section<ProsthekeConfig>,
         providers: Vec<P>,
         event_tx: EventSender,
     ) -> Self {
@@ -74,9 +84,23 @@ impl<P: SubtitleProvider> SubtitleManager<P> {
             read,
             write,
             config,
-            providers,
+            providers: std::sync::RwLock::new(Arc::new(providers)),
             event_tx,
         }
+    }
+
+    /// Swaps the live provider set. Called by archon's prostheke supervisor
+    /// on a `prostheke.opensubtitles` subtree change (INCLUDING None↔Some
+    /// presence). The OpenSubtitles rate limiter resets with the provider —
+    /// acceptable (it's a politeness limiter, not a 429 embargo).
+    pub fn set_providers(&self, providers: Vec<P>) {
+        let mut guard = self.providers.write().unwrap_or_else(|e| e.into_inner());
+        *guard = Arc::new(providers);
+    }
+
+    fn providers_snapshot(&self) -> Arc<Vec<P>> {
+        let guard = self.providers.read().unwrap_or_else(|e| e.into_inner());
+        Arc::clone(&guard)
     }
 }
 
@@ -88,10 +112,14 @@ impl<P: SubtitleProvider> SubtitleService for SubtitleManager<P> {
         media_type: MediaType,
         path: &Path,
     ) -> Result<(), ProsthekeError> {
+        // WHY: one snapshot for the whole operation — a mid-acquire reload
+        // cannot mix an old language preference with a new `min_match_score`
+        // FROM after it.
+        let config = self.config.get();
         let preferences = LanguagePreference {
-            languages: self.config.languages.clone(),
-            include_hearing_impaired: self.config.include_hearing_impaired,
-            include_forced: self.config.include_forced,
+            languages: config.languages.clone(),
+            include_hearing_impaired: config.include_hearing_impaired,
+            include_forced: config.include_forced,
         };
 
         let title = path
@@ -99,8 +127,12 @@ impl<P: SubtitleProvider> SubtitleService for SubtitleManager<P> {
             .and_then(|s| s.to_str())
             .unwrap_or("unknown");
 
+        // WHY: snapshot-clone-drop before the awaits below — never hold the
+        // providers RwLock guard across an .await.
+        let providers = self.providers_snapshot();
+
         let matches = search_all_providers(
-            &self.providers,
+            providers.as_slice(),
             &media_id,
             media_type,
             title,
@@ -109,7 +141,7 @@ impl<P: SubtitleProvider> SubtitleService for SubtitleManager<P> {
             None,
             &preferences,
             None,
-            self.config.min_match_score,
+            config.min_match_score,
         )
         .await?;
 
@@ -120,8 +152,7 @@ impl<P: SubtitleProvider> SubtitleService for SubtitleManager<P> {
         let mut acquired_languages: Vec<String> = Vec::new();
 
         for subtitle_match in &matches {
-            let provider = self
-                .providers
+            let provider = providers
                 .iter()
                 .find(|p| p.name() == subtitle_match.provider)
                 .ok_or_else(|| ProsthekeError::AcquisitionFailed {
@@ -257,7 +288,13 @@ mod tests {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
         let (tx, rx) = create_event_bus(64);
-        let svc = SubtitleManager::new(pool.clone(), pool.clone(), config, providers, tx);
+        let svc = SubtitleManager::new(
+            pool.clone(),
+            pool.clone(),
+            Section::fixed(config),
+            providers,
+            tx,
+        );
         (svc, pool, rx)
     }
 
@@ -306,5 +343,137 @@ mod tests {
             .unwrap();
 
         assert!(rx.try_recv().is_err());
+    }
+
+    // ── Live config (#529 step 8) ────────────────────────────────────────────
+
+    struct RecordingProvider {
+        name: String,
+        seen_languages: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    }
+
+    impl SubtitleProvider for RecordingProvider {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        async fn search(
+            &self,
+            _media_id: &MediaId,
+            _media_type: MediaType,
+            _title: &str,
+            _year: Option<u16>,
+            _season: Option<u32>,
+            _episode: Option<u32>,
+            languages: &[String],
+            _file_hash: Option<&str>,
+        ) -> Result<Vec<SubtitleMatch>, ProsthekeError> {
+            self.seen_languages.lock().unwrap().push(languages.to_vec());
+            Ok(Vec::new())
+        }
+
+        async fn download(&self, _subtitle: &SubtitleMatch) -> Result<Vec<u8>, ProsthekeError> {
+            Ok(Vec::new())
+        }
+    }
+
+    // A `prostheke.languages` change made through a REAL
+    // `ConfigManager::replace` must be visible on the NEXT `acquire_subtitles`
+    // call — no service rebuild.
+    #[tokio::test]
+    async fn language_preference_change_is_visible_on_next_acquire() {
+        let dir = tempfile::tempdir().unwrap();
+        let media_path = dir.path().join("movie.mkv");
+        std::fs::write(&media_path, b"").unwrap();
+
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let (tx, _rx) = create_event_bus(64);
+
+        let mut boot = horismos::Config::default();
+        boot.exousia.jwt_secret = "test-secret-that-is-long-enough-for-hs256".to_string();
+        boot.prostheke.languages = vec!["en".to_string()];
+        let (manager, handle) = horismos::ConfigManager::new(
+            boot.clone(),
+            std::path::PathBuf::from("unused.toml"),
+            horismos::ConfigOverrides::default(),
+        );
+
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = RecordingProvider {
+            name: "mock".to_string(),
+            seen_languages: Arc::clone(&seen),
+        };
+        let svc = SubtitleManager::new(
+            pool.clone(),
+            pool.clone(),
+            handle.section(|c| &c.prostheke),
+            vec![provider],
+            tx,
+        );
+
+        svc.acquire_subtitles(MediaId::new(), MediaType::Movie, &media_path)
+            .await
+            .unwrap();
+
+        let mut raised = boot.clone();
+        raised.prostheke.languages = vec!["fr".to_string()];
+        manager
+            .replace(raised)
+            .expect("replace applies the language change");
+
+        svc.acquire_subtitles(MediaId::new(), MediaType::Movie, &media_path)
+            .await
+            .unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 2, "both acquire calls must have searched");
+        assert!(
+            seen[0].iter().any(|l| l == "en"),
+            "first acquire must search the boot-time language, got {:?}",
+            seen[0]
+        );
+        assert!(
+            seen[1].iter().any(|l| l == "fr"),
+            "second acquire must reflect the live language change, got {:?}",
+            seen[1]
+        );
+    }
+
+    // A `prostheke.opensubtitles` None↔Some swap (simulating what archon's
+    // prostheke supervisor does on that subtree changing) must change the
+    // live provider set without a service rebuild.
+    #[tokio::test]
+    async fn set_providers_swaps_the_live_provider_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let media_path = dir.path().join("movie.mkv");
+        std::fs::write(&media_path, b"").unwrap();
+
+        let (svc, _pool, mut rx) = make_service(vec![], ProsthekeConfig::default()).await;
+
+        svc.acquire_subtitles(MediaId::new(), MediaType::Movie, &media_path)
+            .await
+            .unwrap();
+        assert!(
+            rx.try_recv().is_err(),
+            "an empty provider set must find nothing"
+        );
+
+        let provider = MockProvider::new(
+            "mock",
+            vec![make_match("mock", "en", 0.9)],
+            b"1\n00:00:01,000 --> 00:00:02,000\nHello\n".to_vec(),
+        );
+        svc.set_providers(vec![provider]);
+
+        svc.acquire_subtitles(MediaId::new(), MediaType::Movie, &media_path)
+            .await
+            .unwrap();
+
+        let event = rx.try_recv().unwrap();
+        assert!(
+            matches!(event, HarmoniaEvent::SubtitleAcquired { .. }),
+            "the swapped-in provider must be used by the NEXT acquire call"
+        );
     }
 }

--- a/crates/syndesmos/src/events.rs
+++ b/crates/syndesmos/src/events.rs
@@ -288,4 +288,90 @@ mod tests {
             .expect("handler should exit after cancellation")
             .unwrap();
     }
+
+    // #529 step 8: mirrors EXACTLY the mechanic `run_syndesmos_supervisor`
+    // (archon) performs on a `syndesmos.*` change — cancel the old handler's
+    // token, await it, then respawn on a FRESH subscription with a REBUILT
+    // client. Proves a post-change event reaches the rebuilt client, not the
+    // retired one.
+    #[tokio::test]
+    async fn handler_respawn_processes_post_change_event_with_the_rebuilt_client() {
+        use std::sync::Arc;
+
+        use crate::plex::tests::MockPlexApi;
+
+        // Generation A: section 1.
+        let mock_a = Arc::new(MockPlexApi::new());
+        let sections_a = mock_a.sections_refreshed.clone();
+        let mut sections_map_a = std::collections::HashMap::new();
+        sections_map_a.insert(themelion::MediaType::Music, 1u32);
+
+        let (tx, rx_a) = create_event_bus(32);
+        let service_a = Arc::new(
+            ScrobbleClientBuilder::new(tx.clone(), crate::test_support::test_pool().await)
+                .with_mock_plex(mock_a.clone(), sections_map_a)
+                .build(),
+        );
+
+        let ct_a = CancellationToken::new();
+        let ct_a_clone = ct_a.clone();
+        let handler_a = tokio::spawn(async move {
+            run_event_handler(service_a, rx_a, ct_a_clone).await;
+        });
+
+        tx.send(HarmoniaEvent::PlexNotifyRequired {
+            media_id: MediaId::new(),
+        })
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(*sections_a.lock().unwrap(), vec![1u32]);
+
+        // The supervisor mechanic: cancel + await the OLD handler BEFORE
+        // rebuilding.
+        ct_a.cancel();
+        handler_a.await.unwrap();
+
+        // Generation B: a REBUILT client (different Plex section mapping),
+        // respawned on a FRESH subscription — exactly what
+        // `run_syndesmos_supervisor` does after the cancel+await above.
+        let mock_b = Arc::new(MockPlexApi::new());
+        let sections_b = mock_b.sections_refreshed.clone();
+        let mut sections_map_b = std::collections::HashMap::new();
+        sections_map_b.insert(themelion::MediaType::Music, 2u32);
+
+        let rx_b = tx.subscribe();
+        let service_b = Arc::new(
+            ScrobbleClientBuilder::new(tx.clone(), crate::test_support::test_pool().await)
+                .with_mock_plex(mock_b.clone(), sections_map_b)
+                .build(),
+        );
+
+        let ct_b = CancellationToken::new();
+        let ct_b_clone = ct_b.clone();
+        let handler_b = tokio::spawn(async move {
+            run_event_handler(service_b, rx_b, ct_b_clone).await;
+        });
+
+        // A POST-change event must be processed by the rebuilt client
+        // (section 2) — the old (cancelled) client must see nothing further.
+        tx.send(HarmoniaEvent::PlexNotifyRequired {
+            media_id: MediaId::new(),
+        })
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        ct_b.cancel();
+        handler_b.await.unwrap();
+
+        assert_eq!(
+            *sections_a.lock().unwrap(),
+            vec![1u32],
+            "the OLD (cancelled) client must not see the post-change event"
+        );
+        assert_eq!(
+            *sections_b.lock().unwrap(),
+            vec![2u32],
+            "the respawned handler must dispatch the post-change event through the rebuilt client"
+        );
+    }
 }


### PR DESCRIPTION
Step 8 of the #529 reactive-config migration — the integration services (metadata, subtitles, scrobbling, curation, requests) reconfigure live on a config reload, each via an archon supervisor on its config section.

- **epignosis** — `MetadataAdapter` now holds `RwLock<Arc<ProviderBackedResolver>>` (read through a sync `snapshot()` that clones the `Arc` and drops the guard before any await). `run_epignosis_supervisor` rebuilds the resolver on an `epignosis.*` change; in-flight resolutions finish on the old `Arc`; the metadata cache reset is logged.
- **prostheke** — `SubtitleManager.config` → `Section<ProsthekeConfig>` (language/prefs go live per-op); the provider set is a swappable `RwLock<Arc<Vec<P>>>` (Arc-wrapped because `OpenSubtitlesProvider`'s `RateLimiter` isn't `Clone` — same swap discipline zetesis uses for cf-proxy/cardigann). `run_prostheke_supervisor` rebuilds providers on an `opensubtitles` subtree change (including None↔Some); the politeness-limiter reset is logged.
- **syndesmos** — `run_syndesmos_supervisor` cancels + awaits the old scrobble-handler generation, rebuilds via `build_syndesmos`, respawns the handler on a fresh event subscription, and swaps `ExternalAdapter`'s `RwLock<Arc<ScrobbleClient>>`. Both honest costs are logged: the circuit-breaker state resets, and events broadcast between cancel and re-subscribe are lost (a bounded scrobble-loss window).
- **kritike** — `DefaultCurationService` replaces its fixed `Semaphore` with `themelion::LiveGate` + `Section<KritikeConfig>`; `assess_quality` admits via `gate.enter(|| config.get().quality_check_concurrency.max(1))`, so a concurrency change takes effect on the next admission (LiveGate::enter's first production consumer). The now-unreachable `ConcurrencyLimiterClosed` error variant is removed.
- **aitesis** — `AitesisServiceImpl.config` → `Section<AitesisConfig>`; `submit_request` takes one `.get()` snapshot per op so `max_pending_per_user`/`max_requests_per_day`/`auto_approve_admins` are consistent within a request and live across reloads.

No std lock guard is held across an await anywhere (clippy `await_holding_lock` clean). Tests (real `ConfigManager`/`Section`): each subsystem's change is observed on its next operation (kritike admission bound, aitesis quota, prostheke language pref + provider swap, epignosis resolver rebuild via `Arc::ptr_eq`, syndesmos handler respawn processing a post-change event).

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings`, workspace), nextest 572 (6 crates) / full workspace, deny, kanon lint (0/0). `Gate-Passed` stamped.

Refs #529
