### PR TITLE
fix(zetesis,archon): wire per-indexer result cap, scheduled caps refresh, and CF cookie reuse

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -1114,6 +1114,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
             Arc::clone(&zetesis),
             boot_config.zetesis.clone(),
             config_handle.clone(),
+            CAPS_REFRESH_TICK,
             shutdown_token.child_token(),
         )
         .instrument(tracing::info_span!("zetesis_supervisor")),
@@ -2046,26 +2047,72 @@ async fn run_syntaxis_supervisor(
     }
 }
 
+/// Tick period for the scheduled indexer caps-refresh sweep. Staleness is
+/// judged against the live `zetesis.caps_refresh_hours` on every tick, so
+/// the tick only bounds detection latency, never the refresh threshold.
+const CAPS_REFRESH_TICK: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+
+/// One scheduled caps-refresh sweep: refreshes every eligible indexer whose
+/// last caps observation is older than the live `zetesis.caps_refresh_hours`.
+async fn refresh_stale_indexer_caps(
+    service: &SearchIndexerService,
+    cfg: &horismos::SearchSubsystemConfig,
+    shutdown: &CancellationToken,
+) {
+    let max_age = std::time::Duration::from_secs(cfg.caps_refresh_hours.saturating_mul(3600));
+    match service
+        .refresh_stale_caps(max_age, shutdown.child_token())
+        .await
+    {
+        Ok(refreshed) if refreshed.is_empty() => {}
+        Ok(refreshed) => tracing::info!(
+            subsystem = "zetesis",
+            count = refreshed.len(),
+            "scheduled caps refresh completed"
+        ),
+        Err(e) => tracing::warn!(
+            subsystem = "zetesis",
+            error = %e,
+            "scheduled caps refresh sweep failed"
+        ),
+    }
+}
+
 /// Runs the zetesis LIVE-B mechanisms (per-indexer rate limits, Cloudflare
-/// bypass proxy, Cardigann definitions registry) under a section watcher.
+/// bypass proxy, Cardigann definitions registry) under a section watcher,
+/// plus the scheduled caps-refresh tick (`zetesis.caps_refresh_hours`).
 /// The per-op fields (`max_concurrent_searches`, `search_timeout_seconds`,
