### PR TITLE
fix(komide,paroche,archon): reactive feed subscription and episode auto-download

### DIFF
--- a/crates/apotheke/src/repo/podcast.rs
+++ b/crates/apotheke/src/repo/podcast.rs
@@ -243,6 +243,29 @@ pub async fn update_episode(
     super::require_affected(result, "podcast_episodes", super::id_hex(id))
 }
 
+/// Persist a downloaded episode's local file location and size, leaving the
+/// listen state untouched (unlike `update_episode`, which writes it).
+pub async fn set_episode_file(
+    pool: &SqlitePool,
+    id: &[u8],
+    file_path: &str,
+    file_size_bytes: i64,
+) -> Result<(), DbError> {
+    let result = sqlx::query(
+        "UPDATE podcast_episodes SET file_path = ?, file_size_bytes = ?
+         WHERE id = ?",
+    )
+    .bind(file_path)
+    .bind(file_size_bytes)
+    .bind(id)
+    .execute(pool)
+    .await
+    .context(QuerySnafu {
+        table: "podcast_episodes",
+    })?;
+    super::require_affected(result, "podcast_episodes", super::id_hex(id))
+}
+
 pub async fn delete_episode(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
     let result = sqlx::query("DELETE FROM podcast_episodes WHERE id = ?")
         .bind(id)
@@ -476,6 +499,39 @@ mod tests {
             added_at: now(),
         };
         insert_episode(pool, &ep).await.unwrap();
+    }
+
+    // -- set_episode_file --
+
+    #[tokio::test]
+    async fn set_episode_file_updates_path_and_size_but_not_listened() {
+        let pool = setup().await;
+        let sub_id = seed_subscription(&pool, "https://example.com/f.xml").await;
+        seed_episode(&pool, &sub_id, "ep-file-001").await;
+        let ep_id = list_episodes(&pool, &sub_id, 1, 0).await.unwrap()[0]
+            .id
+            .clone();
+
+        set_episode_file(&pool, &ep_id, "/data/podcasts/ep.mp3", 12345)
+            .await
+            .unwrap();
+
+        let ep = get_episode(&pool, &ep_id).await.unwrap().unwrap();
+        assert_eq!(ep.file_path.as_deref(), Some("/data/podcasts/ep.mp3"));
+        assert_eq!(ep.file_size_bytes, Some(12345));
+        assert_eq!(
+            ep.listened, 0,
+            "file bookkeeping must not touch listen state"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_episode_file_nonexistent_returns_not_found() {
+        let pool = setup().await;
+        let err = set_episode_file(&pool, &make_id(), "/x.mp3", 1)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DbError::NotFound { .. }));
     }
 
     // -- episode_guid_exists dedup guard --

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -15,9 +15,9 @@ use komide::FeedSchedulerService;
 use komide::scheduler::FeedScheduler;
 use kritike::DefaultCurationService;
 use paroche::state::{
-    AppState, DynCurationService, DynDownloadEngine, DynExternalIntegration, DynMetadataResolver,
-    DynQueueManager, DynRequestService, DynSearchService, DynSubtitleService, RequestServiceFut,
-    ServiceError, ServiceFut,
+    AppState, DynCurationService, DynDownloadEngine, DynExternalIntegration, DynFeedService,
+    DynMetadataResolver, DynQueueManager, DynRequestService, DynSearchService, DynSubtitleService,
+    RequestServiceFut, ServiceError, ServiceFut,
 };
 use prostheke::providers::Provider;
 use prostheke::{SubtitleManager, SubtitleService};
@@ -26,6 +26,7 @@ use syndesmos::{ScrobbleClient, ScrobbleClientBuilder};
 use syntaxis::{CompletedDownload, DownloadQueue, QueueManager};
 use themelion::{MediaId, MediaType, create_event_bus};
 use tokio::signal::unix::SignalKind;
