### PR TITLE
fix(epignosis,horismos): provider credential config surface and fingerprint match thresholds

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -885,7 +885,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // the supervisor below).
     let metadata_service = Arc::new(ProviderBackedResolver::new(
         boot_config.epignosis.clone(),
-        ProviderCredentials::default(),
+        ProviderCredentials::from(&boot_config.epignosis),
     ));
     let metadata_adapter = Arc::new(MetadataAdapter::new(Arc::clone(&metadata_service)));
 
@@ -1939,10 +1939,8 @@ async fn run_epignosis_supervisor(
         };
 
         info!("epignosis config changed — resolver rebuilt, metadata cache reset");
-        let resolver = Arc::new(ProviderBackedResolver::new(
-            new_cfg,
-            ProviderCredentials::default(),
-        ));
+        let credentials = ProviderCredentials::from(&new_cfg);
+        let resolver = Arc::new(ProviderBackedResolver::new(new_cfg, credentials));
         adapter.set_resolver(resolver);
     }
 }
@@ -3713,5 +3711,59 @@ mod rebuild_supervisor_tests {
         supervisor
             .await
             .expect("epignosis supervisor joins cleanly after a live rebuild");
+    }
+
+    /// #578: a published provider-credential change (not just a tuning knob
+    /// like `provider_timeout_secs`) must reach the same rebuild path — the
+    /// supervisor re-derives `ProviderCredentials::from(&new_cfg)` on every
+    /// `epignosis.*` change, so key rotation is live for free. `Arc` identity
+    /// is the only externally-observable proof available from archon (the
+    /// resolver's provider clients are epignosis-crate-private); that the
+    /// derived credentials actually carry the new key value into the
+    /// outbound provider request is covered by epignosis's own
+    /// `provider_credentials_from_config_maps_present_keys` (resolver.rs) and
+    /// `configured_api_key_reaches_lookup_request` (providers/acoustid.rs).
+    #[tokio::test]
+    async fn epignosis_supervisor_rebuilds_resolver_on_credential_change() {
+        let config = epignosis_test_config();
+        let (manager, handle) = ConfigManager::new(
+            config.clone(),
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+
+        let initial = Arc::new(ProviderBackedResolver::new(
+            config.epignosis.clone(),
+            ProviderCredentials::default(),
+        ));
+        let adapter = Arc::new(MetadataAdapter::new(Arc::clone(&initial)));
+
+        let shutdown = CancellationToken::new();
+        let supervisor = tokio::spawn(run_epignosis_supervisor(
+            Arc::clone(&adapter),
+            handle,
+            shutdown.clone(),
+        ));
+
+        tokio::task::yield_now().await;
+
+        let mut changed = config.clone();
+        changed.epignosis.acoustid_key = Some("rotated-acoustid-key".to_string());
+        manager
+            .replace(changed)
+            .expect("replace applies the epignosis credential change");
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let after = adapter.snapshot();
+        assert!(
+            !Arc::ptr_eq(&initial, &after),
+            "a published epignosis credential change must rebuild the resolver"
+        );
+
+        shutdown.cancel();
+        supervisor
+            .await
+            .expect("epignosis supervisor joins cleanly after a credential rebuild");
     }
 }

--- a/crates/epignosis/src/identity.rs
+++ b/crates/epignosis/src/identity.rs
@@ -64,12 +64,34 @@ pub struct FingerprintResult {
     pub acoustid_id: Option<String>,
     pub mb_recording_ids: Vec<String>,
     pub confidence: f64,
+    pub match_status: FingerprintMatchStatus,
 }
 
-// Fingerprint match thresholds are now tuning knobs on
+/// Classification of a fingerprint lookup's best-scoring match against
+/// `horismos::EpignosisConfig::{fingerprint_accept_threshold,
+/// fingerprint_ambiguous_threshold}` (#575).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum FingerprintMatchStatus {
+    /// Score met `fingerprint_accept_threshold` — safe to apply
+    /// automatically.
+    Accepted,
+    /// Score met `fingerprint_ambiguous_threshold` but not
+    /// `fingerprint_accept_threshold` — a held candidate; the caller must
+    /// surface it for confirmation rather than auto-apply it.
+    Ambiguous,
+    /// No match scored at least `fingerprint_ambiguous_threshold` (or there
+    /// were no matches at all) — treated as unidentified; match identifiers
+    /// are dropped rather than returned as a false positive.
+    NoMatch,
+}
+
+// Fingerprint match thresholds are tuning knobs on
 // `horismos::EpignosisConfig::{fingerprint_accept_threshold,