-/// `max_response_body_bytes`, `request_timeout_secs`) need no supervisor
-/// action — `SearchIndexerService` already reads them live through its own
-/// `Section`.
+/// `max_response_body_bytes`, `request_timeout_secs`,
+/// `max_results_per_indexer`) need no supervisor action —
+/// `SearchIndexerService` already reads them live through its own `Section`.
 async fn run_zetesis_supervisor(
     service: Arc<SearchIndexerService>,
     initial: horismos::SearchSubsystemConfig,
     config: horismos::ConfigHandle,
+    caps_tick_period: std::time::Duration,
     shutdown: CancellationToken,
 ) {
     let mut watcher = config.watch_section(|c| &c.zetesis);
     let mut current = initial;
+    // WHY: the first tick lands one full period out — caps are already
+    // fetched when an indexer is added or manually tested, so boot needs no
+    // immediate sweep. Delay (not Burst) on missed ticks: a slow sweep must
+    // not be chased by a back-to-back catch-up sweep.
+    let mut caps_tick = tokio::time::interval_at(
+        tokio::time::Instant::now() + caps_tick_period,
+        caps_tick_period,
+    );
+    caps_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     loop {
         let changed = tokio::select! {
             biased;
             _ = shutdown.cancelled() => break,
             changed = watcher.changed() => changed,
+            _ = caps_tick.tick() => {
+                refresh_stale_indexer_caps(&service, &current, &shutdown).await;
+                continue;
+            }
         };
         let Some(new) = changed else {
             shutdown.cancelled().await;
@@ -2091,10 +2138,13 @@ async fn run_zetesis_supervisor(
         if new.cloudflare_bypass_enabled != current.cloudflare_bypass_enabled
             || new.cf_proxy_url != current.cf_proxy_url
             || new.cf_proxy_timeout_seconds != current.cf_proxy_timeout_seconds
+            || new.cf_cookie_refresh_minutes != current.cf_cookie_refresh_minutes
         {
+            // NOTE: a rebuild drops the proxy's cached CF clearance cookies —
+            // the next request per host re-solves (an honest, logged cost).
             tracing::info!(
                 subsystem = "zetesis",
-                "cloudflare bypass config changed  -  rebuilding proxy"
+                "cloudflare bypass config changed  -  rebuilding proxy, cookie cache reset"
             );
             match build_cf_proxy(&new) {
                 Ok(proxy) => service.set_cf_proxy(proxy),
@@ -2369,6 +2419,7 @@ fn build_cf_proxy(
         url.to_string(),
         std::time::Duration::from_secs(config.cf_proxy_timeout_seconds),
         config.max_response_body_bytes,
+        std::time::Duration::from_secs(config.cf_cookie_refresh_minutes.saturating_mul(60)),
     )))
 }
 
@@ -4130,5 +4181,165 @@ mod rebuild_supervisor_tests {
         supervisor
             .await
             .expect("epignosis supervisor joins cleanly after a credential rebuild");
+    }
+
+    // ── zetesis supervisor: scheduled caps refresh (#575) ───────────────────
+
+    const ZETESIS_CAPS_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+  <server title="Test Indexer" version="1.0"/>
+  <limits default="100" max="500"/>
+  <searching>
+    <search available="yes"/>
+  </searching>
+  <categories>
+    <category id="2000" name="Movies"/>
+  </categories>
+</caps>"#;
+
+    /// TCP stub answering every request with a valid torznab caps document.
+    async fn spawn_caps_stub() -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind caps stub");
+        let url = format!("http://{}", listener.local_addr().expect("local addr"));
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{ZETESIS_CAPS_XML}",
+                    ZETESIS_CAPS_XML.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+        url
+    }
+
+    /// #575: a REAL `run_zetesis_supervisor` on a short test tick refreshes
+    /// the caps of an indexer whose `last_tested` exceeds the live
+    /// `caps_refresh_hours` (default 24h) and skips one inside the window,
+    /// then joins cleanly on shutdown. The tick period is parameterized;
+    /// the staleness threshold itself comes from the live config section.
+    #[tokio::test]
+    async fn zetesis_supervisor_tick_refreshes_stale_caps_and_skips_fresh() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        apotheke::migrate::MIGRATOR
+            .run(&pool)
+            .await
+            .expect("migrate");
+
+        // WHY: BOTH indexers get a live caps stub — if the fresh one were
+        // wrongly swept, its refresh would succeed and the last_tested
+        // assertion below would catch it.
+        let stale_url = spawn_caps_stub().await;
+        let fresh_url = spawn_caps_stub().await;
+        let stale = zetesis::repo::insert_indexer(
+            &pool,
+            zetesis::repo::InsertIndexerParams {
+                name: "Stale",
+                url: &stale_url,
+                protocol: "torznab",
+                api_key: None,
+                cf_bypass: false,
+                priority: 10,
+            },
+        )
+        .await
+        .expect("insert stale indexer");
+        let fresh = zetesis::repo::insert_indexer(
+            &pool,
+            zetesis::repo::InsertIndexerParams {
+                name: "Fresh",
+                url: &fresh_url,
+                protocol: "torznab",
+                api_key: None,
+                cf_bypass: false,
+                priority: 20,
+            },
+        )
+        .await
+        .expect("insert fresh indexer");
+        zetesis::repo::update_indexer_caps(&pool, stale, "{}", "2020-01-01T00:00:00Z")
+            .await
+            .expect("age the stale indexer");
+        // WHY: a far-future stamp stays inside any refresh window without
+        // needing a clock dependency in this crate's tests.
+        zetesis::repo::update_indexer_caps(&pool, fresh, "{}", "2099-01-01T00:00:00Z")
+            .await
+            .expect("freshen the fresh indexer");
+
+        let mut boot = Config::default();
+        boot.exousia.jwt_secret = "zetesis-supervisor-test-secret-at-least-32-bytes".to_string();
+        let (manager, handle) = ConfigManager::new(
+            boot.clone(),
+            PathBuf::from("unused.toml"),
+            ConfigOverrides::default(),
+        );
+        let (event_tx, _event_rx) = create_event_bus(16);
+        let service = Arc::new(SearchIndexerService::new(
+            pool.clone(),
+            pool.clone(),
+            Arc::new(NoProxy),
+            handle.section(|c| &c.zetesis),
+            event_tx,
+        ));
+
+        let shutdown = CancellationToken::new();
+        let supervisor = tokio::spawn(run_zetesis_supervisor(
+            Arc::clone(&service),
+            boot.zetesis.clone(),
+            handle,
+            Duration::from_millis(50),
+            shutdown.clone(),
+        ));
+
+        // Bounded real wait for a tick to fire and the sweep to land —
+        // generous relative to the 50ms test tick, nowhere near the
+        // production 15-minute tick.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let row = zetesis::repo::get_indexer(&pool, stale)
+                .await
+                .expect("query stale indexer")
+                .expect("stale indexer row");
+            if row.last_tested.as_deref() != Some("2020-01-01T00:00:00Z") {
+                assert!(
+                    row.caps_json.as_deref() != Some("{}"),
+                    "caps must be rewritten"
+                );
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "caps-refresh tick never refreshed the stale indexer"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        let fresh_row = zetesis::repo::get_indexer(&pool, fresh)
+            .await
+            .expect("query fresh indexer")
+            .expect("fresh indexer row");
+        assert_eq!(
+            fresh_row.last_tested.as_deref(),
+            Some("2099-01-01T00:00:00Z"),
+            "an indexer inside the refresh window must be skipped untouched"
+        );
+
+        shutdown.cancel();
+        supervisor
+            .await
+            .expect("zetesis supervisor joins cleanly after caps-refresh ticks");
+        drop(manager);
     }
 }

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -95,6 +95,15 @@ pub const LIVE: &[&str] = &[
     "zetesis.cardigann_definitions_dir",
     "zetesis.cf_proxy_url",
     "zetesis.cf_proxy_timeout_seconds",
+    // #575: per-op read in the search fan-out — each indexer's results are
+    // truncated to this bound before the merged collect.
+    "zetesis.max_results_per_indexer",
+    // #575: the zetesis supervisor's caps-refresh tick judges staleness
+    // against the live section value on every tick.
+    "zetesis.caps_refresh_hours",
+    // #575: ByparrProxy's per-host cookie reuse window — a change rebuilds
+    // the proxy (same swap as cf_proxy_url; cookie cache resets, logged).
+    "zetesis.cf_cookie_refresh_minutes",
     // ergasia — step 7 (SessionEngine rebuilds ExtractionLimits per call)
     "ergasia.max_extraction_depth",
     "ergasia.max_decompression_ratio",
@@ -155,9 +164,6 @@ pub const LIVE: &[&str] = &[
 /// here (rather than silently vanishing from the schema) until #575
 /// dispositions it: wired to a real consumer, or removed.
 pub const UNWIRED: &[&str] = &[
-    "zetesis.max_results_per_indexer",         // #575
-    "zetesis.caps_refresh_hours",              // #575
-    "zetesis.cf_cookie_refresh_minutes",       // #575
     "ergasia.magnet_resolve_timeout_seconds",  // #575
     "syntaxis.stalled_download_timeout_hours", // #575
     "prostheke.opensubtitles.username",        // #575

--- a/crates/zetesis/src/cf_bypass/byparr.rs
+++ b/crates/zetesis/src/cf_bypass/byparr.rs
@@ -7,6 +7,7 @@ use snafu::ResultExt;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
+use crate::cf_bypass::cookies::CookieStore;
 use crate::cf_bypass::{CloudflareProxy, Cookie, ProxyResponse};
 use crate::error::{self, SearchIndexerError};
 
@@ -15,6 +16,19 @@ pub struct ByparrProxy {
     endpoint: String,
     timeout: Duration,
     max_body_bytes: u64,
+    // WHY: a Cloudflare solve costs seconds — successful solves are cached
+    // per target host and reused via a direct fetch until the clearance
+    // cookies approach expiry (`zetesis.cf_cookie_refresh_minutes`) or the
+    // origin challenges again.
+    cookies: CookieStore,
+    cookie_refresh: Duration,
+}
+
+/// Outcome of a direct (cookie-reuse) fetch: a usable response, or a
+/// Cloudflare re-challenge that demands a fresh solve.
+enum DirectOutcome {
+    Response(ProxyResponse),
+    Challenged,
 }
 
 #[derive(Debug, Serialize)]
@@ -56,7 +70,12 @@ struct ByparrCookie {
 }
 
 impl ByparrProxy {
-    pub fn new(endpoint: String, timeout: Duration, max_body_bytes: u64) -> Self {
+    pub fn new(
+        endpoint: String,
+        timeout: Duration,
+        max_body_bytes: u64,
+        cookie_refresh: Duration,
+    ) -> Self {
         let client = reqwest::Client::builder()
             .timeout(timeout + Duration::from_secs(5))
             .build()
@@ -67,6 +86,8 @@ impl ByparrProxy {
             endpoint,
             timeout,
             max_body_bytes,
+            cookies: CookieStore::new(),
+            cookie_refresh,
         }
     }
 }
@@ -92,6 +113,93 @@ impl ByparrProxy {
         url: &str,
         ct: CancellationToken,
     ) -> Result<ProxyResponse, SearchIndexerError> {
+        // WHY: errors embed the redacted form so the API key never reaches a
+        // log line; the request itself still carries the real URL.
+        let redacted = crate::client::redact_api_key(url);
+        let host = reqwest::Url::parse(url)
+            .ok()
+            .and_then(|u| u.host_str().map(str::to_string));
+
+        if let Some(host) = &host
+            && !self.cookies.needs_refresh(host, self.cookie_refresh)
+            && let Some(cookie_header) = self.cookies.get_cookie_header(host)
+            && let Some(user_agent) = self.cookies.get_user_agent(host)
+        {
+            match self
+                .direct_get(url, &redacted, &cookie_header, &user_agent, &ct)
+                .await?
+            {
+                DirectOutcome::Response(response) => return Ok(response),
+                // WHY: the origin re-challenged despite fresh-looking
+                // cookies — drop the jar and fall through to a new solve.
+                DirectOutcome::Challenged => self.cookies.remove(host),
+            }
+        }
+
+        let response = self.solve(url, &redacted, &ct).await?;
+        // WHY: an empty cookie set has nothing to reuse — storing it would
+        // only add a jar that the reuse guard skips anyway.
+        if let Some(host) = &host
+            && !response.cookies.is_empty()
+        {
+            self.cookies
+                .store(host, response.cookies.clone(), response.user_agent.clone());
+        }
+        Ok(response)
+    }
+
+    /// Direct fetch of `url` reusing solved clearance cookies. A 403/503
+    /// answer is Cloudflare challenging again — reported as `Challenged`
+    /// instead of handing the challenge page to the indexer parser.
+    async fn direct_get(
+        &self,
+        url: &str,
+        redacted: &str,
+        cookie_header: &str,
+        user_agent: &str,
+        ct: &CancellationToken,
+    ) -> Result<DirectOutcome, SearchIndexerError> {
+        let request = self
+            .client
+            .get(url)
+            .header(reqwest::header::COOKIE, cookie_header)
+            .header(reqwest::header::USER_AGENT, user_agent);
+        let response = tokio::select! {
+            result = request.send() => {
+                result.context(error::HttpRequestSnafu { url: redacted.to_string() })?
+            }
+            () = ct.cancelled() => {
+                return Err(SearchIndexerError::Cancelled {
+                    url: redacted.to_string(),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+        };
+
+        let status = response.status().as_u16();
+        if status == 403 || status == 503 {
+            return Ok(DirectOutcome::Challenged);
+        }
+
+        // WHY: same body-size cap as the solve path — a direct fetch returns
+        // third-party bytes and must not buffer unbounded.
+        let raw =
+            crate::client::read_body_bytes_bounded(response, redacted, self.max_body_bytes).await?;
+        Ok(DirectOutcome::Response(ProxyResponse {
+            status,
+            body: String::from_utf8_lossy(&raw).into_owned(),
+            cookies: Vec::new(),
+            user_agent: user_agent.to_string(),
+        }))
+    }
+
+    /// Full Cloudflare solve through the byparr service.
+    async fn solve(
+        &self,
+        url: &str,
+        redacted: &str,
+        ct: &CancellationToken,
+    ) -> Result<ProxyResponse, SearchIndexerError> {
         let req = ByparrRequest {
             cmd: "request.get",
             url: url.to_string(),
@@ -100,16 +208,13 @@ impl ByparrProxy {
 
         let endpoint_url = format!("{}/v1", self.endpoint.trim_end_matches('/'));
 
-        // WHY: errors embed the redacted form so the API key never reaches a
-        // log line; the request itself still carries the real URL.
-        let redacted = crate::client::redact_api_key(url);
         let response = tokio::select! {
             result = self.client.post(&endpoint_url).json(&req).send() => {
-                result.context(error::HttpRequestSnafu { url: redacted.clone() })?
+                result.context(error::HttpRequestSnafu { url: redacted.to_string() })?
             }
             () = ct.cancelled() => {
                 return Err(SearchIndexerError::Cancelled {
-                    url: redacted,
+                    url: redacted.to_string(),
                     location: snafu::Location::new(file!(), line!(), column!()),
                 });
             }
@@ -122,18 +227,18 @@ impl ByparrProxy {
         // (Content-Length precheck + streamed running counter) before it is
         // buffered; the wrapped indexer body is a subset, so the effective
         // ceiling is conservative by the envelope overhead.
-        let raw = crate::client::read_body_bytes_bounded(response, &redacted, self.max_body_bytes)
-            .await?;
+        let raw =
+            crate::client::read_body_bytes_bounded(response, redacted, self.max_body_bytes).await?;
         let byparr_resp: ByparrResponse =
             serde_json::from_slice(&raw).map_err(|e| SearchIndexerError::ParseResponse {
-                url: redacted.clone(),
+                url: redacted.to_string(),
                 error: e.to_string(),
                 location: snafu::Location::new(file!(), line!(), column!()),
             })?;
 
         if byparr_resp.status != "ok" {
             return Err(SearchIndexerError::CfProxyError {
-                url: redacted.clone(),
+                url: redacted.to_string(),
                 status: byparr_resp.status,
                 message: byparr_resp.message,
                 location: snafu::Location::new(file!(), line!(), column!()),
@@ -143,7 +248,7 @@ impl ByparrProxy {
         let solution = byparr_resp
             .solution
             .ok_or_else(|| SearchIndexerError::CfProxyError {
-                url: redacted,
+                url: redacted.to_string(),
                 status: "ok".to_string(),
                 message: "no solution in response".to_string(),
                 location: snafu::Location::new(file!(), line!(), column!()),
@@ -174,8 +279,78 @@ impl ByparrProxy {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
+
     use super::*;
     use crate::test_support::spawn_one_shot_http;
+
+    /// Refresh window for tests where reuse-vs-resolve is not under test.
+    const ANY_REFRESH: Duration = Duration::from_secs(60);
+
+    /// Spawns a TCP server that answers EVERY request with `status` + `body`,
+    /// counting hits and recording each raw request head.
+    async fn spawn_counting_http(
+        status: u16,
+        body: String,
+        hits: Arc<AtomicUsize>,
+        heads: Arc<Mutex<Vec<String>>>,
+    ) -> (String, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let handle = tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                hits.fetch_add(1, Ordering::SeqCst);
+                let mut buf = Vec::new();
+                let mut chunk = [0u8; 4096];
+                loop {
+                    let n = stream.read(&mut chunk).await.unwrap();
+                    buf.extend_from_slice(&chunk[..n]);
+                    if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                heads
+                    .lock()
+                    .unwrap()
+                    .push(String::from_utf8_lossy(&buf).into_owned());
+                let response = format!(
+                    "HTTP/1.1 {status} X\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream.write_all(response.as_bytes()).await.ok();
+                stream.shutdown().await.ok();
+            }
+        });
+        (url, handle)
+    }
+
+    fn counting() -> (Arc<AtomicUsize>, Arc<Mutex<Vec<String>>>) {
+        (
+            Arc::new(AtomicUsize::new(0)),
+            Arc::new(Mutex::new(Vec::new())),
+        )
+    }
+
+    fn solution_json(cookie_expires: f64, response_body: &str) -> String {
+        format!(
+            r#"{{"status":"ok","message":"solved","solution":{{"url":"https://e.example","status":200,"response":"{response_body}","cookies":[{{"name":"cf_clearance","value":"clearance-token","domain":".example.com","path":"/","expires":{cookie_expires},"httpOnly":false,"secure":true}}],"userAgent":"UA-solved"}}}}"#
+        )
+    }
+
+    fn unix_now_plus(secs: f64) -> f64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            + secs
+    }
 
     #[tokio::test]
     async fn get_enforces_body_size_cap() {
@@ -188,7 +363,7 @@ mod tests {
             r#"{{"status":"ok","message":"","solution":{{"url":"https://e.example","status":200,"response":"{big}","cookies":[],"userAgent":"UA"}}}}"#
         );
         let (endpoint, _server) = spawn_one_shot_http(200, "OK", &[], &json).await;
-        let proxy = ByparrProxy::new(endpoint, Duration::from_secs(5), 64);
+        let proxy = ByparrProxy::new(endpoint, Duration::from_secs(5), 64, ANY_REFRESH);
         let err = proxy
             .get(
                 "https://indexer.example/api?apikey=secret",
@@ -199,6 +374,196 @@ mod tests {
         assert!(
             matches!(err, SearchIndexerError::ResponseTooLarge { limit: 64, .. }),
             "expected ResponseTooLarge, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_cookies_reuse_direct_fetch_with_one_solve() {
+        let (byparr_hits, byparr_heads) = counting();
+        let (endpoint, _byparr) = spawn_counting_http(
+            200,
+            solution_json(unix_now_plus(3600.0), "<solved/>"),
+            Arc::clone(&byparr_hits),
+            byparr_heads,
+        )
+        .await;
+        let (indexer_hits, indexer_heads) = counting();
+        let (indexer_url, _indexer) = spawn_counting_http(
+            200,
+            "<direct/>".to_string(),
+            Arc::clone(&indexer_hits),
+            Arc::clone(&indexer_heads),
+        )
+        .await;
+
+        let proxy = ByparrProxy::new(
+            endpoint,
+            Duration::from_secs(5),
+            1024 * 1024,
+            Duration::from_secs(60),
+        );
+
+        let first = proxy
+            .get(&indexer_url, CancellationToken::new())
+            .await
+            .unwrap();
+        assert_eq!(first.body, "<solved/>");
+        assert_eq!(byparr_hits.load(Ordering::SeqCst), 1);
+        assert_eq!(indexer_hits.load(Ordering::SeqCst), 0);
+
+        let second = proxy
+            .get(&indexer_url, CancellationToken::new())
+            .await
+            .unwrap();
+        assert_eq!(second.body, "<direct/>");
+        assert_eq!(
+            byparr_hits.load(Ordering::SeqCst),
+            1,
+            "a fresh cookie must not trigger a second solve"
+        );
+        assert_eq!(indexer_hits.load(Ordering::SeqCst), 1);
+
+        let head = indexer_heads.lock().unwrap().first().cloned().unwrap();
+        assert!(
+            head.contains("cf_clearance=clearance-token"),
+            "direct fetch must send the stored cookie: {head}"
+        );
+        assert!(
+            head.contains("UA-solved"),
+            "direct fetch must reuse the solve's user agent: {head}"
+        );
+    }
+
+    #[tokio::test]
+    async fn near_expiry_cookie_forces_resolve() {
+        let (byparr_hits, byparr_heads) = counting();
+        // WHY: the cookie's remaining life (30s) is inside the refresh window
+        // (300s) — the second request must re-solve, never reuse.
+        let (endpoint, _byparr) = spawn_counting_http(
+            200,
+            solution_json(unix_now_plus(30.0), "<solved/>"),
+            Arc::clone(&byparr_hits),
+            byparr_heads,
+        )
+        .await;
+        let (indexer_hits, indexer_heads) = counting();
+        let (indexer_url, _indexer) = spawn_counting_http(
+            200,
+            "<direct/>".to_string(),
+            Arc::clone(&indexer_hits),
+            indexer_heads,
+        )
+        .await;
+
+        let proxy = ByparrProxy::new(
+            endpoint,
+            Duration::from_secs(5),
+            1024 * 1024,
+            Duration::from_secs(300),
+        );
+
+        proxy
+            .get(&indexer_url, CancellationToken::new())
+            .await
+            .unwrap();
+        let second = proxy
+            .get(&indexer_url, CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert_eq!(second.body, "<solved/>");
+        assert_eq!(
+            byparr_hits.load(Ordering::SeqCst),
+            2,
+            "a near-expiry cookie must force a re-solve"
+        );
+        assert_eq!(indexer_hits.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn challenged_direct_fetch_falls_back_to_resolve() {
+        let (byparr_hits, byparr_heads) = counting();
+        let (endpoint, _byparr) = spawn_counting_http(
+            200,
+            solution_json(unix_now_plus(3600.0), "<solved/>"),
+            Arc::clone(&byparr_hits),
+            byparr_heads,
+        )
+        .await;
+        let (indexer_hits, indexer_heads) = counting();
+        let (indexer_url, _indexer) = spawn_counting_http(
+            403,
+            "challenge page".to_string(),
+            Arc::clone(&indexer_hits),
+            indexer_heads,
+        )
+        .await;
+
+        let proxy = ByparrProxy::new(
+            endpoint,
+            Duration::from_secs(5),
+            1024 * 1024,
+            Duration::from_secs(60),
+        );
+
+        let first = proxy
+            .get(&indexer_url, CancellationToken::new())
+            .await
+            .unwrap();
+        assert_eq!(first.body, "<solved/>");
+
+        let second = proxy
+            .get(&indexer_url, CancellationToken::new())
+            .await
+            .unwrap();
+        assert_eq!(
+            second.body, "<solved/>",
+            "a challenged direct fetch must fall back to a fresh solve"
+        );
+        assert_eq!(
+            indexer_hits.load(Ordering::SeqCst),
+            1,
+            "the direct attempt reached the origin exactly once"
+        );
+        assert_eq!(
+            byparr_hits.load(Ordering::SeqCst),
+            2,
+            "the challenge must force a re-solve"
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_fetch_enforces_body_size_cap() {
+        let (byparr_hits, byparr_heads) = counting();
+        let (endpoint, _byparr) = spawn_counting_http(
+            200,
+            solution_json(unix_now_plus(3600.0), "ok"),
+            byparr_hits,
+            byparr_heads,
+        )
+        .await;
+        let (indexer_hits, indexer_heads) = counting();
+        let (indexer_url, _indexer) =
+            spawn_counting_http(200, "x".repeat(10_000), indexer_hits, indexer_heads).await;
+
+        // WHY: 2048 admits the byparr envelope but not the 10_000-byte direct
+        // body — the cap must bind on the reuse path too.
+        let proxy = ByparrProxy::new(endpoint, Duration::from_secs(5), 2048, ANY_REFRESH);
+
+        proxy
+            .get(&indexer_url, CancellationToken::new())
+            .await
+            .unwrap();
+        let err = proxy
+            .get(&indexer_url, CancellationToken::new())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                SearchIndexerError::ResponseTooLarge { limit: 2048, .. }
+            ),
+            "expected ResponseTooLarge on the direct path, got {err:?}"
         );
     }
 

--- a/crates/zetesis/src/cf_bypass/cookies.rs
+++ b/crates/zetesis/src/cf_bypass/cookies.rs
@@ -5,12 +5,14 @@ use tokio::time::Instant;
 
 use crate::cf_bypass::Cookie;
 
+/// Per-host cache of solved Cloudflare clearance cookies. Keyed by the
+/// target host so every indexer behind the same origin shares one solve.
 pub struct CookieStore {
-    jars: DashMap<i64, IndexerCookieJar>,
+    jars: DashMap<String, HostCookieJar>,
 }
 
-// WHY: pure data — cookie jar for indexer Cloudflare bypass.
-pub struct IndexerCookieJar {
+// WHY: pure data — cookie jar for one Cloudflare-protected host.
+pub struct HostCookieJar {
     pub cookies: Vec<StoredCookie>,
     pub user_agent: String,
     pub last_refreshed: Instant,
@@ -32,7 +34,7 @@ impl CookieStore {
         }
     }
 
-    pub fn store(&self, indexer_id: i64, cookies: Vec<Cookie>, user_agent: String) {
+    pub fn store(&self, host: &str, cookies: Vec<Cookie>, user_agent: String) {
         let stored: Vec<StoredCookie> = cookies
             .into_iter()
             .map(|c| {
@@ -52,8 +54,8 @@ impl CookieStore {
             .collect();
 
         self.jars.insert(
-            indexer_id,
-            IndexerCookieJar {
+            host.to_string(),
+            HostCookieJar {
                 cookies: stored,
                 user_agent,
                 last_refreshed: Instant::now(),
@@ -61,8 +63,8 @@ impl CookieStore {
         );
     }
 
-    pub fn get_cookie_header(&self, indexer_id: i64) -> Option<String> {
-        let jar = self.jars.get(&indexer_id)?;
+    pub fn get_cookie_header(&self, host: &str) -> Option<String> {
+        let jar = self.jars.get(host)?;
         let now = SystemTime::now();
 
         let valid_cookies: Vec<String> = jar
@@ -78,12 +80,12 @@ impl CookieStore {
         Some(valid_cookies.join("; "))
     }
 
-    pub fn get_user_agent(&self, indexer_id: i64) -> Option<String> {
-        self.jars.get(&indexer_id).map(|j| j.user_agent.clone())
+    pub fn get_user_agent(&self, host: &str) -> Option<String> {
+        self.jars.get(host).map(|j| j.user_agent.clone())
     }
 
-    pub fn needs_refresh(&self, indexer_id: i64, refresh_before_expiry: Duration) -> bool {
-        let Some(jar) = self.jars.get(&indexer_id) else {
+    pub fn needs_refresh(&self, host: &str, refresh_before_expiry: Duration) -> bool {
+        let Some(jar) = self.jars.get(host) else {
             return true;
         };
 
@@ -98,12 +100,12 @@ impl CookieStore {
         })
     }
 
-    pub fn remove(&self, indexer_id: i64) {
-        self.jars.remove(&indexer_id);
+    pub fn remove(&self, host: &str) {
+        self.jars.remove(host);
     }
 
-    pub fn has_cookies(&self, indexer_id: i64) -> bool {
-        self.get_cookie_header(indexer_id).is_some()
+    pub fn has_cookies(&self, host: &str) -> bool {
+        self.get_cookie_header(host).is_some()
     }
 }
 
@@ -139,14 +141,17 @@ mod tests {
             + 3600.0;
 
         store.store(
-            1,
+            "indexer.example.com",
             vec![make_cookie("cf_clearance", "abc123", future_ts)],
             "Mozilla/5.0".to_string(),
         );
 
-        let header = store.get_cookie_header(1);
+        let header = store.get_cookie_header("indexer.example.com");
         assert_eq!(header, Some("cf_clearance=abc123".to_string()));
-        assert_eq!(store.get_user_agent(1), Some("Mozilla/5.0".to_string()));
+        assert_eq!(
+            store.get_user_agent("indexer.example.com"),
+            Some("Mozilla/5.0".to_string())
+        );
     }
 
     #[test]
@@ -159,30 +164,30 @@ mod tests {
             - 3600.0;
 
         store.store(
-            1,
+            "indexer.example.com",
             vec![make_cookie("cf_clearance", "expired", past_ts)],
             "Mozilla/5.0".to_string(),
         );
 
-        assert!(store.get_cookie_header(1).is_none());
+        assert!(store.get_cookie_header("indexer.example.com").is_none());
     }
 
     #[test]
     fn session_cookies_always_valid() {
         let store = CookieStore::new();
         store.store(
-            1,
+            "indexer.example.com",
             vec![make_cookie("session", "val", -1.0)],
             "Agent".to_string(),
         );
 
-        assert!(store.get_cookie_header(1).is_some());
+        assert!(store.get_cookie_header("indexer.example.com").is_some());
     }
 
     #[test]
     fn needs_refresh_when_absent() {
         let store = CookieStore::new();
-        assert!(store.needs_refresh(1, Duration::from_secs(1800)));
+        assert!(store.needs_refresh("indexer.example.com", Duration::from_secs(1800)));
     }
 
     #[test]
@@ -195,12 +200,50 @@ mod tests {
             + 900.0; // 15 minutes from now
 
         store.store(
-            1,
+            "indexer.example.com",
             vec![make_cookie("cf_clearance", "val", near_expiry)],
             "Agent".to_string(),
         );
 
-        assert!(store.needs_refresh(1, Duration::from_secs(1800)));
+        assert!(store.needs_refresh("indexer.example.com", Duration::from_secs(1800)));
+    }
+
+    #[test]
+    fn fresh_cookie_does_not_need_refresh() {
+        let store = CookieStore::new();
+        let far_expiry = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            + 3600.0;
+
+        store.store(
+            "indexer.example.com",
+            vec![make_cookie("cf_clearance", "val", far_expiry)],
+            "Agent".to_string(),
+        );
+
+        assert!(!store.needs_refresh("indexer.example.com", Duration::from_secs(1800)));
+    }
+
+    #[test]
+    fn hosts_are_isolated() {
+        let store = CookieStore::new();
+        let future_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64()
+            + 3600.0;
+
+        store.store(
+            "a.example.com",
+            vec![make_cookie("cf_clearance", "for-a", future_ts)],
+            "Agent".to_string(),
+        );
+
+        assert!(store.has_cookies("a.example.com"));
+        assert!(!store.has_cookies("b.example.com"));
+        assert!(store.needs_refresh("b.example.com", Duration::from_secs(1800)));
     }
 
     #[test]
@@ -213,14 +256,14 @@ mod tests {
             + 3600.0;
 
         store.store(
-            1,
+            "indexer.example.com",
             vec![make_cookie("cf_clearance", "val", future_ts)],
             "Agent".to_string(),
         );
-        assert!(store.has_cookies(1));
+        assert!(store.has_cookies("indexer.example.com"));
 
-        store.remove(1);
-        assert!(!store.has_cookies(1));
+        store.remove("indexer.example.com");
+        assert!(!store.has_cookies("indexer.example.com"));
     }
 
     #[test]
@@ -233,7 +276,7 @@ mod tests {
             + 3600.0;
 
         store.store(
-            1,
+            "indexer.example.com",
             vec![
                 make_cookie("cf_clearance", "abc", future_ts),
                 make_cookie("session", "xyz", future_ts),
@@ -241,7 +284,7 @@ mod tests {
             "Agent".to_string(),
         );
 
-        let header = store.get_cookie_header(1).unwrap();
+        let header = store.get_cookie_header("indexer.example.com").unwrap();
         assert!(header.contains("cf_clearance=abc"));
         assert!(header.contains("session=xyz"));
         assert!(header.contains("; "));

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -183,6 +183,7 @@ impl SearchIndexerService {
         let http = self.http_client(cfg.request_timeout_secs);
         let timeout = Duration::from_secs(cfg.search_timeout_seconds);
         let max_body_bytes = cfg.max_response_body_bytes;
+        let max_results_per_indexer = cfg.max_results_per_indexer;
         let rate_limiter = &self.rate_limiter;
 
         let results: Vec<SearchResult> = stream::iter(eligible)
@@ -218,7 +219,13 @@ impl SearchIndexerService {
                             }
                         };
                     match client.search_boxed(&q, ct).await {
-                        Ok(results) => results,
+                        Ok(mut results) => {
+                            // WHY: cap each indexer's contribution BEFORE the
+                            // merged collect — one oversized response must not
+                            // drown out every other indexer in the fan-out.
+                            results.truncate(max_results_per_indexer);
+                            results
+                        }
                         Err(e @ SearchIndexerError::Cancelled { .. }) => {
                             // WHY: cancellation is caller intent, not indexer
                             // failure — no warn, no status change.
@@ -350,6 +357,47 @@ impl SearchIndexerService {
         Ok(caps)
     }
 
+    /// Refreshes caps for every eligible indexer whose `last_tested` is
+    /// missing, unparseable, or older than `max_age`. Called by archon's
+    /// zetesis supervisor on its scheduled caps-refresh tick
+    /// (`zetesis.caps_refresh_hours`); the manual `POST /{id}/caps` route
+    /// remains the on-demand path. Returns the ids actually refreshed; a
+    /// per-indexer failure is logged and skipped — one unreachable indexer
+    /// must not starve the rest of the sweep, and it stays stale for the
+    /// next tick to retry.
+    pub async fn refresh_stale_caps(
+        &self,
+        max_age: Duration,
+        ct: CancellationToken,
+    ) -> Result<Vec<i64>, SearchIndexerError> {
+        let indexers = repo::get_eligible_indexers(&self.read_pool)
+            .await
+            .map_err(|e| SearchIndexerError::Database {
+                source: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let now = jiff::Timestamp::now();
+        let mut refreshed = Vec::new();
+        for indexer in indexers {
+            if ct.is_cancelled() {
+                break;
+            }
+            if !caps_stale(indexer.last_tested.as_deref(), max_age, now) {
+                continue;
+            }
+            match self.refresh_caps(indexer.id, ct.clone()).await {
+                Ok(_) => refreshed.push(indexer.id),
+                Err(e) => warn!(
+                    indexer_id = indexer.id,
+                    indexer_name = %indexer.name,
+                    error = %e,
+                    "scheduled caps refresh failed for indexer"
+                ),
+            }
+        }
+        Ok(refreshed)
+    }
+
     async fn load_indexer(&self, indexer_id: i64) -> Result<IndexerRow, SearchIndexerError> {
         repo::get_indexer(&self.read_pool, indexer_id)
             .await
@@ -415,6 +463,23 @@ impl SearchIndexerService {
                 "failed to UPDATE indexer status"
             );
         }
+    }
+}
+
+/// True when a `last_tested` timestamp is absent, unparseable, or older than
+/// `max_age` — the scheduled caps-refresh eligibility check.
+fn caps_stale(last_tested: Option<&str>, max_age: Duration, now: jiff::Timestamp) -> bool {
+    let Some(raw) = last_tested else {
+        return true;
+    };
+    match raw.parse::<jiff::Timestamp>() {
+        // WHY: a future timestamp (clock skew) yields a negative age, which
+        // u64::try_from rejects — treated as fresh rather than wrapping.
+        Ok(tested) => u64::try_from(now.as_second() - tested.as_second())
+            .is_ok_and(|age_secs| age_secs > max_age.as_secs()),
+        // WHY: an unparseable timestamp counts as stale — a corrupt value
+        // must not permanently exempt an indexer from refresh.
+        Err(_) => true,
     }
 }
 

--- a/crates/zetesis/src/search/tests.rs
+++ b/crates/zetesis/src/search/tests.rs
@@ -575,6 +575,52 @@ async fn cardigann_row_without_definition_marks_failed() {
     assert_eq!(row.status, "failed");
 }
 
+// ── #575: per-indexer result cap (`max_results_per_indexer`) ──────────────
+
+const TWO_ITEM_FEED_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <title>Test Indexer</title>
+    <item>
+      <title>Release.One.2024</title>
+      <guid>guid-one</guid>
+      <size>1000</size>
+      <link>https://example.com/download/one</link>
+      <torznab:attr name="infohash" value="aaa111"/>
+    </item>
+    <item>
+      <title>Release.Two.2024</title>
+      <guid>guid-two</guid>
+      <size>2000</size>
+      <link>https://example.com/download/two</link>
+      <torznab:attr name="infohash" value="bbb222"/>
+    </item>
+  </channel>
+</rss>"#;
+
+#[tokio::test]
+async fn search_truncates_each_indexer_to_max_results_per_indexer() {
+    let (service, pool) = make_service_with(SearchSubsystemConfig {
+        max_results_per_indexer: 1,
+        ..SearchSubsystemConfig::default()
+    })
+    .await;
+    let (url, _server) = spawn_one_shot_http(200, "OK", &[], TWO_ITEM_FEED_XML).await;
+    seed_indexer(&pool, &url).await;
+
+    let results = service
+        .search(SearchQuery::new(), CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        1,
+        "an indexer returning 2 results over a cap of 1 must contribute exactly 1"
+    );
+    assert_eq!(results[0].title, "Release.One.2024");
+}
+
 const CAPS_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <caps>
   <server title="Test Indexer" version="1.0"/>
@@ -623,6 +669,158 @@ async fn refresh_caps_commits_caps_categories_and_status_together() {
             (2000, "Movies".to_string()),
             (2010, "Movies/Foreign".to_string())
         ]
+    );
+}
+
+// ── #575: scheduled caps refresh (`caps_refresh_hours`) ───────────────────
+
+#[test]
+fn caps_stale_when_never_tested() {
+    assert!(caps_stale(
+        None,
+        Duration::from_secs(24 * 3600),
+        jiff::Timestamp::now()
+    ));
+}
+
+#[test]
+fn caps_stale_when_older_than_max_age() {
+    assert!(caps_stale(
+        Some("2020-01-01T00:00:00Z"),
+        Duration::from_secs(24 * 3600),
+        jiff::Timestamp::now()
+    ));
+}
+
+#[test]
+fn caps_fresh_when_within_max_age() {
+    let recent = jiff::Timestamp::now().to_string();
+    assert!(!caps_stale(
+        Some(&recent),
+        Duration::from_secs(24 * 3600),
+        jiff::Timestamp::now()
+    ));
+}
+
+#[test]
+fn caps_stale_when_timestamp_unparseable() {
+    assert!(caps_stale(
+        Some("not-a-timestamp"),
+        Duration::from_secs(24 * 3600),
+        jiff::Timestamp::now()
+    ));
+}
+
+#[test]
+fn caps_fresh_when_timestamp_in_future() {
+    // WHY: clock skew — a future observation must not wrap into "stale".
+    let future = (jiff::Timestamp::now() + jiff::SignedDuration::from_secs(600)).to_string();
+    assert!(!caps_stale(
+        Some(&future),
+        Duration::from_secs(24 * 3600),
+        jiff::Timestamp::now()
+    ));
+}
+
+#[tokio::test]
+async fn refresh_stale_caps_refreshes_stale_and_skips_fresh() {
+    let (service, pool) = make_service().await;
+    // WHY: BOTH indexers get a live caps server — if the fresh one were
+    // wrongly swept, its refresh would succeed and the assertions below
+    // would catch it (rather than masking the bug behind a fetch failure).
+    let (stale_url, _stale_server) = spawn_one_shot_http(200, "OK", &[], CAPS_XML).await;
+    let (fresh_url, _fresh_server) = spawn_one_shot_http(200, "OK", &[], CAPS_XML).await;
+    let stale = seed_indexer(&pool, &stale_url).await;
+    let fresh = seed_indexer(&pool, &fresh_url).await;
+    repo::update_indexer_caps(&pool, stale.id, "{}", "2020-01-01T00:00:00Z")
+        .await
+        .unwrap();
+    let fresh_stamp = jiff::Timestamp::now().to_string();
+    repo::update_indexer_caps(&pool, fresh.id, "{}", &fresh_stamp)
+        .await
+        .unwrap();
+
+    let refreshed = service
+        .refresh_stale_caps(Duration::from_secs(24 * 3600), CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(refreshed, vec![stale.id]);
+    let stale_row = repo::get_indexer(&pool, stale.id).await.unwrap().unwrap();
+    assert_ne!(
+        stale_row.last_tested.as_deref(),
+        Some("2020-01-01T00:00:00Z"),
+        "the stale indexer's caps observation must advance"
+    );
+    let fresh_row = repo::get_indexer(&pool, fresh.id).await.unwrap().unwrap();
+    assert_eq!(
+        fresh_row.last_tested.as_deref(),
+        Some(fresh_stamp.as_str()),
+        "the fresh indexer must be skipped untouched"
+    );
+}
+
+#[tokio::test]
+async fn refresh_stale_caps_treats_never_tested_as_stale() {
+    let (service, pool) = make_service().await;
+    let (url, _server) = spawn_one_shot_http(200, "OK", &[], CAPS_XML).await;
+    let indexer = seed_indexer(&pool, &url).await;
+    assert!(indexer.last_tested.is_none());
+
+    let refreshed = service
+        .refresh_stale_caps(Duration::from_secs(24 * 3600), CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(refreshed, vec![indexer.id]);
+    let row = repo::get_indexer(&pool, indexer.id).await.unwrap().unwrap();
+    assert!(row.last_tested.is_some());
+    assert!(row.caps_json.is_some());
+}
+
+#[tokio::test]
+async fn refresh_stale_caps_continues_past_a_failing_indexer() {
+    let (service, pool) = make_service().await;
+    // WHY: priority order puts the unreachable indexer FIRST — the sweep
+    // must log-and-continue, not abort before reaching the healthy one.
+    let broken = repo::insert_indexer(
+        &pool,
+        InsertIndexerParams {
+            name: "Broken",
+            url: "http://127.0.0.1:9/",
+            protocol: "torznab",
+            api_key: None,
+            cf_bypass: false,
+            priority: 10,
+        },
+    )
+    .await
+    .unwrap();
+    let (url, _server) = spawn_one_shot_http(200, "OK", &[], CAPS_XML).await;
+    let healthy = repo::insert_indexer(
+        &pool,
+        InsertIndexerParams {
+            name: "Healthy",
+            url: &url,
+            protocol: "torznab",
+            api_key: None,
+            cf_bypass: false,
+            priority: 90,
+        },
+    )
+    .await
+    .unwrap();
+
+    let refreshed = service
+        .refresh_stale_caps(Duration::from_secs(24 * 3600), CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(refreshed, vec![healthy]);
+    let broken_row = repo::get_indexer(&pool, broken).await.unwrap().unwrap();
+    assert!(
+        broken_row.last_tested.is_none(),
+        "a failed refresh must leave the indexer stale for the next tick"
     );
 }
 

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -120,15 +120,15 @@ from the new section on change (`SectionWatcher::changed()`).
 |---|---|
 | `buffer_size` | RESTART — broadcast channel capacity fixed at creation |
 
-### zetesis — LIVE (steps 7) except three UNWIRED
+### zetesis — LIVE (step 7)
 
 | Field | Class | Mechanism |
 |---|---|---|
-| `request_timeout_secs` / `max_response_body_bytes` / `max_concurrent_searches` / `search_timeout_seconds` | LIVE | per-op reads |
-| `cloudflare_bypass_enabled` / `cf_proxy_url` / `cf_proxy_timeout_seconds` | LIVE | cf-proxy rebuild + swap |
+| `request_timeout_secs` / `max_response_body_bytes` / `max_concurrent_searches` / `search_timeout_seconds` / `max_results_per_indexer` | LIVE | per-op reads (`max_results_per_indexer` truncates each indexer's contribution before the merged collect) |
+| `cloudflare_bypass_enabled` / `cf_proxy_url` / `cf_proxy_timeout_seconds` / `cf_cookie_refresh_minutes` | LIVE | cf-proxy rebuild + swap — a rebuild resets the proxy's per-host CF clearance cookie cache (logged; the next request per host re-solves) |
 | `per_indexer_rate_limit_requests` / `per_indexer_rate_limit_window_seconds` | LIVE | `RateLimiter::reconfigure` — preserves in-flight embargoes |
+| `caps_refresh_hours` | LIVE | zetesis supervisor caps-refresh tick (15 min) judges each indexer's `last_tested` staleness against the live value on every tick |
 | `cardigann_definitions_dir` | LIVE | registry reload + swap |
-| `max_results_per_indexer` / `caps_refresh_hours` / `cf_cookie_refresh_minutes` | UNWIRED | #575 |
 
 ### ergasia — mostly RESTART/UNWIRED; two LIVE
 
@@ -250,7 +250,9 @@ honest and logged, never silent:
   bounded event-loss window between handler cancel and re-subscribe.
 - **zetesis** is the one exception: `RateLimiter::reconfigure` explicitly
   PRESERVES in-flight embargo/accrual state across a reload — an embargoed
-  indexer must never un-embargo just because a reload happened.
+  indexer must never un-embargo just because a reload happened. The cf-proxy
+  swap, by contrast, drops the proxy's per-host CF clearance cookie cache —
+  the next request per host pays a fresh solve (logged).
 
 ---
 


### PR DESCRIPTION
Wires the three zetesis fields of #575.

- **max_results_per_indexer** — each indexer's contribution is truncated to the cap before the merged collect (torn-config-safe read).
- **caps_refresh_hours** — the zetesis supervisor gains a caps-refresh tick (15 min) that judges each indexer's `last_tested` staleness against the live config value and re-refreshes stale torznab caps; per-indexer failure is logged and skipped, cancellation honored, no lock across await.
- **cf_cookie_refresh_minutes** — the `CookieStore` (host-keyed) is integrated into `ByparrProxy`: a fresh cookie takes a direct GET (stored cookie + solve UA, bounded body); 403/503 re-challenges fall back to a full solve; the field is reactive via the cf-proxy rebuild. Avoids a full Cloudflare solve on every request.

diff.rs: the three move UNWIRED → LIVE (`cf_health_check_interval_minutes` was removed in the removals PR); `every_leaf_is_classified_exactly_once` passes. Gate green (2111 tests). Rebased onto post-removals main.

Part of #575.