+use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info};
@@ -635,6 +636,125 @@ impl ExternalAdapter {
 
 impl DynExternalIntegration for ExternalAdapter {}
 
+/// Swappable behind a std `RwLock` (never held across an .await — every
+/// method snapshots the Arc and drops the guard before any async work) so
+/// the feed supervisor can swap in a rebuilt `FeedSchedulerService` on a
+/// `komide.*` change while paroche's routes keep delegating to the live
+/// instance (pattern: `MetadataAdapter`/`ExternalAdapter`). On a #577
+/// FeedSetChanged re-enumeration the service is deliberately NOT swapped —
+/// reuse keeps its etag/last-modified cache and reqwest client warm.
+struct FeedsAdapter {
+    inner: std::sync::RwLock<Arc<FeedSchedulerService>>,
+    /// Poll-task count of the live scheduler generation, maintained by the
+    /// feed supervisor after every (re)build — construction-time
+    /// introspection for the #577 re-enumeration tests, sibling of
+    /// `FeedScheduler::task_count`.
+    poll_tasks: std::sync::atomic::AtomicUsize,
+}
+
+impl FeedsAdapter {
+    fn new(service: Arc<FeedSchedulerService>, poll_tasks: usize) -> Self {
+        Self {
+            inner: std::sync::RwLock::new(service),
+            poll_tasks: std::sync::atomic::AtomicUsize::new(poll_tasks),
+        }
+    }
+
+    fn snapshot(&self) -> Arc<FeedSchedulerService> {
+        let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        Arc::clone(&guard)
+    }
+
+    /// Swaps the live feed service. Called by archon's feed supervisor
+    /// after a rebuild on a `komide.*` change.
+    fn set_service(&self, new: Arc<FeedSchedulerService>) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        *guard = new;
+    }
+
+    fn set_poll_tasks(&self, count: usize) {
+        self.poll_tasks
+            .store(count, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn poll_tasks(&self) -> usize {
+        self.poll_tasks.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl DynFeedService for FeedsAdapter {
+    fn subscribe_podcast(
+        &self,
+        url: String,
+        title: Option<String>,
+        auto_download: Option<bool>,
+    ) -> ServiceFut<themelion::FeedId> {
+        let service = self.snapshot();
+        Box::pin(async move {
+            service
+                .subscribe_podcast(&url, title.as_deref(), auto_download)
+                .await
+                .map_err(feed_error)
+        })
+    }
+
+    fn subscribe_news(
+        &self,
+        url: String,
+        title: Option<String>,
+        category: Option<String>,
+    ) -> ServiceFut<themelion::FeedId> {
+        let service = self.snapshot();
+        Box::pin(async move {
+            service
+                .subscribe_news(&url, title.as_deref(), category.as_deref())
+                .await
+                .map_err(feed_error)
+        })
+    }
+
+    fn unsubscribe(&self, feed_id: themelion::FeedId) -> ServiceFut<()> {
+        let service = self.snapshot();
+        Box::pin(async move { service.unsubscribe(feed_id).await.map_err(feed_error) })
+    }
+
+    fn download_episode(&self, episode_id: themelion::EpisodeId) -> ServiceFut<()> {
+        let service = self.snapshot();
+        Box::pin(async move {
+            // WHY preflight-then-spawn: the HTTP caller gets a synchronous
+            // 404/422 for a bad episode, while the transfer itself (which
+            // can outlive any API timeout) completes in the background.
+            service
+                .episode_downloadable(episode_id)
+                .await
+                .map_err(feed_error)?;
+            tokio::spawn(
+                async move {
+                    if let Err(e) = service.download_episode_by_id(episode_id).await {
+                        tracing::error!(episode_id = %episode_id, error = %e, "episode download failed");
+                    }
+                }
+                .instrument(tracing::info_span!("episode_download")),
+            );
+            Ok(())
+        })
+    }
+}
+
+fn feed_error(error: komide::KomideError) -> ServiceError {
+    use komide::KomideError as E;
+    match &error {
+        E::FeedNotFound { .. } | E::EpisodeNotFound { .. } => ServiceError::NotFound,
+        E::InvalidUrl { .. }
+        | E::FeedParse { .. }
+        | E::FeedFetch { .. }
+        | E::ResponseTooLarge { .. }
+        | E::EpisodeNotDownloadable { .. } => ServiceError::InvalidInput(error.to_string()),
+        _ => ServiceError::Internal(error.to_string()),
+    }
+}
+
 struct SubtitleAdapter {
     service: Arc<SubtitleManager>,
     read: sqlx::SqlitePool,
@@ -943,16 +1063,25 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // old poll tasks and rebuilds the bounded client + service + scheduler
     // together (`FeedSchedulerService` owns its own `KomideConfig`, so
     // rebuilding the scheduler alone would leave it reading stale config);
-    // process shutdown performs the final teardown (replaces the old direct
-    // `feed_scheduler.shutdown()` call in cleanup below).
+    // a `FeedSetChanged` bus event (#577) re-enumerates the poll tasks
+    // reusing the service; process shutdown performs the final teardown
+    // (replaces the old direct `feed_scheduler.shutdown()` call in cleanup
+    // below). `FeedsAdapter` exposes the live service to paroche's
+    // subscription routes and is the swap point on rebuild.
     let db_pools = clone_db_pools(&db);
-    let feed_scheduler = start_feed_scheduler(&boot_config.komide, &event_tx, &db_pools).await?;
+    let (feed_service, feed_scheduler) =
+        start_feed_scheduler(&boot_config.komide, &event_tx, &db_pools).await?;
+    let feeds_adapter = Arc::new(FeedsAdapter::new(feed_service, feed_scheduler.task_count()));
     let feed_supervisor = tokio::spawn(
         run_feed_supervisor(
-            feed_scheduler,
-            boot_config.komide.clone(),
+            FeedSupervision {
+                scheduler: feed_scheduler,
+                feeds: Arc::clone(&feeds_adapter),
+                komide: boot_config.komide.clone(),
+            },
             config_handle.clone(),
             event_tx.clone(),
+            event_tx.subscribe(),
             db_pools,
             shutdown_token.child_token(),
         )
@@ -1155,6 +1284,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         external: external_adapter,
         subtitles,
         renderers: renderer_registry,
+        feeds: feeds_adapter,
     };
     let router = paroche::build_router(state);
 
@@ -1577,12 +1707,15 @@ fn clone_db_pools(db: &apotheke::DbPools) -> apotheke::DbPools {
 /// Builds the bounded reqwest client + `FeedSchedulerService` + started
 /// `FeedScheduler` FROM one komide config — the full construction boot
 /// performs at step 11 in `run_serve`, extracted so the rebuild supervisor
-/// below and boot share one code path.
+/// below and boot share one code path. Returns the service alongside the
+/// scheduler so the #577 FeedSetChanged re-enumeration can restart the
+/// scheduler REUSING the service (keeping its etag/last-modified cache and
+/// reqwest client), and so `FeedsAdapter` can expose it to paroche's routes.
 async fn start_feed_scheduler(
     config: &horismos::KomideConfig,
     event_tx: &themelion::EventSender,
     db: &apotheke::DbPools,
-) -> Result<FeedScheduler, HostError> {
+) -> Result<(Arc<FeedSchedulerService>, FeedScheduler), HostError> {
     // WHY a bounded client: an unbounded client left `fetch_timeout_secs`
     // configured but unenforced — a stalled feed host could block
     // `response.chunk().await` forever inside `komide::fetch::fetch_feed`,
@@ -1597,9 +1730,10 @@ async fn start_feed_scheduler(
         client,
         config.clone(),
     ));
-    FeedScheduler::start(service, config.clone(), clone_db_pools(db))
+    let scheduler = FeedScheduler::start(Arc::clone(&service), config.clone(), clone_db_pools(db))
         .await
-        .context(FeedSchedulerSnafu)
+        .context(FeedSchedulerSnafu)?;
+    Ok((service, scheduler))
 }
 
 /// Attempts to build a fresh instance FROM `new_cfg`. On failure, logs and
@@ -1716,60 +1850,156 @@ async fn run_scanner_supervisor(
     }
 }
 
-/// Runs the `komide.*` feed scheduler under a REBUILD-class supervisor: on a
-/// section change it aborts the old scheduler's poll tasks and rebuilds the
-/// bounded reqwest client + `FeedSchedulerService` + `FeedScheduler` together
-/// via `start_feed_scheduler` — `FeedSchedulerService` owns its own
-/// `KomideConfig`, so rebuilding the scheduler alone would leave it reading a
-/// stale config. A failed rebuild rolls back to the PREVIOUS komide config
+/// How long the feed supervisor coalesces a burst of `FeedSetChanged`
+/// events (e.g. a bulk subscription import) into ONE re-enumeration.
+const FEED_SET_COALESCE_WINDOW: std::time::Duration = std::time::Duration::from_millis(300);
+
+/// Drains the event receiver until the coalescing window elapses. A single
+/// fixed deadline (not a rolling per-recv timeout) bounds the drain, so a
+/// chatty bus of unrelated events cannot postpone re-enumeration.
+async fn drain_feed_set_events(rx: &mut themelion::EventReceiver) {
+    let deadline = tokio::time::Instant::now() + FEED_SET_COALESCE_WINDOW;
+    loop {
+        match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Ok(Ok(_)) | Ok(Err(RecvError::Lagged(_))) => continue,
+            Ok(Err(RecvError::Closed)) | Err(_) => return,
+        }
+    }
+}
+
+/// Boot-time state the feed supervisor takes ownership of: the initial
+/// scheduler generation, the adapter it swaps on rebuild, and the komide
+/// config that generation reflects (sibling of `SyndesmosGeneration`).
+struct FeedSupervision {
+    scheduler: FeedScheduler,
+    feeds: Arc<FeedsAdapter>,
+    komide: horismos::KomideConfig,
+}
+
+/// Runs the `komide.*` feed scheduler under a REBUILD-class supervisor with
+/// two rebuild triggers:
+///
+/// - **Config change** (`komide.*`): aborts the old scheduler's poll tasks
+///   and rebuilds the bounded reqwest client + `FeedSchedulerService` +
+///   `FeedScheduler` together via `start_feed_scheduler` —
+///   `FeedSchedulerService` owns its own `KomideConfig`, so rebuilding the
+///   scheduler alone would leave it reading a stale config. The fresh
+///   service is swapped into `FeedsAdapter` for paroche's routes.
+/// - **`FeedSetChanged` event** (#577): a subscription was added, removed,
+///   or flipped at runtime. After a short coalescing drain the scheduler is
+///   restarted REUSING the existing service (etag/last-modified cache and
+///   client survive) — `FeedScheduler::start` re-pages the DB, so the fresh
+///   task set reflects the current subscription rows. A `Lagged` receiver
+///   re-enumerates conservatively: enumeration derives FROM the DB, so a
+///   missed event self-heals.
+///
+/// A failed rebuild rolls back to the PREVIOUS komide config
 /// (`rebuild_with_rollback`); if the rollback ALSO fails the feed scheduler
 /// stays down — loudly logged — while the rest of the server keeps serving.
-///
-/// NOTE: `FeedScheduler::start` re-pages every feed row FROM the DB on every
-/// call, so a feed subscribed since boot happens to get a poll loop after ANY
-/// rebuild. This is a side effect of the rebuild, NOT a fix for the
-/// never-polled runtime-subscribed-feeds defect — that stays open as #577.
 async fn run_feed_supervisor(
-    initial: FeedScheduler,
-    initial_komide: horismos::KomideConfig,
+    supervision: FeedSupervision,
     config: horismos::ConfigHandle,
     event_tx: themelion::EventSender,
+    mut event_rx: themelion::EventReceiver,
     db: apotheke::DbPools,
     shutdown: CancellationToken,
 ) {
+    let FeedSupervision {
+        scheduler: initial,
+        feeds,
+        komide: initial_komide,
+    } = supervision;
     let mut watcher = config.watch_section(|c| &c.komide);
     let mut scheduler = Some(initial);
+    let mut service = feeds.snapshot();
     let mut current = initial_komide;
 
     loop {
-        let changed = tokio::select! {
+        tokio::select! {
             biased;
             _ = shutdown.cancelled() => break,
-            changed = watcher.changed() => changed,
-        };
-        let Some(new_komide) = changed else {
-            shutdown.cancelled().await;
-            break;
-        };
+            changed = watcher.changed() => {
+                let Some(new_komide) = changed else {
+                    shutdown.cancelled().await;
+                    break;
+                };
 
-        tracing::info!(
-            subsystem = "feed_scheduler",
-            "komide config changed  -  rebuilding feed scheduler"
-        );
-        if let Some(old) = scheduler.take() {
-            old.shutdown();
+                tracing::info!(
+                    subsystem = "feed_scheduler",
+                    "komide config changed  -  rebuilding feed scheduler"
+                );
+                if let Some(old) = scheduler.take() {
+                    old.shutdown();
+                }
+                let event_tx_for_build = event_tx.clone();
+                let db_for_build = clone_db_pools(&db);
+                let (rebuilt, effective) =
+                    rebuild_with_rollback("feed_scheduler", new_komide, current, move |cfg| {
+                        let event_tx = event_tx_for_build.clone();
+                        let db = clone_db_pools(&db_for_build);
+                        async move { start_feed_scheduler(&cfg, &event_tx, &db).await }
+                    })
+                    .await;
+                match rebuilt {
+                    Some((new_service, new_scheduler)) => {
+                        service = new_service;
+                        feeds.set_service(Arc::clone(&service));
+                        scheduler = Some(new_scheduler);
+                    }
+                    // NOTE: on a total rebuild failure the ADAPTER keeps the
+                    // old service — paroche's subscribe/download routes stay
+                    // functional even while no poll tasks run.
+                    None => scheduler = None,
+                }
+                feeds.set_poll_tasks(scheduler.as_ref().map_or(0, FeedScheduler::task_count));
+                current = effective;
+            }
+            event = event_rx.recv() => {
+                let reenumerate = match event {
+                    Ok(themelion::HarmoniaEvent::FeedSetChanged { .. })
+                    | Err(RecvError::Lagged(_)) => true,
+                    Ok(_) => false,
+                    Err(RecvError::Closed) => {
+                        // INVARIANT: unreachable while this task holds
+                        // `event_tx`; resubscribe defensively so a logic
+                        // change can never spin a hot recv loop.
+                        event_rx = event_tx.subscribe();
+                        false
+                    }
+                };
+                if !reenumerate {
+                    continue;
+                }
+                drain_feed_set_events(&mut event_rx).await;
+
+                tracing::info!(
+                    subsystem = "feed_scheduler",
+                    "feed set changed  -  re-enumerating poll tasks"
+                );
+                if let Some(old) = scheduler.take() {
+                    old.shutdown();
+                }
+                // WHY the same config on both slots: this is a re-enumeration,
+                // not a config change — rollback degrades to one retry against
+                // the identical (already-proven) config.
+                let service_for_build = Arc::clone(&service);
+                let db_for_build = clone_db_pools(&db);
+                let (rebuilt, effective) = rebuild_with_rollback(
+                    "feed_scheduler",
+                    current.clone(),
+                    current.clone(),
+                    move |cfg| {
+                        let service = Arc::clone(&service_for_build);
+                        let db = clone_db_pools(&db_for_build);
+                        async move { FeedScheduler::start(service, cfg, db).await }
+                    },
+                )
+                .await;
+                scheduler = rebuilt;
+                feeds.set_poll_tasks(scheduler.as_ref().map_or(0, FeedScheduler::task_count));
+                current = effective;
+            }
         }
-        let event_tx_for_build = event_tx.clone();
-        let db_for_build = clone_db_pools(&db);
-        let (rebuilt, effective) =
-            rebuild_with_rollback("feed_scheduler", new_komide, current, move |cfg| {
-                let event_tx = event_tx_for_build.clone();
-                let db = clone_db_pools(&db_for_build);
-                async move { start_feed_scheduler(&cfg, &event_tx, &db).await }
-            })
-            .await;
-        scheduler = rebuilt;
-        current = effective;
     }
 
     if let Some(scheduler) = scheduler {
@@ -3579,16 +3809,21 @@ mod rebuild_supervisor_tests {
             PathBuf::from("unused.toml"),
             ConfigOverrides::default(),
         );
-        let initial = start_feed_scheduler(&boot_config.komide, &event_tx, &db)
+        let (service, initial) = start_feed_scheduler(&boot_config.komide, &event_tx, &db)
             .await
             .expect("initial scheduler starts cleanly");
+        let feeds = Arc::new(FeedsAdapter::new(service, initial.task_count()));
 
         let shutdown = CancellationToken::new();
         let supervisor = tokio::spawn(run_feed_supervisor(
-            initial,
-            boot_config.komide.clone(),
+            FeedSupervision {
+                scheduler: initial,
+                feeds: Arc::clone(&feeds),
+                komide: boot_config.komide.clone(),
+            },
             handle,
-            event_tx,
+            event_tx.clone(),
+            event_tx.subscribe(),
             clone_db_pools(&db),
             shutdown.clone(),
         ));
@@ -3628,9 +3863,10 @@ mod rebuild_supervisor_tests {
         };
         let (event_tx, _event_rx) = themelion::create_event_bus(16);
 
-        let before = start_feed_scheduler(&horismos::KomideConfig::default(), &event_tx, &db)
-            .await
-            .expect("scheduler starts with zero subscriptions");
+        let (_service, before) =
+            start_feed_scheduler(&horismos::KomideConfig::default(), &event_tx, &db)
+                .await
+                .expect("scheduler starts with zero subscriptions");
         assert_eq!(before.task_count(), 0);
         before.shutdown();
 
@@ -3640,7 +3876,7 @@ mod rebuild_supervisor_tests {
             podcast_poll_interval_minutes: 45,
             ..Default::default()
         };
-        let after = start_feed_scheduler(&changed, &event_tx, &db)
+        let (_service, after) = start_feed_scheduler(&changed, &event_tx, &db)
             .await
             .expect("scheduler starts with the new subscription");
         assert_eq!(
@@ -3649,6 +3885,137 @@ mod rebuild_supervisor_tests {
             "a rebuild FROM the new config must re-page the DB and pick up the subscription"
         );
         after.shutdown();
+    }
+
+    /// #577: the EXACT re-enumeration the feed supervisor performs on a
+    /// `FeedSetChanged` event — `rebuild_with_rollback` +
+    /// `FeedScheduler::start` REUSING the existing service — picks up a
+    /// subscription added after boot, with NO config change involved.
+    /// Constructor-visible via `task_count()`, no polling/timing involved.
+    #[tokio::test]
+    async fn feed_reenumeration_reuses_service_and_picks_up_new_subscription() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        apotheke::migrate::MIGRATOR
+            .run(&pool)
+            .await
+            .expect("migrate");
+        let db = apotheke::DbPools {
+            read: pool.clone(),
+            write: pool.clone(),
+        };
+        let (event_tx, _event_rx) = themelion::create_event_bus(16);
+        let komide_config = horismos::KomideConfig::default();
+
+        let (service, before) = start_feed_scheduler(&komide_config, &event_tx, &db)
+            .await
+            .expect("scheduler starts with zero subscriptions");
+        assert_eq!(before.task_count(), 0);
+        before.shutdown();
+
+        seed_podcast_subscription(&pool, "https://example.com/runtime-sub.xml").await;
+
+        let service_for_build = Arc::clone(&service);
+        let db_for_build = clone_db_pools(&db);
+        let (rebuilt, _effective) = rebuild_with_rollback(
+            "feed_scheduler",
+            komide_config.clone(),
+            komide_config,
+            move |cfg| {
+                let service = Arc::clone(&service_for_build);
+                let db = clone_db_pools(&db_for_build);
+                async move { FeedScheduler::start(service, cfg, db).await }
+            },
+        )
+        .await;
+        let after = rebuilt.expect("re-enumeration succeeds");
+        assert_eq!(
+            after.task_count(),
+            1,
+            "re-enumeration must re-page the DB and schedule the runtime subscription"
+        );
+        after.shutdown();
+    }
+
+    /// #577 end-to-end at the supervisor: a REAL `run_feed_supervisor`,
+    /// driven by a `FeedSetChanged` bus event (NO config reload — the
+    /// ConfigManager is never replaced), re-enumerates the poll tasks and
+    /// picks up a runtime-added subscription, REUSING the boot service
+    /// (same Arc identity in the adapter), then joins cleanly.
+    #[tokio::test]
+    async fn feed_supervisor_reenumerates_on_feed_set_changed_without_config_reload() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        apotheke::migrate::MIGRATOR
+            .run(&pool)
+            .await
+            .expect("migrate");
+        let db = apotheke::DbPools {
+            read: pool.clone(),
+            write: pool.clone(),
+        };
+
+        let (event_tx, _event_rx) = themelion::create_event_bus(16);
+        let boot_config = feed_test_config(600);
+        let (_manager, handle) = ConfigManager::new(
+            boot_config.clone(),
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+        let (service, initial) = start_feed_scheduler(&boot_config.komide, &event_tx, &db)
+            .await
+            .expect("initial scheduler starts cleanly");
+        let boot_service = Arc::clone(&service);
+        let feeds = Arc::new(FeedsAdapter::new(service, initial.task_count()));
+        assert_eq!(feeds.poll_tasks(), 0);
+
+        // WHY: the receiver is subscribed HERE (before spawn), so the event
+        // sent below cannot race the supervisor task's startup.
+        let supervisor_rx = event_tx.subscribe();
+        let shutdown = CancellationToken::new();
+        let supervisor = tokio::spawn(run_feed_supervisor(
+            FeedSupervision {
+                scheduler: initial,
+                feeds: Arc::clone(&feeds),
+                komide: boot_config.komide.clone(),
+            },
+            handle,
+            event_tx.clone(),
+            supervisor_rx,
+            clone_db_pools(&db),
+            shutdown.clone(),
+        ));
+
+        seed_podcast_subscription(&pool, "https://example.com/runtime-sub.xml").await;
+        event_tx
+            .send(themelion::HarmoniaEvent::FeedSetChanged {
+                feed_id: themelion::FeedId::new(),
+                media_type: themelion::MediaType::Podcast,
+            })
+            .expect("supervisor holds a live receiver");
+
+        // Bounded real wait covering the coalescing window + rebuild.
+        let observed = tokio::time::timeout(Duration::from_secs(5), async {
+            while feeds.poll_tasks() != 1 {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(
+            observed.is_ok(),
+            "FeedSetChanged must re-enumerate the poll set without a config reload"
+        );
+        assert!(
+            Arc::ptr_eq(&boot_service, &feeds.snapshot()),
+            "re-enumeration must REUSE the service (etag cache + client), not rebuild it"
+        );
+
+        shutdown.cancel();
+        supervisor
+            .await
+            .expect("feed supervisor joins cleanly after a re-enumeration");
     }
 
     // ── epignosis supervisor: real MetadataAdapter + real ConfigManager ────

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -101,14 +101,18 @@ pub const LIVE: &[&str] = &[
     "prostheke.opensubtitles.api_key",
     "prostheke.opensubtitles.rate_limit_per_second",
     "prostheke.opensubtitles.max_download_bytes",
-    // komide — step 6 (feed scheduler rebuild supervisor)
+    // komide — step 6 (feed scheduler rebuild supervisor); podcast_dir +
+    // max_episode_bytes joined via the #575 episode-download wire (read FROM
+    // the service's own config, which the supervisor rebuilds on change)
     "komide.podcast_poll_interval_minutes",
     "komide.news_poll_interval_minutes",
+    "komide.podcast_dir",
     "komide.news_retention_days",
     "komide.news_retention_articles",
     "komide.auto_download_latest_n",
     "komide.fetch_timeout_secs",
     "komide.max_feed_bytes",
+    "komide.max_episode_bytes",
     "komide.max_backoff_minutes",
     "komide.jitter_percent",
     // syndesmos — step 8 (REBUILD: client + handler respawn + adapter swap)
@@ -134,7 +138,7 @@ pub const LIVE: &[&str] = &[
     "aitesis.auto_approve_admins",
 ];
 
-/// Full dotted leaf paths with NO production consumer — the 31 dead-config
+/// Full dotted leaf paths with NO production consumer — the dead-config
 /// fields inventoried by #529's design pass and filed as harmonia issue
 /// #575. Each stays here (rather than silently vanishing from the schema)
 /// until #575 dispositions it: wired to a real consumer, or removed.
@@ -162,8 +166,6 @@ pub const UNWIRED: &[&str] = &[
     "syntaxis.stalled_download_timeout_hours", // #575
     "prostheke.opensubtitles.username", // #575
     "prostheke.opensubtitles.password", // #575
-    "komide.podcast_dir",            // #575
-    "komide.max_episode_bytes",      // #575
     "syndesmos.tidal.client_id",     // #575
     "syndesmos.tidal.client_secret", // #575
     "syndesmos.tidal.refresh_token", // #575

--- a/crates/komide/src/error.rs
+++ b/crates/komide/src/error.rs
@@ -58,6 +58,20 @@ pub enum KomideError {
         location: snafu::Location,
     },
 
+    #[snafu(display("episode not found: {episode_id}"))]
+    EpisodeNotFound {
+        episode_id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("episode {episode_id} has no audio enclosure to download"))]
+    EpisodeNotDownloadable {
+        episode_id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("retention error: {message}"))]
     RetentionViolation {
         message: String,

--- a/crates/komide/src/scheduler.rs
+++ b/crates/komide/src/scheduler.rs
@@ -103,10 +103,10 @@ impl FeedScheduler {
                     .context(DatabaseSnafu)?;
             let page_len = page.len();
 
+            // NOTE: every subscription is polled — `auto_download` is the
+            // episode-download COUNT, not a poll gate (#577 conflated the
+            // two, leaving auto_download=0 subscriptions permanently stale).
             for sub in page {
-                if sub.auto_download == 0 {
-                    continue;
-                }
                 let interval = config.podcast_poll_interval_minutes;
                 let state = FeedState::new(interval, &config);
                 let svc = service.clone();
@@ -415,6 +415,57 @@ mod tests {
             scheduler.handles.len(),
             total,
             "all feeds past the first page must be scheduled"
+        );
+        scheduler.shutdown();
+    }
+
+    #[tokio::test]
+    async fn auto_download_zero_subscription_still_gets_poll_loop() {
+        use apotheke::migrate::MIGRATOR;
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let db = DbPools {
+            read: pool.clone(),
+            write: pool.clone(),
+        };
+        let service_db = DbPools {
+            read: pool.clone(),
+            write: pool,
+        };
+
+        let sub = apotheke::repo::podcast::PodcastSubscription {
+            id: uuid::Uuid::new_v4().as_bytes().to_vec(),
+            feed_url: "https://example.com/no-auto-download.xml".to_string(),
+            title: Some("Poll Only".to_string()),
+            description: None,
+            author: None,
+            image_url: None,
+            language: None,
+            last_checked_at: None,
+            auto_download: 0,
+            quality_profile_id: None,
+            added_at: "2024-01-01T00:00:00Z".to_string(),
+        };
+        apotheke::repo::podcast::insert_subscription(&db.write, &sub)
+            .await
+            .unwrap();
+
+        let (tx, _rx) = themelion::aggelia::create_event_bus(64);
+        let service = std::sync::Arc::new(FeedSchedulerService::new(
+            service_db,
+            tx,
+            reqwest::Client::new(),
+            test_config(),
+        ));
+
+        let scheduler = FeedScheduler::start(service, test_config(), db)
+            .await
+            .unwrap();
+        assert_eq!(
+            scheduler.task_count(),
+            1,
+            "auto_download=0 means download nothing, NOT skip polling (#577)"
         );
         scheduler.shutdown();
     }

--- a/crates/komide/src/service/mod.rs
+++ b/crates/komide/src/service/mod.rs
@@ -3,15 +3,16 @@ use std::collections::HashMap;
 use apotheke::DbPools;
 use apotheke::repo::{news, podcast};
 use horismos::KomideConfig;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use themelion::aggelia::EventSender;
 use themelion::ids::{EpisodeId, FeedId, MediaId};
 use themelion::media::MediaType;
-use tracing::{debug, info, instrument, warn};
+use tracing::{Instrument, debug, info, instrument, warn};
 use uuid::Uuid;
 
 use crate::error::{
-    CorruptFeedIdSnafu, DatabaseSnafu, FeedNotFoundSnafu, InvalidUrlSnafu, KomideError,
+    CorruptFeedIdSnafu, DatabaseSnafu, EpisodeIoSnafu, EpisodeNotDownloadableSnafu,
+    EpisodeNotFoundSnafu, FeedNotFoundSnafu, InvalidUrlSnafu, KomideError,
 };
 use crate::fetch::{FetchResult, fetch_feed};
 use crate::news::apply_retention;
@@ -61,11 +62,17 @@ impl FeedSchedulerService {
     }
 
     /// Add a new podcast subscription.
+    ///
+    /// `auto_download` sets the subscription's episode-download COUNT:
+    /// `Some(false)` stores 0 (poll the feed, download nothing), anything
+    /// else stores the configured `auto_download_latest_n`. Polling never
+    /// depends on this value — every subscription gets a poll loop.
     #[instrument(skip(self), fields(url))]
     pub async fn subscribe_podcast(
         &self,
         url: &str,
         label: Option<&str>,
+        auto_download: Option<bool>,
     ) -> Result<FeedId, KomideError> {
         validate_url(url)?;
 
@@ -86,6 +93,10 @@ impl FeedSchedulerService {
         let id_bytes = feed_id.as_bytes().to_vec();
         let now = now_iso8601();
 
+        let auto_download_latest_n = match auto_download {
+            Some(false) => 0,
+            _ => self.config.auto_download_latest_n,
+        };
         let sub = podcast::PodcastSubscription {
             id: id_bytes.clone(),
             feed_url: url.to_string(),
@@ -97,7 +108,7 @@ impl FeedSchedulerService {
             image_url: parsed.image_url.clone(),
             language: None,
             last_checked_at: Some(now.clone()),
-            auto_download: i64::try_from(self.config.auto_download_latest_n).unwrap_or_default(), // WHY: auto_download_latest_n is a small config value; bounded within i64
+            auto_download: i64::try_from(auto_download_latest_n).unwrap_or_default(), // WHY: auto_download_latest_n is a small config value; bounded within i64
             quality_profile_id: None,
             added_at: now.clone(),
         };
@@ -105,10 +116,14 @@ impl FeedSchedulerService {
             .await
             .context(DatabaseSnafu)?;
 
+        self.emit_feed_set_changed(feed_id, MediaType::Podcast);
+
         // Insert initial episodes
         let new_count = self
             .insert_new_podcast_episodes(&id_bytes, &parsed.entries, &now)
             .await?;
+
+        self.spawn_auto_downloads(id_bytes, auto_download_latest_n);
 
         self.emit_feed_refreshed(feed_id, new_count, MediaType::Podcast);
         info!(feed_id = %feed_id, episodes = new_count, "podcast subscribed");
@@ -121,6 +136,7 @@ impl FeedSchedulerService {
         &self,
         url: &str,
         label: Option<&str>,
+        category: Option<&str>,
     ) -> Result<FeedId, KomideError> {
         validate_url(url)?;
 
@@ -147,7 +163,7 @@ impl FeedSchedulerService {
             url: url.to_string(),
             site_url: parsed.link.clone(),
             description: parsed.description.clone(),
-            category: None,
+            category: category.map(str::to_owned),
             icon_url: parsed.image_url.clone(),
             last_fetched_at: Some(now.clone()),
             fetch_interval_minutes: i64::try_from(self.config.news_poll_interval_minutes)
@@ -159,6 +175,8 @@ impl FeedSchedulerService {
         news::insert_feed(&self.db.write, &feed)
             .await
             .context(DatabaseSnafu)?;
+
+        self.emit_feed_set_changed(feed_id, MediaType::News);
 
         let new_count = self
             .insert_new_articles(&id_bytes, &parsed.entries, &now)
@@ -183,6 +201,7 @@ impl FeedSchedulerService {
             podcast::delete_subscription(&self.db.write, &id_bytes)
                 .await
                 .context(DatabaseSnafu)?;
+            self.emit_feed_set_changed(feed_id, MediaType::Podcast);
             return Ok(());
         }
 
@@ -195,6 +214,7 @@ impl FeedSchedulerService {
             news::delete_feed(&self.db.write, &id_bytes)
                 .await
                 .context(DatabaseSnafu)?;
+            self.emit_feed_set_changed(feed_id, MediaType::News);
             return Ok(());
         }
 
@@ -275,6 +295,21 @@ impl FeedSchedulerService {
         }
     }
 
+    /// Check an episode exists and carries a downloadable audio enclosure —
+    /// the cheap preflight paroche's episode-download route runs before
+    /// spawning the actual transfer.
+    pub async fn episode_downloadable(&self, episode_id: EpisodeId) -> Result<(), KomideError> {
+        self.episode_for_download(episode_id).await.map(|_| ())
+    }
+
+    /// Download one episode's audio enclosure into `podcast_dir`, persisting
+    /// the file location and size on the episode row. Returns bytes written.
+    #[instrument(skip(self))]
+    pub async fn download_episode_by_id(&self, episode_id: EpisodeId) -> Result<u64, KomideError> {
+        let (ep, url) = self.episode_for_download(episode_id).await?;
+        transfer_episode(&self.db, &self.client, &self.config, &ep, &url).await
+    }
+
     /// Mark a podcast episode or news article as consumed (listened/read).
     #[instrument(skip(self))]
     pub async fn mark_consumed(&self, item_id: MediaId) -> Result<(), KomideError> {
@@ -310,6 +345,56 @@ impl FeedSchedulerService {
     }
 
     // ── Private helpers ──────────────────────────────────────────────────────
+
+    async fn episode_for_download(
+        &self,
+        episode_id: EpisodeId,
+    ) -> Result<(podcast::PodcastEpisode, String), KomideError> {
+        let ep = podcast::get_episode(&self.db.read, episode_id.as_bytes())
+            .await
+            .context(DatabaseSnafu)?
+            .context(EpisodeNotFoundSnafu {
+                episode_id: episode_id.to_string(),
+            })?;
+        let url = ep
+            .enclosure_url
+            .clone()
+            .context(EpisodeNotDownloadableSnafu {
+                episode_id: episode_id.to_string(),
+            })?;
+        Ok((ep, url))
+    }
+
+    /// Fire-and-forget the initial episode downloads for a new subscription.
+    ///
+    /// WHY spawned: subscribe is HTTP-facing (paroche delegates to it) and
+    /// must return before the API timeout, while episode audio can be
+    /// arbitrarily large. The scheduler's refresh path downloads INLINE
+    /// instead — its poll task is the natural backpressure.
+    fn spawn_auto_downloads(&self, subscription_id: Vec<u8>, latest_n: u64) {
+        if latest_n == 0 {
+            return;
+        }
+        let db = DbPools {
+            read: self.db.read.clone(),
+            write: self.db.write.clone(),
+        };
+        let client = self.client.clone();
+        let config = self.config.clone();
+        tokio::spawn(
+            async move {
+                match download_latest_episodes(&db, &client, &config, &subscription_id, latest_n)
+                    .await
+                {
+                    Ok(count) => {
+                        info!(episodes = count, "initial episode auto-download complete");
+                    }
+                    Err(e) => warn!(error = %e, "initial episode auto-download failed"),
+                }
+            }
+            .instrument(tracing::info_span!("episode_auto_download")),
+        );
+    }
 
     async fn refresh_podcast_feed(
         &self,
@@ -363,6 +448,26 @@ impl FeedSchedulerService {
                 )
                 .await
                 .context(DatabaseSnafu)?;
+
+                if new_count > 0 {
+                    let latest_n = u64::try_from(sub.auto_download).unwrap_or_default(); // WHY: auto_download is a small episode count; a corrupt negative row means "download nothing"
+                    // WHY inline (not spawned): the caller is the scheduler's
+                    // per-feed poll task — awaiting here is the natural
+                    // backpressure for bulk audio transfers. A failed
+                    // download must not fail the refresh: the feed fetch
+                    // itself succeeded.
+                    if let Err(e) = download_latest_episodes(
+                        &self.db,
+                        &self.client,
+                        &self.config,
+                        &sub.id,
+                        latest_n,
+                    )
+                    .await
+                    {
+                        warn!(feed_id = %feed_id, error = %e, "episode auto-download after refresh failed");
+                    }
+                }
 
                 let total = podcast::count_episodes_for_subscription(&self.db.read, &sub.id)
                     .await
@@ -576,6 +681,15 @@ impl FeedSchedulerService {
             });
     }
 
+    fn emit_feed_set_changed(&self, feed_id: FeedId, media_type: MediaType) {
+        let _ = self
+            .event_tx
+            .send(themelion::aggelia::HarmoniaEvent::FeedSetChanged {
+                feed_id,
+                media_type,
+            });
+    }
+
     fn emit_episode_available(&self, subscription_id: FeedId, episode_id: EpisodeId, title: &str) {
         let _ = self
             .event_tx
@@ -585,6 +699,112 @@ impl FeedSchedulerService {
                 title: title.to_string(),
             });
     }
+}
+
+/// Download the audio enclosures of a subscription's most recent episodes
+/// (up to `latest_n`) that have no local file yet. A single failed episode
+/// is logged and skipped — one dead enclosure must not block the rest.
+/// Returns how many episode files were written.
+pub(crate) async fn download_latest_episodes(
+    db: &DbPools,
+    client: &reqwest::Client,
+    config: &KomideConfig,
+    subscription_id: &[u8],
+    latest_n: u64,
+) -> Result<usize, KomideError> {
+    if latest_n == 0 {
+        return Ok(0);
+    }
+    let total = podcast::count_episodes_for_subscription(&db.read, subscription_id)
+        .await
+        .context(DatabaseSnafu)?;
+    let total = usize::try_from(total).unwrap_or_default(); // WHY: a COUNT(*) is non-negative; a corrupt value degrades to "nothing to download"
+    let want = crate::podcast::episodes_to_download(total, latest_n);
+    if want == 0 {
+        return Ok(0);
+    }
+
+    let recent = podcast::list_recent_episodes(
+        &db.read,
+        subscription_id,
+        i64::try_from(want).unwrap_or(i64::MAX), // WHY: want is bounded by latest_n, a small config value
+    )
+    .await
+    .context(DatabaseSnafu)?;
+
+    let mut downloaded = 0;
+    for ep in recent {
+        if ep.file_path.is_some() {
+            continue;
+        }
+        let Some(url) = ep.enclosure_url.clone() else {
+            continue;
+        };
+        match transfer_episode(db, client, config, &ep, &url).await {
+            Ok(_) => downloaded += 1,
+            Err(e) => {
+                warn!(
+                    episode_title = ep.title.as_deref().unwrap_or(""),
+                    url,
+                    error = %e,
+                    "episode auto-download failed; continuing with the rest"
+                );
+            }
+        }
+    }
+    Ok(downloaded)
+}
+
+/// Fetch one episode's enclosure into `podcast_dir` (capped at
+/// `max_episode_bytes`) and persist the file location on the episode row.
+/// Returns the bytes written.
+async fn transfer_episode(
+    db: &DbPools,
+    client: &reqwest::Client,
+    config: &KomideConfig,
+    ep: &podcast::PodcastEpisode,
+    url: &str,
+) -> Result<u64, KomideError> {
+    tokio::fs::create_dir_all(&config.podcast_dir)
+        .await
+        .context(EpisodeIoSnafu {
+            path: config.podcast_dir.display().to_string(),
+        })?;
+    let dest = config.podcast_dir.join(episode_file_name(ep, url));
+    let written =
+        crate::fetch::download_episode(client, url, &dest, config.max_episode_bytes).await?;
+    podcast::set_episode_file(
+        &db.write,
+        &ep.id,
+        &dest.to_string_lossy(),
+        i64::try_from(written).unwrap_or(i64::MAX), // WHY: written is capped by max_episode_bytes, well within i64
+    )
+    .await
+    .context(DatabaseSnafu)?;
+    info!(path = %dest.display(), bytes = written, "episode downloaded");
+    Ok(written)
+}
+
+/// `{episode-uuid}.{ext}` — the uuid keeps names collision-free; the
+/// extension comes from the enclosure URL's path, falling back to `mp3`
+/// (the dominant podcast enclosure format).
+fn episode_file_name(ep: &podcast::PodcastEpisode, url: &str) -> String {
+    let id = Uuid::from_slice(&ep.id).unwrap_or(Uuid::nil());
+    format!("{id}.{}", enclosure_extension(url))
+}
+
+fn enclosure_extension(url: &str) -> String {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|parsed| {
+            let path = parsed.path().to_string();
+            let name = path.rsplit('/').next()?.to_string();
+            let (_, ext) = name.rsplit_once('.')?;
+            let ext = ext.to_ascii_lowercase();
+            (!ext.is_empty() && ext.len() <= 4 && ext.chars().all(|c| c.is_ascii_alphanumeric()))
+                .then_some(ext)
+        })
+        .unwrap_or_else(|| "mp3".to_string())
 }
 
 fn validate_url(input: &str) -> Result<(), KomideError> {

--- a/crates/komide/src/service/tests.rs
+++ b/crates/komide/src/service/tests.rs
@@ -54,6 +54,12 @@ fn atom_two_articles() -> Vec<u8> {
 }
 
 async fn setup() -> (FeedSchedulerService, themelion::aggelia::EventReceiver) {
+    setup_with_config(KomideConfig::default()).await
+}
+
+async fn setup_with_config(
+    config: KomideConfig,
+) -> (FeedSchedulerService, themelion::aggelia::EventReceiver) {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     MIGRATOR.run(&pool).await.unwrap();
     let db = DbPools {
@@ -62,7 +68,6 @@ async fn setup() -> (FeedSchedulerService, themelion::aggelia::EventReceiver) {
     };
     let (tx, rx) = create_event_bus(64);
     let client = reqwest::Client::new();
-    let config = KomideConfig::default();
     let svc = FeedSchedulerService::new(db, tx, client, config);
     (svc, rx)
 }
@@ -394,6 +399,404 @@ async fn refresh_news_feed_second_call_with_304_returns_zero_new_items() {
     );
 }
 
+// ── subscribe / unsubscribe (FeedSetChanged + auto_download semantics) ───
+
+/// RSS fixture whose items carry NO enclosures — subscribe tests that leave
+/// auto-download enabled use it so the spawned download task finds nothing
+/// to fetch (no network reachout from a unit test).
+const RSS_TWO_EPISODES_NO_ENCLOSURES: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Podcast</title>
+    <description>A test podcast feed</description>
+    <item>
+      <title>Episode 1</title>
+      <guid>ep-001</guid>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Episode 2</title>
+      <guid>ep-002</guid>
+      <pubDate>Tue, 02 Jan 2024 00:00:00 +0000</pubDate>
+    </item>
+  </channel>
+</rss>"#;
+
+/// RSS fixture with both enclosures pointing at the scripted test server.
+fn rss_two_episodes_with_enclosures(base: &str) -> Vec<u8> {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Podcast</title>
+    <description>A test podcast feed</description>
+    <item>
+      <title>Episode 1</title>
+      <guid>ep-001</guid>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+      <enclosure url="{base}/ep1.mp3" type="audio/mpeg" length="4"/>
+    </item>
+    <item>
+      <title>Episode 2</title>
+      <guid>ep-002</guid>
+      <pubDate>Tue, 02 Jan 2024 00:00:00 +0000</pubDate>
+      <enclosure url="{base}/ep2.mp3" type="audio/mpeg" length="4"/>
+    </item>
+  </channel>
+</rss>"#
+    )
+    .into_bytes()
+}
+
+fn drain_events(rx: &mut themelion::aggelia::EventReceiver) -> Vec<HarmoniaEvent> {
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    events
+}
+
+#[tokio::test]
+async fn subscribe_podcast_emits_feed_set_changed() {
+    let (svc, mut rx) = setup().await;
+    let (url, _handle) =
+        spawn_scripted_http(vec![http_response(200, "OK", &[], RSS_TWO_EPISODES)]).await;
+
+    let feed_id = svc
+        .subscribe_podcast(&url, None, Some(false))
+        .await
+        .unwrap();
+
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            HarmoniaEvent::FeedSetChanged {
+                feed_id: id,
+                media_type: MediaType::Podcast,
+            } if *id == feed_id
+        )),
+        "subscribe must emit FeedSetChanged so the supervisor re-enumerates"
+    );
+
+    let sub = podcast::get_subscription(&svc.db.read, feed_id.as_bytes())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        sub.auto_download, 0,
+        "auto_download=false must store an episode count of 0"
+    );
+}
+
+#[tokio::test]
+async fn subscribe_podcast_defaults_auto_download_count_from_config() {
+    let (svc, _rx) = setup().await;
+    let (url, _handle) = spawn_scripted_http(vec![http_response(
+        200,
+        "OK",
+        &[],
+        RSS_TWO_EPISODES_NO_ENCLOSURES,
+    )])
+    .await;
+
+    let feed_id = svc.subscribe_podcast(&url, None, None).await.unwrap();
+
+    let sub = podcast::get_subscription(&svc.db.read, feed_id.as_bytes())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        sub.auto_download,
+        i64::try_from(KomideConfig::default().auto_download_latest_n).unwrap(),
+        "the stored auto_download is the configured episode COUNT, not a 0/1 bool"
+    );
+}
+
+#[tokio::test]
+async fn subscribe_podcast_downloads_initial_episodes_in_background() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = KomideConfig {
+        podcast_dir: dir.path().to_path_buf(),
+        auto_download_latest_n: 2,
+        ..KomideConfig::default()
+    };
+    let (svc, _rx) = setup_with_config(config).await;
+
+    let (base, _handle) = spawn_scripted_http(vec![
+        http_response(200, "OK", &[], b"AUD1"),
+        http_response(200, "OK", &[], b"AUD2"),
+    ])
+    .await;
+    // WHY two servers: the feed body must embed the audio server's base URL,
+    // so the audio server exists first and a second server serves the feed.
+    let feed_body = rss_two_episodes_with_enclosures(&base);
+    let (feed_url, _feed_handle) =
+        spawn_scripted_http(vec![http_response(200, "OK", &[], &feed_body)]).await;
+
+    let feed_id = svc.subscribe_podcast(&feed_url, None, None).await.unwrap();
+
+    // Bounded wait for the spawned download task to finish both transfers.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let episodes = podcast::list_episodes(&svc.db.read, feed_id.as_bytes(), 10, 0)
+            .await
+            .unwrap();
+        if episodes.len() == 2 && episodes.iter().all(|e| e.file_path.is_some()) {
+            for ep in &episodes {
+                let path = std::path::Path::new(ep.file_path.as_deref().unwrap());
+                assert!(
+                    path.starts_with(dir.path()),
+                    "file must land in podcast_dir"
+                );
+                assert!(path.exists(), "downloaded file must exist on disk");
+                assert_eq!(ep.file_size_bytes, Some(4));
+            }
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "spawned initial downloads did not complete in time: {episodes:?}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn subscribe_news_emits_feed_set_changed_and_stores_category() {
+    let (svc, mut rx) = setup().await;
+    let (url, _handle) =
+        spawn_scripted_http(vec![http_response(200, "OK", &[], &atom_two_articles())]).await;
+
+    let feed_id = svc
+        .subscribe_news(&url, Some("My News"), Some("tech"))
+        .await
+        .unwrap();
+
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            HarmoniaEvent::FeedSetChanged {
+                feed_id: id,
+                media_type: MediaType::News,
+            } if *id == feed_id
+        )),
+        "news subscribe must emit FeedSetChanged"
+    );
+
+    let feed = news::get_feed(&svc.db.read, feed_id.as_bytes())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(feed.title, "My News");
+    assert_eq!(feed.category.as_deref(), Some("tech"));
+    assert_eq!(
+        feed.fetch_interval_minutes,
+        i64::try_from(KomideConfig::default().news_poll_interval_minutes).unwrap(),
+        "the poll interval comes FROM config, never a hardcoded literal"
+    );
+}
+
+#[tokio::test]
+async fn unsubscribe_emits_feed_set_changed() {
+    let (svc, mut rx) = setup().await;
+    let sub_id = make_subscription(&svc, "https://example.com/bye.xml").await;
+    let feed_id = bytes_to_feed_id(&sub_id).unwrap();
+
+    svc.unsubscribe(feed_id).await.unwrap();
+
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            HarmoniaEvent::FeedSetChanged {
+                feed_id: id,
+                media_type: MediaType::Podcast,
+            } if *id == feed_id
+        )),
+        "unsubscribe must emit FeedSetChanged"
+    );
+}
+
+// ── episode download (#575 wire: podcast_dir + max_episode_bytes) ────────
+
+#[tokio::test]
+async fn refresh_downloads_latest_n_new_episodes_inline() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = KomideConfig {
+        podcast_dir: dir.path().to_path_buf(),
+        ..KomideConfig::default()
+    };
+    let (svc, _rx) = setup_with_config(config).await;
+
+    let (base, _audio_handle) =
+        spawn_scripted_http(vec![http_response(200, "OK", &[], b"AUDIO")]).await;
+    let feed_body = rss_two_episodes_with_enclosures(&base);
+    let (feed_url, _feed_handle) =
+        spawn_scripted_http(vec![http_response(200, "OK", &[], &feed_body)]).await;
+
+    // auto_download = 1 → only the most recent episode (ep-002) downloads.
+    let sub_id = make_subscription_with_auto_download(&svc, &feed_url, 1).await;
+    let feed_id = bytes_to_feed_id(&sub_id).unwrap();
+
+    let result = svc.refresh_feed(feed_id).await.unwrap();
+    assert_eq!(result.new_items, 2);
+
+    let episodes = podcast::list_episodes(&svc.db.read, &sub_id, 10, 0)
+        .await
+        .unwrap();
+    let ep2 = episodes.iter().find(|e| e.guid == "ep-002").unwrap();
+    let ep1 = episodes.iter().find(|e| e.guid == "ep-001").unwrap();
+    assert!(
+        ep2.file_path.is_some(),
+        "the most recent episode must be downloaded inline by the refresh"
+    );
+    assert_eq!(ep2.file_size_bytes, Some(5));
+    assert!(
+        std::path::Path::new(ep2.file_path.as_deref().unwrap()).exists(),
+        "downloaded audio must exist under podcast_dir"
+    );
+    assert!(
+        ep1.file_path.is_none(),
+        "episodes beyond auto_download's count must not download"
+    );
+}
+
+#[tokio::test]
+async fn download_episode_by_id_writes_file_and_updates_row() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = KomideConfig {
+        podcast_dir: dir.path().to_path_buf(),
+        ..KomideConfig::default()
+    };
+    let (svc, _rx) = setup_with_config(config).await;
+
+    let (base, _handle) =
+        spawn_scripted_http(vec![http_response(200, "OK", &[], b"AUDIOBYTES")]).await;
+    let sub_id = make_subscription(&svc, "https://example.com/pod.xml").await;
+    let entry =
+        make_podcast_entry_with_enclosure("ep-dl", "Download Me", &format!("{base}/ep.m4a"));
+    svc.insert_new_podcast_episodes(&sub_id, &[entry], &now_iso8601())
+        .await
+        .unwrap();
+    let ep = podcast::list_episodes(&svc.db.read, &sub_id, 1, 0)
+        .await
+        .unwrap()[0]
+        .clone();
+    let episode_id = EpisodeId::from_uuid(Uuid::from_slice(&ep.id).unwrap());
+
+    let written = svc.download_episode_by_id(episode_id).await.unwrap();
+    assert_eq!(written, 10);
+
+    let ep = podcast::get_episode(&svc.db.read, &ep.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let path = std::path::PathBuf::from(ep.file_path.as_deref().unwrap());
+    assert!(
+        path.starts_with(dir.path()),
+        "file must land in podcast_dir"
+    );
+    assert_eq!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("m4a"),
+        "the file extension comes FROM the enclosure URL"
+    );
+    assert_eq!(std::fs::read(&path).unwrap(), b"AUDIOBYTES");
+    assert_eq!(ep.file_size_bytes, Some(10));
+}
+
+#[tokio::test]
+async fn download_episode_by_id_respects_max_episode_bytes() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = KomideConfig {
+        podcast_dir: dir.path().to_path_buf(),
+        max_episode_bytes: 4,
+        ..KomideConfig::default()
+    };
+    let (svc, _rx) = setup_with_config(config).await;
+
+    let (base, _handle) =
+        spawn_scripted_http(vec![http_response(200, "OK", &[], b"WAY TOO LARGE")]).await;
+    let sub_id = make_subscription(&svc, "https://example.com/cap.xml").await;
+    let entry = make_podcast_entry_with_enclosure("ep-cap", "Too Big", &format!("{base}/big.mp3"));
+    svc.insert_new_podcast_episodes(&sub_id, &[entry], &now_iso8601())
+        .await
+        .unwrap();
+    let ep = podcast::list_episodes(&svc.db.read, &sub_id, 1, 0)
+        .await
+        .unwrap()[0]
+        .clone();
+    let episode_id = EpisodeId::from_uuid(Uuid::from_slice(&ep.id).unwrap());
+
+    let result = svc.download_episode_by_id(episode_id).await;
+    assert!(
+        matches!(result, Err(KomideError::ResponseTooLarge { .. })),
+        "an over-cap enclosure must be rejected: {result:?}"
+    );
+
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
+    assert!(leftovers.is_empty(), "no partial file may remain on disk");
+    let ep = podcast::get_episode(&svc.db.read, &ep.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        ep.file_path.is_none(),
+        "a failed download must not set file_path"
+    );
+}
+
+#[tokio::test]
+async fn download_episode_unknown_id_returns_episode_not_found() {
+    let (svc, _rx) = setup().await;
+    let result = svc.download_episode_by_id(EpisodeId::new()).await;
+    assert!(matches!(result, Err(KomideError::EpisodeNotFound { .. })));
+}
+
+#[tokio::test]
+async fn download_episode_without_enclosure_returns_not_downloadable() {
+    let (svc, _rx) = setup().await;
+    let sub_id = make_subscription(&svc, "https://example.com/noenc.xml").await;
+    let entry = crate::parser::NormalizedEntry {
+        guid: "ep-noenc".to_string(),
+        title: "No Enclosure".to_string(),
+        published: Some("2026-01-01T00:00:00Z".to_string()),
+        summary: None,
+        content: None,
+        enclosures: vec![],
+        link: None,
+    };
+    svc.insert_new_podcast_episodes(&sub_id, &[entry], &now_iso8601())
+        .await
+        .unwrap();
+    let ep = podcast::list_episodes(&svc.db.read, &sub_id, 1, 0)
+        .await
+        .unwrap()[0]
+        .clone();
+    let episode_id = EpisodeId::from_uuid(Uuid::from_slice(&ep.id).unwrap());
+
+    let result = svc.episode_downloadable(episode_id).await;
+    assert!(matches!(
+        result,
+        Err(KomideError::EpisodeNotDownloadable { .. })
+    ));
+}
+
+#[test]
+fn enclosure_extension_falls_back_to_mp3() {
+    assert_eq!(enclosure_extension("https://x.com/audio/ep.M4A"), "m4a");
+    assert_eq!(enclosure_extension("https://x.com/audio/ep"), "mp3");
+    assert_eq!(enclosure_extension("https://x.com/ep.mp3?tk=1"), "mp3");
+    assert_eq!(enclosure_extension("not a url"), "mp3");
+    assert_eq!(
+        enclosure_extension("https://x.com/ep.tooLong"),
+        "mp3",
+        "an implausibly long extension must not be trusted"
+    );
+}
+
 #[tokio::test]
 async fn store_validators_ignores_empty_pair_and_keeps_nonempty() {
     let (svc, _rx) = setup().await;
@@ -423,7 +826,18 @@ async fn store_validators_ignores_empty_pair_and_keeps_nonempty() {
 
 // ── Test helpers ─────────────────────────────────────────────────────────
 
+// NOTE: auto_download 0 — refresh tests exercising feed parsing/eventing
+// must never spill into real enclosure fetches (the fixture enclosure URLs
+// point at example.com). Download tests seed a nonzero count explicitly.
 async fn make_subscription(svc: &FeedSchedulerService, feed_url: &str) -> Vec<u8> {
+    make_subscription_with_auto_download(svc, feed_url, 0).await
+}
+
+async fn make_subscription_with_auto_download(
+    svc: &FeedSchedulerService,
+    feed_url: &str,
+    auto_download: i64,
+) -> Vec<u8> {
     let feed_id = FeedId::new();
     let id_bytes = feed_id.as_bytes().to_vec();
     let sub = podcast::PodcastSubscription {
@@ -435,7 +849,7 @@ async fn make_subscription(svc: &FeedSchedulerService, feed_url: &str) -> Vec<u8
         image_url: None,
         language: None,
         last_checked_at: None,
-        auto_download: 1,
+        auto_download,
         quality_profile_id: None,
         added_at: now_iso8601(),
     };
@@ -467,6 +881,14 @@ async fn make_news_feed(svc: &FeedSchedulerService, url: &str) -> Vec<u8> {
 }
 
 fn make_podcast_entry(guid: &str, title: &str) -> crate::parser::NormalizedEntry {
+    make_podcast_entry_with_enclosure(guid, title, &format!("https://example.com/{guid}.mp3"))
+}
+
+fn make_podcast_entry_with_enclosure(
+    guid: &str,
+    title: &str,
+    enclosure_url: &str,
+) -> crate::parser::NormalizedEntry {
     crate::parser::NormalizedEntry {
         guid: guid.to_string(),
         title: title.to_string(),
@@ -474,7 +896,7 @@ fn make_podcast_entry(guid: &str, title: &str) -> crate::parser::NormalizedEntry
         summary: None,
         content: None,
         enclosures: vec![crate::parser::Enclosure {
-            url: format!("https://example.com/{guid}.mp3"),
+            url: enclosure_url.to_string(),
             content_type: Some("audio/mpeg".to_string()),
             length: None,
         }],

--- a/crates/paroche/src/response.rs
+++ b/crates/paroche/src/response.rs
@@ -54,6 +54,19 @@ impl<T: Serialize> ApiResponse<T> {
         )
     }
 
+    /// 202 — the request was validated and the work started, but completes
+    /// in the background (e.g. an episode audio download).
+    pub fn accepted(data: T) -> (StatusCode, Json<Self>) {
+        (
+            StatusCode::ACCEPTED,
+            Json(Self {
+                data,
+                meta: None,
+                correlation_id: new_correlation_id(),
+            }),
+        )
+    }
+
     pub fn paginated(data: T, page: u64, per_page: u64, total: u64) -> (StatusCode, Json<Self>) {
         (
             StatusCode::OK,

--- a/crates/paroche/src/routes/news.rs
+++ b/crates/paroche/src/routes/news.rs
@@ -106,6 +106,11 @@ pub async fn get_feed(
     Ok(ApiResponse::ok(FeedResponse::from(feed)))
 }
 
+/// Delegates to komide's rich subscribe (fetch + parse + article seeding +
+/// `FeedSetChanged`, poll interval FROM config) instead of a bare row insert
+/// with a hardcoded 60-minute interval (#577). An unreachable or
+/// unparseable feed URL is now an error instead of a silently-inserted dead
+/// row.
 pub async fn create_feed(
     State(state): State<AppState>,
     _admin: RequireAdmin,
@@ -122,27 +127,12 @@ pub async fn create_feed(
         });
     }
 
-    let id = Uuid::now_v7().as_bytes().to_vec();
-    let now = chrono_now_pub();
+    let feed_id = state
+        .feeds
+        .subscribe_news(body.url, Some(body.title), body.category)
+        .await?;
 
-    let feed = apotheke::repo::news::NewsFeed {
-        id: id.clone(),
-        title: body.title,
-        url: body.url,
-        site_url: None,
-        description: None,
-        category: body.category,
-        icon_url: None,
-        last_fetched_at: None,
-        fetch_interval_minutes: 60,
-        is_active: 1,
-        added_at: now.clone(),
-        updated_at: now,
-    };
-
-    apotheke::repo::news::insert_feed(&state.db.write, &feed).await?;
-
-    let created = apotheke::repo::news::get_feed(&state.db.read, &id)
+    let created = apotheke::repo::news::get_feed(&state.db.read, feed_id.as_bytes())
         .await?
         .ok_or(ParocheError::Internal)?;
 
@@ -173,6 +163,15 @@ pub async fn update_feed(
     )
     .await?;
 
+    // WHY: an is_active flip changes the poll set — tell the feed
+    // supervisor to re-enumerate (fire-and-forget bus fact).
+    let _ = state
+        .event_tx
+        .send(themelion::HarmoniaEvent::FeedSetChanged {
+            feed_id: themelion::FeedId::from_uuid(uuid),
+            media_type: themelion::MediaType::News,
+        });
+
     let updated = apotheke::repo::news::get_feed(&state.db.read, &id_bytes)
         .await?
         .ok_or(ParocheError::Internal)?;
@@ -188,11 +187,16 @@ pub async fn delete_feed(
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
     let id_bytes = uuid.as_bytes().to_vec();
 
+    // WHY: the existence check keeps this endpoint scoped to news rows —
+    // komide's unsubscribe also matches podcast subscriptions by id.
     apotheke::repo::news::get_feed(&state.db.read, &id_bytes)
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    apotheke::repo::news::delete_feed(&state.db.write, &id_bytes).await?;
+    state
+        .feeds
+        .unsubscribe(themelion::FeedId::from_uuid(uuid))
+        .await?;
 
     Ok(deleted())
 }
@@ -202,4 +206,218 @@ pub fn news_routes() -> axum::Router<AppState> {
     axum::Router::new()
         .route("/", get(list_feeds).post(create_feed))
         .route("/{id}", get(get_feed).put(update_feed).delete(delete_feed))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[expect(
+        unused_imports,
+        reason = "kanon: test-missing-use-super; parent items accessed via explicit super:: prefix in test bodies"
+    )]
+    use super::*;
+    use crate::state::{AppState, DynFeedService, ServiceError, ServiceFut};
+    use crate::test_helpers::{admin_token, test_state};
+
+    /// Recording `DynFeedService` stub for the news routes.
+    struct RecordingFeeds {
+        feed_id: themelion::FeedId,
+        subscribe_news_calls: Mutex<Vec<(String, Option<String>, Option<String>)>>,
+        unsubscribe_calls: AtomicUsize,
+    }
+
+    impl RecordingFeeds {
+        fn succeeding(feed_id: themelion::FeedId) -> Arc<Self> {
+            Arc::new(Self {
+                feed_id,
+                subscribe_news_calls: Mutex::new(Vec::new()),
+                unsubscribe_calls: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    impl DynFeedService for RecordingFeeds {
+        fn subscribe_podcast(
+            &self,
+            _url: String,
+            _title: Option<String>,
+            _auto_download: Option<bool>,
+        ) -> ServiceFut<themelion::FeedId> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+
+        fn subscribe_news(
+            &self,
+            url: String,
+            title: Option<String>,
+            category: Option<String>,
+        ) -> ServiceFut<themelion::FeedId> {
+            self.subscribe_news_calls
+                .lock()
+                .unwrap()
+                .push((url, title, category));
+            let feed_id = self.feed_id;
+            Box::pin(async move { Ok(feed_id) })
+        }
+
+        fn unsubscribe(&self, _feed_id: themelion::FeedId) -> ServiceFut<()> {
+            self.unsubscribe_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok(()) })
+        }
+
+        fn download_episode(&self, _episode_id: themelion::EpisodeId) -> ServiceFut<()> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+    }
+
+    async fn seed_feed(state: &AppState, feed_id: themelion::FeedId) {
+        let feed = apotheke::repo::news::NewsFeed {
+            id: feed_id.as_bytes().to_vec(),
+            title: "Seeded News".to_string(),
+            url: "https://news.example.com/rss".to_string(),
+            site_url: None,
+            description: None,
+            category: Some("tech".to_string()),
+            icon_url: None,
+            last_fetched_at: None,
+            fetch_interval_minutes: 15,
+            is_active: 1,
+            added_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        apotheke::repo::news::insert_feed(&state.db.write, &feed)
+            .await
+            .unwrap();
+    }
+
+    fn json_request(
+        method: &str,
+        uri: &str,
+        token: &str,
+        body: serde_json::Value,
+    ) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_feed_delegates_to_feed_service() {
+        let (mut state, auth) = test_state().await;
+        let feed_id = themelion::FeedId::new();
+        // WHY: the stub returns the id; the ROW comes FROM the DB — komide
+        // inserts it in production, so the test seeds it up front.
+        seed_feed(&state, feed_id).await;
+        let feeds = RecordingFeeds::succeeding(feed_id);
+        state.feeds = feeds.clone();
+        let token = admin_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(json_request(
+                "POST",
+                "/api/news",
+                &token,
+                serde_json::json!({
+                    "title": "Seeded News",
+                    "url": "https://news.example.com/rss",
+                    "category": "tech",
+                }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        // WHY the block: the guard must provably end before the next await —
+        // clippy's await_holding_lock does not credit an explicit drop().
+        {
+            let calls = feeds.subscribe_news_calls.lock().unwrap();
+            assert_eq!(
+                calls.as_slice(),
+                &[(
+                    "https://news.example.com/rss".to_string(),
+                    Some("Seeded News".to_string()),
+                    Some("tech".to_string()),
+                )]
+            );
+        }
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["data"]["id"], feed_id.as_uuid().to_string());
+        assert_eq!(body["data"]["category"], "tech");
+    }
+
+    #[tokio::test]
+    async fn delete_feed_delegates_unsubscribe() {
+        let (mut state, auth) = test_state().await;
+        let feed_id = themelion::FeedId::new();
+        seed_feed(&state, feed_id).await;
+        let feeds = RecordingFeeds::succeeding(feed_id);
+        state.feeds = feeds.clone();
+        let token = admin_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/news/{}", feed_id.as_uuid()))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert_eq!(feeds.unsubscribe_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn update_feed_emits_feed_set_changed() {
+        let (state, auth) = test_state().await;
+        let feed_id = themelion::FeedId::new();
+        seed_feed(&state, feed_id).await;
+        let token = admin_token(&auth).await;
+        let mut event_rx = state.event_tx.subscribe();
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(json_request(
+                "PUT",
+                &format!("/api/news/{}", feed_id.as_uuid()),
+                &token,
+                serde_json::json!({ "title": "Renamed", "is_active": false }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut saw_feed_set_changed = false;
+        while let Ok(event) = event_rx.try_recv() {
+            if matches!(
+                event,
+                themelion::HarmoniaEvent::FeedSetChanged {
+                    feed_id: id,
+                    media_type: themelion::MediaType::News,
+                } if id == feed_id
+            ) {
+                saw_feed_set_changed = true;
+            }
+        }
+        assert!(
+            saw_feed_set_changed,
+            "an is_active flip must emit FeedSetChanged"
+        );
+    }
 }

--- a/crates/paroche/src/routes/podcast.rs
+++ b/crates/paroche/src/routes/podcast.rs
@@ -7,7 +7,6 @@ use uuid::Uuid;
 
 use crate::error::ParocheError;
 use crate::response::{ApiResponse, deleted};
-use crate::routes::music::chrono_now_pub;
 use crate::state::AppState;
 
 #[derive(Deserialize)]
@@ -103,6 +102,10 @@ pub async fn get_subscription(
     Ok(ApiResponse::ok(SubscriptionResponse::from(sub)))
 }
 
+/// Delegates to komide's rich subscribe (fetch + parse + episode seeding +
+/// `FeedSetChanged`) instead of a bare row insert — the bare insert left a
+/// dead, never-polled row (#577). An unreachable or unparseable feed URL is
+/// now an error instead of a silently-inserted dead subscription.
 pub async fn create_subscription(
     State(state): State<AppState>,
     _admin: RequireAdmin,
@@ -114,30 +117,12 @@ pub async fn create_subscription(
         });
     }
 
-    let id = Uuid::now_v7().as_bytes().to_vec();
-    let now = chrono_now_pub();
+    let feed_id = state
+        .feeds
+        .subscribe_podcast(body.feed_url, body.title, body.auto_download)
+        .await?;
 
-    let sub = apotheke::repo::podcast::PodcastSubscription {
-        id: id.clone(),
-        feed_url: body.feed_url,
-        title: body.title,
-        description: None,
-        author: None,
-        image_url: None,
-        language: None,
-        last_checked_at: None,
-        auto_download: if body.auto_download.unwrap_or(false) {
-            1
-        } else {
-            0
-        },
-        quality_profile_id: None,
-        added_at: now,
-    };
-
-    apotheke::repo::podcast::insert_subscription(&state.db.write, &sub).await?;
-
-    let created = apotheke::repo::podcast::get_subscription(&state.db.read, &id)
+    let created = apotheke::repo::podcast::get_subscription(&state.db.read, feed_id.as_bytes())
         .await?
         .ok_or(ParocheError::Internal)?;
 
@@ -157,14 +142,30 @@ pub async fn update_subscription(
         .await?
         .ok_or(ParocheError::NotFound)?;
 
+    // NOTE: the stored auto_download is komide's episode-download COUNT —
+    // the API bool maps to the configured count or 0, never a raw 0/1.
+    let auto_download_count = if body.auto_download {
+        i64::try_from(state.config.current().komide.auto_download_latest_n).unwrap_or_default() // WHY: auto_download_latest_n is a small config value; bounded within i64
+    } else {
+        0
+    };
     apotheke::repo::podcast::update_subscription(
         &state.db.write,
         &id_bytes,
         body.title.as_deref(),
-        if body.auto_download { 1 } else { 0 },
+        auto_download_count,
         None,
     )
     .await?;
+
+    // WHY: a subscription flip changes what the poll set should do — tell
+    // the feed supervisor to re-enumerate (fire-and-forget bus fact).
+    let _ = state
+        .event_tx
+        .send(themelion::HarmoniaEvent::FeedSetChanged {
+            feed_id: themelion::FeedId::from_uuid(uuid),
+            media_type: themelion::MediaType::Podcast,
+        });
 
     let updated = apotheke::repo::podcast::get_subscription(&state.db.read, &id_bytes)
         .await?
@@ -181,17 +182,43 @@ pub async fn delete_subscription(
     let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
     let id_bytes = uuid.as_bytes().to_vec();
 
+    // WHY: the existence check keeps this endpoint scoped to podcast rows —
+    // komide's unsubscribe also matches news feeds by id.
     apotheke::repo::podcast::get_subscription(&state.db.read, &id_bytes)
         .await?
         .ok_or(ParocheError::NotFound)?;
 
-    apotheke::repo::podcast::delete_subscription(&state.db.write, &id_bytes).await?;
+    state
+        .feeds
+        .unsubscribe(themelion::FeedId::from_uuid(uuid))
+        .await?;
 
     Ok(deleted())
 }
 
+/// Starts a server-side download of one episode's audio enclosure — the
+/// route the desktop client already posts to. Returns 202 immediately; the
+/// transfer completes in the background and lands on the episode row.
+pub async fn download_episode(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Path(id): Path<String>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ParocheError::InvalidId)?;
+
+    state
+        .feeds
+        .download_episode(themelion::EpisodeId::from_uuid(uuid))
+        .await?;
+
+    Ok(ApiResponse::accepted(serde_json::json!({
+        "episode_id": id,
+        "status": "downloading",
+    })))
+}
+
 pub fn podcast_routes() -> axum::Router<AppState> {
-    use axum::routing::get;
+    use axum::routing::{get, post};
     axum::Router::new()
         .route("/", get(list_subscriptions).post(create_subscription))
         .route(
@@ -200,4 +227,380 @@ pub fn podcast_routes() -> axum::Router<AppState> {
                 .put(update_subscription)
                 .delete(delete_subscription),
         )
+        .route("/episodes/{id}/download", post(download_episode))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[expect(
+        unused_imports,
+        reason = "kanon: test-missing-use-super; parent items accessed via explicit super:: prefix in test bodies"
+    )]
+    use super::*;
+    use crate::state::{AppState, DynFeedService, ServiceError, ServiceFut};
+    use crate::test_helpers::{admin_token, test_state};
+
+    enum StubOutcome {
+        Succeed,
+        InvalidInput,
+        NotFound,
+    }
+
+    /// Recording `DynFeedService` stub: every call is captured, and the
+    /// configured outcome is returned.
+    struct RecordingFeeds {
+        feed_id: themelion::FeedId,
+        outcome: StubOutcome,
+        subscribe_podcast_calls: Mutex<Vec<(String, Option<String>, Option<bool>)>>,
+        unsubscribe_calls: AtomicUsize,
+        download_calls: Mutex<Vec<themelion::EpisodeId>>,
+    }
+
+    impl RecordingFeeds {
+        fn with_outcome(feed_id: themelion::FeedId, outcome: StubOutcome) -> Arc<Self> {
+            Arc::new(Self {
+                feed_id,
+                outcome,
+                subscribe_podcast_calls: Mutex::new(Vec::new()),
+                unsubscribe_calls: AtomicUsize::new(0),
+                download_calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn succeeding(feed_id: themelion::FeedId) -> Arc<Self> {
+            Self::with_outcome(feed_id, StubOutcome::Succeed)
+        }
+
+        fn error(&self) -> Option<ServiceError> {
+            match self.outcome {
+                StubOutcome::Succeed => None,
+                StubOutcome::InvalidInput => {
+                    Some(ServiceError::InvalidInput("invalid feed URL".to_string()))
+                }
+                StubOutcome::NotFound => Some(ServiceError::NotFound),
+            }
+        }
+    }
+
+    impl DynFeedService for RecordingFeeds {
+        fn subscribe_podcast(
+            &self,
+            url: String,
+            title: Option<String>,
+            auto_download: Option<bool>,
+        ) -> ServiceFut<themelion::FeedId> {
+            self.subscribe_podcast_calls
+                .lock()
+                .unwrap()
+                .push((url, title, auto_download));
+            let result = match self.error() {
+                Some(e) => Err(e),
+                None => Ok(self.feed_id),
+            };
+            Box::pin(async move { result })
+        }
+
+        fn subscribe_news(
+            &self,
+            _url: String,
+            _title: Option<String>,
+            _category: Option<String>,
+        ) -> ServiceFut<themelion::FeedId> {
+            let result = match self.error() {
+                Some(e) => Err(e),
+                None => Ok(self.feed_id),
+            };
+            Box::pin(async move { result })
+        }
+
+        fn unsubscribe(&self, _feed_id: themelion::FeedId) -> ServiceFut<()> {
+            self.unsubscribe_calls.fetch_add(1, Ordering::SeqCst);
+            let result = match self.error() {
+                Some(e) => Err(e),
+                None => Ok(()),
+            };
+            Box::pin(async move { result })
+        }
+
+        fn download_episode(&self, episode_id: themelion::EpisodeId) -> ServiceFut<()> {
+            self.download_calls.lock().unwrap().push(episode_id);
+            let result = match self.error() {
+                Some(e) => Err(e),
+                None => Ok(()),
+            };
+            Box::pin(async move { result })
+        }
+    }
+
+    async fn seed_subscription(state: &AppState, feed_id: themelion::FeedId, auto_download: i64) {
+        let sub = apotheke::repo::podcast::PodcastSubscription {
+            id: feed_id.as_bytes().to_vec(),
+            feed_url: "https://example.com/feed.xml".to_string(),
+            title: Some("Seeded".to_string()),
+            description: None,
+            author: None,
+            image_url: None,
+            language: None,
+            last_checked_at: None,
+            auto_download,
+            quality_profile_id: None,
+            added_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        apotheke::repo::podcast::insert_subscription(&state.db.write, &sub)
+            .await
+            .unwrap();
+    }
+
+    fn json_request(
+        method: &str,
+        uri: &str,
+        token: &str,
+        body: serde_json::Value,
+    ) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    fn empty_request(method: &str, uri: &str, token: &str) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("Authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_subscription_delegates_to_feed_service() {
+        let (mut state, auth) = test_state().await;
+        let feed_id = themelion::FeedId::new();
+        // WHY: the stub returns the id; the ROW comes FROM the DB — komide
+        // inserts it in production, so the test seeds it up front.
+        seed_subscription(&state, feed_id, 3).await;
+        let feeds = RecordingFeeds::succeeding(feed_id);
+        state.feeds = feeds.clone();
+        let token = admin_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(json_request(
+                "POST",
+                "/api/podcasts",
+                &token,
+                serde_json::json!({
+                    "feed_url": "https://example.com/feed.xml",
+                    "title": "My Show",
+                    "auto_download": true,
+                }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        // WHY the block: the guard must provably end before the next await —
+        // clippy's await_holding_lock does not credit an explicit drop().
+        {
+            let calls = feeds.subscribe_podcast_calls.lock().unwrap();
+            assert_eq!(
+                calls.as_slice(),
+                &[(
+                    "https://example.com/feed.xml".to_string(),
+                    Some("My Show".to_string()),
+                    Some(true),
+                )]
+            );
+        }
+        let body = body_json(resp).await;
+        assert_eq!(
+            body["data"]["id"],
+            feed_id.as_uuid().to_string(),
+            "the response row is the one komide created"
+        );
+        assert_eq!(
+            body["data"]["auto_download"], true,
+            "a nonzero episode count reads back as auto_download=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_subscription_maps_invalid_feed_to_validation_error() {
+        let (mut state, auth) = test_state().await;
+        state.feeds =
+            RecordingFeeds::with_outcome(themelion::FeedId::new(), StubOutcome::InvalidInput);
+        let token = admin_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(json_request(
+                "POST",
+                "/api/podcasts",
+                &token,
+                serde_json::json!({ "feed_url": "https://bad.example.com/feed.xml" }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = body_json(resp).await;
+        assert_eq!(body["code"], "VALIDATION_ERROR");
+    }
+
+    #[tokio::test]
+    async fn delete_subscription_delegates_unsubscribe() {
+        let (mut state, auth) = test_state().await;
+        let feed_id = themelion::FeedId::new();
+        seed_subscription(&state, feed_id, 0).await;
+        let feeds = RecordingFeeds::succeeding(feed_id);
+        state.feeds = feeds.clone();
+        let token = admin_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(empty_request(
+                "DELETE",
+                &format!("/api/podcasts/{}", feed_id.as_uuid()),
+                &token,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert_eq!(feeds.unsubscribe_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn update_subscription_stores_count_and_emits_feed_set_changed() {
+        let (state, auth) = test_state().await;
+        let feed_id = themelion::FeedId::new();
+        seed_subscription(&state, feed_id, 0).await;
+        let token = admin_token(&auth).await;
+        let mut event_rx = state.event_tx.subscribe();
+        let db_read = state.db.read.clone();
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(json_request(
+                "PUT",
+                &format!("/api/podcasts/{}", feed_id.as_uuid()),
+                &token,
+                serde_json::json!({ "title": "Renamed", "auto_download": true }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let row = apotheke::repo::podcast::get_subscription(&db_read, feed_id.as_bytes())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.auto_download,
+            i64::try_from(horismos::Config::default().komide.auto_download_latest_n).unwrap(),
+            "the API bool maps to komide's configured episode COUNT, not a raw 1"
+        );
+
+        let mut saw_feed_set_changed = false;
+        while let Ok(event) = event_rx.try_recv() {
+            if matches!(
+                event,
+                themelion::HarmoniaEvent::FeedSetChanged {
+                    feed_id: id,
+                    media_type: themelion::MediaType::Podcast,
+                } if id == feed_id
+            ) {
+                saw_feed_set_changed = true;
+            }
+        }
+        assert!(
+            saw_feed_set_changed,
+            "an auto_download flip must emit FeedSetChanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_episode_route_accepts_and_delegates() {
+        let (mut state, auth) = test_state().await;
+        let feeds = RecordingFeeds::succeeding(themelion::FeedId::new());
+        state.feeds = feeds.clone();
+        let token = admin_token(&auth).await;
+        let episode_id = themelion::EpisodeId::new();
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(empty_request(
+                "POST",
+                &format!("/api/podcasts/episodes/{}/download", episode_id.as_uuid()),
+                &token,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        assert_eq!(
+            feeds.download_calls.lock().unwrap().as_slice(),
+            &[episode_id]
+        );
+        let body = body_json(resp).await;
+        assert_eq!(body["data"]["status"], "downloading");
+    }
+
+    #[tokio::test]
+    async fn download_episode_unknown_maps_to_not_found() {
+        let (mut state, auth) = test_state().await;
+        state.feeds = RecordingFeeds::with_outcome(themelion::FeedId::new(), StubOutcome::NotFound);
+        let token = admin_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(empty_request(
+                "POST",
+                &format!("/api/podcasts/episodes/{}/download", uuid::Uuid::now_v7()),
+                &token,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn download_episode_invalid_id_is_bad_request() {
+        let (mut state, auth) = test_state().await;
+        let feeds = RecordingFeeds::succeeding(themelion::FeedId::new());
+        state.feeds = feeds.clone();
+        let token = admin_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(empty_request(
+                "POST",
+                "/api/podcasts/episodes/not-a-uuid/download",
+                &token,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            feeds.download_calls.lock().unwrap().is_empty(),
+            "an unparseable id must never reach the service"
+        );
+    }
 }

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -106,6 +106,39 @@ pub trait DynSearchService: Send + Sync {
     fn refresh_caps(&self, indexer_id: i64) -> ServiceFut<serde_json::Value>;
 }
 
+/// Feed subscription lifecycle via komide's `FeedSchedulerService`
+/// (fetch + parse + episode/article seeding + `FeedSetChanged` emission) —
+/// the rich path the raw-row route handlers used to bypass (#577).
+pub trait DynFeedService: Send + Sync {
+    /// Subscribe to a podcast feed. Fetches and parses the feed, seeds its
+    /// episodes, and returns the subscription's feed id. `auto_download`
+    /// maps to komide's episode-download COUNT (`false` → 0, otherwise the
+    /// configured `auto_download_latest_n`).
+    fn subscribe_podcast(
+        &self,
+        url: String,
+        title: Option<String>,
+        auto_download: Option<bool>,
+    ) -> ServiceFut<themelion::FeedId>;
+
+    /// Subscribe to a news feed. Fetches and parses the feed, seeds its
+    /// articles, and returns the feed id.
+    fn subscribe_news(
+        &self,
+        url: String,
+        title: Option<String>,
+        category: Option<String>,
+    ) -> ServiceFut<themelion::FeedId>;
+
+    /// Remove a podcast or news subscription.
+    fn unsubscribe(&self, feed_id: themelion::FeedId) -> ServiceFut<()>;
+
+    /// Start a background download of one episode's audio enclosure.
+    /// Resolves once the download is validated and started, not when it
+    /// completes.
+    fn download_episode(&self, episode_id: themelion::EpisodeId) -> ServiceFut<()>;
+}
+
 pub trait DynDownloadEngine: Send + Sync {}
 
 // WHY: pure data — enqueue parameters for the live download queue, kept as
@@ -384,6 +417,35 @@ impl DynRequestService for NullRequestService {
 struct NullExternalIntegration;
 impl DynExternalIntegration for NullExternalIntegration {}
 
+struct NullFeedService;
+impl DynFeedService for NullFeedService {
+    fn subscribe_podcast(
+        &self,
+        _url: String,
+        _title: Option<String>,
+        _auto_download: Option<bool>,
+    ) -> ServiceFut<themelion::FeedId> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
+    fn subscribe_news(
+        &self,
+        _url: String,
+        _title: Option<String>,
+        _category: Option<String>,
+    ) -> ServiceFut<themelion::FeedId> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
+    fn unsubscribe(&self, _feed_id: themelion::FeedId) -> ServiceFut<()> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
+    fn download_episode(&self, _episode_id: themelion::EpisodeId) -> ServiceFut<()> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+}
+
 struct NullSubtitleService;
 impl DynSubtitleService for NullSubtitleService {
     fn search_for_media(&self, _media_id: Vec<u8>) -> ServiceFut<()> {
@@ -416,6 +478,7 @@ pub struct AppState {
     pub external: Arc<dyn DynExternalIntegration>,
     pub subtitles: Arc<dyn DynSubtitleService>,
     pub renderers: Arc<dyn DynRendererRegistry>,
+    pub feeds: Arc<dyn DynFeedService>,
 }
 
 impl AppState {
@@ -448,6 +511,7 @@ impl AppState {
             external: Arc::new(NullExternalIntegration),
             subtitles: Arc::new(NullSubtitleService),
             renderers: Arc::new(NullRendererRegistry),
+            feeds: Arc::new(NullFeedService),
         }
     }
 }

--- a/crates/themelion/src/aggelia/events.rs
+++ b/crates/themelion/src/aggelia/events.rs
@@ -137,6 +137,14 @@ pub enum HarmoniaEvent {
         new_items: usize,
         media_type: MediaType,
     },
+
+    /// The set of pollable feed subscriptions changed (subscribe,
+    /// unsubscribe, or an activation flip).
+    /// Subscribers: archon feed supervisor (re-enumerate poll tasks)
+    FeedSetChanged {
+        feed_id: FeedId,
+        media_type: MediaType,
+    },
 }
 
 #[cfg(test)]
@@ -270,6 +278,27 @@ mod tests {
         match recovered {
             HarmoniaEvent::NowPlayingStarted { media_type, .. } => {
                 assert_eq!(media_type, MediaType::Music);
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn feed_set_changed_serde_roundtrip() {
+        let feed_id = FeedId::new();
+        let event = HarmoniaEvent::FeedSetChanged {
+            feed_id,
+            media_type: MediaType::Podcast,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let recovered: HarmoniaEvent = serde_json::from_str(&json).unwrap();
+        match recovered {
+            HarmoniaEvent::FeedSetChanged {
+                feed_id: recovered_id,
+                media_type,
+            } => {
+                assert_eq!(recovered_id, feed_id);
+                assert_eq!(media_type, MediaType::Podcast);
             }
             _ => panic!("unexpected variant"),
         }

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -160,12 +160,18 @@ from the new section on change (`SectionWatcher::changed()`).
 | `opensubtitles.api_key` / `.rate_limit_per_second` / `.max_download_bytes` | LIVE | provider rebuild + `set_providers` — rate limiter state RESETS with the provider (logged) |
 | `opensubtitles.username` / `.password` | UNWIRED | #575 — no login flow exists |
 
-### komide — LIVE (feed scheduler REBUILD, step 6) except two UNWIRED
+### komide — LIVE (feed scheduler REBUILD, step 6)
 
 | Field | Class |
 |---|---|
 | `podcast_poll_interval_minutes`, `news_poll_interval_minutes`, `news_retention_days`, `news_retention_articles`, `auto_download_latest_n`, `fetch_timeout_secs`, `max_feed_bytes`, `max_backoff_minutes`, `jitter_percent` | LIVE |
-| `podcast_dir` / `max_episode_bytes` | UNWIRED — #575, episode download is test-only |
+| `podcast_dir` / `max_episode_bytes` | LIVE — episode auto-download (after subscribe/refresh) and the `POST /api/podcasts/episodes/{id}/download` route read them FROM the service's config, which the supervisor rebuilds on any `komide.*` change |
+
+The feed supervisor has a second, non-config rebuild trigger: a
+`FeedSetChanged` bus event (runtime subscribe/unsubscribe/activation flip)
+re-enumerates the poll tasks after a short coalescing window, REUSING the
+existing `FeedSchedulerService` — the etag/last-modified cache and reqwest
+client survive, and no config reload is involved (#577).
 
 ### syndesmos — LIVE (client REBUILD, step 8) except four UNWIRED
 


### PR DESCRIPTION
Runtime-subscribed feeds were never polled and the rich subscribe API was unreachable.

**Mechanism** — a new past-tense `HarmoniaEvent::FeedSetChanged` (emitted by komide subscribe/unsubscribe and paroche update handlers) drives the feed supervisor to re-enumerate its poll tasks: after a 300ms coalescing drain it shuts the current scheduler down and restarts `FeedScheduler::start` **reusing the existing `FeedSchedulerService`** (etag/last-modified cache + reqwest client preserved). A `komide.*` config change still does the full service+scheduler rebuild via the #529 `rebuild_with_rollback` machinery. `Lagged` self-heals (re-enumeration re-pages the DB). The `FeedsAdapter` sits behind a std `RwLock` never held across an `.await`.

**Reachable subscribe** — a `DynFeedService` trait (mirroring `DynImportService`) lets paroche delegate `POST /api/{podcasts,news}` to komide's real fetch+parse+seed path instead of raw apotheke inserts. This fixes the old bypass (hardcoded 60-min news interval, `auto_download` bool-vs-count mismatch). **Honest behavior change:** create now fetches+parses the feed, so an unreachable/invalid URL returns an error instead of silently inserting a dead row.

**Poll-gate fix** — the scheduler no longer skips `auto_download == 0` subscriptions; `auto_download` is the episode-download COUNT, not a poll gate. Every subscription polls.

**Episode auto-download (part of #575)** — wires the dead `komide.podcast_dir` / `max_episode_bytes`: after refresh/subscribe, `episodes_to_download` are downloaded into `podcast_dir` capped at `max_episode_bytes`, and the `POST /api/podcasts/episodes/{id}/download` server route is added.

Gate green (full workspace). Tests: FeedSetChanged emission, auto_download=0-still-polls, runtime-subscribe→re-enumerate (task_count +1, no config reload), route delegation + error mapping. No theatron changes.

Closes #577
