### PR TITLE
chore(horismos): remove 20 dead config fields with no consumer

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -2436,7 +2436,6 @@ mod service_adapter_tests {
             event_tx,
             horismos::Section::fixed(horismos::KritikeConfig {
                 quality_check_concurrency: 4,
-                ..Default::default()
             }),
         )));
 
@@ -2466,7 +2465,6 @@ mod service_adapter_tests {
             event_tx,
             horismos::Section::fixed(horismos::KritikeConfig {
                 quality_check_concurrency: 4,
-                ..Default::default()
             }),
         )));
 
@@ -3675,7 +3673,6 @@ mod rebuild_supervisor_tests {
                 media_type: horismos::MediaType::Music,
                 watcher_mode: horismos::WatcherMode::Poll,
                 poll_interval_seconds: 1,
-                auto_import: true,
                 scan_interval_hours: 9999, // don't auto-scan; trigger_scan drives it
             },
         );

--- a/crates/archon/tests/config_reload_e2e.rs
+++ b/crates/archon/tests/config_reload_e2e.rs
@@ -76,7 +76,6 @@ opds_page_size = {opds_page_size}
 [ergasia]
 download_dir = "{download_dir}"
 session_state_path = "{download_dir}/.librqbit-state"
-extraction_temp_dir = "{download_dir}/.extraction"
 "#,
             db_path = db_path.display(),
             http_port = self.http_port,

--- a/crates/ergasia/src/progress.rs
+++ b/crates/ergasia/src/progress.rs
@@ -1,5 +1,3 @@
-use std::time::{Duration, Instant};
-
 use serde::{Deserialize, Serialize};
 use themelion::ids::DownloadId;
 
@@ -17,75 +15,9 @@ pub struct DownloadProgress {
     pub eta_seconds: Option<u64>,
 }
 