-// fingerprint_ambiguous_threshold}`. Use the config at call sites rather than
-// reading a module-level constant.
+// fingerprint_ambiguous_threshold}`, read from the resolver's own config in
+// `ProviderBackedResolver::merge_lookup_matches` rather than a module-level
+// constant.
 
 /// Parse a filename stem INTO metadata hints.
 ///

--- a/crates/epignosis/src/lib.rs
+++ b/crates/epignosis/src/lib.rs
@@ -11,8 +11,8 @@ use std::path::Path;
 
 pub use error::EpignosisError;
 pub use identity::{
-    EnrichedMetadata, FingerprintResult, MediaIdentity, ParsedFilename, ProviderEnrichment,
-    UnidentifiedItem, parse_filename,
+    EnrichedMetadata, FingerprintMatchStatus, FingerprintResult, MediaIdentity, ParsedFilename,
+    ProviderEnrichment, UnidentifiedItem, parse_filename,
 };
 pub use resolver::ProviderBackedResolver;
 use tokio_util::sync::CancellationToken;

--- a/crates/epignosis/src/providers/acoustid.rs
+++ b/crates/epignosis/src/providers/acoustid.rs
@@ -191,3 +191,39 @@ impl MetadataProvider for AcoustIdProvider {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::FingerprintMatchStatus;
+    use crate::test_support::spawn_sequential_http;
+
+    // #578: proves a configured AcoustID key actually reaches the outbound
+    // request (the `client` query parameter) — the config-surface fix is
+    // meaningless if the credential never leaves the provider struct.
+    #[tokio::test]
+    async fn configured_api_key_reaches_lookup_request() {
+        let body = serde_json::json!({ "results": [] }).to_string();
+        let (base_url, handle) = spawn_sequential_http(vec![(200, body)]).await;
+
+        let provider =
+            AcoustIdProvider::with_base_url(reqwest::Client::new(), "my-real-key", base_url);
+        let fingerprint = FingerprintResult {
+            fingerprint: "AQFAKE".to_string(),
+            duration_secs: 30.0,
+            acoustid_id: None,
+            mb_recording_ids: Vec::new(),
+            confidence: 0.0,
+            match_status: FingerprintMatchStatus::NoMatch,
+        };
+
+        provider.lookup_fingerprint(&fingerprint).await.unwrap();
+
+        let requests = handle.await.unwrap();
+        assert!(
+            requests[0].contains("client=my-real-key"),
+            "the configured key must be sent as the `client` query parameter: {}",
+            requests[0]
+        );
+    }
+}

--- a/crates/epignosis/src/resolver.rs
+++ b/crates/epignosis/src/resolver.rs
@@ -10,7 +10,8 @@ use crate::MetadataResolver;
 use crate::cache::MetadataCache;
 use crate::error::EpignosisError;
 use crate::identity::{
-    EnrichedMetadata, FingerprintResult, MediaIdentity, ProviderEnrichment, UnidentifiedItem,
+    EnrichedMetadata, FingerprintMatchStatus, FingerprintResult, MediaIdentity, ProviderEnrichment,
+    UnidentifiedItem,
 };
 use crate::providers::acoustid::AcoustIdProvider;
 use crate::providers::audnexus::AudnexusProvider;
@@ -37,12 +38,30 @@ pub struct ProviderCredentials {
     pub google_books_key: Option<String>,
 }
 
