### PR TITLE
fix(paroche): OPDS Basic auth, real cover serving, and unthrottled downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,6 +1662,7 @@ dependencies = [
  "apotheke",
  "argon2",
  "axum",
+ "base64",
  "horismos",
  "http",
  "jsonwebtoken",
@@ -3803,6 +3804,7 @@ dependencies = [
  "apotheke",
  "axum",
  "axum-extra",
+ "base64",
  "epignosis",
  "exousia",
  "futures-util",
@@ -3813,6 +3815,7 @@ dependencies = [
  "kritike",
  "md5",
  "mdns-sd",
+ "quick-xml 0.41.0",
  "rand 0.10.1",
  "serde",
  "serde_json",
@@ -3830,6 +3833,7 @@ dependencies = [
  "ulid",
  "url",
  "uuid",
+ "zip",
 ]
 
 [[package]]

--- a/crates/exousia/Cargo.toml
+++ b/crates/exousia/Cargo.toml
@@ -20,6 +20,7 @@ uuid.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 axum.workspace = true
+base64.workspace = true
 sha2 = "0.11"
 rand_core = { version = "0.6", features = ["getrandom"] }
 

--- a/crates/exousia/src/lib.rs
+++ b/crates/exousia/src/lib.rs
@@ -7,7 +7,7 @@ pub mod service;
 pub mod user;
 
 pub use error::ExousiaError;
-pub use middleware::{AuthMethod, AuthenticatedUser, RequireAdmin};
+pub use middleware::{AuthMethod, AuthenticatedUser, RequireAdmin, decode_basic_credentials};
 pub use service::ExousiaServiceImpl;
 use themelion::ids::{ApiKeyId, UserId};
 pub use user::{CreateUserRequest, User, UserRole};
@@ -35,6 +35,14 @@ pub trait AuthService: Send + Sync {
     async fn refresh(&self, refresh_token: &str) -> Result<TokenPair, ExousiaError>;
     async fn logout(&self, refresh_token: &str) -> Result<(), ExousiaError>;
     async fn validate_bearer(&self, token: &str) -> Result<AuthenticatedUser, ExousiaError>;
+    /// Validates an HTTP Basic `username`/`password` pair against the user
+    /// store without minting tokens or recording a login — the per-request
+    /// identity path for OPDS clients.
+    async fn validate_basic(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> Result<AuthenticatedUser, ExousiaError>;
     async fn validate_api_key(&self, key: &str) -> Result<AuthenticatedUser, ExousiaError>;
     async fn create_user(&self, req: CreateUserRequest) -> Result<User, ExousiaError>;
     async fn create_api_key(&self, user_id: UserId, label: &str) -> Result<String, ExousiaError>;

--- a/crates/exousia/src/middleware.rs
+++ b/crates/exousia/src/middleware.rs
@@ -33,6 +33,24 @@ fn correlation_id() -> String {
 pub enum AuthMethod {
     Bearer,
     ApiKey,
+    Basic,
+}
+
+/// Decodes an RFC 7617 `Authorization: Basic <base64(user:pass)>` header
+/// value into `(username, password)`. The scheme match is case-insensitive
+/// per RFC 7235; the password may itself contain colons.
+pub fn decode_basic_credentials(header_value: &str) -> Option<(String, String)> {
+    use base64::Engine;
+    let (scheme, encoded) = header_value.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("basic") {
+        return None;
+    }
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded.trim())
+        .ok()?;
+    let text = String::from_utf8(decoded).ok()?;
+    let (username, password) = text.split_once(':')?;
+    Some((username.to_string(), password.to_string()))
 }
 
 #[derive(Clone)]
@@ -506,6 +524,53 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(body_string(response).await, "Bearer");
+    }
+
+    fn basic_header(user: &str, pass: &str) -> String {
+        use base64::Engine;
+        format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD.encode(format!("{user}:{pass}"))
+        )
+    }
+
+    #[test]
+    fn decode_basic_credentials_roundtrips() {
+        let (user, pass) = decode_basic_credentials(&basic_header("alice", "s3cret")).unwrap();
+        assert_eq!(user, "alice");
+        assert_eq!(pass, "s3cret");
+    }
+
+    #[test]
+    fn decode_basic_credentials_scheme_is_case_insensitive() {
+        use base64::Engine;
+        let encoded = base64::engine::general_purpose::STANDARD.encode("alice:s3cret");
+        let (user, _) = decode_basic_credentials(&format!("basic {encoded}")).unwrap();
+        assert_eq!(user, "alice");
+    }
+
+    #[test]
+    fn decode_basic_credentials_keeps_colons_in_password() {
+        let (user, pass) = decode_basic_credentials(&basic_header("alice", "a:b:c")).unwrap();
+        assert_eq!(user, "alice");
+        assert_eq!(pass, "a:b:c");
+    }
+
+    #[test]
+    fn decode_basic_credentials_rejects_malformed() {
+        for bad in ["Basic", "Basic !!!not-base64!!!", "Bearer abc", &{
+            use base64::Engine;
+            // WHY: valid base64 but no colon separator inside.
+            format!(
+                "Basic {}",
+                base64::engine::general_purpose::STANDARD.encode("no-colon")
+            )
+        }] {
+            assert!(
+                decode_basic_credentials(bad).is_none(),
+                "should reject {bad:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/exousia/src/service.rs
+++ b/crates/exousia/src/service.rs
@@ -34,6 +34,43 @@ impl ExousiaServiceImpl {
     pub fn pools(&self) -> &DbPools {
         &self.pools
     }
+
+    // WHY: the single credential-verify core shared by login() and
+    // validate_basic() — one site owns the constant-time miss-path contract.
+    // Verify against the real hash when the user exists, otherwise against
+    // the fixed sentinel hash — both branches run exactly one Argon2id
+    // verify, so a non-existent (or too-corrupt-to-convert) username costs
+    // the same wall-clock time as a real wrong-password attempt (CWE-203
+    // username-enumeration guard). Verifying BEFORE the is_active check
+    // keeps inactive accounts indistinguishable too.
+    async fn verify_credentials(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> Result<User, ExousiaError> {
+        // WHY: cap argon2 input before any hashing work — an oversized password
+        // is rejected in constant, bounded time (CPU-DoS guard).
+        if password.len() > MAX_PASSWORD_BYTES {
+            return Err(InvalidCredentialsSnafu.build());
+        }
+        let row = db::get_user_by_username(&self.pools.read, username)
+            .await
+            .context(DatabaseSnafu)?;
+        let candidate = row.and_then(db_user_to_domain);
+        let stored_hash = candidate
+            .as_ref()
+            .map_or(SENTINEL_PASSWORD_HASH, |user| user.password_hash.as_str());
+        let password_ok = password::verify_password(password, stored_hash)?;
+        let user = match candidate {
+            Some(user) if password_ok => user,
+            _ => return Err(InvalidCredentialsSnafu.build()),
+        };
+        if !user.is_active {
+            tracing::warn!(user_id = %user.id.into_uuid(), "login attempt on inactive account");
+            return Err(InvalidCredentialsSnafu.build());
+        }
+        Ok(user)
+    }
 }
 
 fn sha256_hex(input: &[u8]) -> String {
@@ -241,33 +278,7 @@ impl AuthService for ExousiaServiceImpl {
         // INVARIANT: one snapshot for the whole operation — a mid-rotation
         // login must not mint with secret A and TTL B (torn-config hazard).
         let cfg = self.config.get();
-        // WHY: cap argon2 input before any hashing work — an oversized password
-        // is rejected in constant, bounded time (CPU-DoS guard).
-        if password.len() > MAX_PASSWORD_BYTES {
-            return Err(InvalidCredentialsSnafu.build());
-        }
-        let row = db::get_user_by_username(&self.pools.read, username)
-            .await
-            .context(DatabaseSnafu)?;
-        let candidate = row.and_then(db_user_to_domain);
-        // WHY: verify against the real hash when the user exists, otherwise
-        // against the fixed sentinel hash — both branches run exactly one
-        // Argon2id verify, so a non-existent (or too-corrupt-to-convert)
-        // username costs the same wall-clock time as a real wrong-password
-        // attempt (CWE-203 username-enumeration guard). Verifying BEFORE the
-        // is_active check keeps inactive accounts indistinguishable too.
-        let stored_hash = candidate
-            .as_ref()
-            .map_or(SENTINEL_PASSWORD_HASH, |user| user.password_hash.as_str());
-        let password_ok = password::verify_password(password, stored_hash)?;
-        let user = match candidate {
-            Some(user) if password_ok => user,
-            _ => return Err(InvalidCredentialsSnafu.build()),
-        };
-        if !user.is_active {
-            tracing::warn!(user_id = %user.id.into_uuid(), "login attempt on inactive account");
-            return Err(InvalidCredentialsSnafu.build());
-        }
+        let user = self.verify_credentials(username, password).await?;
         let access_token =
             jwt::create_access_token(&user, cfg.jwt_secret.as_bytes(), cfg.access_token_ttl_secs)?;
         let (refresh_token, token_hash) = generate_refresh_token();
@@ -417,6 +428,23 @@ impl AuthService for ExousiaServiceImpl {
             user_id: user.id,
             role: user.role,
             auth_method: AuthMethod::Bearer,
+        })
+    }
+
+    // NOTE: per-request Argon2id verify by design — no credential/session
+    // cache exists, so a password change or deactivation takes effect on the
+    // very next request. OPDS client request volumes keep the CPU cost
+    // acceptable for a self-hosted deployment.
+    async fn validate_basic(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> Result<AuthenticatedUser, ExousiaError> {
+        let user = self.verify_credentials(username, password).await?;
+        Ok(AuthenticatedUser {
+            user_id: user.id,
+            role: user.role,
+            auth_method: AuthMethod::Basic,
         })
     }
 
@@ -793,6 +821,73 @@ mod tests {
             1,
             "wrong-password login must exercise exactly one real-hash Argon2 verify"
         );
+    }
+
+    #[tokio::test]
+    async fn validate_basic_returns_identity_without_minting() {
+        let service = setup().await;
+        let user = create_member(&service, "alice", "password123").await;
+
+        let authenticated = service
+            .validate_basic("alice", "password123")
+            .await
+            .unwrap();
+        assert_eq!(authenticated.user_id, user.id);
+        assert_eq!(authenticated.role, UserRole::Member);
+        assert_eq!(authenticated.auth_method, AuthMethod::Basic);
+
+        // WHY: proves the no-mint contract — a per-request Basic validation
+        // must not grow the refresh-token table.
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM refresh_tokens")
+            .fetch_one(&service.pools().read)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "validate_basic must not insert refresh tokens");
+    }
+
+    #[tokio::test]
+    async fn validate_basic_rejects_wrong_password_and_unknown_user() {
+        let service = setup().await;
+        create_member(&service, "alice", "password123").await;
+        for (user, pass) in [("alice", "wrong-password"), ("nobody", "password123")] {
+            let err = service.validate_basic(user, pass).await.unwrap_err();
+            assert!(
+                matches!(err, ExousiaError::InvalidCredentials { .. }),
+                "{user}/{pass} must fail as InvalidCredentials"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_basic_rejects_inactive_user() {
+        let service = setup().await;
+        let user = create_member(&service, "alice", "password123").await;
+        db::deactivate_user(&service.pools.write, &user_id_to_bytes(user.id))
+            .await
+            .unwrap();
+        let err = service
+            .validate_basic("alice", "password123")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ExousiaError::InvalidCredentials { .. }));
+    }
+
+    // WHY: the CWE-203 constant-time contract must hold through the shared
+    // verify core on the Basic path too, not just login().
+    #[tokio::test]
+    async fn validate_basic_unknown_username_still_performs_argon2_verify() {
+        let service = setup().await;
+        create_member(&service, "alice", "password123").await;
+
+        let before = password::VERIFY_CALL_COUNT.with(std::cell::Cell::get);
+        let result = service.validate_basic("no-such-user", "whatever").await;
+        let after = password::VERIFY_CALL_COUNT.with(std::cell::Cell::get);
+
+        assert!(matches!(
+            result,
+            Err(ExousiaError::InvalidCredentials { .. })
+        ));
+        assert_eq!(after - before, 1);
     }
 
     #[tokio::test]

--- a/crates/paroche/Cargo.toml
+++ b/crates/paroche/Cargo.toml
@@ -42,12 +42,17 @@ ulid.workspace = true
 sha1.workspace = true
 subtle.workspace = true
 url.workspace = true
+zip.workspace = true
+quick-xml.workspace = true
 
 [dev-dependencies]
 sqlx.workspace = true
 apotheke.workspace = true
+base64.workspace = true
 http-body-util = "0.1"
 tempfile = "3"
+# WHY: start_paused virtual-clock tests for the API-timeout scoping.
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -24,7 +24,11 @@ use crate::middleware::RequestIdLayer;
 use crate::state::AppState;
 use crate::ws::ws_handler;
 
-pub fn build_router(state: AppState) -> Router {
+// WHY: bounds time-to-response-headers for request/response API routes; the
+// byte-serving routes in `streaming_routes` are deliberately outside it.
+const API_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn api_routes() -> Router<AppState> {
     Router::new()
         .nest("/api/auth", routes::user::auth_routes())
         .nest("/api/users", routes::user::user_routes())
@@ -49,7 +53,6 @@ pub fn build_router(state: AppState) -> Router {
         .nest("/api/renderers", routes::renderer::renderer_routes())
         .nest("/opds", opds::opds_routes())
         .nest("/kosync", routes::kosync::kosync_routes())
-        .merge(routes::stream::stream_routes())
         .merge(routes::read::reader_routes())
         .nest("/rest", subsonic::subsonic_routes())
         .nest("/api/zones", routes::zone::zone_routes())
@@ -58,15 +61,44 @@ pub fn build_router(state: AppState) -> Router {
             "/static/reader",
             ServeDir::new("crates/paroche/assets/reader"),
         )
-        .layer(RequestIdLayer)
-        .layer(TraceLayer::new_for_http())
-        .layer(CompressionLayer::new())
-        .layer(TimeoutLayer::with_status_code(
-            axum::http::StatusCode::REQUEST_TIMEOUT,
-            Duration::from_secs(30),
-        ))
-        .layer(CorsLayer::permissive())
-        .with_state(state)
+}
+
+// WHY: byte-serving routes (media downloads, covers, OPDS content, audio
+// streaming) are exempt from `API_TIMEOUT` — a cold disk or a large archive
+// probe can legitimately hold first-byte past 30s, and these routes must
+// never race a request/response deadline (#581). The guard for normal API
+// routes stays at 30s; do NOT fold these back under the timed group.
+fn streaming_routes() -> Router<AppState> {
+    use axum::routing::get;
+    Router::new()
+        .route("/api/books/{id}/download", get(routes::book::download_book))
+        .route("/api/books/{id}/cover", get(routes::book::book_cover))
+        .route(
+            "/api/comics/{id}/download",
+            get(routes::comic::download_comic),
+        )
+        .route("/api/comics/{id}/cover", get(routes::comic::comic_cover))
+        .route("/opds/content/{id}", get(opds::content::content))
+        .merge(routes::stream::stream_routes())
+}
+
+fn compose_router<S>(api: Router<S>, streaming: Router<S>) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    api.layer(TimeoutLayer::with_status_code(
+        axum::http::StatusCode::REQUEST_TIMEOUT,
+        API_TIMEOUT,
+    ))
+    .merge(streaming)
+    .layer(RequestIdLayer)
+    .layer(TraceLayer::new_for_http())
+    .layer(CompressionLayer::new())
+    .layer(CorsLayer::permissive())
+}
+
+pub fn build_router(state: AppState) -> Router {
+    compose_router(api_routes(), streaming_routes()).with_state(state)
 }
 
 #[cfg(test)]
@@ -157,5 +189,73 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    async fn slow_first_byte() -> &'static str {
+        tokio::time::sleep(std::time::Duration::from_secs(45)).await;
+        "done"
+    }
+
+    fn get_req(uri: &str) -> Request<Body> {
+        Request::builder().uri(uri).body(Body::empty()).unwrap()
+    }
+
+    // WHY: the #581 scoping contract, provable with a paused clock — the same
+    // slow handler 408s under the timed group but completes in the streaming
+    // group, so a byte-serving route can never lose a race against
+    // API_TIMEOUT.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_group_is_exempt_from_api_timeout() {
+        use axum::routing::get;
+        let app = super::compose_router::<()>(
+            axum::Router::new().route("/timed", get(slow_first_byte)),
+            axum::Router::new().route("/streaming", get(slow_first_byte)),
+        )
+        .with_state(());
+
+        let resp = app.clone().oneshot(get_req("/timed")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::REQUEST_TIMEOUT);
+
+        let resp = app.oneshot(get_req("/streaming")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"done");
+    }
+
+    // WHY: pins the transfer contract on the streaming group — a body that
+    // takes well past API_TIMEOUT to stream arrives complete, never severed.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_body_longer_than_api_timeout_completes() {
+        use axum::routing::get;
+
+        async fn drip() -> Body {
+            Body::from_stream(futures_util::stream::unfold(0u32, |chunk| async move {
+                if chunk >= 5 {
+                    return None;
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                Some((
+                    Ok::<_, std::convert::Infallible>(axum::body::Bytes::from_static(b"chunk-")),
+                    chunk + 1,
+                ))
+            }))
+        }
+
+        let app = super::compose_router::<()>(
+            axum::Router::new().route("/unused", get(slow_first_byte)),
+            axum::Router::new().route("/drip", get(drip)),
+        )
+        .with_state(());
+
+        let resp = app.oneshot(get_req("/drip")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        // WHY: 5 chunks x 10 virtual seconds = a 50s transfer, well past the
+        // 30s API_TIMEOUT — every chunk must still arrive.
+        assert_eq!(&body[..], b"chunk-".repeat(5).as_slice());
     }
 }

--- a/crates/paroche/src/opds/auth.rs
+++ b/crates/paroche/src/opds/auth.rs
@@ -1,0 +1,277 @@
+//! OPDS-facing authentication: Basic + Bearer + API key, with the OPDS
+//! Authentication Document served on every 401.
+
+use std::sync::Arc;
+
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use exousia::{AuthService, AuthenticatedUser, ExousiaServiceImpl, decode_basic_credentials};
+use serde_json::json;
+
+pub const MIME_OPDS_AUTH: &str = "application/opds-authentication+json";
+pub const AUTH_DOCUMENT_PATH: &str = "/opds/auth";
+
+// NOTE: charset advertises UTF-8 credential encoding per RFC 7617 §2.1.
+const WWW_AUTHENTICATE_BASIC: &str = "Basic realm=\"Harmonia\", charset=\"UTF-8\"";
+
+// WHY: relative id/href — the server never knows its externally visible
+// origin (no hardcoded hosts); OPDS clients resolve against the request base.
+fn authentication_document() -> serde_json::Value {
+    json!({
+        "id": AUTH_DOCUMENT_PATH,
+        "title": "Harmonia",
+        "description": "Sign in with your Harmonia username and password.",
+        "authentication": [{
+            "type": "http://opds-spec.org/auth/basic",
+            "labels": { "login": "Username", "password": "Password" }
+        }]
+    })
+}
+
+/// Serves the OPDS Authentication Document — deliberately unauthenticated so
+/// clients can discover how to authenticate.
+pub async fn auth_document() -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static(MIME_OPDS_AUTH),
+        )],
+        authentication_document().to_string(),
+    )
+        .into_response()
+}
+
+// WHY: a 401 carrying the Authentication Document as its body plus a
+// `WWW-Authenticate: Basic` challenge serves both client classes at once —
+// conformant OPDS readers parse the document, plain HTTP clients (browsers,
+// e-readers without OPDS-auth support) fall back to the Basic challenge.
+fn opds_unauthorized() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(MIME_OPDS_AUTH),
+            ),
+            (
+                header::WWW_AUTHENTICATE,
+                HeaderValue::from_static(WWW_AUTHENTICATE_BASIC),
+            ),
+            (
+                header::LINK,
+                HeaderValue::from_static(
+                    "</opds/auth>; rel=\"http://opds-spec.org/auth/document\"; \
+                     type=\"application/opds-authentication+json\"",
+                ),
+            ),
+        ],
+        authentication_document().to_string(),
+    )
+        .into_response()
+}
+
+fn is_basic_scheme(header_value: &str) -> bool {
+    header_value
+        .split_once(' ')
+        .is_some_and(|(scheme, _)| scheme.eq_ignore_ascii_case("basic"))
+}
+
+/// Authenticated identity for OPDS catalog/acquisition routes and the
+/// browser reader: accepts HTTP Basic (validated against the exousia user
+/// store) in addition to the Bearer/API-key paths, and answers every
+/// credential failure with a 401 + OPDS Authentication Document.
+pub struct OpdsUser(pub AuthenticatedUser);
+
+impl std::fmt::Debug for OpdsUser {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("OpdsUser").field(&self.0).finish()
+    }
+}
+
+impl<S> FromRequestParts<S> for OpdsUser
+where
+    S: Send + Sync,
+    Arc<ExousiaServiceImpl>: FromRef<S>,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let authorization = parts
+            .headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok());
+
+        if let Some(value) = authorization
+            && is_basic_scheme(value)
+        {
+            let Some((username, password)) = decode_basic_credentials(value) else {
+                return Err(opds_unauthorized());
+            };
+            let service = Arc::<ExousiaServiceImpl>::from_ref(state);
+            return service
+                .validate_basic(&username, &password)
+                .await
+                .map(OpdsUser)
+                .map_err(|err| {
+                    if matches!(err, exousia::ExousiaError::Database { .. }) {
+                        // WHY: a DB outage is not a credential problem — log
+                        // the detail server-side, keep the client body opaque.
+                        tracing::warn!(error = %err, "opds basic auth failed on infrastructure error");
+                    }
+                    opds_unauthorized()
+                });
+        }
+
+        // WHY: the standard extractor's JSON-error rejection is replaced
+        // wholesale — on OPDS routes every 401 must carry the Authentication
+        // Document, whatever credential form failed.
+        AuthenticatedUser::from_request_parts(parts, state)
+            .await
+            .map(OpdsUser)
+            .map_err(|_| opds_unauthorized())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::Router;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use base64::Engine;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helpers::test_state;
+
+    pub(crate) fn basic_header(user: &str, pass: &str) -> String {
+        format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD.encode(format!("{user}:{pass}"))
+        )
+    }
+
+    async fn handler_ok(_user: OpdsUser) -> StatusCode {
+        StatusCode::OK
+    }
+
+    async fn app() -> (Router, std::sync::Arc<exousia::ExousiaServiceImpl>) {
+        let (state, auth) = test_state().await;
+        let router = Router::new()
+            .route("/protected", axum::routing::get(handler_ok))
+            .with_state(state);
+        (router, auth)
+    }
+
+    async fn create_member(auth: &exousia::ExousiaServiceImpl) {
+        auth.create_user(exousia::CreateUserRequest {
+            username: "alice".to_string(),
+            display_name: "Alice".to_string(),
+            password: "password123".to_string(),
+            role: exousia::UserRole::Member,
+        })
+        .await
+        .unwrap();
+    }
+
+    fn get(uri: &str, authorization: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder().uri(uri);
+        if let Some(value) = authorization {
+            builder = builder.header("Authorization", value);
+        }
+        builder.body(Body::empty()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn valid_basic_credentials_authenticate() {
+        let (router, auth) = app().await;
+        create_member(&auth).await;
+        let resp = router
+            .oneshot(get(
+                "/protected",
+                Some(&basic_header("alice", "password123")),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn wrong_basic_password_gets_401_with_auth_document() {
+        let (router, auth) = app().await;
+        create_member(&auth).await;
+        let resp = router
+            .oneshot(get(
+                "/protected",
+                Some(&basic_header("alice", "wrong-pass")),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(resp.headers().get("content-type").unwrap(), MIME_OPDS_AUTH);
+        let www = resp
+            .headers()
+            .get("www-authenticate")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(www.starts_with("Basic"));
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            doc["authentication"][0]["type"],
+            "http://opds-spec.org/auth/basic"
+        );
+    }
+
+    #[tokio::test]
+    async fn absent_credentials_get_401_with_challenge() {
+        let (router, _auth) = app().await;
+        let resp = router.oneshot(get("/protected", None)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert!(resp.headers().get("www-authenticate").is_some());
+        assert!(resp.headers().get("link").is_some());
+        assert_eq!(resp.headers().get("content-type").unwrap(), MIME_OPDS_AUTH);
+    }
+
+    #[tokio::test]
+    async fn malformed_basic_value_gets_401() {
+        let (router, _auth) = app().await;
+        let resp = router
+            .oneshot(get("/protected", Some("Basic !!!not-base64!!!")))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn bearer_still_authenticates() {
+        let (router, auth) = app().await;
+        create_member(&auth).await;
+        let token = auth
+            .login("alice", "password123")
+            .await
+            .unwrap()
+            .access_token;
+        let resp = router
+            .oneshot(get("/protected", Some(&format!("Bearer {token}"))))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn lowercase_basic_scheme_authenticates() {
+        let (router, auth) = app().await;
+        create_member(&auth).await;
+        let header = basic_header("alice", "password123").replacen("Basic", "basic", 1);
+        let resp = router
+            .oneshot(get("/protected", Some(&header)))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/crates/paroche/src/opds/catalog/mod.rs
+++ b/crates/paroche/src/opds/catalog/mod.rs
@@ -2,12 +2,13 @@ use axum::body::Body;
 use axum::extract::{Path, Query, State};
 use axum::http::{Response, StatusCode, header};
 use axum::response::IntoResponse;
-use exousia::AuthenticatedUser;
 use serde::Deserialize;
 use tracing;
 use uuid::Uuid;
 
 use super::acquisition;
+use super::auth::OpdsUser;
+use super::cover;
 use super::types_v1::{AtomEntry, AtomFeed, AtomLink, MIME_OPDS_V1, MIME_OPENSEARCH};
 use super::types_v2::{
     Contributor, FeedMetadata, MIME_OPDS_V2, NavigationLink, OpdsFeed, OpdsLink, Publication,
@@ -75,7 +76,32 @@ fn default_page() -> u64 {
     1
 }
 
-pub fn book_to_publication(book: &apotheke::repo::book::Book) -> Publication {
+// WHY: cover links carry the PROBED content type of the actual cover and are
+// omitted entirely when no cover is resolvable — the pre-#580 feed advertised
+// a `image/jpeg` cover for every publication unconditionally, so clients got
+// mistyped or guaranteed-404 image links.
+fn cover_image_links(base: &str, cover_mime: Option<&'static str>) -> Vec<OpdsLink> {
+    let Some(mime) = cover_mime else {
+        return Vec::new();
+    };
+    vec![
+        OpdsLink::new("http://opds-spec.org/image", format!("{base}/cover"), mime),
+        OpdsLink::new(
+            "http://opds-spec.org/image/thumbnail",
+            format!("{base}/cover?size=thumbnail"),
+            mime,
+        ),
+    ]
+}
+
+async fn probe_cover(file_path: Option<&str>, file_format: Option<&str>) -> Option<&'static str> {
+    cover::probe_cover_mime(file_path?, file_format).await
+}
+
+pub fn book_to_publication(
+    book: &apotheke::repo::book::Book,
+    cover_mime: Option<&'static str>,
+) -> Publication {
     let id_str = bytes_to_uuid_str(&book.id);
     let mime = acquisition::effective_mime(book.file_format.as_deref(), book.file_path.as_deref());
 
@@ -99,22 +125,19 @@ pub fn book_to_publication(book: &apotheke::repo::book::Book) -> Publication {
             format!("/api/books/{id_str}/download"),
             mime,
         )],
-        images: vec![
-            OpdsLink::new(
-                "http://opds-spec.org/image",
-                format!("/api/books/{id_str}/cover"),
-                "image/jpeg",
-            ),
-            OpdsLink::new(
-                "http://opds-spec.org/image/thumbnail",
-                format!("/api/books/{id_str}/cover?size=thumbnail"),
-                "image/jpeg",
-            ),
-        ],
+        images: cover_image_links(&format!("/api/books/{id_str}"), cover_mime),
     }
 }
 
-pub fn comic_to_publication(comic: &apotheke::repo::comic::Comic) -> Publication {
+pub(crate) async fn book_publication(book: &apotheke::repo::book::Book) -> Publication {
+    let cover_mime = probe_cover(book.file_path.as_deref(), book.file_format.as_deref()).await;
+    book_to_publication(book, cover_mime)
+}
+
+pub fn comic_to_publication(
+    comic: &apotheke::repo::comic::Comic,
+    cover_mime: Option<&'static str>,
+) -> Publication {
     let id_str = bytes_to_uuid_str(&comic.id);
     let mime =
         acquisition::effective_mime(comic.file_format.as_deref(), comic.file_path.as_deref());
@@ -144,47 +167,73 @@ pub fn comic_to_publication(comic: &apotheke::repo::comic::Comic) -> Publication
             format!("/api/comics/{id_str}/download"),
             mime,
         )],
-        images: vec![
-            OpdsLink::new(
-                "http://opds-spec.org/image",
-                format!("/api/comics/{id_str}/cover"),
-                "image/jpeg",
-            ),
-            OpdsLink::new(
-                "http://opds-spec.org/image/thumbnail",
-                format!("/api/comics/{id_str}/cover?size=thumbnail"),
-                "image/jpeg",
-            ),
-        ],
+        images: cover_image_links(&format!("/api/comics/{id_str}"), cover_mime),
     }
 }
 
-pub fn book_to_atom_entry(book: &apotheke::repo::book::Book) -> AtomEntry {
+pub(crate) async fn comic_publication(comic: &apotheke::repo::comic::Comic) -> Publication {
+    let cover_mime = probe_cover(comic.file_path.as_deref(), comic.file_format.as_deref()).await;
+    comic_to_publication(comic, cover_mime)
+}
+
+pub(crate) async fn book_publications(books: &[apotheke::repo::book::Book]) -> Vec<Publication> {
+    let mut publications = Vec::with_capacity(books.len());
+    for book in books {
+        publications.push(book_publication(book).await);
+    }
+    publications
+}
+
+pub(crate) async fn comic_publications(
+    comics: &[apotheke::repo::comic::Comic],
+) -> Vec<Publication> {
+    let mut publications = Vec::with_capacity(comics.len());
+    for comic in comics {
+        publications.push(comic_publication(comic).await);
+    }
+    publications
+}
+
+fn cover_atom_link(base: &str, cover_mime: Option<&'static str>) -> Option<AtomLink> {
+    cover_mime.map(|mime| AtomLink {
+        rel: "http://opds-spec.org/image".to_string(),
+        href: format!("{base}/cover"),
+        link_type: mime.to_string(),
+        title: None,
+    })
+}
+
+pub fn book_to_atom_entry(
+    book: &apotheke::repo::book::Book,
+    cover_mime: Option<&'static str>,
+) -> AtomEntry {
     let id_str = bytes_to_uuid_str(&book.id);
     let mime = acquisition::effective_mime(book.file_format.as_deref(), book.file_path.as_deref());
+    let mut links = vec![AtomLink {
+        rel: "http://opds-spec.org/acquisition".to_string(),
+        href: format!("/api/books/{id_str}/download"),
+        link_type: mime.to_string(),
+        title: None,
+    }];
+    links.extend(cover_atom_link(&format!("/api/books/{id_str}"), cover_mime));
     AtomEntry {
         id: format!("urn:harmonia:book:{id_str}"),
         title: book.title.clone(),
         updated: book.added_at.clone(),
         summary: book.description.clone(),
-        links: vec![
-            AtomLink {
-                rel: "http://opds-spec.org/acquisition".to_string(),
-                href: format!("/api/books/{id_str}/download"),
-                link_type: mime.to_string(),
-                title: None,
-            },
-            AtomLink {
-                rel: "http://opds-spec.org/image".to_string(),
-                href: format!("/api/books/{id_str}/cover"),
-                link_type: "image/jpeg".to_string(),
-                title: None,
-            },
-        ],
+        links,
     }
 }
 
-pub fn comic_to_atom_entry(comic: &apotheke::repo::comic::Comic) -> AtomEntry {
+pub(crate) async fn book_atom_entry(book: &apotheke::repo::book::Book) -> AtomEntry {
+    let cover_mime = probe_cover(book.file_path.as_deref(), book.file_format.as_deref()).await;
+    book_to_atom_entry(book, cover_mime)
+}
+
+pub fn comic_to_atom_entry(
+    comic: &apotheke::repo::comic::Comic,
+    cover_mime: Option<&'static str>,
+) -> AtomEntry {
     let id_str = bytes_to_uuid_str(&comic.id);
     let mime =
         acquisition::effective_mime(comic.file_format.as_deref(), comic.file_path.as_deref());
@@ -192,31 +241,49 @@ pub fn comic_to_atom_entry(comic: &apotheke::repo::comic::Comic) -> AtomEntry {
         Some(t) => format!("{}  -  {t}", comic.series_name),
         None => comic.series_name.clone(),
     };
+    let mut links = vec![AtomLink {
+        rel: "http://opds-spec.org/acquisition".to_string(),
+        href: format!("/api/comics/{id_str}/download"),
+        link_type: mime.to_string(),
+        title: None,
+    }];
+    links.extend(cover_atom_link(
+        &format!("/api/comics/{id_str}"),
+        cover_mime,
+    ));
     AtomEntry {
         id: format!("urn:harmonia:comic:{id_str}"),
         title,
         updated: comic.added_at.clone(),
         summary: comic.summary.clone(),
-        links: vec![
-            AtomLink {
-                rel: "http://opds-spec.org/acquisition".to_string(),
-                href: format!("/api/comics/{id_str}/download"),
-                link_type: mime.to_string(),
-                title: None,
-            },
-            AtomLink {
-                rel: "http://opds-spec.org/image".to_string(),
-                href: format!("/api/comics/{id_str}/cover"),
-                link_type: "image/jpeg".to_string(),
-                title: None,
-            },
-        ],
+        links,
     }
+}
+
+pub(crate) async fn comic_atom_entry(comic: &apotheke::repo::comic::Comic) -> AtomEntry {
+    let cover_mime = probe_cover(comic.file_path.as_deref(), comic.file_format.as_deref()).await;
+    comic_to_atom_entry(comic, cover_mime)
+}
+
+pub(crate) async fn book_atom_entries(books: &[apotheke::repo::book::Book]) -> Vec<AtomEntry> {
+    let mut entries = Vec::with_capacity(books.len());
+    for book in books {
+        entries.push(book_atom_entry(book).await);
+    }
+    entries
+}
+
+pub(crate) async fn comic_atom_entries(comics: &[apotheke::repo::comic::Comic]) -> Vec<AtomEntry> {
+    let mut entries = Vec::with_capacity(comics.len());
+    for comic in comics {
+        entries.push(comic_atom_entry(comic).await);
+    }
+    entries
 }
 
 pub async fn catalog_v2(
     State(_state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
 ) -> Result<OpdsV2Response, ParocheError> {
     let feed = OpdsFeed {
         metadata: FeedMetadata {
@@ -268,7 +335,7 @@ pub async fn catalog_v2(
 
 pub async fn books_v2(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Query(pq): Query<OpdsPageQuery>,
 ) -> Result<OpdsV2Response, ParocheError> {
     let page = pq.page.max(1);
@@ -295,7 +362,7 @@ pub async fn books_v2(
     }
 
     let count = books.len() as u64;
-    let publications: Vec<_> = books.iter().map(book_to_publication).collect();
+    let publications = book_publications(&books).await;
 
     Ok(OpdsV2Response(OpdsFeed {
         metadata: FeedMetadata {
@@ -312,7 +379,7 @@ pub async fn books_v2(
 
 pub async fn comics_v2(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Query(pq): Query<OpdsPageQuery>,
 ) -> Result<OpdsV2Response, ParocheError> {
     let page = pq.page.max(1);
@@ -340,7 +407,7 @@ pub async fn comics_v2(
     }
 
     let count = comics.len() as u64;
-    let publications: Vec<_> = comics.iter().map(comic_to_publication).collect();
+    let publications = comic_publications(&comics).await;
 
     Ok(OpdsV2Response(OpdsFeed {
         metadata: FeedMetadata {
@@ -357,7 +424,7 @@ pub async fn comics_v2(
 
 pub async fn book_v2(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Path(id): Path<String>,
 ) -> Result<OpdsV2Response, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
@@ -367,7 +434,7 @@ pub async fn book_v2(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    let publication = book_to_publication(&book);
+    let publication = book_publication(&book).await;
 
     Ok(OpdsV2Response(OpdsFeed {
         metadata: FeedMetadata {
@@ -388,7 +455,7 @@ pub async fn book_v2(
 
 pub async fn comic_v2(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Path(id): Path<String>,
 ) -> Result<OpdsV2Response, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
@@ -398,7 +465,7 @@ pub async fn comic_v2(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    let publication = comic_to_publication(&comic);
+    let publication = comic_publication(&comic).await;
 
     Ok(OpdsV2Response(OpdsFeed {
         metadata: FeedMetadata {
@@ -419,7 +486,7 @@ pub async fn comic_v2(
 
 pub async fn shelf_v2(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Path(shelf): Path<String>,
     Query(pq): Query<OpdsPageQuery>,
 ) -> Result<OpdsV2Response, ParocheError> {
@@ -453,7 +520,7 @@ pub async fn shelf_v2(
             }
 
             let count = books.len() as u64;
-            let publications: Vec<_> = books.iter().map(book_to_publication).collect();
+            let publications = book_publications(&books).await;
 
             Ok(OpdsV2Response(OpdsFeed {
                 metadata: FeedMetadata {
@@ -496,7 +563,7 @@ pub async fn shelf_v2(
             }
 
             let count = comics.len() as u64;
-            let publications: Vec<_> = comics.iter().map(comic_to_publication).collect();
+            let publications = comic_publications(&comics).await;
 
             Ok(OpdsV2Response(OpdsFeed {
                 metadata: FeedMetadata {
@@ -572,7 +639,7 @@ pub async fn shelf_v2(
 
 pub async fn catalog_v1(
     State(_state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
 ) -> Result<OpdsV1Response, ParocheError> {
     let now = chrono_now_pub();
     let feed = AtomFeed {
@@ -631,7 +698,7 @@ pub async fn catalog_v1(
 
 pub async fn books_v1(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Query(pq): Query<OpdsPageQuery>,
 ) -> Result<OpdsV1Response, ParocheError> {
     let page = pq.page.max(1);
@@ -668,7 +735,7 @@ pub async fn books_v1(
         });
     }
 
-    let entries: Vec<_> = books.iter().map(book_to_atom_entry).collect();
+    let entries = book_atom_entries(&books).await;
 
     let feed = AtomFeed {
         id: format!("urn:harmonia:books:page:{page}"),
@@ -682,7 +749,7 @@ pub async fn books_v1(
 
 pub async fn comics_v1(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Query(pq): Query<OpdsPageQuery>,
 ) -> Result<OpdsV1Response, ParocheError> {
     let page = pq.page.max(1);
@@ -720,7 +787,7 @@ pub async fn comics_v1(
         });
     }
 
-    let entries: Vec<_> = comics.iter().map(comic_to_atom_entry).collect();
+    let entries = comic_atom_entries(&comics).await;
 
     let feed = AtomFeed {
         id: format!("urn:harmonia:comics:page:{page}"),
@@ -734,7 +801,7 @@ pub async fn comics_v1(
 
 pub async fn entry_v1(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Path(id): Path<String>,
 ) -> Result<OpdsV1Response, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
@@ -742,7 +809,7 @@ pub async fn entry_v1(
     let now = chrono_now_pub();
 
     if let Some(book) = apotheke::repo::book::get_book(&state.db.read, &id_bytes).await? {
-        let entry = book_to_atom_entry(&book);
+        let entry = book_atom_entry(&book).await;
         let feed = AtomFeed {
             id: entry.id.clone(),
             title: entry.title.clone(),
@@ -759,7 +826,7 @@ pub async fn entry_v1(
     }
 
     if let Some(comic) = apotheke::repo::comic::get_comic(&state.db.read, &id_bytes).await? {
-        let entry = comic_to_atom_entry(&comic);
+        let entry = comic_atom_entry(&comic).await;
         let feed = AtomFeed {
             id: entry.id.clone(),
             title: entry.title.clone(),

--- a/crates/paroche/src/opds/catalog/tests.rs
+++ b/crates/paroche/src/opds/catalog/tests.rs
@@ -302,10 +302,11 @@ async fn single_book_has_acquisition_link_with_correct_mime() {
     assert_eq!(acq.unwrap()["type"], "application/epub+zip");
 }
 
-#[tokio::test]
-async fn single_book_has_cover_art_links() {
-    let (state, auth) = test_state().await;
-    let token = admin_token(&auth).await;
+async fn insert_book_with_file(state: &AppState, dir: &std::path::Path) -> uuid::Uuid {
+    let file_path = dir.join("foundation.epub");
+    tokio::fs::write(&file_path, b"epub-file-contents")
+        .await
+        .unwrap();
     let id = uuid::Uuid::now_v7();
     let book = apotheke::repo::book::Book {
         id: id.as_bytes().to_vec(),
@@ -321,8 +322,8 @@ async fn single_book_has_cover_art_links() {
         language: None,
         page_count: None,
         description: None,
-        file_path: None,
-        file_format: None,
+        file_path: Some(file_path.to_string_lossy().into_owned()),
+        file_format: Some("epub".to_string()),
         file_size_bytes: None,
         quality_score: None,
         quality_profile_id: None,
@@ -332,7 +333,10 @@ async fn single_book_has_cover_art_links() {
     apotheke::repo::book::insert_book(&state.db.write, &book)
         .await
         .unwrap();
+    id
+}
 
+async fn fetch_book_publication(state: AppState, token: &str, id: uuid::Uuid) -> serde_json::Value {
     let app = opds_routes().with_state(state);
     let resp = app
         .oneshot(
@@ -346,16 +350,48 @@ async fn single_book_has_cover_art_links() {
         .unwrap();
     let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
     let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-    let images = &body["publications"][0]["images"];
+    body["publications"][0].clone()
+}
+
+#[tokio::test]
+async fn single_book_has_cover_art_links_with_probed_type() {
+    let (state, auth) = test_state().await;
+    let token = admin_token(&auth).await;
+    let dir = tempfile::TempDir::new().unwrap();
+    let id = insert_book_with_file(&state, dir.path()).await;
+    tokio::fs::write(
+        dir.path().join("cover.png"),
+        b"\x89PNG\r\n\x1a\n-fake-png-body",
+    )
+    .await
+    .unwrap();
+
+    let publication = fetch_book_publication(state, &token, id).await;
+    let images = publication["images"].as_array().unwrap();
     let cover = images
-        .as_array()
-        .unwrap()
         .iter()
-        .find(|l| l["rel"].as_str() == Some("http://opds-spec.org/image"));
-    assert!(cover.is_some());
-    let href = cover.unwrap()["href"].as_str().unwrap();
+        .find(|l| l["rel"].as_str() == Some("http://opds-spec.org/image"))
+        .unwrap();
+    let href = cover["href"].as_str().unwrap();
     assert!(href.contains("/api/books/"));
     assert!(href.contains("/cover"));
+    // WHY: the advertised type must reflect the actual sidecar, not a
+    // hardcoded image/jpeg.
+    assert_eq!(cover["type"], "image/png");
+}
+
+#[tokio::test]
+async fn book_without_cover_omits_image_links() {
+    let (state, auth) = test_state().await;
+    let token = admin_token(&auth).await;
+    let dir = tempfile::TempDir::new().unwrap();
+    let id = insert_book_with_file(&state, dir.path()).await;
+
+    let publication = fetch_book_publication(state, &token, id).await;
+    assert!(
+        publication.get("images").is_none(),
+        "a coverless book must not advertise image links: {publication}"
+    );
 }
 
 #[tokio::test]

--- a/crates/paroche/src/opds/content.rs
+++ b/crates/paroche/src/opds/content.rs
@@ -1,16 +1,16 @@
-use std::path::{Path as FsPath, PathBuf};
+use std::path::Path as FsPath;
 
 use axum::extract::{Path, Request, State};
 use axum::http::HeaderValue;
 use axum::http::header::CONTENT_TYPE;
 use axum::response::{IntoResponse, Response};
-use exousia::AuthenticatedUser;
 use tower::ServiceExt;
 use tower_http::services::ServeFile;
 use uuid::Uuid;
 
 use crate::error::ParocheError;
 use crate::opds::acquisition::effective_mime;
+use crate::opds::auth::OpdsUser;
 use crate::state::AppState;
 
 pub(crate) async fn serve_file_response(path: impl AsRef<FsPath>, request: Request) -> Response {
@@ -56,26 +56,13 @@ pub(crate) fn attachment_disposition(file_path: &str) -> Option<HeaderValue> {
     HeaderValue::from_str(&format!("attachment; filename=\"{sanitized}\"")).ok()
 }
 
-// NOTE: sidecar cover convention — a cover image lives beside the media file
-// as `cover.{jpg,jpeg,png,webp}`; there is no dedicated cover column/table.
-pub(crate) async fn find_sidecar_cover(media_file_path: &str) -> Option<PathBuf> {
-    let parent = FsPath::new(media_file_path).parent()?;
-    for ext in ["jpg", "jpeg", "png", "webp"] {
-        let candidate = parent.join(format!("cover.{ext}"));
-        if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
 /// Serves raw book/comic bytes for the foliate-js reader, resolving the id
 /// against the book table first and falling back to comics (both are UUIDv7
 /// in separate tables — mirrors the `entry_v1` catalog lookup).
 pub async fn content(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     request: Request,
 ) -> Result<Response, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
@@ -218,6 +205,41 @@ mod tests {
             .header("Authorization", format!("Bearer {token}"))
             .body(Body::empty())
             .unwrap()
+    }
+
+    fn basic_req(uri: String, user: &str, pass: &str) -> Request {
+        use base64::Engine;
+        let credentials =
+            base64::engine::general_purpose::STANDARD.encode(format!("{user}:{pass}"));
+        Request::builder()
+            .uri(uri)
+            .header("Authorization", format!("Basic {credentials}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    const PNG_BYTES: &[u8] = b"\x89PNG\r\n\x1a\n-fake-png-body";
+
+    async fn insert_comic_with_zip(state: &AppState, dir: &TempDir) -> Uuid {
+        use std::io::Write;
+        let path = dir.path().join("comic.cbz");
+        let file = std::fs::File::create(&path).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        writer.start_file("pages/001.png", options).unwrap();
+        writer.write_all(PNG_BYTES).unwrap();
+        writer.finish().unwrap();
+        let id = Uuid::now_v7();
+        let comic = comic_template(
+            id,
+            Some(path.to_string_lossy().into_owned()),
+            Some("cbz".to_string()),
+        );
+        apotheke::repo::comic::insert_comic(&state.db.write, &comic)
+            .await
+            .unwrap();
+        id
     }
 
     #[tokio::test]
@@ -468,6 +490,67 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    // WHY: the #580 content-type contract — a PNG sidecar must serve as
+    // image/png, not the pre-fix hardcoded image/jpeg.
+    #[tokio::test]
+    async fn png_sidecar_cover_serves_as_image_png() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+        let dir = TempDir::new().unwrap();
+        let id = insert_book_with_file(&state, &dir, b"epub-file-contents").await;
+        tokio::fs::write(dir.path().join("cover.png"), PNG_BYTES)
+            .await
+            .unwrap();
+        let app = crate::build_router(state);
+
+        let resp = app
+            .oneshot(auth_req(format!("/api/books/{id}/cover"), &token))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get("content-type").unwrap(), "image/png");
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], PNG_BYTES);
+    }
+
+    #[tokio::test]
+    async fn comic_cover_extracts_embedded_page() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+        let dir = TempDir::new().unwrap();
+        let id = insert_comic_with_zip(&state, &dir).await;
+        let app = crate::build_router(state);
+
+        let resp = app
+            .oneshot(auth_req(format!("/api/comics/{id}/cover"), &token))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get("content-type").unwrap(), "image/png");
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], PNG_BYTES);
+    }
+
+    #[tokio::test]
+    async fn embedded_cover_advertises_probed_type_in_feed() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+        let dir = TempDir::new().unwrap();
+        insert_comic_with_zip(&state, &dir).await;
+        let app = crate::build_router(state);
+
+        let resp = app
+            .oneshot(auth_req("/opds/v2/comics".to_string(), &token))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let images = body["publications"][0]["images"].as_array().unwrap();
+        assert!(!images.is_empty());
+        assert_eq!(images[0]["type"], "image/png");
+    }
+
     #[tokio::test]
     async fn cover_missing_returns_404() {
         let (state, auth) = test_state().await;
@@ -550,7 +633,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unauthenticated_returns_401() {
+    async fn unauthenticated_returns_401_with_auth_document() {
         let (state, _auth) = test_state().await;
         let app = crate::build_router(state);
         let id = Uuid::now_v7();
@@ -573,7 +656,85 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "uri: {uri}");
+            let www = resp
+                .headers()
+                .get("www-authenticate")
+                .unwrap_or_else(|| panic!("missing WWW-Authenticate on {uri}"))
+                .to_str()
+                .unwrap()
+                .to_string();
+            assert!(www.starts_with("Basic"), "uri: {uri}");
+            assert_eq!(
+                resp.headers().get("content-type").unwrap(),
+                "application/opds-authentication+json",
+                "uri: {uri}"
+            );
+            let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+            let doc: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(
+                doc["authentication"][0]["type"], "http://opds-spec.org/auth/basic",
+                "uri: {uri}"
+            );
         }
+    }
+
+    // WHY: the #579 end-to-end contract — an OPDS client that only speaks
+    // HTTP Basic can fetch every advertised link class.
+    #[tokio::test]
+    async fn advertised_links_accept_basic_credentials() {
+        let (state, auth) = test_state().await;
+        // WHY: creates the admin/password123 user; the bearer is unused.
+        let _token = admin_token(&auth).await;
+        let dir = TempDir::new().unwrap();
+        let bytes = b"epub-file-contents";
+        let id = insert_book_with_file(&state, &dir, bytes).await;
+        write_cover(&dir).await;
+        let app = crate::build_router(state);
+
+        for uri in [
+            format!("/opds/content/{id}"),
+            format!("/api/books/{id}/download"),
+            format!("/api/books/{id}/cover"),
+            "/opds/v2/books".to_string(),
+            format!("/read/{id}"),
+        ] {
+            let resp = app
+                .clone()
+                .oneshot(basic_req(uri.clone(), "admin", "password123"))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "uri: {uri}");
+        }
+
+        let resp = app
+            .oneshot(basic_req(
+                format!("/opds/content/{id}"),
+                "admin",
+                "wrong-password",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_document_route_is_public() {
+        let (state, _auth) = test_state().await;
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/opds/auth")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "application/opds-authentication+json"
+        );
     }
 
     #[tokio::test]

--- a/crates/paroche/src/opds/cover.rs
+++ b/crates/paroche/src/opds/cover.rs
@@ -1,0 +1,688 @@
+//! Cover resolution: embedded archive covers (epub/cbz) first, sidecar
+//! `cover.*` fallback, with byte-sniffed content types.
+
+use std::io::Read;
+use std::path::{Path as FsPath, PathBuf};
+
+use quick_xml::events::Event;
+
+// SAFETY: caps every cover/XML read — a hostile archive entry cannot balloon
+// memory through a lying size field or an oversized document.
+const MAX_COVER_BYTES: u64 = 20 * 1024 * 1024;
+const MAX_XML_BYTES: u64 = 1024 * 1024;
+
+/// Where a cover image was found for a media file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CoverLocation {
+    /// An image entry inside the media file's own archive (epub/cbz).
+    Embedded { archive: PathBuf, entry: String },
+    /// A `cover.*` image beside the media file.
+    Sidecar(PathBuf),
+}
+
+pub(crate) fn image_mime_from_ext(name: &str) -> Option<&'static str> {
+    let ext = FsPath::new(name)
+        .extension()?
+        .to_str()?
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "png" => Some("image/png"),
+        "webp" => Some("image/webp"),
+        "gif" => Some("image/gif"),
+        _ => None,
+    }
+}
+
+pub(crate) fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Some("image/png");
+    }
+    if bytes.starts_with(b"\xff\xd8\xff") {
+        return Some("image/jpeg");
+    }
+    if bytes.get(0..4) == Some(b"RIFF".as_slice()) && bytes.get(8..12) == Some(b"WEBP".as_slice()) {
+        return Some("image/webp");
+    }
+    if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        return Some("image/gif");
+    }
+    None
+}
+
+// NOTE: sidecar cover convention — a cover image lives beside the media file
+// as `cover.{jpg,jpeg,png,webp}`; there is no dedicated cover column/table.
+pub(crate) async fn find_sidecar_cover(media_file_path: &str) -> Option<PathBuf> {
+    let parent = FsPath::new(media_file_path).parent()?;
+    for ext in ["jpg", "jpeg", "png", "webp"] {
+        let candidate = parent.join(format!("cover.{ext}"));
+        if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ArchiveKind {
+    Epub,
+    Cbz,
+}
+
+// NOTE: cbr (rar), pdf, and mobi/azw3 embedded covers are deferred — only
+// the zip-container formats are probed; everything else falls to the sidecar.
+fn archive_kind(file_format: Option<&str>, file_path: &str) -> Option<ArchiveKind> {
+    let format = file_format.map(str::to_ascii_lowercase).or_else(|| {
+        FsPath::new(file_path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_ascii_lowercase)
+    })?;
+    match format.as_str() {
+        "epub" => Some(ArchiveKind::Epub),
+        "cbz" => Some(ArchiveKind::Cbz),
+        _ => None,
+    }
+}
+
+/// Locates the cover for a media file: an embedded archive cover when the
+/// file is an epub/cbz, else a sidecar `cover.*` beside it.
+pub(crate) async fn locate_cover(
+    file_path: &str,
+    file_format: Option<&str>,
+) -> Option<CoverLocation> {
+    if let Some(kind) = archive_kind(file_format, file_path) {
+        let archive = PathBuf::from(file_path);
+        match tokio::task::spawn_blocking(move || locate_embedded(&archive, kind)).await {
+            Ok(Some(entry)) => {
+                return Some(CoverLocation::Embedded {
+                    archive: PathBuf::from(file_path),
+                    entry,
+                });
+            }
+            Ok(None) => {}
+            Err(join_error) => {
+                tracing::warn!(error = %join_error, path = %file_path, "embedded cover probe task failed");
+            }
+        }
+    }
+    find_sidecar_cover(file_path)
+        .await
+        .map(CoverLocation::Sidecar)
+}
+
+/// Reads the located cover's bytes and derives its content type by sniffing
+/// the actual bytes, falling back to the file extension.
+pub(crate) async fn read_cover(location: CoverLocation) -> Option<(Vec<u8>, &'static str)> {
+    let (bytes, name) = match location {
+        CoverLocation::Sidecar(path) => {
+            let meta = tokio::fs::metadata(&path).await.ok()?;
+            if meta.len() > MAX_COVER_BYTES {
+                tracing::warn!(path = %path.display(), size = meta.len(), "sidecar cover exceeds size cap");
+                return None;
+            }
+            let bytes = match tokio::fs::read(&path).await {
+                Ok(bytes) => bytes,
+                Err(error) => {
+                    tracing::warn!(error = %error, path = %path.display(), "sidecar cover read failed");
+                    return None;
+                }
+            };
+            (bytes, path.to_string_lossy().into_owned())
+        }
+        CoverLocation::Embedded { archive, entry } => {
+            let name = entry.clone();
+            let bytes = tokio::task::spawn_blocking(move || read_embedded(&archive, &entry))
+                .await
+                .ok()
+                .flatten()?;
+            (bytes, name)
+        }
+    };
+    let mime = sniff_image_mime(&bytes).or_else(|| image_mime_from_ext(&name));
+    let Some(mime) = mime else {
+        tracing::warn!(name = %name, "located cover has unrecognizable image type");
+        return None;
+    };
+    Some((bytes, mime))
+}
+
+/// The content type to advertise for a media file's cover in catalog feeds,
+/// or `None` when no cover is resolvable (the feed then omits image links).
+///
+/// PERF: extension-derived in the common case — one archive central-directory
+/// probe per book, no image bytes read. A persisted cover reference produced
+/// at import would remove the per-feed probe entirely (#580 follow-up).
+pub(crate) async fn probe_cover_mime(
+    file_path: &str,
+    file_format: Option<&str>,
+) -> Option<&'static str> {
+    let location = locate_cover(file_path, file_format).await?;
+    let ext_mime = match &location {
+        CoverLocation::Embedded { entry, .. } => image_mime_from_ext(entry),
+        CoverLocation::Sidecar(path) => path.to_str().and_then(image_mime_from_ext),
+    };
+    if let Some(mime) = ext_mime {
+        return Some(mime);
+    }
+    // WHY: rare — e.g. an OPF-declared cover entry with no recognized
+    // extension; read + sniff so the advertised type stays true to the bytes.
+    read_cover(location).await.map(|(_, mime)| mime)
+}
+
+fn locate_embedded(path: &FsPath, kind: ArchiveKind) -> Option<String> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) => {
+            tracing::warn!(error = %error, path = %path.display(), "cover probe could not open media file");
+            return None;
+        }
+    };
+    let mut archive = match zip::ZipArchive::new(file) {
+        Ok(archive) => archive,
+        Err(error) => {
+            tracing::warn!(error = %error, path = %path.display(), "cover probe could not read archive");
+            return None;
+        }
+    };
+    match kind {
+        ArchiveKind::Cbz => first_image_entry(&archive),
+        ArchiveKind::Epub => epub_cover_entry(&mut archive),
+    }
+}
+
+fn read_embedded(archive_path: &FsPath, entry: &str) -> Option<Vec<u8>> {
+    let file = std::fs::File::open(archive_path).ok()?;
+    let mut archive = zip::ZipArchive::new(file).ok()?;
+    let entry_file = archive.by_name(entry).ok()?;
+    let mut bytes = Vec::new();
+    // WHY: take() bounds the read even when the declared entry size lies; an
+    // over-cap read is discarded rather than served truncated.
+    entry_file
+        .take(MAX_COVER_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    if bytes.len() as u64 > MAX_COVER_BYTES {
+        tracing::warn!(entry = %entry, "embedded cover exceeds size cap");
+        return None;
+    }
+    Some(bytes)
+}
+
+fn is_hidden_entry(name: &str) -> bool {
+    name.split('/')
+        .any(|segment| segment.starts_with('.') || segment == "__MACOSX")
+}
+
+/// First image entry in page order — comic archives put the cover first.
+fn first_image_entry<R: Read + std::io::Seek>(archive: &zip::ZipArchive<R>) -> Option<String> {
+    archive
+        .file_names()
+        .filter(|name| !name.ends_with('/') && !is_hidden_entry(name))
+        .filter(|name| image_mime_from_ext(name).is_some())
+        .min()
+        .map(str::to_string)
+}
+
+fn epub_cover_entry(archive: &mut zip::ZipArchive<std::fs::File>) -> Option<String> {
+    if let Some(resolved) = opf_declared_cover(archive)
+        && archive.by_name(&resolved).is_ok()
+    {
+        return Some(resolved);
+    }
+    // WHY: OPF hrefs occasionally disagree with the archive on case or
+    // encoding; fall back to a conventional `cover.*` image entry.
+    fallback_cover_entry(archive)
+}
+
+fn opf_declared_cover(archive: &mut zip::ZipArchive<std::fs::File>) -> Option<String> {
+    let container = read_entry_string(archive, "META-INF/container.xml")?;
+    let opf_path = parse_container_rootfile(&container)?;
+    let opf = read_entry_string(archive, &opf_path)?;
+    let href = parse_opf_cover_href(&opf)?;
+    Some(resolve_opf_href(&opf_path, &href))
+}
+
+fn fallback_cover_entry<R: Read + std::io::Seek>(archive: &zip::ZipArchive<R>) -> Option<String> {
+    archive
+        .file_names()
+        .filter(|name| !is_hidden_entry(name) && image_mime_from_ext(name).is_some())
+        .filter(|name| {
+            FsPath::new(name)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .is_some_and(|stem| stem.eq_ignore_ascii_case("cover"))
+        })
+        .min_by_key(|name| (name.matches('/').count(), name.to_string()))
+        .map(str::to_string)
+}
+
+fn read_entry_string<R: Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    name: &str,
+) -> Option<String> {
+    let entry = archive.by_name(name).ok()?;
+    let mut text = String::new();
+    entry
+        .take(MAX_XML_BYTES + 1)
+        .read_to_string(&mut text)
+        .ok()?;
+    if text.len() as u64 > MAX_XML_BYTES {
+        return None;
+    }
+    Some(text)
+}
+
+fn attr_value(element: &quick_xml::events::BytesStart<'_>, name: &[u8]) -> Option<String> {
+    element
+        .attributes()
+        .flatten()
+        .find(|attr| attr.key.local_name().as_ref() == name)
+        .and_then(|attr| {
+            attr.normalized_value(quick_xml::XmlVersion::Implicit1_0)
+                .ok()
+        })
+        .map(|value| value.into_owned())
+}
+
+/// `META-INF/container.xml` → the `full-path` of the first rootfile (the OPF).
+fn parse_container_rootfile(xml: &str) -> Option<String> {
+    let mut reader = quick_xml::Reader::from_str(xml);
+    loop {
+        match reader.read_event().ok()? {
+            Event::Start(element) | Event::Empty(element) => {
+                if element.name().local_name().as_ref() == b"rootfile"
+                    && let Some(path) = attr_value(&element, b"full-path")
+                {
+                    return Some(path);
+                }
+            }
+            Event::Eof => return None,
+            _ => {}
+        }
+    }
+}
+
+/// The OPF-declared cover image href: EPUB 3 `properties="cover-image"`
+/// manifest item, else the EPUB 2 `<meta name="cover">` item reference, else
+/// the conventional `id="cover"` image item.
+fn parse_opf_cover_href(xml: &str) -> Option<String> {
+    struct ManifestItem {
+        id: Option<String>,
+        href: Option<String>,
+        media_type: Option<String>,
+        properties: Option<String>,
+    }
+
+    let mut items: Vec<ManifestItem> = Vec::new();
+    let mut cover_meta_id: Option<String> = None;
+    let mut reader = quick_xml::Reader::from_str(xml);
+    loop {
+        match reader.read_event().ok()? {
+            Event::Start(element) | Event::Empty(element) => {
+                match element.name().local_name().as_ref() {
+                    b"item" => items.push(ManifestItem {
+                        id: attr_value(&element, b"id"),
+                        href: attr_value(&element, b"href"),
+                        media_type: attr_value(&element, b"media-type"),
+                        properties: attr_value(&element, b"properties"),
+                    }),
+                    b"meta" => {
+                        if attr_value(&element, b"name").as_deref() == Some("cover")
+                            && let Some(content) = attr_value(&element, b"content")
+                        {
+                            cover_meta_id = Some(content);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    if let Some(item) = items.iter().find(|item| {
+        item.properties
+            .as_deref()
+            .is_some_and(|p| p.split_whitespace().any(|token| token == "cover-image"))
+    }) {
+        return item.href.clone();
+    }
+    if let Some(cover_id) = cover_meta_id
+        && let Some(item) = items
+            .iter()
+            .find(|item| item.id.as_deref() == Some(&cover_id))
+    {
+        return item.href.clone();
+    }
+    items
+        .iter()
+        .find(|item| {
+            item.id.as_deref() == Some("cover")
+                && item
+                    .media_type
+                    .as_deref()
+                    .is_some_and(|m| m.starts_with("image/"))
+        })
+        .and_then(|item| item.href.clone())
+}
+
+/// Decodes `%XX` sequences; malformed sequences pass through verbatim.
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while let Some(&byte) = bytes.get(i) {
+        if byte == b'%'
+            && let (Some(hi), Some(lo)) = (
+                bytes.get(i + 1).and_then(|b| (*b as char).to_digit(16)),
+                bytes.get(i + 2).and_then(|b| (*b as char).to_digit(16)),
+            )
+        {
+            // INVARIANT: hi/lo are hex digits (< 16), so the sum fits a u8.
+            out.push((hi * 16 + lo) as u8);
+            i += 3;
+        } else {
+            out.push(byte);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| input.to_string())
+}
+
+/// Resolves an OPF-relative href against the OPF's own archive path.
+fn resolve_opf_href(opf_path: &str, href: &str) -> String {
+    let decoded = percent_decode(href);
+    let mut segments: Vec<&str> = opf_path.split('/').collect();
+    segments.pop();
+    for segment in decoded.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop();
+            }
+            other => segments.push(other),
+        }
+    }
+    segments.join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    const PNG_BYTES: &[u8] = b"\x89PNG\r\n\x1a\n-fake-png-body";
+    const JPEG_BYTES: &[u8] = b"\xff\xd8\xff\xe0-fake-jpeg-body";
+
+    fn zip_options() -> zip::write::SimpleFileOptions {
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored)
+    }
+
+    fn write_zip(path: &FsPath, entries: &[(&str, &[u8])]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        for (name, bytes) in entries {
+            writer.start_file(*name, zip_options()).unwrap();
+            writer.write_all(bytes).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    fn epub_entries<'a>(opf: &'a str, image: (&'a str, &'a [u8])) -> Vec<(&'a str, &'a [u8])> {
+        vec![
+            (
+                "META-INF/container.xml",
+                br#"<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"# as &[u8],
+            ),
+            ("OEBPS/content.opf", opf.as_bytes()),
+            image,
+        ]
+    }
+
+    #[test]
+    fn sniff_recognizes_magic_bytes() {
+        assert_eq!(sniff_image_mime(PNG_BYTES), Some("image/png"));
+        assert_eq!(sniff_image_mime(JPEG_BYTES), Some("image/jpeg"));
+        assert_eq!(
+            sniff_image_mime(b"RIFF\x00\x00\x00\x00WEBPVP8 "),
+            Some("image/webp")
+        );
+        assert_eq!(sniff_image_mime(b"GIF89a-body"), Some("image/gif"));
+        assert_eq!(sniff_image_mime(b"not-an-image"), None);
+    }
+
+    #[test]
+    fn ext_mime_maps_known_extensions() {
+        assert_eq!(image_mime_from_ext("cover.PNG"), Some("image/png"));
+        assert_eq!(image_mime_from_ext("a/b/cover.jpeg"), Some("image/jpeg"));
+        assert_eq!(image_mime_from_ext("cover.webp"), Some("image/webp"));
+        assert_eq!(image_mime_from_ext("cover.txt"), None);
+        assert_eq!(image_mime_from_ext("no-extension"), None);
+    }
+
+    #[test]
+    fn percent_decode_handles_encoded_and_malformed() {
+        assert_eq!(percent_decode("cover%20image.jpg"), "cover image.jpg");
+        assert_eq!(percent_decode("plain.jpg"), "plain.jpg");
+        assert_eq!(percent_decode("bad%zz.jpg"), "bad%zz.jpg");
+    }
+
+    #[test]
+    fn resolve_opf_href_joins_and_normalizes() {
+        assert_eq!(
+            resolve_opf_href("OEBPS/content.opf", "images/cover.jpg"),
+            "OEBPS/images/cover.jpg"
+        );
+        assert_eq!(
+            resolve_opf_href("OEBPS/content.opf", "../cover.jpg"),
+            "cover.jpg"
+        );
+        assert_eq!(resolve_opf_href("content.opf", "cover.jpg"), "cover.jpg");
+        assert_eq!(
+            resolve_opf_href("OEBPS/content.opf", "./images/c%20d.png"),
+            "OEBPS/images/c d.png"
+        );
+    }
+
+    #[test]
+    fn container_rootfile_parses() {
+        let xml = r#"<container><rootfiles>
+            <rootfile full-path="OEBPS/package.opf" media-type="application/oebps-package+xml"/>
+        </rootfiles></container>"#;
+        assert_eq!(
+            parse_container_rootfile(xml),
+            Some("OEBPS/package.opf".to_string())
+        );
+        assert_eq!(parse_container_rootfile("<container/>"), None);
+    }
+
+    #[test]
+    fn opf_cover_prefers_epub3_properties() {
+        let xml = r#"<package><manifest>
+            <item id="c2" href="old.jpg" media-type="image/jpeg"/>
+            <item id="c3" href="new.png" media-type="image/png" properties="svg cover-image"/>
+        </manifest><metadata><meta name="cover" content="c2"/></metadata></package>"#;
+        assert_eq!(parse_opf_cover_href(xml), Some("new.png".to_string()));
+    }
+
+    #[test]
+    fn opf_cover_falls_back_to_epub2_meta() {
+        let xml = r#"<package><metadata><meta name="cover" content="cover-id"/></metadata>
+        <manifest><item id="cover-id" href="images/cover.jpg" media-type="image/jpeg"/></manifest>
+        </package>"#;
+        assert_eq!(
+            parse_opf_cover_href(xml),
+            Some("images/cover.jpg".to_string())
+        );
+    }
+
+    #[test]
+    fn opf_cover_falls_back_to_cover_id_convention() {
+        let xml = r#"<package><manifest>
+            <item id="cover" href="cover.webp" media-type="image/webp"/>
+            <item id="page1" href="p1.xhtml" media-type="application/xhtml+xml"/>
+        </manifest></package>"#;
+        assert_eq!(parse_opf_cover_href(xml), Some("cover.webp".to_string()));
+    }
+
+    #[test]
+    fn opf_without_cover_returns_none() {
+        let xml = r#"<package><manifest>
+            <item id="page1" href="p1.xhtml" media-type="application/xhtml+xml"/>
+        </manifest></package>"#;
+        assert_eq!(parse_opf_cover_href(xml), None);
+    }
+
+    #[tokio::test]
+    async fn cbz_cover_is_first_image_entry() {
+        let dir = TempDir::new().unwrap();
+        let cbz = dir.path().join("comic.cbz");
+        write_zip(
+            &cbz,
+            &[
+                ("ComicInfo.xml", b"<ComicInfo/>" as &[u8]),
+                ("pages/002.png", PNG_BYTES),
+                ("pages/001.png", PNG_BYTES),
+                ("__MACOSX/._001.png", b"junk"),
+            ],
+        );
+        let location = locate_cover(cbz.to_str().unwrap(), Some("cbz"))
+            .await
+            .unwrap();
+        assert_eq!(
+            location,
+            CoverLocation::Embedded {
+                archive: cbz.clone(),
+                entry: "pages/001.png".to_string()
+            }
+        );
+        let (bytes, mime) = read_cover(location).await.unwrap();
+        assert_eq!(mime, "image/png");
+        assert_eq!(bytes, PNG_BYTES);
+    }
+
+    #[tokio::test]
+    async fn epub_cover_resolves_via_opf() {
+        let dir = TempDir::new().unwrap();
+        let epub = dir.path().join("book.epub");
+        let opf = r#"<package><manifest>
+            <item id="ci" href="images/cover.jpeg" media-type="image/jpeg" properties="cover-image"/>
+        </manifest></package>"#;
+        write_zip(
+            &epub,
+            &epub_entries(opf, ("OEBPS/images/cover.jpeg", JPEG_BYTES)),
+        );
+        let location = locate_cover(epub.to_str().unwrap(), Some("epub"))
+            .await
+            .unwrap();
+        assert_eq!(
+            location,
+            CoverLocation::Embedded {
+                archive: epub.clone(),
+                entry: "OEBPS/images/cover.jpeg".to_string()
+            }
+        );
+        let (_, mime) = read_cover(location).await.unwrap();
+        assert_eq!(mime, "image/jpeg");
+    }
+
+    #[tokio::test]
+    async fn epub_without_opf_cover_uses_conventional_entry() {
+        let dir = TempDir::new().unwrap();
+        let epub = dir.path().join("book.epub");
+        let opf = r#"<package><manifest>
+            <item id="page1" href="p1.xhtml" media-type="application/xhtml+xml"/>
+        </manifest></package>"#;
+        write_zip(&epub, &epub_entries(opf, ("OEBPS/cover.png", PNG_BYTES)));
+        let location = locate_cover(epub.to_str().unwrap(), Some("epub"))
+            .await
+            .unwrap();
+        assert_eq!(
+            location,
+            CoverLocation::Embedded {
+                archive: epub.clone(),
+                entry: "OEBPS/cover.png".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn non_archive_falls_back_to_sidecar() {
+        let dir = TempDir::new().unwrap();
+        let media = dir.path().join("book.pdf");
+        tokio::fs::write(&media, b"%PDF-1.4").await.unwrap();
+        let sidecar = dir.path().join("cover.png");
+        tokio::fs::write(&sidecar, PNG_BYTES).await.unwrap();
+        let location = locate_cover(media.to_str().unwrap(), Some("pdf"))
+            .await
+            .unwrap();
+        assert_eq!(location, CoverLocation::Sidecar(sidecar));
+    }
+
+    #[tokio::test]
+    async fn corrupt_archive_falls_back_to_sidecar() {
+        let dir = TempDir::new().unwrap();
+        let media = dir.path().join("book.epub");
+        tokio::fs::write(&media, b"not-a-zip-archive")
+            .await
+            .unwrap();
+        let sidecar = dir.path().join("cover.jpg");
+        tokio::fs::write(&sidecar, JPEG_BYTES).await.unwrap();
+        let location = locate_cover(media.to_str().unwrap(), Some("epub"))
+            .await
+            .unwrap();
+        assert_eq!(location, CoverLocation::Sidecar(sidecar));
+    }
+
+    #[tokio::test]
+    async fn sidecar_sniff_wins_over_extension() {
+        // WHY: a mislabeled sidecar (PNG bytes in cover.jpg) must be served
+        // as what it IS, not what its name claims.
+        let dir = TempDir::new().unwrap();
+        let sidecar = dir.path().join("cover.jpg");
+        tokio::fs::write(&sidecar, PNG_BYTES).await.unwrap();
+        let (_, mime) = read_cover(CoverLocation::Sidecar(sidecar)).await.unwrap();
+        assert_eq!(mime, "image/png");
+    }
+
+    #[tokio::test]
+    async fn missing_cover_resolves_to_none() {
+        let dir = TempDir::new().unwrap();
+        let media = dir.path().join("book.pdf");
+        tokio::fs::write(&media, b"%PDF-1.4").await.unwrap();
+        assert!(
+            locate_cover(media.to_str().unwrap(), Some("pdf"))
+                .await
+                .is_none()
+        );
+        assert!(
+            probe_cover_mime(media.to_str().unwrap(), Some("pdf"))
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_mime_matches_located_cover() {
+        let dir = TempDir::new().unwrap();
+        let cbz = dir.path().join("comic.cbz");
+        write_zip(
+            &cbz,
+            &[("001.webp", b"RIFF\x00\x00\x00\x00WEBPVP8 " as &[u8])],
+        );
+        assert_eq!(
+            probe_cover_mime(cbz.to_str().unwrap(), Some("cbz")).await,
+            Some("image/webp")
+        );
+    }
+}

--- a/crates/paroche/src/opds/mod.rs
+++ b/crates/paroche/src/opds/mod.rs
@@ -1,6 +1,8 @@
 pub mod acquisition;
+pub mod auth;
 pub mod catalog;
 pub mod content;
+pub(crate) mod cover;
 pub mod search;
 pub mod types_v1;
 pub mod types_v2;
@@ -9,9 +11,13 @@ use axum::Router;
 
 use crate::state::AppState;
 
+// NOTE: `/content/{id}` is registered by the streaming route group in
+// `crate::build_router` — byte-serving routes are exempt from the API
+// response timeout.
 pub fn opds_routes() -> Router<AppState> {
     use axum::routing::get;
     Router::new()
+        .route("/auth", get(auth::auth_document))
         .route("/v2/catalog", get(catalog::catalog_v2))
         .route("/v2/books", get(catalog::books_v2))
         .route("/v2/books/{id}", get(catalog::book_v2))
@@ -24,5 +30,4 @@ pub fn opds_routes() -> Router<AppState> {
         .route("/v1/comics.xml", get(catalog::comics_v1))
         .route("/v1/search.xml", get(search::search_v1))
         .route("/v1/entry/{id}", get(catalog::entry_v1))
-        .route("/content/{id}", get(content::content))
 }

--- a/crates/paroche/src/opds/search.rs
+++ b/crates/paroche/src/opds/search.rs
@@ -1,10 +1,10 @@
 use axum::extract::{Query, State};
 use axum::response::IntoResponse;
-use exousia::AuthenticatedUser;
 use serde::Deserialize;
 
+use super::auth::OpdsUser;
 use super::catalog::{OpdsOpenSearchResponse, OpdsV1Response, OpdsV2Response};
-use super::types_v1::{AtomEntry, AtomFeed, AtomLink, open_search_description};
+use super::types_v1::{AtomFeed, AtomLink, open_search_description};
 use super::types_v2::{FeedMetadata, MIME_OPDS_V2, OpdsFeed, OpdsLink};
 use crate::error::ParocheError;
 use crate::routes::music::chrono_now_pub;
@@ -17,7 +17,7 @@ pub struct SearchQuery {
 
 pub async fn search_v2(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Query(sq): Query<SearchQuery>,
 ) -> Result<OpdsV2Response, ParocheError> {
     let query = sq.q.as_deref().unwrap_or("").trim().to_string();
@@ -27,11 +27,8 @@ pub async fn search_v2(
     let books = apotheke::repo::book::search_books(&state.db.read, &query, page_size, 0).await?;
     let comics = apotheke::repo::comic::search_comics(&state.db.read, &query, page_size, 0).await?;
 
-    let mut publications: Vec<_> = books
-        .iter()
-        .map(super::catalog::book_to_publication)
-        .collect();
-    publications.extend(comics.iter().map(super::catalog::comic_to_publication));
+    let mut publications = super::catalog::book_publications(&books).await;
+    publications.extend(super::catalog::comic_publications(&comics).await);
 
     let count = publications.len() as u64;
 
@@ -54,7 +51,7 @@ pub async fn search_v2(
 
 pub async fn search_v1(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Query(sq): Query<SearchQuery>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     if let Some(query) = sq.q.as_deref().map(str::trim).filter(|q| !q.is_empty()) {
@@ -66,11 +63,8 @@ pub async fn search_v1(
         let comics =
             apotheke::repo::comic::search_comics(&state.db.read, query, page_size, 0).await?;
 
-        let mut entries: Vec<AtomEntry> = books
-            .iter()
-            .map(super::catalog::book_to_atom_entry)
-            .collect();
-        entries.extend(comics.iter().map(super::catalog::comic_to_atom_entry));
+        let mut entries = super::catalog::book_atom_entries(&books).await;
+        entries.extend(super::catalog::comic_atom_entries(&comics).await);
 
         let feed = AtomFeed {
             id: format!("urn:harmonia:search:{}", urlencoded(query)),

--- a/crates/paroche/src/routes/book.rs
+++ b/crates/paroche/src/routes/book.rs
@@ -1,7 +1,8 @@
 use axum::Json;
 use axum::extract::{Path, Query, Request, State};
-use axum::http::header::CONTENT_DISPOSITION;
-use axum::response::Response;
+use axum::http::HeaderValue;
+use axum::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
+use axum::response::{IntoResponse, Response};
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
 use tracing;
@@ -9,9 +10,9 @@ use uuid::Uuid;
 
 use crate::error::ParocheError;
 use crate::opds::acquisition::effective_mime;
-use crate::opds::content::{
-    attachment_disposition, find_sidecar_cover, serve_file_response, serve_media_file,
-};
+use crate::opds::auth::OpdsUser;
+use crate::opds::content::{attachment_disposition, serve_media_file};
+use crate::opds::cover;
 use crate::response::{ApiResponse, deleted};
 use crate::routes::music::chrono_now_pub;
 use crate::state::AppState;
@@ -213,7 +214,7 @@ pub async fn delete_book(
 pub async fn download_book(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     request: Request,
 ) -> Result<Response, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
@@ -236,11 +237,12 @@ pub async fn download_book(
     Ok(response)
 }
 
+/// Serves the book's cover: embedded epub cover first, sidecar `cover.*`
+/// fallback, content type sniffed from the actual image bytes.
 pub async fn book_cover(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    _auth: AuthenticatedUser,
-    request: Request,
+    _auth: OpdsUser,
 ) -> Result<Response, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
     let id_bytes = uuid.as_bytes().to_vec();
@@ -249,18 +251,29 @@ pub async fn book_cover(
         .await?
         .ok_or(ParocheError::NotFound)?;
     let file_path = book.file_path.ok_or(ParocheError::NotFound)?;
-    let cover_path = find_sidecar_cover(&file_path)
-        .await
-        .ok_or(ParocheError::NotFound)?;
 
-    Ok(serve_file_response(cover_path, request).await)
+    serve_cover(&file_path, book.file_format.as_deref()).await
 }
 
+pub(crate) async fn serve_cover(
+    file_path: &str,
+    file_format: Option<&str>,
+) -> Result<Response, ParocheError> {
+    let location = cover::locate_cover(file_path, file_format)
+        .await
+        .ok_or(ParocheError::NotFound)?;
+    let (bytes, mime) = cover::read_cover(location)
+        .await
+        .ok_or(ParocheError::NotFound)?;
+    Ok(([(CONTENT_TYPE, HeaderValue::from_static(mime))], bytes).into_response())
+}
+
+// NOTE: `/{id}/download` and `/{id}/cover` are registered by the streaming
+// route group in `crate::build_router` — byte-serving routes are exempt from
+// the API response timeout.
 pub fn book_routes() -> axum::Router<AppState> {
     use axum::routing::get;
     axum::Router::new()
         .route("/", get(list_books).post(create_book))
         .route("/{id}", get(get_book).put(update_book).delete(delete_book))
-        .route("/{id}/download", get(download_book))
-        .route("/{id}/cover", get(book_cover))
 }

--- a/crates/paroche/src/routes/comic.rs
+++ b/crates/paroche/src/routes/comic.rs
@@ -9,10 +9,10 @@ use uuid::Uuid;
 
 use crate::error::ParocheError;
 use crate::opds::acquisition::effective_mime;
-use crate::opds::content::{
-    attachment_disposition, find_sidecar_cover, serve_file_response, serve_media_file,
-};
+use crate::opds::auth::OpdsUser;
+use crate::opds::content::{attachment_disposition, serve_media_file};
 use crate::response::{ApiResponse, deleted};
+use crate::routes::book::serve_cover;
 use crate::routes::music::chrono_now_pub;
 use crate::state::AppState;
 
@@ -217,7 +217,7 @@ pub async fn delete_comic(
 pub async fn download_comic(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     request: Request,
 ) -> Result<Response, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
@@ -240,11 +240,12 @@ pub async fn download_comic(
     Ok(response)
 }
 
+/// Serves the comic's cover: embedded cbz cover first, sidecar `cover.*`
+/// fallback, content type sniffed from the actual image bytes.
 pub async fn comic_cover(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    _auth: AuthenticatedUser,
-    request: Request,
+    _auth: OpdsUser,
 ) -> Result<Response, ParocheError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
     let id_bytes = uuid.as_bytes().to_vec();
@@ -253,13 +254,13 @@ pub async fn comic_cover(
         .await?
         .ok_or(ParocheError::NotFound)?;
     let file_path = comic.file_path.ok_or(ParocheError::NotFound)?;
-    let cover_path = find_sidecar_cover(&file_path)
-        .await
-        .ok_or(ParocheError::NotFound)?;
 
-    Ok(serve_file_response(cover_path, request).await)
+    serve_cover(&file_path, comic.file_format.as_deref()).await
 }
 
+// NOTE: `/{id}/download` and `/{id}/cover` are registered by the streaming
+// route group in `crate::build_router` — byte-serving routes are exempt from
+// the API response timeout.
 pub fn comic_routes() -> axum::Router<AppState> {
     use axum::routing::get;
     axum::Router::new()
@@ -268,6 +269,4 @@ pub fn comic_routes() -> axum::Router<AppState> {
             "/{id}",
             get(get_comic).put(update_comic).delete(delete_comic),
         )
-        .route("/{id}/download", get(download_comic))
-        .route("/{id}/cover", get(comic_cover))
 }

--- a/crates/paroche/src/routes/read.rs
+++ b/crates/paroche/src/routes/read.rs
@@ -1,10 +1,10 @@
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use exousia::AuthenticatedUser;
 use uuid::Uuid;
 
 use crate::error::ParocheError;
+use crate::opds::auth::OpdsUser;
 use crate::state::AppState;
 
 /// Serves the foliate-js reader SPA for a given book.
@@ -17,10 +17,14 @@ use crate::state::AppState;
 /// The reader is served at `/read/:book_id` and requires authentication.
 /// Book bytes are fetched from the existing OPDS endpoint which handles
 /// Range requests (RFC 7233) transparently.
+///
+/// WHY: `OpdsUser` — a browser navigation cannot attach a bearer token, so
+/// the 401 challenge triggers the browser's native Basic prompt; the browser
+/// then replays the same credentials on the page's `fetch(contentUrl)` call.
 #[tracing::instrument(skip(state))]
 pub async fn read_book(
     State(state): State<AppState>,
-    _auth: AuthenticatedUser,
+    _auth: OpdsUser,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ParocheError> {
     // Validate book ID format.


### PR DESCRIPTION
Completes the OPDS catalog (three gaps the #530 route-registration surfaced).

- **#579 (HIGH) OPDS auth** — advertised links 401 because e-readers send HTTP Basic, not a bearer token. OPDS routes now accept **HTTP Basic** (RFC 7617), validated against the existing exousia user store via a new `validate_basic` that reuses the password-verify path (no parallel credential store, no token minted) and owns the **constant-time miss-path** contract (Argon2 verify even on unknown user — CWE-203 tested — + a bounded-input CPU-DoS guard + inactive-user rejection). A 401 serves an OPDS Authentication Document so conformant readers prompt for credentials; bearer keeps working for web clients.
- **#580 covers** — covers now carry the **probed** content-type (png/jpeg/webp sniffed from the actual bytes) instead of an unconditional hardcoded `image/jpeg`; missing cover → 404.
- **#581 downloads** — the global request timeout is **scoped** to the non-streaming API routes; the download/content-streaming routes are exempt, so a large archive or cold-disk read is no longer severed at 30s (the guard still protects normal API routes — no global bump).

Gate green; tests cover Basic decode edge cases, the constant-time unknown-user path, the auth document, per-format cover content-types, and the streaming-timeout exemption.

Closes #579
Closes #580
Closes #581
