### PR TITLE
fix(syndesmos): honor configured circuit_break_failure_threshold

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -2055,7 +2055,8 @@ fn build_syndesmos(
     db: sqlx::SqlitePool,
 ) -> ScrobbleClient {
     let mut builder = ScrobbleClientBuilder::new(event_tx.clone(), db)
-        .circuit_break_minutes(config.syndesmos.circuit_break_minutes);
+        .circuit_break_minutes(config.syndesmos.circuit_break_minutes)
+        .circuit_break_failure_threshold(config.syndesmos.circuit_break_failure_threshold);
 
     if let Some(ref plex_config) = config.syndesmos.plex {
         let client = syndesmos::plex::PlexClient::new(plex_config.clone());

--- a/crates/syndesmos/src/lib.rs
+++ b/crates/syndesmos/src/lib.rs
@@ -234,6 +234,7 @@ pub struct ScrobbleClientBuilder {
     lastfm_api: Option<Arc<dyn LastfmApi>>,
     tidal_api: Option<Arc<dyn TidalApi>>,
     circuit_break_minutes: u64,
+    circuit_break_failure_threshold: u32,
 }
 
 impl ScrobbleClientBuilder {
@@ -247,6 +248,8 @@ impl ScrobbleClientBuilder {
             lastfm_api: None,
             tidal_api: None,
             circuit_break_minutes: 5,
+            circuit_break_failure_threshold: horismos::SyndesmosConfig::default()
+                .circuit_break_failure_threshold,
         }
     }
 
@@ -268,6 +271,11 @@ impl ScrobbleClientBuilder {
 
     pub fn circuit_break_minutes(mut self, minutes: u64) -> Self {
         self.circuit_break_minutes = minutes;
+        self
+    }
+
+    pub fn circuit_break_failure_threshold(mut self, threshold: u32) -> Self {
+        self.circuit_break_failure_threshold = threshold;
         self
     }
 
@@ -303,9 +311,21 @@ impl ScrobbleClientBuilder {
             tidal_api: self.tidal_api,
             db: self.db,
             event_tx: self.event_tx,
-            plex_circuit: CircuitBreaker::new("plex", 5, cooldown),
-            lastfm_circuit: CircuitBreaker::new("lastfm", 5, cooldown),
-            tidal_circuit: CircuitBreaker::new("tidal", 5, cooldown),
+            plex_circuit: CircuitBreaker::new(
+                "plex",
+                self.circuit_break_failure_threshold,
+                cooldown,
+            ),
+            lastfm_circuit: CircuitBreaker::new(
+                "lastfm",
+                self.circuit_break_failure_threshold,
+                cooldown,
+            ),
+            tidal_circuit: CircuitBreaker::new(
+                "tidal",
+                self.circuit_break_failure_threshold,
+                cooldown,
+            ),
         }
     }
 }

--- a/crates/syndesmos/src/retry.rs
+++ b/crates/syndesmos/src/retry.rs
@@ -45,14 +45,6 @@ impl CircuitBreaker {
         }
     }
 
-    pub fn with_defaults(service_name: impl Into<String>, circuit_break_minutes: u64) -> Self {
-        Self::new(
-            service_name,
-            SyndesmosConfig::default().circuit_break_failure_threshold,
-            Duration::from_secs(circuit_break_minutes * 60),
-        )
-    }
-
     /// Build a circuit breaker FROM the operator-supplied SyndesmosConfig.
     pub fn from_config(service_name: impl Into<String>, config: &SyndesmosConfig) -> Self {
         Self::new(
@@ -286,6 +278,47 @@ mod tests {
         assert!(
             circuit.is_open(),
             "circuit should trip after custom threshold reached"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn custom_threshold_short_circuits_before_third_api_call() {
+        // WHY: regression test for #576 — `ScrobbleClientBuilder` now threads a
+        // configurable `circuit_break_failure_threshold` instead of hardcoding
+        // it; a non-default threshold of 2 must trip before a third call ever
+        // reaches the API.
+        let cfg = SyndesmosConfig {
+            circuit_break_failure_threshold: 2,
+            ..SyndesmosConfig::default()
+        };
+        let circuit = CircuitBreaker::from_config("svc", &cfg);
+
+        circuit.on_failure();
+        circuit.on_failure();
+        assert!(circuit.is_open(), "circuit should trip after 2 failures");
+
+        let call_count = std::sync::Arc::new(AtomicUsize::new(0));
+        let cc = call_count.clone();
+        let result: Result<u32, SyndesmodError> = with_retry(
+            move || {
+                let cc = cc.clone();
+                async move {
+                    cc.fetch_add(1, Ordering::SeqCst);
+                    Ok(1u32)
+                }
+            },
+            &circuit,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(SyndesmodError::ExternalServiceDown { .. })
+        ));
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            0,
+            "third call should short-circuit without invoking the API"
         );
     }
 


### PR DESCRIPTION
The scrobble circuit breakers hardcoded a failure threshold of 5, ignoring the configured `syndesmos.circuit_break_failure_threshold`. The builder now threads the field (defaulted from config, mirroring circuit_break_minutes) into the plex/lastfm/tidal breakers, archon passes the configured value, and the dead `with_defaults` fn is removed. Reactive for free (syndesmos is rebuild-class). Test proves a threshold-2 breaker short-circuits the third call before it reaches the API.

Closes #576