+impl From<&EpignosisConfig> for ProviderCredentials {
+    /// WHY `unwrap_or_default()` for the four `String`-typed keys: an absent
+    /// config key must reproduce today's anonymous behavior (empty string —
+    /// each provider already runs unauthenticated/rate-limited on an empty
+    /// key, never rejects it), so wiring credentials in is behavior-
+    /// preserving for an operator who sets none. `google_books_key` stays
+    /// `Option` — `GoogleBooksProvider::new` already treats `None` as
+    /// keyless.
+    fn from(config: &EpignosisConfig) -> Self {
+        Self {
+            acoustid_key: config.acoustid_key.clone().unwrap_or_default(),
+            tmdb_key: config.tmdb_key.clone().unwrap_or_default(),
+            tvdb_key: config.tvdb_key.clone().unwrap_or_default(),
+            comicvine_key: config.comicvine_key.clone().unwrap_or_default(),
+            google_books_key: config.google_books_key.clone(),
+        }
+    }
+}
+
 pub struct ProviderBackedResolver {
     #[expect(dead_code)]
     client: reqwest::Client,
     queues: Arc<ProviderQueues>,
     cache: Arc<MetadataCache<String, serde_json::Value>>,
-    #[expect(dead_code)]
     config: EpignosisConfig,
     musicbrainz: MusicBrainzProvider,
     acoustid: AcoustIdProvider,
@@ -231,10 +250,16 @@ impl ProviderBackedResolver {
         0.2
     }
 
-    /// Folds AcoustID lookup matches into a computed fingerprint: the
-    /// best-scoring match supplies the AcoustID id and confidence, and every
-    /// match contributes its MusicBrainz recording id.
+    /// Folds AcoustID lookup matches into a computed fingerprint, classified
+    /// against `self.config`'s fingerprint thresholds (#575): the
+    /// best-scoring match's score decides whether the match is `Accepted`
+    /// (>= `fingerprint_accept_threshold`), `Ambiguous` (>=
+    /// `fingerprint_ambiguous_threshold` but below accept — a held
+    /// candidate, never auto-applied), or `NoMatch` (below ambiguous, or no
+    /// matches at all) — in which case match identifiers are dropped rather
+    /// than surfaced as a false positive.
     fn merge_lookup_matches(
+        &self,
         computed: FingerprintResult,
         matches: &[ProviderResult],
     ) -> FingerprintResult {
@@ -244,6 +269,25 @@ impl ProviderBackedResolver {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
+        let confidence = best.map_or(0.0, |m| m.score);
+        let match_status = if confidence >= self.config.fingerprint_accept_threshold {
+            FingerprintMatchStatus::Accepted
+        } else if confidence >= self.config.fingerprint_ambiguous_threshold {
+            FingerprintMatchStatus::Ambiguous
+        } else {
+            FingerprintMatchStatus::NoMatch
+        };
+
+        if match_status == FingerprintMatchStatus::NoMatch {
+            return FingerprintResult {
+                acoustid_id: None,
+                confidence,
+                mb_recording_ids: Vec::new(),
+                match_status,
+                ..computed
+            };
+        }
+
         FingerprintResult {
             acoustid_id: best.and_then(|m| {
                 m.raw
@@ -251,8 +295,9 @@ impl ProviderBackedResolver {
                     .and_then(|v| v.as_str())
                     .map(String::from)
             }),
-            confidence: best.map_or(0.0, |m| m.score),
+            confidence,
             mb_recording_ids: matches.iter().map(|m| m.provider_id.0.clone()).collect(),
+            match_status,
             ..computed
         }
     }
@@ -406,6 +451,7 @@ impl MetadataResolver for ProviderBackedResolver {
             acoustid_id: None,
             mb_recording_ids: Vec::new(),
             confidence: 0.0,
+            match_status: FingerprintMatchStatus::NoMatch,
         };
 
         self.queues.acoustid.acquire().await;
@@ -416,7 +462,7 @@ impl MetadataResolver for ProviderBackedResolver {
             _ = ct.cancelled() => return Ok(computed),
         };
 
-        Ok(Self::merge_lookup_matches(computed, &matches))
+        Ok(self.merge_lookup_matches(computed, &matches))
     }
 }
 
@@ -591,6 +637,49 @@ mod tests {
         )
     }
 
