### PR TITLE
test(horismos,archon): config completeness + E2E SIGHUP regression; fix(archon,ergasia): reload deadlock + DHT isolation (#529 step 9)

### DIFF
--- a/crates/archon/src/main.rs
+++ b/crates/archon/src/main.rs
@@ -16,15 +16,23 @@ use cli::{Cli, Command};
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
-    let stdout = std::io::stdout();
-    let mut stdout_lock = stdout.lock();
+    // WHY: #529 — a pre-locked `StdoutLock` held across the whole `Serve`
+    // arm (which runs for the server's entire lifetime) deadlocked every
+    // OTHER thread's `tracing` output the instant a concurrently-scheduled
+    // task (verified: the SIGHUP reload handler) tried to log — `main`'s own
+    // future never migrates threads (`block_on` drives it on the calling
+    // thread only), so its held guard just sat there forever, invisible
+    // until a genuinely-concurrent logger contended for the same reentrant
+    // lock. An unlocked `Stdout` handle locks/releases per call instead, so
+    // no thread holds it across an await point.
+    let mut stdout = std::io::stdout();
 
     let result = match cli.command {
-        Command::Serve(args) => serve::run_serve(args, &mut stdout_lock).await,
+        Command::Serve(args) => serve::run_serve(args, &mut stdout).await,
         Command::Db(db_args) => match db_args.command {
-            cli::DbCommand::Migrate(args) => db::run_db_migrate(args, &mut stdout_lock).await,
+            cli::DbCommand::Migrate(args) => db::run_db_migrate(args, &mut stdout).await,
         },
-        Command::Play(args) => play::run_play(args, &mut stdout_lock).await,
+        Command::Play(args) => play::run_play(args, &mut stdout).await,
         Command::Render(args) => {
             render::run_render(render::RenderArgs {
                 server: args.server,
@@ -36,7 +44,7 @@ async fn main() {
             })
             .await
         }
-        Command::Migrate(args) => migrate::run_migrate(args, &mut stdout_lock).await,
+        Command::Migrate(args) => migrate::run_migrate(args, &mut stdout).await,
         Command::Mcp => mcp::run_stdio().await,
     };
 

--- a/crates/archon/tests/config_reload_e2e.rs
+++ b/crates/archon/tests/config_reload_e2e.rs
@@ -1,0 +1,339 @@
+//! #529 step 9 — end-to-end SIGHUP reload regression.
+//!
+//! Spawns the REAL `harmonia serve` binary, drives it over its actual HTTP
+//! API, rewrites its TOML on disk, sends a real `SIGHUP`, and observes the
+//! three reload classes through the real signal path: LIVE (`opds_page_size`
+//! visible on the next request), auth-LIVE (`jwt_secret` rotation
+//! invalidates the outstanding bearer immediately, refresh recovers), and
+//! RESTART (`database.db_path` held back + reported in `restart_pending`).
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+// WHY: the same gitleaks-allowlisted fixture secret used across the
+// exousia/paroche/archon test suites (`.gitleaks.toml` allowlist regex).
+const JWT_SECRET_INITIAL: &str = "test-secret-that-is-long-enough-for-hs256";
+
+const STARTUP_DEADLINE: Duration = Duration::from_secs(20);
+const RELOAD_DEADLINE: Duration = Duration::from_secs(15);
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Kills and reaps the spawned `harmonia` process on drop so a test panic
+/// (or an early return) never leaks a running server.
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        // WHY: best-effort teardown — the process may have already exited
+        // (e.g. it crashed during the test); failure to kill/reap here is
+        // non-fatal to the test outcome and the OS reclaims an orphan.
+        self.0.kill().ok();
+        self.0.wait().ok();
+    }
+}
+
+fn pick_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener
+        .local_addr()
+        .expect("listener has a local addr")
+        .port()
+}
+
+/// The parts of `harmonia.toml` that stay fixed across the pre- and
+/// post-reload rewrite (config file location, download dir, ports).
+struct HarmoniaFixture {
+    config_path: std::path::PathBuf,
+    download_dir: std::path::PathBuf,
+    http_port: u16,
+    quic_port: u16,
+}
+
+impl HarmoniaFixture {
+    /// Writes `harmonia.toml` with the given (variable, reload-relevant)
+    /// field values. Called twice: once before spawning the child, once
+    /// after — to construct the config-reload delta the test drives via
+    /// SIGHUP.
+    fn write_toml(&self, db_path: &std::path::Path, opds_page_size: u32, jwt_secret: &str) {
+        let download_dir = self.download_dir.display();
+        let toml = format!(
+            r#"[database]
+db_path = "{db_path}"
+
+[exousia]
+jwt_secret = "{jwt_secret}"
+
+[paroche]
+listen_addr = "127.0.0.1"
+port = {http_port}
+renderer_quic_port = {quic_port}
+opds_page_size = {opds_page_size}
+
+[ergasia]
+download_dir = "{download_dir}"
+session_state_path = "{download_dir}/.librqbit-state"
+extraction_temp_dir = "{download_dir}/.extraction"
+"#,
+            db_path = db_path.display(),
+            http_port = self.http_port,
+            quic_port = self.quic_port,
+        );
+        std::fs::write(&self.config_path, toml).expect("write harmonia.toml");
+    }
+}
+
+/// Spawns the real `harmonia serve` binary against `config_path`, capturing
+/// stdout on a background thread so the child never blocks on a full pipe
+/// buffer. Returns the guard (kills the child on drop) and a channel that
+/// yields every stdout line as it is written.
+fn spawn_harmonia(config_path: &std::path::Path) -> (ChildGuard, mpsc::Receiver<String>) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harmonia"))
+        .arg("serve")
+        .arg("-c")
+        .arg(config_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn harmonia serve");
+
+    let stdout = child.stdout.take().expect("child stdout is piped");
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            // WHY: a send error means the test thread stopped receiving
+            // (test already finished) — nothing left to do but stop reading.
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    (ChildGuard(child), rx)
+}
+
+/// Blocks (bounded) until the first-run admin-password banner appears on the
+/// child's stdout, returning the parsed password. No fixed sleep: this waits
+/// on the actual stdout stream via the channel, bounded by `STARTUP_DEADLINE`.
+fn wait_for_admin_password(rx: &mpsc::Receiver<String>) -> String {
+    let deadline = Instant::now() + STARTUP_DEADLINE;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            remaining > Duration::ZERO,
+            "admin password banner not observed within {STARTUP_DEADLINE:?}"
+        );
+        let line = rx
+            .recv_timeout(remaining)
+            .expect("child stdout closed before the admin-password banner appeared");
+        if let Some(password) = line.strip_prefix("  First run detected. Admin password: ") {
+            return password.trim().to_string();
+        }
+    }
+}
+
+async fn try_login(
+    client: &reqwest::Client,
+    base: &str,
+    password: &str,
+) -> Option<(String, String)> {
+    let resp = client
+        .post(format!("{base}/api/auth/login"))
+        .json(&serde_json::json!({"username": "admin", "password": password}))
+        .send()
+        .await
+        .ok()?;
+    if resp.status() != reqwest::StatusCode::OK {
+        return None;
+    }
+    let body: Value = resp.json().await.ok()?;
+    Some((
+        body["data"]["access_token"].as_str()?.to_string(),
+        body["data"]["refresh_token"].as_str()?.to_string(),
+    ))
+}
+
+/// Bounded-poll login: the server may not be accepting connections yet even
+/// after the admin-password banner (the HTTP listener binds slightly later
+/// in startup), so retry the login call itself until it succeeds.
+async fn wait_for_server_ready(
+    client: &reqwest::Client,
+    base: &str,
+    password: &str,
+) -> (String, String) {
+    let deadline = Instant::now() + STARTUP_DEADLINE;
+    loop {
+        if let Some(pair) = try_login(client, base, password).await {
+            return pair;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "server never became ready to accept logins within {STARTUP_DEADLINE:?}"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+async fn get_config(client: &reqwest::Client, base: &str, token: &str) -> reqwest::Response {
+    client
+        .get(format!("{base}/api/system/config"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .expect("config request sends")
+}
+
+/// Bounded-poll: waits until `GET /api/system/config` (using `token`)
+/// returns 401 — the observable signal that a JWT-secret rotation has
+/// invalidated this specific outstanding bearer.
+async fn wait_for_token_invalidated(client: &reqwest::Client, base: &str, token: &str) {
+    let deadline = Instant::now() + RELOAD_DEADLINE;
+    loop {
+        let resp = get_config(client, base, token).await;
+        if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "pre-rotation bearer was never invalidated within {RELOAD_DEADLINE:?}"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Bounded-poll: waits until `GET /api/system/config` (using `token`, which
+/// must be a POST-rotation bearer) reports `opds_page_size == expected`,
+/// then returns the full JSON payload for further assertions.
+async fn wait_for_opds_page_size(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+    expected: u32,
+) -> Value {
+    let deadline = Instant::now() + RELOAD_DEADLINE;
+    loop {
+        let resp = get_config(client, base, token).await;
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::OK,
+            "post-rotation bearer must authenticate"
+        );
+        let body: Value = resp.json().await.expect("config response is JSON");
+        if body["paroche"]["opds_page_size"].as_u64() == Some(u64::from(expected)) {
+            return body;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "opds_page_size never reached {expected} within {RELOAD_DEADLINE:?} (last seen: {body})"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sighup_reload_applies_live_rotates_jwt_and_holds_back_restart_class() {
+    let workdir = tempfile::tempdir().expect("create tempdir");
+    let download_dir = workdir.path().join("downloads");
+    std::fs::create_dir_all(&download_dir).expect("create download dir");
+
+    let db_path_initial = workdir.path().join("harmonia.db");
+
+    let http_port = pick_free_port();
+    let mut quic_port = pick_free_port();
+    // WHY: two independent ephemeral-port picks could theoretically collide;
+    // validation requires them to differ, so re-pick rather than flake.
+    while quic_port == http_port {
+        quic_port = pick_free_port();
+    }
+
+    let fixture = HarmoniaFixture {
+        config_path: workdir.path().join("harmonia.toml"),
+        download_dir,
+        http_port,
+        quic_port,
+    };
+    fixture.write_toml(&db_path_initial, 50, JWT_SECRET_INITIAL);
+
+    let (guard, stdout_rx) = spawn_harmonia(&fixture.config_path);
+    let admin_password = wait_for_admin_password(&stdout_rx);
+
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{http_port}");
+
+    let (access_pre, refresh_pre) = wait_for_server_ready(&client, &base, &admin_password).await;
+
+    // Sanity: the pre-rotation bearer authenticates and sees the pre-reload
+    // page size before any config change.
+    let initial = get_config(&client, &base, &access_pre).await;
+    assert_eq!(initial.status(), reqwest::StatusCode::OK);
+    let initial_body: Value = initial.json().await.expect("config response is JSON");
+    assert_eq!(initial_body["paroche"]["opds_page_size"], 50);
+    assert_eq!(
+        initial_body["restart_pending"]
+            .as_array()
+            .expect("restart_pending is an array")
+            .len(),
+        0
+    );
+
+    // Rewrite the TOML: one LIVE field (opds_page_size), one auth-LIVE field
+    // (jwt_secret rotation — derived from the allowlisted constant at
+    // runtime rather than a second hardcoded secret literal, per #529 step 9),
+    // and one RESTART-class field (database.db_path).
+    let jwt_secret_rotated = format!("{JWT_SECRET_INITIAL}-rotated");
+    let db_path_rotated = workdir.path().join("harmonia-rotated.db");
+    fixture.write_toml(&db_path_rotated, 999, &jwt_secret_rotated);
+
+    let pid = guard.0.id();
+    tokio::task::spawn_blocking(move || {
+        Command::new("/bin/kill")
+            .arg("-HUP")
+            .arg(pid.to_string())
+            .status()
+    })
+    .await
+    .expect("spawn_blocking joins")
+    .expect("kill -HUP runs");
+
+    // 1. The pre-rotation bearer must be rejected as soon as the reload
+    //    lands (immediate JWT invalidation, not the next natural expiry).
+    wait_for_token_invalidated(&client, &base, &access_pre).await;
+
+    // 2. Refresh recovers a working token pair without re-login.
+    let refresh_resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .json(&serde_json::json!({"refresh_token": refresh_pre}))
+        .send()
+        .await
+        .expect("refresh request sends");
+    assert_eq!(
+        refresh_resp.status(),
+        reqwest::StatusCode::OK,
+        "refresh must recover a working session across a jwt_secret rotation"
+    );
+    let refresh_body: Value = refresh_resp.json().await.expect("refresh response is JSON");
+    let access_post = refresh_body["data"]["access_token"]
+        .as_str()
+        .expect("access_token present")
+        .to_string();
+
+    // 3. The LIVE field is visible via the new bearer, and the RESTART-class
+    //    field is reported (held back, not silently dropped).
+    let reloaded = wait_for_opds_page_size(&client, &base, &access_post, 999).await;
+    let restart_pending = reloaded["restart_pending"]
+        .as_array()
+        .expect("restart_pending is an array");
+    assert!(
+        restart_pending
+            .iter()
+            .any(|v| v.as_str() == Some("database.db_path")),
+        "restart_pending must list database.db_path, got: {restart_pending:?}"
+    );
+
+    drop(guard);
+}

--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -74,6 +74,16 @@ impl TorrentSession {
         let opts = SessionOptions {
             disable_dht: false,
             disable_dht_persistence: false,
+            // WHY: pin DHT routing-table persistence inside this instance's own
+            // session_state_path rather than librqbit's global default
+            // (~/.cache/com.rqbit.dht/dht.json). A shared default races and
+            // corrupts across concurrent instances — and parallel tests — that
+            // initialize the persistent DHT at once; instance-local state keeps
+            // each session self-contained.
+            dht_config: Some(librqbit::dht::PersistentDhtConfig {
+                config_filename: Some(PathBuf::from(&config.session_state_path).join("dht.json")),
+                ..Default::default()
+            }),
             persistence: Some(persistence),
             listen_port_range: Some(
                 config

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -35,6 +35,183 @@ fn requires_restart(path: &str) -> bool {
         .any(|prefix| path.starts_with(prefix))
 }
 
+// #529 step 9: the reactive-config completeness contract. Every leaf path
+// produced by `classification_leaf_paths` (below) must appear in EXACTLY one
+// of `LIVE`, `RESTART_REQUIRED` (above), or `UNWIRED` — enforced by
+// `every_leaf_is_classified_exactly_once`. Dynamic map keys (`taxis.libraries`)
+// are canonicalized to a literal `*` segment so the set is deterministic
+// regardless of what key a test/exemplar config happens to use.
+
+/// Full dotted leaf paths wired live by #529 steps 2-8: a per-op read
+/// (`Section::get()`), a swappable internal (LIVE-B), or a teardown+rebuild
+/// supervisor (REBUILD) — anything that is NOT held back by
+/// `RESTART_REQUIRED` and DOES have a real production consumer.
+pub const LIVE: &[&str] = &[
+    // exousia — step 3 (Section<ExousiaConfig>, immediate JWT rotation)
+    "exousia.access_token_ttl_secs",
+    "exousia.refresh_token_ttl_days",
+    "exousia.jwt_secret",
+    // paroche — steps 2, 4, 5 (per-op reads, renderer QUIC LiveGate, dual-listener rebind)
+    "paroche.listen_addr",
+    "paroche.port",
+    "paroche.opds_page_size",
+    "paroche.renderer_api_key",
+    "paroche.kosync_registration_enabled",
+    "paroche.renderer_max_connections",
+    "paroche.renderer_session_init_timeout_secs",
+    "paroche.renderer_quic_port",
+    // taxis — step 6 (scanner rebuild supervisor)
+    "taxis.libraries.*.path",
+    "taxis.libraries.*.media_type",
+    "taxis.libraries.*.watcher_mode",
+    "taxis.libraries.*.poll_interval_seconds",
+    "taxis.libraries.*.scan_interval_hours",
+    "taxis.watcher_debounce_ms",
+    "taxis.scan_concurrency",
+    // epignosis — step 8 (resolver rebuild + swap behind MetadataAdapter)
+    "epignosis.cache_ttl_secs",
+    "epignosis.provider_timeout_secs",
+    "epignosis.provider_response_max_bytes",
+    // kritike — step 8 (LiveGate)
+    "kritike.quality_check_concurrency",
+    // zetesis — step 7 (per-op reads, RateLimiter::reconfigure, cf-proxy/cardigann swap)
+    "zetesis.request_timeout_secs",
+    "zetesis.max_response_body_bytes",
+    "zetesis.cloudflare_bypass_enabled",
+    "zetesis.max_concurrent_searches",
+    "zetesis.per_indexer_rate_limit_requests",
+    "zetesis.per_indexer_rate_limit_window_seconds",
+    "zetesis.search_timeout_seconds",
+    "zetesis.cardigann_definitions_dir",
+    "zetesis.cf_proxy_url",
+    "zetesis.cf_proxy_timeout_seconds",
+    // ergasia — step 7 (SessionEngine rebuilds ExtractionLimits per call)
+    "ergasia.max_extraction_depth",
+    "ergasia.max_decompression_ratio",
+    // syntaxis — step 7 (DownloadQueue::update_config + SlotAllocator::set_limits)
+    "syntaxis.max_concurrent_downloads",
+    "syntaxis.max_per_tracker",
+    "syntaxis.retry_count",
+    "syntaxis.retry_backoff_base_seconds",
+    // prostheke — step 8 (per-op prefs, provider rebuild + set_providers)
+    "prostheke.languages",
+    "prostheke.include_hearing_impaired",
+    "prostheke.include_forced",
+    "prostheke.min_match_score",
+    "prostheke.opensubtitles.api_key",
+    "prostheke.opensubtitles.rate_limit_per_second",
+    "prostheke.opensubtitles.max_download_bytes",
+    // komide — step 6 (feed scheduler rebuild supervisor)
+    "komide.podcast_poll_interval_minutes",
+    "komide.news_poll_interval_minutes",
+    "komide.news_retention_days",
+    "komide.news_retention_articles",
+    "komide.auto_download_latest_n",
+    "komide.fetch_timeout_secs",
+    "komide.max_feed_bytes",
+    "komide.max_backoff_minutes",
+    "komide.jitter_percent",
+    // syndesmos — step 8 (REBUILD: client + handler respawn + adapter swap)
+    "syndesmos.plex.url",
+    "syndesmos.plex.token",
+    "syndesmos.plex.library_sections",
+    "syndesmos.lastfm.api_key",
+    "syndesmos.lastfm.shared_secret",
+    "syndesmos.lastfm.session_key",
+    "syndesmos.tidal.access_token",
+    "syndesmos.circuit_break_minutes",
+    // NOTE: `circuit_break_failure_threshold` reaches the rebuild supervisor
+    // (a change to it triggers the same teardown+rebuild as every other
+    // syndesmos.* leaf) but `ScrobbleClientBuilder::build()` hardcodes the
+    // breaker threshold to 5 internally — the config-plumbing contract this
+    // test enforces is honored; the internal no-op is tracked separately
+    // (see harmonia issue tracking the syndesmos hardcoded-threshold finding,
+    // NOT #575's dead-config-surface list).
+    "syndesmos.circuit_break_failure_threshold",
+    // aitesis — step 8 (Section<AitesisConfig>, per-op reads)
+    "aitesis.max_pending_per_user",
+    "aitesis.max_requests_per_day",
+    "aitesis.auto_approve_admins",
+];
+
+/// Full dotted leaf paths with NO production consumer — the 31 dead-config
+/// fields inventoried by #529's design pass and filed as harmonia issue
+/// #575. Each stays here (rather than silently vanishing from the schema)
+/// until #575 dispositions it: wired to a real consumer, or removed.
+pub const UNWIRED: &[&str] = &[
+    "paroche.stream_buffer_kb",                  // #575
+    "paroche.transcode_concurrency",             // #575
+    "taxis.libraries.*.auto_import",             // #575
+    "taxis.file_naming_dry_run",                 // #575
+    "epignosis.max_retries",                     // #575
+    "epignosis.fingerprint_accept_threshold",    // #575
+    "epignosis.fingerprint_ambiguous_threshold", // #575
+    "kritike.scan_interval_hours",               // #575
+    "aggelia.download_queue_size",               // #575
+    "zetesis.max_results_per_indexer",           // #575
+    "zetesis.caps_refresh_hours",                // #575
+    "zetesis.cf_cookie_refresh_minutes",         // #575
+    "zetesis.cf_health_check_interval_minutes",  // #575
+    "ergasia.max_concurrent_downloads",          // #575
+    "ergasia.tracker_seed_policies", // #575 — whole TrackerSeedPolicy struct is dead; the map is empty by default and collapses to this one leaf (see `classification_leaf_paths`)
+    "ergasia.progress_throttle_seconds", // #575
+    "ergasia.extraction_temp_dir",   // #575
+    "ergasia.max_connections_per_torrent", // #575
+    "ergasia.magnet_resolve_timeout_seconds", // #575
+    "ergasia.extraction_cleanup_hours", // #575
+    "syntaxis.stalled_download_timeout_hours", // #575
+    "prostheke.opensubtitles.username", // #575
+    "prostheke.opensubtitles.password", // #575
+    "komide.podcast_dir",            // #575
+    "komide.max_episode_bytes",      // #575
+    "syndesmos.tidal.client_id",     // #575
+    "syndesmos.tidal.client_secret", // #575
+    "syndesmos.tidal.refresh_token", // #575
+    "syndesmos.tidal.sync_interval_minutes", // #575
+    "syndesis.jitter_buffer_max_frames", // #575
+    "syndesis.max_sessions",         // #575
+];
+
+// NOTE: paths a test/exemplar config walks under a dynamic-key map are
+// canonicalized to this parent path with a literal `*` child segment, so
+// the leaf set is deterministic regardless of the real map key used.
+#[cfg(test)]
+const DYNAMIC_MAP_PATHS: &[&str] = &["taxis.libraries"];
+
+/// Single-tree leaf walker for the completeness test — a sibling of
+/// `diff_value` (same Object-recursion shape) that walks ONE config tree
+/// instead of diffing two, pushing every scalar/array/empty-object node as a
+/// leaf. A dynamic-key map listed in `DYNAMIC_MAP_PATHS` recurses through its
+/// (single, exemplar-populated) entry under a canonical `*` segment instead
+/// of the real key. An empty map with no synthetic entry (e.g.
+/// `ergasia.tracker_seed_policies`) has no children to recurse into, so it
+/// reports its own path as one leaf — the same "dead subtree" signal a
+/// removed feature would produce.
+#[cfg(test)]
+fn classification_leaf_paths(path: &str, value: &Value, out: &mut Vec<String>) {
+    let Value::Object(map) = value else {
+        out.push(path.to_string());
+        return;
+    };
+    if map.is_empty() {
+        out.push(path.to_string());
+        return;
+    }
+    for (key, child) in map {
+        let canonical_key = if DYNAMIC_MAP_PATHS.contains(&path) {
+            "*"
+        } else {
+            key.as_str()
+        };
+        let child_path = if path.is_empty() {
+            canonical_key.to_string()
+        } else {
+            format!("{path}.{canonical_key}")
+        };
+        classification_leaf_paths(&child_path, child, out);
+    }
+}
+
 /// Compare two configs and return the changed leaves as dotted paths
 /// (e.g. `paroche.port`, `taxis.libraries.music.path`), sorted.
 pub fn diff_config(old: &Config, new: &Config) -> Vec<ConfigChange> {
@@ -324,5 +501,142 @@ mod tests {
             old.ergasia.seed_time_threshold_hours
         );
         assert_eq!(effective.paroche.port, 9090);
+    }
+
+    // ── #529 step 9: classification completeness ─────────────────────────────
+
+    // WHY: every Option<Struct> subtree is populated with `Some(..)` (rather
+    // than left at its `None` default) so the leaf walker descends into its
+    // fields instead of collapsing the whole subtree to one leaf — the only
+    // way a mixed LIVE/UNWIRED subtree (e.g. `prostheke.opensubtitles`) gets
+    // per-field classification instead of one opaque leaf. `taxis.libraries`
+    // gets exactly ONE synthetic entry so `classification_leaf_paths` walks
+    // it once under the canonical `*` key; `ergasia.tracker_seed_policies`
+    // and `syndesmos.plex.library_sections` are deliberately left EMPTY —
+    // both are uniformly classified as a whole (UNWIRED / LIVE respectively),
+    // so the "empty map collapses to its own leaf" fallback is sufficient.
+    fn exemplar_config() -> Config {
+        use crate::subsystems::{
+            LastfmConfig, LibraryConfig, OpenSubtitlesConfig, PlexConfig, TidalConfig,
+        };
+
+        let mut config = Config::default();
+
+        config
+            .taxis
+            .libraries
+            .insert("sample".to_string(), LibraryConfig::default());
+
+        config.paroche.renderer_api_key = Some("sample-api-key".to_string());
+        config.zetesis.cardigann_definitions_dir =
+            Some(std::path::PathBuf::from("/etc/harmonia/cardigann"));
+        config.zetesis.cf_proxy_url = Some("http://127.0.0.1:8191".to_string());
+        config.prostheke.opensubtitles = Some(OpenSubtitlesConfig::default());
+        config.syndesmos.plex = Some(PlexConfig {
+            url: "http://localhost:32400".to_string(),
+            token: "sample-token".to_string(),
+            library_sections: std::collections::HashMap::new(),
+        });
+        config.syndesmos.lastfm = Some(LastfmConfig {
+            api_key: "sample-key".to_string(),
+            shared_secret: "sample-secret".to_string(),
+            session_key: Some("sample-session".to_string()),
+        });
+        config.syndesmos.tidal = Some(TidalConfig {
+            access_token: Some("sample-access".to_string()),
+            refresh_token: Some("sample-refresh".to_string()),
+            ..TidalConfig::default()
+        });
+
+        config
+    }
+
+    /// Makes an unclassified config leaf a build failure: every leaf the
+    /// exemplar config produces must land in exactly one of `LIVE`,
+    /// `RESTART_REQUIRED`, or `UNWIRED`, and the union of the three must
+    /// exactly equal the full leaf set (disjoint + exhaustive).
+    #[test]
+    fn every_leaf_is_classified_exactly_once() {
+        let config = exemplar_config();
+        let value = serde_json::to_value(&config).unwrap(); // WHY: Config -> Value cannot fail (see diff_config)
+
+        let mut leaves = Vec::new();
+        classification_leaf_paths("", &value, &mut leaves);
+        let leaf_set: BTreeSet<&str> = leaves.iter().map(String::as_str).collect();
+        assert_eq!(
+            leaf_set.len(),
+            leaves.len(),
+            "leaf walker produced duplicate paths: {leaves:?}"
+        );
+
+        let live: BTreeSet<&str> = LIVE.iter().copied().collect();
+        let unwired: BTreeSet<&str> = UNWIRED.iter().copied().collect();
+        assert_eq!(live.len(), LIVE.len(), "LIVE contains a duplicate entry");
+        assert_eq!(
+            unwired.len(),
+            UNWIRED.len(),
+            "UNWIRED contains a duplicate entry"
+        );
+
+        // No ghost entries: every declared LIVE/UNWIRED leaf must exist in
+        // the real leaf set (catches a stale entry left behind by a removed
+        // or renamed field).
+        for &l in LIVE {
+            assert!(
+                leaf_set.contains(l),
+                "LIVE lists nonexistent config leaf: {l}"
+            );
+        }
+        for &u in UNWIRED {
+            assert!(
+                leaf_set.contains(u),
+                "UNWIRED lists nonexistent config leaf: {u}"
+            );
+        }
+
+        // Per-leaf: exactly one classification.
+        let mut unclassified = Vec::new();
+        let mut multi_classified = Vec::new();
+        for &leaf in &leaf_set {
+            let matches = [
+                live.contains(leaf),
+                requires_restart(leaf),
+                unwired.contains(leaf),
+            ]
+            .iter()
+            .filter(|hit| **hit)
+            .count();
+            match matches {
+                0 => unclassified.push(leaf),
+                1 => {}
+                _ => multi_classified.push(leaf),
+            }
+        }
+        assert!(
+            unclassified.is_empty(),
+            "config leaf(s) not in LIVE, RESTART_REQUIRED, or UNWIRED — classify the new field: {unclassified:#?}"
+        );
+        assert!(
+            multi_classified.is_empty(),
+            "config leaf(s) classified in more than one list: {multi_classified:#?}"
+        );
+
+        // Cross-check: the union must exactly equal the full leaf set.
+        let restart_leaves: BTreeSet<&str> = leaf_set
+            .iter()
+            .copied()
+            .filter(|leaf| requires_restart(leaf))
+            .collect();
+        let union: BTreeSet<&str> = live
+            .union(&restart_leaves)
+            .copied()
+            .collect::<BTreeSet<&str>>()
+            .union(&unwired)
+            .copied()
+            .collect();
+        assert_eq!(
+            union, leaf_set,
+            "LIVE ∪ RESTART_REQUIRED ∪ UNWIRED must exactly equal the full config leaf set"
+        );
     }
 }

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -9,7 +9,7 @@ mod validation;
 use std::path::Path;
 
 pub use config::Config;
-pub use diff::{ConfigChange, diff_config};
+pub use diff::{ConfigChange, LIVE, UNWIRED, diff_config};
 pub use error::HorismosError;
 use figment::Figment;
 use figment::providers::{Env, Format, Serialized, Toml};

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -1,0 +1,280 @@
+# Config reload (#529)
+
+> How a running Harmonia process picks up a config change without a restart.
+> Companion to [configuration.md](configuration.md) (load/merge/validate) and
+> [subsystems.md](subsystems.md) (which crate owns which section).
+> The Horismos crate that owns this logic is in [cargo.md](cargo.md).
+
+## Purpose
+
+`SIGHUP` re-reads `harmonia.toml` (+ `secrets.toml` + `HARMONIA__` env) and
+applies the delta to the running process. Every config leaf falls into
+exactly one of three classes:
+
+- **LIVE** — takes effect on the next operation, with no restart. Some LIVE
+  fields are read per-op straight from the live config (`Section::get()`);
+  others are LIVE via a swap or a teardown+rebuild supervisor watching the
+  section for changes.
+- **RESTART-required** — held back: the running process keeps the OLD
+  effective value, and the field is reported in `restart_pending` until the
+  process restarts or the on-disk value reverts. Nothing is silently dropped.
+- **UNWIRED** — parsed and validated, but no code reads it to change
+  behavior. Tracked as tech debt ([#575](https://github.com/forkwright/harmonia/issues/575)),
+  not part of the reactive-config contract.
+
+`crates/horismos/src/diff.rs` is the single source of truth for this
+classification (`LIVE`, `RESTART_REQUIRED`, `UNWIRED` — the last two are
+crate-private/pub respectively; `LIVE` and `UNWIRED` are re-exported from
+`horismos`). A test in that file (`every_leaf_is_classified_exactly_once`)
+walks every leaf of a fully-populated `Config` and fails the build if a leaf
+is in zero or more-than-one of the three lists — adding a new config field
+without classifying it is a test failure, not a silent gap.
+
+---
+
+## Mechanism
+
+| Type | Where | Role |
+|---|---|---|
+| `ConfigManager` | `handle.rs` | Owner side (archon holds this). `reload()` re-reads from disk; `replace()` publishes a config programmatically (the test lever). Both funnel through `publish()`. |
+| `ConfigHandle` | `handle.rs` | Subscriber side, cheaply `Clone`. `.current()` returns an owned `Arc<Config>` snapshot; `.section(fn)` returns a typed `Section<T>`; `.watch_section(fn)` returns a `SectionWatcher<T>` for supervisor loops; `.restart_pending()` returns the held-back dotted paths. |
+| `Section<T>` | `handle.rs` | Typed live sub-view. `.get()` returns an OWNED clone — the idiom is ONE `get()` per operation (a mid-operation second read would risk a torn config: e.g. minting a JWT with the new secret but the old TTL). |
+| `SectionWatcher<T>` | `handle.rs` | `.changed().await` yields only when its projected section differs from the last-seen value; returns `None` once the `ConfigManager` is dropped (a supervisor's exit signal). |
+| `ReloadOutcome` | `handle.rs` | `{ warnings, applied, restart_pending }` — dotted leaf paths, not values (values are never logged for secrets like `jwt_secret`). |
+
+`publish()` (`handle.rs`) is the only place a reload actually happens:
+
+1. Diff the current effective config against the newly-parsed one
+   (`diff_config`, `crates/horismos/src/diff.rs`) — produces dotted leaf
+   paths (`taxis.libraries.<key>.path`, arrays are atomic leaves).
+2. Every changed leaf whose path starts with a `RESTART_REQUIRED` prefix goes
+   to `restart_pending`; everything else goes to `applied`.
+3. If anything is `applied`, `held_back_merge` builds the new EFFECTIVE
+   config — restart-class leaves keep their OLD value, everything else takes
+   the new value — and broadcasts it over the `watch` channel.
+4. `restart_pending` is derived fresh on every publish (not accumulated), so
+   reverting the on-disk value clears it automatically.
+
+Archon's SIGHUP handler (`crates/archon/src/serve.rs`) calls
+`reload_config()` (extracted so tests can drive a reload without a real
+signal) and logs `ReloadOutcome` honestly: applied paths at `info!`,
+restart-pending paths at `warn!`. The admin diagnostic endpoint
+`GET /api/system/config` (`crates/paroche/src/routes/system.rs`) echoes
+`restart_pending` so an operator can see a held-back change without reading
+logs.
+
+---
+
+## Field classification
+
+Grouped by config section. "Mechanism" names how a LIVE field actually takes
+effect; REBUILD means a supervisor tears the subsystem down and rebuilds it
+from the new section on change (`SectionWatcher::changed()`).
+
+### exousia — LIVE (per-op `Section`, step 3)
+
+| Field | Mechanism |
+|---|---|
+| `access_token_ttl_secs` | per-op read at mint; mint-forward only (already-issued expirations honored) |
+| `refresh_token_ttl_days` | per-op read at mint |
+| `jwt_secret` | per-op read at verify — see **JWT rotation** below |
+
+### paroche — LIVE (steps 2, 4, 5) except two UNWIRED
+
+| Field | Class | Mechanism |
+|---|---|---|
+| `listen_addr` | LIVE | HTTP dual-listener rebind (step 5) |
+| `port` | LIVE | HTTP dual-listener rebind (step 5) |
+| `stream_buffer_kb` | UNWIRED | #575 — only echoed in diagnostics |
+| `transcode_concurrency` | UNWIRED | #575 — no transcoding implementation exists |
+| `opds_page_size` | LIVE | per-op read off `ConfigHandle` |
+| `renderer_api_key` | LIVE | per-connection section read at SessionInit; rotation affects new registrations only |
+| `kosync_registration_enabled` | LIVE | per-request read |
+| `renderer_max_connections` | LIVE | `themelion::LiveGate` admission cap |
+| `renderer_session_init_timeout_secs` | LIVE | per-connection section read |
+| `renderer_quic_port` | LIVE | QUIC dual-endpoint rebind (step 5) |
+
+### taxis — LIVE (scanner REBUILD, step 6) except two UNWIRED
+
+| Field | Class |
+|---|---|
+| `libraries.<key>.path` / `.media_type` / `.watcher_mode` / `.poll_interval_seconds` / `.scan_interval_hours` | LIVE |
+| `libraries.<key>.auto_import` | UNWIRED — #575, scanner emits unconditionally |
+| `file_naming_dry_run` | UNWIRED — #575, no dry-run logic exists |
+| `watcher_debounce_ms` | LIVE |
+| `scan_concurrency` | LIVE |
+
+### epignosis — LIVE (resolver REBUILD, step 8) except three UNWIRED
+
+| Field | Class |
+|---|---|
+| `cache_ttl_secs` / `provider_timeout_secs` / `provider_response_max_bytes` | LIVE — metadata cache RESETS on rebuild (logged) |
+| `max_retries` | UNWIRED — #575 |
+| `fingerprint_accept_threshold` / `fingerprint_ambiguous_threshold` | UNWIRED — #575, resolver never compares |
+
+### kritike
+
+| Field | Class | Mechanism |
+|---|---|---|
+| `scan_interval_hours` | UNWIRED | #575 — no scan loop exists |
+| `quality_check_concurrency` | LIVE | `themelion::LiveGate` (step 8) |
+
+### aggelia
+
+| Field | Class |
+|---|---|
+| `buffer_size` | RESTART — broadcast channel capacity fixed at creation |
+| `download_queue_size` | UNWIRED — #575, only `buffer_size` is consumed |
+
+### zetesis — LIVE (steps 7) except four UNWIRED
+
+| Field | Class | Mechanism |
+|---|---|---|
+| `request_timeout_secs` / `max_response_body_bytes` / `max_concurrent_searches` / `search_timeout_seconds` | LIVE | per-op reads |
+| `cloudflare_bypass_enabled` / `cf_proxy_url` / `cf_proxy_timeout_seconds` | LIVE | cf-proxy rebuild + swap |
+| `per_indexer_rate_limit_requests` / `per_indexer_rate_limit_window_seconds` | LIVE | `RateLimiter::reconfigure` — preserves in-flight embargoes |
+| `cardigann_definitions_dir` | LIVE | registry reload + swap |
+| `max_results_per_indexer` / `caps_refresh_hours` / `cf_cookie_refresh_minutes` / `cf_health_check_interval_minutes` | UNWIRED | #575 |
+
+### ergasia — mostly RESTART/UNWIRED; two LIVE
+
+| Field | Class | Why |
+|---|---|---|
+| `download_dir` / `session_state_path` / `listen_port_range` / `peer_connect_timeout_seconds` | RESTART | frozen into the librqbit session at build |
+| `seed_ratio_threshold` / `seed_time_threshold_hours` | RESTART | frozen into librqbit's `SeedingPolicy`, no reconfigure API (reclassified in step 7 — previously a silent no-op) |
+| `max_extraction_depth` / `max_decompression_ratio` | LIVE | `SessionEngine` rebuilds `ExtractionLimits` per extract call |
+| `max_concurrent_downloads`, `tracker_seed_policies`, `progress_throttle_seconds`, `extraction_temp_dir`, `max_connections_per_torrent`, `magnet_resolve_timeout_seconds`, `extraction_cleanup_hours` | UNWIRED | #575 |
+
+### syntaxis — LIVE (step 7) except one UNWIRED
+
+| Field | Class |
+|---|---|
+| `max_concurrent_downloads` / `max_per_tracker` / `retry_count` / `retry_backoff_base_seconds` | LIVE — `DownloadQueue::update_config` + `SlotAllocator::set_limits` |
+| `stalled_download_timeout_hours` | UNWIRED — #575 |
+
+### prostheke — LIVE (step 8) except two UNWIRED
+
+| Field | Class | Mechanism |
+|---|---|---|
+| `languages` / `include_hearing_impaired` / `include_forced` / `min_match_score` | LIVE | per-op `Section` read |
+| `opensubtitles.api_key` / `.rate_limit_per_second` / `.max_download_bytes` | LIVE | provider rebuild + `set_providers` — rate limiter state RESETS with the provider (logged) |
+| `opensubtitles.username` / `.password` | UNWIRED | #575 — no login flow exists |
+
+### komide — LIVE (feed scheduler REBUILD, step 6) except two UNWIRED
+
+| Field | Class |
+|---|---|
+| `podcast_poll_interval_minutes`, `news_poll_interval_minutes`, `news_retention_days`, `news_retention_articles`, `auto_download_latest_n`, `fetch_timeout_secs`, `max_feed_bytes`, `max_backoff_minutes`, `jitter_percent` | LIVE |
+| `podcast_dir` / `max_episode_bytes` | UNWIRED — #575, episode download is test-only |
+
+### syndesmos — LIVE (client REBUILD, step 8) except four UNWIRED
+
+| Field | Class | Notes |
+|---|---|---|
+| `plex.url` / `.token` / `.library_sections` | LIVE | rebuild + swap |
+| `lastfm.api_key` / `.shared_secret` / `.session_key` | LIVE | rebuild + swap |
+| `tidal.access_token` | LIVE | the only Tidal field a real client reads |
+| `circuit_break_minutes` | LIVE | feeds `CircuitBreaker` cooldown |
+| `circuit_break_failure_threshold` | LIVE | reaches the rebuild supervisor like every other `syndesmos.*` leaf, but `ScrobbleClientBuilder::build()` currently hardcodes the breaker threshold to 5 — a within-crate wiring gap tracked separately, NOT part of #575's dead-config list |
+| `tidal.client_id` / `.client_secret` / `.refresh_token` / `.sync_interval_minutes` | UNWIRED | #575 — no OAuth refresh flow, no sync scheduler |
+
+Rebuilding the client on ANY `syndesmos.*` change costs two honest things,
+both logged: circuit breakers reset (fresh breakers, no carried trip state),
+and events published between handler-cancel and re-subscribe are lost (a
+bounded scrobble-loss window — broadcast receivers only see
+post-subscription events).
+
+### syndesis — UNWIRED (both fields)
+
+| Field | Class | Why |
+|---|---|---|
+| `jitter_buffer_max_frames` / `max_sessions` | UNWIRED | #575 — the syndesis crate is never constructed from archon |
+
+### aitesis — LIVE (step 8)
+
+| Field | Class |
+|---|---|
+| `max_pending_per_user` / `max_requests_per_day` / `auto_approve_admins` | LIVE — per-op `Section` read |
+
+### database — RESTART (all three fields)
+
+| Field | Why |
+|---|---|
+| `db_path` / `read_pool_size` / `write_pool_max` | sqlx pool sizing is fixed at connect (no resize API); every service holds a frozen `SqlitePool` clone |
+
+---
+
+## Special semantics
+
+### JWT immediate rotation (exousia)
+
+Rotating `exousia.jwt_secret` (edit + `SIGHUP`) takes effect at the next
+`validate_bearer` call: every in-flight access token signed with the OLD
+secret fails signature verification **immediately** → HTTP 401
+(`UNAUTHORIZED`), not `TOKEN_EXPIRED`. This is deliberate — rotating a
+compromised secret must kill outstanding bearers at once; there is no
+dual-secret grace window.
+
+Refresh tokens are opaque, sha256-hashed, DB-stored values — NOT signed with
+`jwt_secret` — so a session survives rotation: a client that refreshes on any
+401 (not just `TOKEN_EXPIRED`) recovers a token pair verifiable under the NEW
+secret, without re-login. TTL changes are mint-forward only: an
+`access_token_ttl_secs`/`refresh_token_ttl_days` change affects tokens minted
+AFTER the reload; already-issued expirations are honored as-is.
+
+An invalid rotation (secret too short or a placeholder value) is rejected
+atomically at validation — the OLD secret stays in force, and the process
+never observes the bad value.
+
+### QUIC / HTTP dual-endpoint unbounded drain (paroche listener rebind, step 5)
+
+A change to `(listen_addr, port)` or `(listen_addr, renderer_quic_port)`
+triggers **make-before-break**: bind the NEW endpoint/listener first, then
+retire the OLD generation's ACCEPT loop only (new connections stop landing
+there; already-connected sessions are untouched). The retiring generation
+drains via `wait_idle()` (QUIC) or axum graceful shutdown (HTTP) with **no
+bound** — a deliberate operator-locked posture: a wedged renderer or immortal
+WebSocket keeps an old generation alive rather than being force-closed
+mid-session. A `DRAIN_HEARTBEAT` (`render/server.rs`) logs `info!` every 30s
+for a still-draining generation so a stuck drain stays visible instead of
+silent. If the new bind fails (e.g. an address conflict), the supervisor
+falls back to break-before-make with bounded retries and a rollback attempt
+to the previous address — every stage logged at `error!`; the server keeps
+running regardless (a failed rebind never crashes the process).
+
+### Rebuild-class resets (steps 6-8)
+
+A REBUILD-class subsystem (scanner, feed scheduler, epignosis resolver,
+syndesmos client, prostheke's OpenSubtitles provider) is torn down and
+reconstructed from the new config on any change to its section. Costs are
+honest and logged, never silent:
+
+- **epignosis**: the metadata cache resets (`"resolver rebuilt, metadata
+  cache reset"`) — a rebuild is stateless-cheap except for this cache.
+- **prostheke**: the OpenSubtitles rate limiter resets with the provider
+  (politeness limiter, not an embargo — acceptable).
+- **syndesmos**: circuit breakers reset (fresh breakers) and there is a
+  bounded event-loss window between handler cancel and re-subscribe.
+- **zetesis** is the one exception: `RateLimiter::reconfigure` explicitly
+  PRESERVES in-flight embargo/accrual state across a reload — an embargoed
+  indexer must never un-embargo just because a reload happened.
+
+---
+
+## Completeness test
+
+`crates/horismos/src/diff.rs::every_leaf_is_classified_exactly_once` walks
+every leaf of an exemplar `Config` (every `Option<Struct>` subsystem
+populated with `Some(..)` so mixed LIVE/UNWIRED subtrees like
+`prostheke.opensubtitles` expose per-field granularity instead of collapsing
+to one leaf; `taxis.libraries` gets one synthetic entry canonicalized to a
+`taxis.libraries.*.<field>` path so the leaf set is deterministic regardless
+of the real library key) and asserts:
+
+1. Every leaf is in exactly one of `LIVE`, `RESTART_REQUIRED`, `UNWIRED`.
+2. `LIVE ∪ RESTART_REQUIRED ∪ UNWIRED` exactly equals the full leaf set (no
+   ghost entries in either direction).
+
+Adding a new config field without adding it to one of the three lists fails
+this test — "silently unobserved config" is a build failure, not a
+production incident waiting to be discovered.

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -3,6 +3,9 @@
 > How Harmonia configuration is loaded, merged, validated, and distributed.
 > Subsystem names used as config section keys match [subsystems.md](subsystems.md) and [lexicon.md](../lexicon.md).
 > The Horismos crate that owns this logic is in [cargo.md](cargo.md).
+> For what happens to a config change AFTER load — SIGHUP reload, the
+> LIVE/RESTART/UNWIRED classification of every field, and rotation/drain
+> semantics — see [config-reload.md](config-reload.md).
 
 ## Purpose
 
@@ -343,7 +346,7 @@ impl ZetesisService {
 }
 ```
 
-**No runtime config reload in v1.** Configuration is read once at startup. To apply config changes, restart the process. This is a deliberate simplification; runtime config reload requires distributed consensus across subsystems and adds substantial complexity for minimal benefit in a single-binary system. Document restart as the intended config update path for v1.
+**Runtime config reload exists (#529).** `SIGHUP` re-reads and applies config changes without a restart, for every field classified LIVE. A field classified RESTART-required is held back (the running process keeps its old effective value) and reported in `restart_pending` until the process restarts or the on-disk value reverts — nothing is silently dropped either way. See [config-reload.md](config-reload.md) for the mechanism and the full field classification.
 
 ---
 
@@ -392,7 +395,7 @@ Feature flags that are not enabled skip their credential validation; a system ru
 
 **No hardcoded values that should be configurable.** File paths, timeouts, buffer sizes, API endpoints, retry limits; if the value might need to differ between development, staging, and production, it belongs in the config struct. The test for "should this be configurable" is: "would a user ever need to change this?" Timeouts, limits, paths, and URLs always qualify.
 
-**No config mutation after startup.** Config structs are read-only after `Config::load()` returns. Subsystems must not hold `&mut ZetesisConfig` or any other mutable config reference. Dynamic values that change at runtime (download progress, queue depth, session state) belong in subsystem-internal state, not in config.
+**No direct config mutation.** Subsystems never hold `&mut SubsystemConfig` or write to a config struct in place. A LIVE field changes only by publishing a whole new validated `Config` through `ConfigManager` (`SIGHUP` or `.replace()`) — see [config-reload.md](config-reload.md). Dynamic values that change at runtime (download progress, queue depth, session state) belong in subsystem-internal state, not in config.
 
 **No full Config passed to subsystems.** Each subsystem receives only its own `Arc<SubsystemConfig>` slice. Passing the full `Config` to subsystems couples every subsystem's constructor to the full config shape; adding a field to any subsystem's config would recompile all of them. The slice boundary also prevents a subsystem from accidentally reading another subsystem's credentials.
 


### PR DESCRIPTION
Step 9 — the final step of the #529 reactive-config migration. Makes the config classification self-enforcing, proves the whole SIGHUP path end-to-end, and documents it. Building the E2E test surfaced two real bugs (below), both fixed here.

**Completeness classification test** (`crates/horismos/src/diff.rs`): walks every serde-json leaf of a fully-populated exemplar `Config` (each `Option<Struct>` subsystem set to `Some(..)` so mixed subtrees expose per-field leaves; `taxis.libraries.<id>.*` canonicalized). Asserts every leaf is in exactly one of three lists — `LIVE` (66 leaves, the reactive contract wired by steps 2-8), `RESTART_REQUIRED` (10 leaves), or `UNWIRED` (31 dead-config leaves, each `// #575`-commented) — and that their union is exactly the full 107-leaf set (disjoint + exhaustive, no ghosts either direction). **Adding a config field without classifying it now fails the build.**

**E2E SIGHUP regression** (`crates/archon/tests/config_reload_e2e.rs`): spawns the real `harmonia` binary, parses the first-run admin password from stdout, logs in, rewrites the TOML (`opds_page_size` LIVE, `jwt_secret` rotation, `db_path` RESTART), sends `SIGHUP`, then bounded-polls (no fixed sleeps) to assert the page-size change is live, the pre-rotation bearer now 401s while a refresh recovers, and `restart_pending` contains `database.db_path`. The child is reaped in a `Drop` guard.

**Two production bugs the E2E test caught and this PR fixes:**
1. **SIGHUP deadlocked the whole server** (`archon/src/main.rs`) — `main` held a `StdoutLock` guard across the entire `run_serve` lifetime (its future never migrates threads under `tokio::main`), so the first concurrent `tracing::` call (the SIGHUP handler) blocked forever on the same lock. Fixed by passing an unlocked `Stdout` handle (locks per write, never across an await). Without this, every prior step's reload machinery would have hung on the first reload.
2. **DHT-init flake / shared-state hazard** (`crates/ergasia/src/session.rs`) — librqbit's persistent DHT defaulted to the global `~/.cache/com.rqbit.dht/dht.json`, so concurrent instances (and parallel test processes) raced/corrupted each other's DHT routing state. Now pinned to an instance-local path under `session_state_path` via `PersistentDhtConfig.config_filename` — isolating tests and preventing two harmonia instances on one box from clobbering each other's DHT state.

**Docs**: new `docs/architecture/config-reload.md` (mechanism + per-field live/restart table + JWT-rotation / dual-endpoint-drain / rebuild-reset semantics, grounded against shipped code); corrected two now-false claims in `configuration.md`. CHANGELOG is release-please-managed.

Gate: `kanon gate --full` green — fmt, check, clippy (`-D warnings`), nextest (full workspace), deny, kanon lint (0/0). `Gate-Passed` stamped.

Closes #529