-#[derive(Debug)]
-pub struct ProgressThrottle {
-    last_emit: Instant,
-    last_percent: u8,
-    throttle_duration: Duration,
-}
-
-impl ProgressThrottle {
-    pub fn new(throttle_duration: Duration) -> Self {
-        Self {
-            last_emit: Instant::now() - throttle_duration,
-            last_percent: 0,
-            throttle_duration,
-        }
-    }
-
-    pub fn should_emit(&mut self, percent: u8) -> bool {
-        let now = Instant::now();
-        let elapsed = now.duration_since(self.last_emit);
-        let delta = percent.abs_diff(self.last_percent);
-
-        if elapsed >= self.throttle_duration && delta >= 1 {
-            self.last_emit = now;
-            self.last_percent = percent;
-            true
-        } else {
-            false
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn throttle_allows_first_emission_with_change() {
-        let mut throttle = ProgressThrottle::new(Duration::from_secs(2));
-        assert!(throttle.should_emit(1));
-    }
-
-    #[test]
-    fn throttle_blocks_within_window() {
-        let mut throttle = ProgressThrottle::new(Duration::from_secs(100));
-        assert!(throttle.should_emit(1));
-        assert!(!throttle.should_emit(5));
-    }
-
-    #[test]
-    fn throttle_blocks_small_delta() {
-        let mut throttle = ProgressThrottle::new(Duration::from_millis(0));
-        assert!(throttle.should_emit(1));
-        assert!(!throttle.should_emit(1));
-    }
-
-    #[test]
-    fn throttle_allows_after_window_and_delta() {
-        let mut throttle = ProgressThrottle::new(Duration::from_millis(0));
-        assert!(throttle.should_emit(1));
-        assert!(throttle.should_emit(2));
-        assert!(throttle.should_emit(5));
-    }
-
-    #[test]
-    fn throttle_blocks_zero_delta_even_after_window() {
-        let mut throttle = ProgressThrottle::new(Duration::from_millis(0));
-        assert!(throttle.should_emit(5));
-        assert!(!throttle.should_emit(5));
-    }
 
     #[test]
     fn download_progress_serde_roundtrip() {

--- a/crates/horismos/src/config.rs
+++ b/crates/horismos/src/config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
     KomideConfig, KritikeConfig, ParocheConfig, ProsthekeConfig, SearchSubsystemConfig,
-    SyndesisConfig, SyndesmosConfig, SyntaxisConfig, TaxisConfig,
+    SyndesmosConfig, SyntaxisConfig, TaxisConfig,
 };
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -35,8 +35,6 @@ pub struct Config {
     pub komide: KomideConfig,
     #[serde(default)]
     pub syndesmos: SyndesmosConfig,
-    #[serde(default)]
-    pub syndesis: SyndesisConfig,
     #[serde(default)]
     pub aitesis: AitesisConfig,
 }

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -148,38 +148,20 @@ pub const LIVE: &[&str] = &[
     "aitesis.auto_approve_admins",
 ];
 
-/// Full dotted leaf paths with NO production consumer — the dead-config
-/// fields inventoried by #529's design pass and filed as harmonia issue
-/// #575. Each stays here (rather than silently vanishing from the schema)
-/// until #575 dispositions it: wired to a real consumer, or removed.
+/// Full dotted leaf paths with NO production consumer — the remaining
+/// dead-config fields inventoried by #529's design pass and filed as
+/// harmonia issue #575 (the WIRE half; the REMOVE half's 20 fields were
+/// deleted from the schema entirely rather than tracked here). Each stays
+/// here (rather than silently vanishing from the schema) until #575
+/// dispositions it: wired to a real consumer, or removed.
 pub const UNWIRED: &[&str] = &[
-    "paroche.stream_buffer_kb",                 // #575
-    "paroche.transcode_concurrency",            // #575
-    "taxis.libraries.*.auto_import",            // #575
-    "taxis.file_naming_dry_run",                // #575
-    "epignosis.max_retries",                    // #575
-    "kritike.scan_interval_hours",              // #575
-    "aggelia.download_queue_size",              // #575
-    "zetesis.max_results_per_indexer",          // #575
-    "zetesis.caps_refresh_hours",               // #575
-    "zetesis.cf_cookie_refresh_minutes",        // #575
-    "zetesis.cf_health_check_interval_minutes", // #575
-    "ergasia.max_concurrent_downloads",         // #575
-    "ergasia.tracker_seed_policies", // #575 — whole TrackerSeedPolicy struct is dead; the map is empty by default and collapses to this one leaf (see `classification_leaf_paths`)
-    "ergasia.progress_throttle_seconds", // #575
-    "ergasia.extraction_temp_dir",   // #575
-    "ergasia.max_connections_per_torrent", // #575
-    "ergasia.magnet_resolve_timeout_seconds", // #575
-    "ergasia.extraction_cleanup_hours", // #575
+    "zetesis.max_results_per_indexer",         // #575
+    "zetesis.caps_refresh_hours",              // #575
+    "zetesis.cf_cookie_refresh_minutes",       // #575
+    "ergasia.magnet_resolve_timeout_seconds",  // #575
     "syntaxis.stalled_download_timeout_hours", // #575
-    "prostheke.opensubtitles.username", // #575
-    "prostheke.opensubtitles.password", // #575
-    "syndesmos.tidal.client_id",     // #575
-    "syndesmos.tidal.client_secret", // #575
-    "syndesmos.tidal.refresh_token", // #575
-    "syndesmos.tidal.sync_interval_minutes", // #575
-    "syndesis.jitter_buffer_max_frames", // #575
-    "syndesis.max_sessions",         // #575
+    "prostheke.opensubtitles.username",        // #575
+    "prostheke.opensubtitles.password",        // #575
 ];
 
 // NOTE: paths a test/exemplar config walks under a dynamic-key map are
@@ -194,7 +176,7 @@ const DYNAMIC_MAP_PATHS: &[&str] = &["taxis.libraries"];
 /// leaf. A dynamic-key map listed in `DYNAMIC_MAP_PATHS` recurses through its
 /// (single, exemplar-populated) entry under a canonical `*` segment instead
 /// of the real key. An empty map with no synthetic entry (e.g.
-/// `ergasia.tracker_seed_policies`) has no children to recurse into, so it
+/// `syndesmos.plex.library_sections`) has no children to recurse into, so it
 /// reports its own path as one leaf — the same "dead subtree" signal a
 /// removed feature would produce.
 #[cfg(test)]
@@ -443,12 +425,12 @@ mod tests {
         let old = base_config();
         let mut new = base_config();
         new.paroche.port = 9090;
-        new.kritike.scan_interval_hours = 12;
+        new.kritike.quality_check_concurrency = 8;
 
         let changes = diff_config(&old, &new);
         assert_eq!(
             paths(&changes),
-            vec!["kritike.scan_interval_hours", "paroche.port"]
+            vec!["kritike.quality_check_concurrency", "paroche.port"]
         );
         assert!(changes.iter().all(|c| !c.requires_restart));
     }
@@ -472,7 +454,7 @@ mod tests {
         let old = base_config();
         let mut new = base_config();
         new.paroche.port = 9090;
-        new.kritike.scan_interval_hours = 12;
+        new.kritike.quality_check_concurrency = 8;
 
         let effective = held_back_merge(&old, &new).unwrap();
         assert!(diff_config(&effective, &new).is_empty());
@@ -521,10 +503,9 @@ mod tests {
     // way a mixed LIVE/UNWIRED subtree (e.g. `prostheke.opensubtitles`) gets
     // per-field classification instead of one opaque leaf. `taxis.libraries`
     // gets exactly ONE synthetic entry so `classification_leaf_paths` walks
-    // it once under the canonical `*` key; `ergasia.tracker_seed_policies`
-    // and `syndesmos.plex.library_sections` are deliberately left EMPTY —
-    // both are uniformly classified as a whole (UNWIRED / LIVE respectively),
-    // so the "empty map collapses to its own leaf" fallback is sufficient.
+    // it once under the canonical `*` key; `syndesmos.plex.library_sections`
+    // is deliberately left EMPTY — uniformly classified as a whole (LIVE), so
+    // the "empty map collapses to its own leaf" fallback is sufficient.
     fn exemplar_config() -> Config {
         use crate::subsystems::{
             LastfmConfig, LibraryConfig, OpenSubtitlesConfig, PlexConfig, TidalConfig,
@@ -554,8 +535,6 @@ mod tests {
         });
         config.syndesmos.tidal = Some(TidalConfig {
             access_token: Some("sample-access".to_string()),
-            refresh_token: Some("sample-refresh".to_string()),
-            ..TidalConfig::default()
         });
 
         config

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -20,8 +20,8 @@ use snafu::ResultExt;
 pub use subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
     KomideConfig, KritikeConfig, LastfmConfig, LibraryConfig, MediaType, OpenSubtitlesConfig,
-    ParocheConfig, PlexConfig, ProsthekeConfig, SearchSubsystemConfig, SyndesisConfig,
-    SyndesmosConfig, SyntaxisConfig, TaxisConfig, TidalConfig, TrackerSeedPolicy, WatcherMode,
+    ParocheConfig, PlexConfig, ProsthekeConfig, SearchSubsystemConfig, SyndesmosConfig,
+    SyntaxisConfig, TaxisConfig, TidalConfig, WatcherMode,
 };
 pub use validation::ValidationWarning;
 
@@ -85,11 +85,10 @@ mod tests {
         assert_eq!(config.paroche.port, 8096);
         assert_eq!(config.paroche.renderer_quic_port, 4433);
         assert_eq!(config.aggelia.buffer_size, 1024);
-        assert_eq!(config.aggelia.download_queue_size, 512);
         assert_eq!(config.zetesis.request_timeout_secs, 30);
         assert_eq!(config.zetesis.max_response_body_bytes, 16 * 1024 * 1024);
         assert_eq!(config.epignosis.cache_ttl_secs, 86400);
-        assert_eq!(config.kritike.scan_interval_hours, 24);
+        assert_eq!(config.kritike.quality_check_concurrency, 4);
     }
 
     #[test]
@@ -108,43 +107,6 @@ mod tests {
         assert!(config.syndesmos.lastfm.is_none());
         assert!(config.syndesmos.tidal.is_none());
         assert_eq!(config.syndesmos.circuit_break_minutes, 5);
-    }
-
-    #[test]
-    fn default_syndesis_config_has_correct_values() {
-        let config = Config::default();
-        assert_eq!(config.syndesis.jitter_buffer_max_frames, 512);
-        assert_eq!(config.syndesis.max_sessions, 32);
-    }
-
-    #[test]
-    fn syndesis_toml_section_overrides_defaults() {
-        with_jail(|jail| {
-            jail.create_file(
-                "harmonia.toml",
-                &format!(
-                    "[exousia]\njwt_secret = \"{}\"\n\n[syndesis]\njitter_buffer_max_frames = 64\nmax_sessions = 4\n",
-                    valid_jwt_secret()
-                ),
-            )
-            .unwrap();
-            let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
-            assert_eq!(config.syndesis.jitter_buffer_max_frames, 64);
-            assert_eq!(config.syndesis.max_sessions, 4);
-        });
-    }
-
-    #[test]
-    fn validation_rejects_zero_syndesis_limits() {
-        let mut config = config_with_jwt(valid_jwt_secret());
-        config.syndesis.max_sessions = 0;
-        let err = validate_config(&config).unwrap_err();
-        assert!(err.to_string().contains("max_sessions"));
-
-        let mut config = config_with_jwt(valid_jwt_secret());
-        config.syndesis.jitter_buffer_max_frames = 0;
-        let err = validate_config(&config).unwrap_err();
-        assert!(err.to_string().contains("jitter_buffer_max_frames"));
     }
 
     // ── TOML file overrides defaults ──────────────────────────────────────────
@@ -554,7 +516,6 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let restored: AggeliaConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.buffer_size, 1024);
-        assert_eq!(restored.download_queue_size, 512);
     }
 
     #[test]

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -53,8 +53,6 @@ impl Default for ExousiaConfig {
 pub struct ParocheConfig {
     pub listen_addr: String,
     pub port: u16,
-    pub stream_buffer_kb: usize,
-    pub transcode_concurrency: usize,
     pub opds_page_size: usize,
     /// Shared secret renderers must present when registering over QUIC.
     /// Leaving it unset rejects every renderer registration (fail closed).
@@ -94,8 +92,6 @@ impl std::fmt::Debug for ParocheConfig {
         f.debug_struct("ParocheConfig")
             .field("listen_addr", &self.listen_addr)
             .field("port", &self.port)
-            .field("stream_buffer_kb", &self.stream_buffer_kb)
-            .field("transcode_concurrency", &self.transcode_concurrency)
             .field("opds_page_size", &self.opds_page_size)
             .field(
                 "renderer_api_key",
@@ -120,8 +116,6 @@ impl Default for ParocheConfig {
         Self {
             listen_addr: "0.0.0.0".to_string(),
             port: 8096,
-            stream_buffer_kb: 256,
-            transcode_concurrency: 2,
             opds_page_size: 50,
             renderer_api_key: None,
             kosync_registration_enabled: true,
@@ -161,7 +155,6 @@ pub struct LibraryConfig {
     pub media_type: MediaType,
     pub watcher_mode: WatcherMode,
     pub poll_interval_seconds: u64,
-    pub auto_import: bool,
     pub scan_interval_hours: u64,
 }
 
@@ -172,7 +165,6 @@ impl Default for LibraryConfig {
             media_type: MediaType::default(),
             watcher_mode: WatcherMode::default(),
             poll_interval_seconds: 300,
-            auto_import: true,
             scan_interval_hours: 24,
         }
     }
@@ -182,7 +174,6 @@ impl Default for LibraryConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct TaxisConfig {
     pub libraries: HashMap<String, LibraryConfig>,
-    pub file_naming_dry_run: bool,
     /// Filesystem watcher debounce window (milliseconds) before an event batch
     /// is flushed.
     pub watcher_debounce_ms: u64,
@@ -194,7 +185,6 @@ impl Default for TaxisConfig {
     fn default() -> Self {
         Self {
             libraries: HashMap::new(),
-            file_naming_dry_run: false,
             watcher_debounce_ms: 500,
             scan_concurrency: 4,
         }
@@ -205,7 +195,6 @@ impl Default for TaxisConfig {
 #[serde(deny_unknown_fields)]
 pub struct EpignosisConfig {
     pub cache_ttl_secs: u64,
-    pub max_retries: u32,
     pub provider_timeout_secs: u64,
     /// Minimum AcoustID confidence score to accept a fingerprint match
     /// without ambiguity.
@@ -248,7 +237,6 @@ impl std::fmt::Debug for EpignosisConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EpignosisConfig")
             .field("cache_ttl_secs", &self.cache_ttl_secs)
-            .field("max_retries", &self.max_retries)
             .field("provider_timeout_secs", &self.provider_timeout_secs)
             .field(
                 "fingerprint_accept_threshold",
@@ -284,7 +272,6 @@ impl Default for EpignosisConfig {
     fn default() -> Self {
         Self {
             cache_ttl_secs: 86400,
-            max_retries: 3,
             provider_timeout_secs: 10,
             fingerprint_accept_threshold: 0.8,
             fingerprint_ambiguous_threshold: 0.5,
@@ -301,14 +288,12 @@ impl Default for EpignosisConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct KritikeConfig {
-    pub scan_interval_hours: u64,
     pub quality_check_concurrency: usize,
 }
 
 impl Default for KritikeConfig {
     fn default() -> Self {
         Self {
-            scan_interval_hours: 24,
             quality_check_concurrency: 4,
         }
     }
@@ -318,15 +303,11 @@ impl Default for KritikeConfig {
 #[serde(deny_unknown_fields)]
 pub struct AggeliaConfig {
     pub buffer_size: usize,
-    pub download_queue_size: usize,
 }
 
 impl Default for AggeliaConfig {
     fn default() -> Self {
-        Self {
-            buffer_size: 1024,
-            download_queue_size: 512,
-        }
+        Self { buffer_size: 1024 }
     }
 }
 
@@ -350,7 +331,6 @@ pub struct SearchSubsystemConfig {
     pub cf_proxy_url: Option<String>,
     pub cf_proxy_timeout_seconds: u64,
     pub cf_cookie_refresh_minutes: u64,
-    pub cf_health_check_interval_minutes: u64,
 }
 
 impl Default for SearchSubsystemConfig {
@@ -369,16 +349,8 @@ impl Default for SearchSubsystemConfig {
             cf_proxy_url: None,
             cf_proxy_timeout_seconds: 60,
             cf_cookie_refresh_minutes: 30,
-            cf_health_check_interval_minutes: 5,
         }
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct TrackerSeedPolicy {
-    pub ratio_threshold: f64,
-    pub time_threshold_hours: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -387,18 +359,12 @@ pub struct ErgasiaConfig {
     pub download_dir: PathBuf,
     pub session_state_path: PathBuf,
     pub listen_port_range: [u16; 2],
-    pub max_concurrent_downloads: usize,
     pub seed_ratio_threshold: f64,
     pub seed_time_threshold_hours: u64,
-    pub tracker_seed_policies: HashMap<String, TrackerSeedPolicy>,
-    pub progress_throttle_seconds: u64,
-    pub extraction_temp_dir: PathBuf,
     pub peer_connect_timeout_seconds: u64,
-    pub max_connections_per_torrent: u32,
     pub magnet_resolve_timeout_seconds: u64,
     pub max_extraction_depth: u8,
     pub max_decompression_ratio: f64,
-    pub extraction_cleanup_hours: u64,
 }
 
 impl Default for ErgasiaConfig {
@@ -407,18 +373,12 @@ impl Default for ErgasiaConfig {
             download_dir: PathBuf::from("/data/downloads"),
             session_state_path: PathBuf::from("/data/downloads/.librqbit-state"),
             listen_port_range: [6881, 6889],
-            max_concurrent_downloads: 5,
             seed_ratio_threshold: 1.0,
             seed_time_threshold_hours: 72,
-            tracker_seed_policies: HashMap::new(),
-            progress_throttle_seconds: 2,
-            extraction_temp_dir: PathBuf::from("/data/downloads/.extraction"),
             peer_connect_timeout_seconds: 10,
-            max_connections_per_torrent: 0,
             magnet_resolve_timeout_seconds: 120,
             max_extraction_depth: 3,
             max_decompression_ratio: 100.0,
-            extraction_cleanup_hours: 48,
         }
     }
 }
@@ -597,38 +557,17 @@ impl std::fmt::Debug for LastfmConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TidalConfig {
-    pub client_id: String,
-    pub client_secret: String,
     /// OAuth2 access token; refreshed automatically when expired.
     pub access_token: Option<String>,
-    pub refresh_token: Option<String>,
-    /// How often to sync the Tidal favorites list (minutes).
-    pub sync_interval_minutes: u64,
 }
 impl std::fmt::Debug for TidalConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TidalConfig")
-            .field("client_id", &"[redacted]")
-            .field("client_secret", &"[redacted]")
             .field("access_token", &"[redacted]")
-            .field("refresh_token", &"[redacted]")
-            .field("sync_interval_minutes", &self.sync_interval_minutes)
             .finish()
-    }
-}
-
-impl Default for TidalConfig {
-    fn default() -> Self {
-        Self {
-            client_id: String::new(),
-            client_secret: String::new(),
-            access_token: None,
-            refresh_token: None,
-            sync_interval_minutes: 60,
-        }
     }
 }
 
@@ -655,26 +594,6 @@ impl Default for SyndesmosConfig {
             tidal: None,
             circuit_break_minutes: 5,
             circuit_break_failure_threshold: 5,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct SyndesisConfig {
-    /// Maximum frames a renderer's jitter buffer holds before evicting the
-    /// oldest. Bounds renderer memory when playout stalls mid-stream.
-    pub jitter_buffer_max_frames: usize,
-    /// Maximum concurrent renderer sessions the streaming server accepts;
-    /// further connections are refused before the TLS handshake.
-    pub max_sessions: usize,
-}
-
-impl Default for SyndesisConfig {
-    fn default() -> Self {
-        Self {
-            jitter_buffer_max_frames: 512,
-            max_sessions: 32,
         }
     }
 }

--- a/crates/horismos/src/validation.rs
+++ b/crates/horismos/src/validation.rs
@@ -48,18 +48,6 @@ fn validate_token_ttls(config: &Config) -> Result<(), HorismosError> {
 }
 
 fn validate_limits(config: &Config) -> Result<(), HorismosError> {
-    if config.syndesis.jitter_buffer_max_frames == 0 {
-        return ValidationSnafu {
-            message: "syndesis.jitter_buffer_max_frames must be greater than 0".to_string(),
-        }
-        .fail();
-    }
-    if config.syndesis.max_sessions == 0 {
-        return ValidationSnafu {
-            message: "syndesis.max_sessions must be greater than 0".to_string(),
-        }
-        .fail();
-    }
     if config.zetesis.max_response_body_bytes == 0 {
         return ValidationSnafu {
             message: "zetesis.max_response_body_bytes must be greater than 0".to_string(),

--- a/crates/kritike/src/lib.rs
+++ b/crates/kritike/src/lib.rs
@@ -144,7 +144,6 @@ mod tests {
     fn fixed_config(quality_check_concurrency: usize) -> Section<KritikeConfig> {
         Section::fixed(KritikeConfig {
             quality_check_concurrency,
-            ..Default::default()
         })
     }
 

--- a/crates/paroche/src/routes/system.rs
+++ b/crates/paroche/src/routes/system.rs
@@ -25,7 +25,6 @@ pub async fn config(
             "paroche": {
                 "port": cfg.paroche.port,
                 "listen_addr": cfg.paroche.listen_addr,
-                "stream_buffer_kb": cfg.paroche.stream_buffer_kb,
                 "opds_page_size": cfg.paroche.opds_page_size,
             },
             "restart_pending": state.config.restart_pending(),

--- a/crates/syndesmos/src/tidal/mod.rs
+++ b/crates/syndesmos/src/tidal/mod.rs
@@ -155,7 +155,6 @@ pub(crate) mod tests {
     fn test_config() -> TidalConfig {
         TidalConfig {
             access_token: Some("tidaltok".to_string()),
-            ..TidalConfig::default()
         }
     }
 

--- a/crates/zetesis/src/cf_bypass/byparr.rs
+++ b/crates/zetesis/src/cf_bypass/byparr.rs
@@ -69,20 +69,6 @@ impl ByparrProxy {
             max_body_bytes,
         }
     }
-
-    pub async fn health_check(&self) -> bool {
-        let req = ByparrRequest {
-            cmd: "request.get",
-            url: "http://localhost".to_string(),
-            max_timeout: 5000,
-        };
-
-        let url = format!("{}/v1", self.endpoint.trim_end_matches('/'));
-        matches!(
-            self.client.post(&url).json(&req).send().await,
-            Ok(resp) if resp.status().is_success() || resp.status().is_client_error()
-        )
-    }
 }
 
 impl CloudflareProxy for ByparrProxy {

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -79,14 +79,12 @@ from the new section on change (`SectionWatcher::changed()`).
 | `refresh_token_ttl_days` | per-op read at mint |
 | `jwt_secret` | per-op read at verify — see **JWT rotation** below |
 
-### paroche — LIVE (steps 2, 4, 5) except two UNWIRED
+### paroche — LIVE (steps 2, 4, 5)
 
 | Field | Class | Mechanism |
 |---|---|---|
 | `listen_addr` | LIVE | HTTP dual-listener rebind (step 5) |
 | `port` | LIVE | HTTP dual-listener rebind (step 5) |
-| `stream_buffer_kb` | UNWIRED | #575 — only echoed in diagnostics |
-| `transcode_concurrency` | UNWIRED | #575 — no transcoding implementation exists |
 | `opds_page_size` | LIVE | per-op read off `ConfigHandle` |
 | `renderer_api_key` | LIVE | per-connection section read at SessionInit; rotation affects new registrations only |
 | `kosync_registration_enabled` | LIVE | per-request read |
@@ -94,30 +92,26 @@ from the new section on change (`SectionWatcher::changed()`).
 | `renderer_session_init_timeout_secs` | LIVE | per-connection section read |
 | `renderer_quic_port` | LIVE | QUIC dual-endpoint rebind (step 5) |
 
-### taxis — LIVE (scanner REBUILD, step 6) except two UNWIRED
+### taxis — LIVE (scanner REBUILD, step 6)
 
 | Field | Class |
 |---|---|
 | `libraries.<key>.path` / `.media_type` / `.watcher_mode` / `.poll_interval_seconds` / `.scan_interval_hours` | LIVE |
-| `libraries.<key>.auto_import` | UNWIRED — #575, scanner emits unconditionally |
-| `file_naming_dry_run` | UNWIRED — #575, no dry-run logic exists |
 | `watcher_debounce_ms` | LIVE |
 | `scan_concurrency` | LIVE |
 
-### epignosis — LIVE (resolver REBUILD, step 8) except one UNWIRED
+### epignosis — LIVE (resolver REBUILD, step 8)
 
 | Field | Class | Mechanism |
 |---|---|---|
 | `cache_ttl_secs` / `provider_timeout_secs` / `provider_response_max_bytes` | LIVE | metadata cache RESETS on rebuild (logged) |
 | `acoustid_key` / `tmdb_key` / `tvdb_key` / `comicvine_key` / `google_books_key` | LIVE | #578 — resolver rebuild re-derives `ProviderCredentials::from(&new_cfg)`; key rotation is live for free |
-| `max_retries` | UNWIRED | #575 |
 | `fingerprint_accept_threshold` / `fingerprint_ambiguous_threshold` | LIVE | #575 — `merge_lookup_matches` classifies every fingerprint lookup against both thresholds (accepted / ambiguous-held / dropped) |
 
 ### kritike
 
 | Field | Class | Mechanism |
 |---|---|---|
-| `scan_interval_hours` | UNWIRED | #575 — no scan loop exists |
 | `quality_check_concurrency` | LIVE | `themelion::LiveGate` (step 8) |
 
 ### aggelia
@@ -125,9 +119,8 @@ from the new section on change (`SectionWatcher::changed()`).
 | Field | Class |
 |---|---|
 | `buffer_size` | RESTART — broadcast channel capacity fixed at creation |
-| `download_queue_size` | UNWIRED — #575, only `buffer_size` is consumed |
 
-### zetesis — LIVE (steps 7) except four UNWIRED
+### zetesis — LIVE (steps 7) except three UNWIRED
 
 | Field | Class | Mechanism |
 |---|---|---|
@@ -135,7 +128,7 @@ from the new section on change (`SectionWatcher::changed()`).
 | `cloudflare_bypass_enabled` / `cf_proxy_url` / `cf_proxy_timeout_seconds` | LIVE | cf-proxy rebuild + swap |
 | `per_indexer_rate_limit_requests` / `per_indexer_rate_limit_window_seconds` | LIVE | `RateLimiter::reconfigure` — preserves in-flight embargoes |
 | `cardigann_definitions_dir` | LIVE | registry reload + swap |
-| `max_results_per_indexer` / `caps_refresh_hours` / `cf_cookie_refresh_minutes` / `cf_health_check_interval_minutes` | UNWIRED | #575 |
+| `max_results_per_indexer` / `caps_refresh_hours` / `cf_cookie_refresh_minutes` | UNWIRED | #575 |
 
 ### ergasia — mostly RESTART/UNWIRED; two LIVE
 
@@ -144,7 +137,7 @@ from the new section on change (`SectionWatcher::changed()`).
 | `download_dir` / `session_state_path` / `listen_port_range` / `peer_connect_timeout_seconds` | RESTART | frozen into the librqbit session at build |
 | `seed_ratio_threshold` / `seed_time_threshold_hours` | RESTART | frozen into librqbit's `SeedingPolicy`, no reconfigure API (reclassified in step 7 — previously a silent no-op) |
 | `max_extraction_depth` / `max_decompression_ratio` | LIVE | `SessionEngine` rebuilds `ExtractionLimits` per extract call |
-| `max_concurrent_downloads`, `tracker_seed_policies`, `progress_throttle_seconds`, `extraction_temp_dir`, `max_connections_per_torrent`, `magnet_resolve_timeout_seconds`, `extraction_cleanup_hours` | UNWIRED | #575 |
+| `magnet_resolve_timeout_seconds` | UNWIRED | #575 |
 
 ### syntaxis — LIVE (step 7) except one UNWIRED
 
@@ -174,7 +167,7 @@ re-enumerates the poll tasks after a short coalescing window, REUSING the
 existing `FeedSchedulerService` — the etag/last-modified cache and reqwest
 client survive, and no config reload is involved (#577).
 
-### syndesmos — LIVE (client REBUILD, step 8) except four UNWIRED
+### syndesmos — LIVE (client REBUILD, step 8)
 
 | Field | Class | Notes |
 |---|---|---|
@@ -183,19 +176,12 @@ client survive, and no config reload is involved (#577).
 | `tidal.access_token` | LIVE | the only Tidal field a real client reads |
 | `circuit_break_minutes` | LIVE | feeds `CircuitBreaker` cooldown |
 | `circuit_break_failure_threshold` | LIVE | reaches the rebuild supervisor like every other `syndesmos.*` leaf, but `ScrobbleClientBuilder::build()` currently hardcodes the breaker threshold to 5 — a within-crate wiring gap tracked separately, NOT part of #575's dead-config list |
-| `tidal.client_id` / `.client_secret` / `.refresh_token` / `.sync_interval_minutes` | UNWIRED | #575 — no OAuth refresh flow, no sync scheduler |
 
 Rebuilding the client on ANY `syndesmos.*` change costs two honest things,
 both logged: circuit breakers reset (fresh breakers, no carried trip state),
 and events published between handler-cancel and re-subscribe are lost (a
 bounded scrobble-loss window — broadcast receivers only see
 post-subscription events).
-
-### syndesis — UNWIRED (both fields)
-
-| Field | Class | Why |
-|---|---|---|
-| `jitter_buffer_max_frames` / `max_sessions` | UNWIRED | #575 — the syndesis crate is never constructed from archon |
 
 ### aitesis — LIVE (step 8)
 

--- a/docs/media/scanner.md
+++ b/docs/media/scanner.md
@@ -29,21 +29,18 @@ path = "/media/music"
 media_type = "music"
 watcher_mode = "auto"          # "inotify" | "poll" | "auto"
 poll_interval_seconds = 30
-auto_import = true             # false = manual review mode
 scan_interval_hours = 6
 
 [taxis.libraries.movies]
 path = "/media/movies"
 media_type = "movie"
 watcher_mode = "auto"
-auto_import = true
 scan_interval_hours = 6
 
 [taxis.libraries.audiobooks]
 path = "/media/audiobooks"
 media_type = "audiobook"
 watcher_mode = "auto"
-auto_import = true
 scan_interval_hours = 6
 ```
 
@@ -52,7 +49,6 @@ scan_interval_hours = 6
 - Each library has a single `media_type`; no mixed-type libraries. This simplifies media detection and naming templates.
 - Multiple libraries can share the same `media_type` (e.g., two music libraries on different mounts).
 - `watcher_mode = "auto"`: try `RecommendedWatcher`. If the mount is detected as NFS (via `/proc/mounts` or `nix::sys::statvfs`), fall back to `PollWatcher`.
-- `auto_import = false` queues discovered files for manual review instead of importing immediately.
 
 ---
 
@@ -260,7 +256,7 @@ Full library walk on a configurable schedule.
 1. Use `ignore::WalkBuilder` to walk the library path (respects `.harmoniaignore`).
 2. For each file: compare against `haves` table by `file_path`.
 3. Identify three categories:
-   - **New:** path not in `haves` → dispatch to import pipeline (or manual review queue if `auto_import = false`).
+   - **New:** path not in `haves` → dispatch to import pipeline.
    - **Missing:** path in `haves` but not on disk → set `haves.status = 'missing'`, evaluate want re-activation.
    - **Modified:** path in `haves`, size or mtime changed → re-read tags, update metadata.
 4. Unchanged files (path matches, same size+mtime) → skip, no DB write.
@@ -346,7 +342,6 @@ path = "/media/music"
 media_type = "music"
 watcher_mode = "auto"          # "inotify" | "poll" | "auto"
 poll_interval_seconds = 30
-auto_import = true
 scan_interval_hours = 6
 
 # Additional libraries follow the same pattern
@@ -369,7 +364,6 @@ pub struct LibraryConfig {
     pub media_type: MediaType,
     pub watcher_mode: WatcherModeConfig, // Auto | Inotify | Poll
     pub poll_interval_seconds: u64,      // default: 30
-    pub auto_import: bool,               // default: true
     pub scan_interval_hours: u64,        // default: 6
     pub naming_template: Option<String>, // overrides default template
 }


### PR DESCRIPTION
Removes 20 config fields that parse but reach no consumer (the REMOVE half of #575). `deny_unknown_fields` makes each deletion auto-reject any config still setting the key, so removal *is* the validation.

Removed across paroche/taxis/epignosis/kritike/aggelia/zetesis/ergasia/syndesmos.tidal/syndesis, plus the dead code they gated: `ByparrProxy::health_check`, the horismos `TrackerSeedPolicy` and `ProgressThrottle` types, and the entire unused `SyndesisConfig` struct + `Config.syndesis` field (syndesis is never constructed from archon; the syndesis crate's own live config is a distinct, untouched type). The grep sweep also caught runtime stragglers a compile check wouldn't — an e2e TOML fixture setting a removed field (would fail parse under deny_unknown_fields) and diff.rs test exemplars referencing removed fields — all fixed.

`UNWIRED` in diff.rs now holds only the 9 wire-side fields (handled in follow-up PRs); `every_leaf_is_classified_exactly_once` passes. Taxis `auto_import`/`file_naming_dry_run` return with the #300 import pipeline; the four Tidal fields return under #596. Broader docs drift found during the sweep is filed as #597.

Gate green (2060 tests, all 10 stages).

Part of #575 (REMOVE half; the WIRE half is separate PRs).