+    // ── #578: EpignosisConfig -> ProviderCredentials mapping ───────────────
+
+    #[test]
+    fn provider_credentials_from_config_maps_present_keys() {
+        let config = horismos::EpignosisConfig {
+            acoustid_key: Some("acoustid-secret".to_string()),
+            tmdb_key: Some("tmdb-secret".to_string()),
+            tvdb_key: Some("tvdb-secret".to_string()),
+            comicvine_key: Some("comicvine-secret".to_string()),
+            google_books_key: Some("google-books-secret".to_string()),
+            ..horismos::EpignosisConfig::default()
+        };
+
+        let credentials = ProviderCredentials::from(&config);
+
+        assert_eq!(credentials.acoustid_key, "acoustid-secret");
+        assert_eq!(credentials.tmdb_key, "tmdb-secret");
+        assert_eq!(credentials.tvdb_key, "tvdb-secret");
+        assert_eq!(credentials.comicvine_key, "comicvine-secret");
+        assert_eq!(
+            credentials.google_books_key.as_deref(),
+            Some("google-books-secret")
+        );
+    }
+
+    #[test]
+    fn provider_credentials_from_config_absent_keys_are_behavior_preserving() {
+        // WHY: absent keys must reproduce today's anonymous behavior — an
+        // empty string for the four String-typed fields (each provider
+        // already tolerates that as keyless/rate-limited, never rejects it)
+        // and `None` for google_books_key (GoogleBooksProvider's existing
+        // keyless path).
+        let config = horismos::EpignosisConfig::default();
+
+        let credentials = ProviderCredentials::from(&config);
+
+        assert_eq!(credentials.acoustid_key, "");
+        assert_eq!(credentials.tmdb_key, "");
+        assert_eq!(credentials.tvdb_key, "");
+        assert_eq!(credentials.comicvine_key, "");
+        assert_eq!(credentials.google_books_key, None);
+    }
+
     #[tokio::test]
     async fn enrich_from_secondary_tv_resolves_via_tmdb_find_cross_reference() {
         let find_body = serde_json::json!({
@@ -726,35 +815,39 @@ mod tests {
         }
     }
 
-    #[test]
-    fn merge_lookup_matches_picks_best_score() {
-        let computed = FingerprintResult {
+    fn fp_computed() -> FingerprintResult {
+        FingerprintResult {
             fingerprint: "AQ".to_string(),
             duration_secs: 10.0,
             acoustid_id: None,
             mb_recording_ids: Vec::new(),
             confidence: 0.0,
-        };
+            match_status: FingerprintMatchStatus::NoMatch,
+        }
+    }
+
+    fn score_match(id: &str, acoustid: &str, score: f64) -> ProviderResult {
+        ProviderResult {
+            provider_id: MetadataProviderId(id.to_string()),
+            title: id.to_string(),
+            artist: None,
+            year: None,
+            score,
+            raw: serde_json::json!({ "acoustid": acoustid }),
+        }
+    }
+
+    // WHY tokio::test: ProviderBackedResolver::new spawns the cache-eviction
+    // sweeper via tokio::spawn — constructing one (even just to call the sync
+    // merge_lookup_matches method) requires a running reactor.
+    #[tokio::test]
+    async fn merge_lookup_matches_picks_best_score() {
         let matches = vec![
-            ProviderResult {
-                provider_id: MetadataProviderId("mb-low".to_string()),
-                title: "Low".to_string(),
-                artist: None,
-                year: None,
-                score: 0.4,
-                raw: serde_json::json!({ "acoustid": "acoustid-low" }),
-            },
-            ProviderResult {
-                provider_id: MetadataProviderId("mb-high".to_string()),
-                title: "High".to_string(),
-                artist: None,
-                year: None,
-                score: 0.9,
-                raw: serde_json::json!({ "acoustid": "acoustid-high" }),
-            },
+            score_match("mb-low", "acoustid-low", 0.4),
+            score_match("mb-high", "acoustid-high", 0.9),
         ];
 
-        let merged = ProviderBackedResolver::merge_lookup_matches(computed, &matches);
+        let merged = test_resolver().merge_lookup_matches(fp_computed(), &matches);
 
         assert_eq!(merged.acoustid_id.as_deref(), Some("acoustid-high"));
         assert!((merged.confidence - 0.9).abs() < f64::EPSILON);
@@ -763,19 +856,12 @@ mod tests {
             vec!["mb-low".to_string(), "mb-high".to_string()]
         );
         assert_eq!(merged.fingerprint, "AQ");
+        assert_eq!(merged.match_status, FingerprintMatchStatus::Accepted);
     }
 
-    #[test]
-    fn merge_lookup_matches_empty_is_unidentified() {
-        let computed = FingerprintResult {
-            fingerprint: "AQ".to_string(),
-            duration_secs: 10.0,
-            acoustid_id: None,
-            mb_recording_ids: Vec::new(),
-            confidence: 0.0,
-        };
-
-        let merged = ProviderBackedResolver::merge_lookup_matches(computed, &[]);
+    #[tokio::test]
+    async fn merge_lookup_matches_empty_is_unidentified() {
+        let merged = test_resolver().merge_lookup_matches(fp_computed(), &[]);
 
         assert_eq!(merged.acoustid_id, None);
         assert!(merged.mb_recording_ids.is_empty());
@@ -784,6 +870,81 @@ mod tests {
             merged.fingerprint, "AQ",
             "the raw fingerprint survives a no-match lookup"
         );
+        assert_eq!(merged.match_status, FingerprintMatchStatus::NoMatch);
+    }
+
+    // ── #575: fingerprint match classification ────────────────────────────
+
+    #[tokio::test]
+    async fn merge_lookup_matches_accept_threshold_score_is_accepted() {
+        // WHY 0.8: default EpignosisConfig::fingerprint_accept_threshold.
+        let matches = vec![score_match("mb-1", "acoustid-1", 0.8)];
+
+        let merged = test_resolver().merge_lookup_matches(fp_computed(), &matches);
+
+        assert_eq!(merged.match_status, FingerprintMatchStatus::Accepted);
+        assert_eq!(merged.acoustid_id.as_deref(), Some("acoustid-1"));
+        assert_eq!(merged.mb_recording_ids, vec!["mb-1".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn merge_lookup_matches_ambiguous_score_is_held_not_applied() {
+        // WHY 0.6: between the default ambiguous (0.5) and accept (0.8)
+        // thresholds — a real candidate, but not confident enough to apply
+        // automatically.
+        let matches = vec![score_match("mb-1", "acoustid-1", 0.6)];
+
+        let merged = test_resolver().merge_lookup_matches(fp_computed(), &matches);
+
+        assert_eq!(merged.match_status, FingerprintMatchStatus::Ambiguous);
+        assert!(
+            (merged.confidence - 0.6).abs() < f64::EPSILON,
+            "an ambiguous match is still returned as a candidate, not silently blanked"
+        );
+        assert_eq!(
+            merged.acoustid_id.as_deref(),
+            Some("acoustid-1"),
+            "the candidate identity must be present for the caller to hold/confirm"
+        );
+    }
+
+    #[tokio::test]
+    async fn merge_lookup_matches_below_ambiguous_threshold_is_dropped() {
+        // WHY 0.1: below the default ambiguous threshold (0.5) — this is the
+        // #575 bug scenario, a low-confidence garbage match.
+        let matches = vec![score_match("mb-garbage", "acoustid-garbage", 0.1)];
+
+        let merged = test_resolver().merge_lookup_matches(fp_computed(), &matches);
+
+        assert_eq!(merged.match_status, FingerprintMatchStatus::NoMatch);
+        assert_eq!(
+            merged.acoustid_id, None,
+            "a below-threshold match must never surface an acoustid id"
+        );
+        assert!(
+            merged.mb_recording_ids.is_empty(),
+            "a below-threshold match must never surface an MB recording id"
+        );
+    }
+
+    #[tokio::test]
+    async fn merge_lookup_matches_uses_configured_thresholds_not_hardcoded_defaults() {
+        // WHY: proves the resolver reads ITS OWN config, not a module
+        // constant — a score that is "accepted" under the default thresholds
+        // must classify as ambiguous under stricter configured ones.
+        let resolver = ProviderBackedResolver::new(
+            horismos::EpignosisConfig {
+                fingerprint_accept_threshold: 0.95,
+                fingerprint_ambiguous_threshold: 0.6,
+                ..horismos::EpignosisConfig::default()
+            },
+            ProviderCredentials::default(),
+        );
+        let matches = vec![score_match("mb-1", "acoustid-1", 0.8)];
+
+        let merged = resolver.merge_lookup_matches(fp_computed(), &matches);
+
+        assert_eq!(merged.match_status, FingerprintMatchStatus::Ambiguous);
     }
 
     #[test]

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -72,6 +72,16 @@ pub const LIVE: &[&str] = &[
     "epignosis.cache_ttl_secs",
     "epignosis.provider_timeout_secs",
     "epignosis.provider_response_max_bytes",
+    // #578: provider credentials — rebuild supervisor re-derives
+    // ProviderCredentials FROM the new section on every rebuild.
+    "epignosis.acoustid_key",
+    "epignosis.tmdb_key",
+    "epignosis.tvdb_key",
+    "epignosis.comicvine_key",
+    "epignosis.google_books_key",
+    // #575: merge_lookup_matches now compares against both thresholds.
+    "epignosis.fingerprint_accept_threshold",
+    "epignosis.fingerprint_ambiguous_threshold",
     // kritike — step 8 (LiveGate)
     "kritike.quality_check_concurrency",
     // zetesis — step 7 (per-op reads, RateLimiter::reconfigure, cf-proxy/cardigann swap)
@@ -139,20 +149,18 @@ pub const LIVE: &[&str] = &[
 /// #575. Each stays here (rather than silently vanishing from the schema)
 /// until #575 dispositions it: wired to a real consumer, or removed.
 pub const UNWIRED: &[&str] = &[
-    "paroche.stream_buffer_kb",                  // #575
-    "paroche.transcode_concurrency",             // #575
-    "taxis.libraries.*.auto_import",             // #575
-    "taxis.file_naming_dry_run",                 // #575
-    "epignosis.max_retries",                     // #575
-    "epignosis.fingerprint_accept_threshold",    // #575
-    "epignosis.fingerprint_ambiguous_threshold", // #575
-    "kritike.scan_interval_hours",               // #575
-    "aggelia.download_queue_size",               // #575
-    "zetesis.max_results_per_indexer",           // #575
-    "zetesis.caps_refresh_hours",                // #575
-    "zetesis.cf_cookie_refresh_minutes",         // #575
-    "zetesis.cf_health_check_interval_minutes",  // #575
-    "ergasia.max_concurrent_downloads",          // #575
+    "paroche.stream_buffer_kb",                 // #575
+    "paroche.transcode_concurrency",            // #575
+    "taxis.libraries.*.auto_import",            // #575
+    "taxis.file_naming_dry_run",                // #575
+    "epignosis.max_retries",                    // #575
+    "kritike.scan_interval_hours",              // #575
+    "aggelia.download_queue_size",              // #575
+    "zetesis.max_results_per_indexer",          // #575
+    "zetesis.caps_refresh_hours",               // #575
+    "zetesis.cf_cookie_refresh_minutes",        // #575
+    "zetesis.cf_health_check_interval_minutes", // #575
+    "ergasia.max_concurrent_downloads",         // #575
     "ergasia.tracker_seed_policies", // #575 — whole TrackerSeedPolicy struct is dead; the map is empty by default and collapses to this one leaf (see `classification_leaf_paths`)
     "ergasia.progress_throttle_seconds", // #575
     "ergasia.extraction_temp_dir",   // #575

--- a/crates/horismos/src/handle.rs
+++ b/crates/horismos/src/handle.rs
@@ -434,7 +434,20 @@ mod tests {
             );
 
             let outcome = manager.reload().unwrap();
-            assert!(outcome.warnings.is_empty());
+            // WHY not empty: #578 — a config with no provider credentials set
+            // (this fixture's default) always carries standing
+            // absent-credential warnings; they're re-derived on every load,
+            // not a one-time diff signal, so an "unchanged" reload still
+            // reports them.
+            assert!(
+                outcome
+                    .warnings
+                    .iter()
+                    .all(|w| w.field.starts_with("epignosis.")),
+                "the only warnings on a bare fixture must be the absent-provider-credential ones: {:?}",
+                outcome.warnings
+            );
+            assert!(!outcome.warnings.is_empty());
             assert!(outcome.applied.is_empty());
             assert!(outcome.restart_pending.is_empty());
             assert!(outcome.is_unchanged());

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -279,8 +279,11 @@ mod tests {
         };
         config.taxis.libraries.insert("music".to_string(), library);
         let warnings = validate_config(&config).unwrap();
-        assert!(!warnings.is_empty());
-        assert!(warnings[0].field.contains("taxis.libraries.music.path"));
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.field.contains("taxis.libraries.music.path"))
+        );
     }
 
     #[test]
@@ -292,7 +295,11 @@ mod tests {
         };
         config.taxis.libraries.insert("music".to_string(), library);
         let warnings = validate_config(&config).unwrap();
-        assert!(warnings.is_empty());
+        assert!(
+            !warnings.iter().any(|w| w.field.contains("taxis.libraries")),
+            "an accessible library path must not warn, independent of the \
+             standing #578 absent-provider-credential warnings: {warnings:?}"
+        );
     }
 
     // ── Port validation ───────────────────────────────────────────────────────
@@ -422,6 +429,69 @@ mod tests {
         config.zetesis.cloudflare_bypass_enabled = true;
         config.zetesis.cf_proxy_url = Some("http://byparr:8191".to_string());
         assert!(validate_config(&config).is_ok());
+    }
+
+    // ── #578: provider credential validation ──────────────────────────────────
+
+    #[test]
+    fn validation_warns_on_absent_provider_credentials() {
+        let config = config_with_jwt(valid_jwt_secret());
+        let warnings = validate_config(&config).unwrap();
+        let fields: Vec<&str> = warnings.iter().map(|w| w.field.as_str()).collect();
+        assert!(fields.contains(&"epignosis.acoustid_key"));
+        assert!(fields.contains(&"epignosis.tmdb_key"));
+        assert!(fields.contains(&"epignosis.tvdb_key"));
+        assert!(fields.contains(&"epignosis.comicvine_key"));
+        assert!(fields.contains(&"epignosis.google_books_key"));
+    }
+
+    #[test]
+    fn validation_absent_credential_warning_names_degraded_capability() {
+        let config = config_with_jwt(valid_jwt_secret());
+        let warnings = validate_config(&config).unwrap();
+        let tmdb = warnings
+            .iter()
+            .find(|w| w.field == "epignosis.tmdb_key")
+            .expect("absent tmdb_key must produce a warning");
+        assert!(tmdb.message.contains("movie"));
+    }
+
+    #[test]
+    fn validation_rejects_empty_string_provider_credential() {
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.epignosis.acoustid_key = Some(String::new());
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("epignosis.acoustid_key"));
+    }
+
+    #[test]
+    fn validation_rejects_placeholder_provider_credential() {
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.epignosis.tmdb_key = Some("changeme".to_string());
+        let err = validate_config(&config).unwrap_err();
+        assert!(err.to_string().contains("epignosis.tmdb_key"));
+    }
+
+    #[test]
+    fn validation_accepts_real_provider_credential_with_no_warning_for_that_field() {
+        let mut config = config_with_jwt(valid_jwt_secret());
+        config.epignosis.acoustid_key = Some("real-acoustid-key".to_string());
+        let warnings = validate_config(&config).unwrap();
+        assert!(
+            !warnings.iter().any(|w| w.field == "epignosis.acoustid_key"),
+            "a configured key must not also warn as absent"
+        );
+    }
+
+    #[test]
+    fn epignosis_config_debug_redacts_keys() {
+        let config = EpignosisConfig {
+            acoustid_key: Some("super-secret-acoustid-key".to_string()),
+            ..EpignosisConfig::default()
+        };
+        let debug = format!("{config:?}");
+        assert!(debug.contains("[redacted]"));
+        assert!(!debug.contains("super-secret-acoustid-key"));
     }
 
     // ── Serialize/Deserialize roundtrip ───────────────────────────────────────

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -201,7 +201,7 @@ impl Default for TaxisConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct EpignosisConfig {
     pub cache_ttl_secs: u64,
@@ -216,10 +216,68 @@ pub struct EpignosisConfig {
     /// Maximum bytes buffered FROM a single metadata-provider response.
     #[serde(default = "default_provider_response_max_bytes")]
     pub provider_response_max_bytes: u64,
+    /// AcoustID API key for fingerprint lookups. Absent = fingerprinting
+    /// runs unauthenticated (degraded/rate-limited, not rejected).
+    #[serde(default)]
+    pub acoustid_key: Option<String>,
+    /// TMDB API Read Access Token (v4); sent as an Authorization Bearer
+    /// header, never as a URL query parameter. Absent = movie/secondary-TV
+    /// metadata resolution is unavailable.
+    #[serde(default)]
+    pub tmdb_key: Option<String>,
+    /// TheTVDB API key. Absent = TV metadata resolution is unavailable.
+    #[serde(default)]
+    pub tvdb_key: Option<String>,
+    /// Comic Vine API key. Absent = comic metadata resolution is
+    /// unavailable.
+    #[serde(default)]
+    pub comicvine_key: Option<String>,
+    /// Google Books API key. Absent = the Google Books fallback (used when
+    /// the canonical book provider returns nothing) runs unauthenticated
+    /// (rate-limited, not rejected) — keyless book lookups still work via
+    /// OpenLibrary.
+    #[serde(default)]
+    pub google_books_key: Option<String>,
 }
 
 fn default_provider_response_max_bytes() -> u64 {
     10 * 1024 * 1024
+}
+
+impl std::fmt::Debug for EpignosisConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EpignosisConfig")
+            .field("cache_ttl_secs", &self.cache_ttl_secs)
+            .field("max_retries", &self.max_retries)
+            .field("provider_timeout_secs", &self.provider_timeout_secs)
+            .field(
+                "fingerprint_accept_threshold",
+                &self.fingerprint_accept_threshold,
+            )
+            .field(
+                "fingerprint_ambiguous_threshold",
+                &self.fingerprint_ambiguous_threshold,
+            )
+            .field(
+                "provider_response_max_bytes",
+                &self.provider_response_max_bytes,
+            )
+            .field(
+                "acoustid_key",
+                &self.acoustid_key.as_ref().map(|_| "[redacted]"),
+            )
+            .field("tmdb_key", &self.tmdb_key.as_ref().map(|_| "[redacted]"))
+            .field("tvdb_key", &self.tvdb_key.as_ref().map(|_| "[redacted]"))
+            .field(
+                "comicvine_key",
+                &self.comicvine_key.as_ref().map(|_| "[redacted]"),
+            )
+            .field(
+                "google_books_key",
+                &self.google_books_key.as_ref().map(|_| "[redacted]"),
+            )
+            .finish()
+    }
 }
 
 impl Default for EpignosisConfig {
@@ -231,6 +289,11 @@ impl Default for EpignosisConfig {
             fingerprint_accept_threshold: 0.8,
             fingerprint_ambiguous_threshold: 0.5,
             provider_response_max_bytes: default_provider_response_max_bytes(),
+            acoustid_key: None,
+            tmdb_key: None,
+            tvdb_key: None,
+            comicvine_key: None,
+            google_books_key: None,
         }
     }
 }

--- a/crates/horismos/src/validation.rs
+++ b/crates/horismos/src/validation.rs
@@ -18,6 +18,7 @@ pub fn validate_config(config: &Config) -> Result<Vec<ValidationWarning>, Horism
     validate_timeouts(config)?;
     validate_limits(config)?;
     validate_token_ttls(config)?;
+    validate_provider_credentials(config, &mut warnings)?;
     collect_library_warnings(config, &mut warnings);
 
     Ok(warnings)
@@ -120,6 +121,75 @@ fn validate_jwt_secret(config: &Config) -> Result<(), HorismosError> {
         .fail();
     }
     Ok(())
+}
+
+// #578: metadata-provider API credentials. Keyless operation is a
+// legitimate posture (MusicBrainz + OpenLibrary need no key at all, and
+// Google Books falls back to unauthenticated/rate-limited requests) — an
+// absent key is a WARNING naming the degraded capability, never an error.
+// An explicitly-set placeholder (empty string, "changeme", "default") IS an
+// error: it can only come from a botched config edit, never from simply
+// omitting the field.
+fn validate_provider_credentials(
+    config: &Config,
+    warnings: &mut Vec<ValidationWarning>,
+) -> Result<(), HorismosError> {
+    validate_credential(
+        "epignosis.acoustid_key",
+        config.epignosis.acoustid_key.as_deref(),
+        "AcoustID fingerprint identification unavailable",
+        warnings,
+    )?;
+    validate_credential(
+        "epignosis.tmdb_key",
+        config.epignosis.tmdb_key.as_deref(),
+        "movie and secondary TV metadata resolution unavailable",
+        warnings,
+    )?;
+    validate_credential(
+        "epignosis.tvdb_key",
+        config.epignosis.tvdb_key.as_deref(),
+        "TV metadata resolution unavailable",
+        warnings,
+    )?;
+    validate_credential(
+        "epignosis.comicvine_key",
+        config.epignosis.comicvine_key.as_deref(),
+        "comic metadata resolution unavailable",
+        warnings,
+    )?;
+    validate_credential(
+        "epignosis.google_books_key",
+        config.epignosis.google_books_key.as_deref(),
+        "Google Books fallback runs unauthenticated and rate-limited",
+        warnings,
+    )?;
+    Ok(())
+}
+
+fn validate_credential(
+    field: &str,
+    value: Option<&str>,
+    absent_degrades: &str,
+    warnings: &mut Vec<ValidationWarning>,
+) -> Result<(), HorismosError> {
+    match value {
+        None => {
+            warnings.push(ValidationWarning {
+                field: field.to_string(),
+                message: format!("{field} unset — {absent_degrades}"),
+            });
+            Ok(())
+        }
+        Some(v) if v.is_empty() || v == "changeme" || v == "default" => ValidationSnafu {
+            message: format!(
+                "{field} must not be an empty string or a placeholder value — set a real key, \
+                 or remove the field entirely for keyless operation"
+            ),
+        }
+        .fail(),
+        Some(_) => Ok(()),
+    }
 }
 
 fn validate_ports(config: &Config) -> Result<(), HorismosError> {

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -104,13 +104,14 @@ from the new section on change (`SectionWatcher::changed()`).
 | `watcher_debounce_ms` | LIVE |
 | `scan_concurrency` | LIVE |
 
-### epignosis — LIVE (resolver REBUILD, step 8) except three UNWIRED
+### epignosis — LIVE (resolver REBUILD, step 8) except one UNWIRED
 
-| Field | Class |
-|---|---|
-| `cache_ttl_secs` / `provider_timeout_secs` / `provider_response_max_bytes` | LIVE — metadata cache RESETS on rebuild (logged) |
-| `max_retries` | UNWIRED — #575 |
-| `fingerprint_accept_threshold` / `fingerprint_ambiguous_threshold` | UNWIRED — #575, resolver never compares |
+| Field | Class | Mechanism |
+|---|---|---|
+| `cache_ttl_secs` / `provider_timeout_secs` / `provider_response_max_bytes` | LIVE | metadata cache RESETS on rebuild (logged) |
+| `acoustid_key` / `tmdb_key` / `tvdb_key` / `comicvine_key` / `google_books_key` | LIVE | #578 — resolver rebuild re-derives `ProviderCredentials::from(&new_cfg)`; key rotation is live for free |
+| `max_retries` | UNWIRED | #575 |
+| `fingerprint_accept_threshold` / `fingerprint_ambiguous_threshold` | LIVE | #575 — `merge_lookup_matches` classifies every fingerprint lookup against both thresholds (accepted / ambiguous-held / dropped) |
 
 ### kritike
 


### PR DESCRIPTION
**#578** — metadata provider API keys (acoustid/tmdb/tvdb/comicvine/google_books) had no config surface, so operators couldn't set their own keys. Adds 5 `Option<String>` fields to `EpignosisConfig` (redacting Debug — values never logged), validation (reject empty/placeholder; absent key → capability-naming warning, since keyless operation is legitimate), a `From<&EpignosisConfig>` mapping, and both archon construction sites now build credentials from config — so key rotation is live via the existing rebuild supervisor.

Also wires the two dead fingerprint thresholds (part of #575): `merge_lookup_matches` now classifies the best AcoustID match (>=accept → applied, >=ambiguous → held candidate via a new `match_status`, <ambiguous → dropped) instead of returning a 0.0-confidence garbage match as-is.

Gate green (2067 tests); validation, redaction, From-mapping, fingerprint-classification, and supervisor-rebuild tests added.

Closes #578