### PR TITLE
fix(ergasia,syntaxis,prostheke): wire magnet-resolve timeout, stalled-download detection, and OpenSubtitles login

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -1121,8 +1121,13 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     );
 
     // Layer 1: Ergasia (download execution)
+    // WHY: a `Section` (not the frozen boot_config) — #575 makes
+    // `ergasia.magnet_resolve_timeout_seconds` a per-add live read; the
+    // restart-class ergasia leaves are held back by `publish()`, so the
+    // session's construction-time snapshot cannot drift from the effective
+    // config.
     let ergasia_session = Arc::new(
-        TorrentSession::new(&boot_config.ergasia)
+        TorrentSession::new(config_handle.section(|c| &c.ergasia))
             .await
             .context(DownloadEngineSnafu)?,
     );

--- a/crates/ergasia/src/error.rs
+++ b/crates/ergasia/src/error.rs
@@ -22,6 +22,17 @@ pub enum ErgasiaError {
         location: snafu::Location,
     },
 
+    #[snafu(display(
+        "adding torrent for {download_id} timed out after {timeout_seconds}s (magnet did not resolve)"
+    ))]
+    MagnetResolveTimeout {
+        download_id: DownloadId,
+        timeout_seconds: u64,
+        source: tokio::time::error::Elapsed,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("torrent not found: {download_id}"))]
     TorrentNotFound {
         download_id: DownloadId,

--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -5,20 +5,21 @@ use std::time::Duration;
 
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
-use horismos::ErgasiaConfig;
+use horismos::{ErgasiaConfig, Section};
 use librqbit::api::TorrentIdOrHash;
 use librqbit::{
     AddTorrent, AddTorrentOptions, AddTorrentResponse, ManagedTorrent, Session, SessionOptions,
     SessionPersistenceConfig, TorrentStats,
 };
 use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
 use themelion::ids::DownloadId;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 use crate::error::{
-    AddTorrentSnafu, DeleteActionSnafu, ErgasiaError, PauseActionSnafu, SessionInitSnafu,
-    TorrentMapPersistenceSnafu, TorrentNotFoundSnafu,
+    AddTorrentSnafu, DeleteActionSnafu, ErgasiaError, MagnetResolveTimeoutSnafu, PauseActionSnafu,
+    SessionInitSnafu, TorrentMapPersistenceSnafu, TorrentNotFoundSnafu,
 };
 use crate::seeding::SeedingPolicy;
 
@@ -56,11 +57,18 @@ pub struct TorrentSession {
     torrent_refcounts: DashMap<usize, usize>,
     map_path: PathBuf,
     persist_lock: tokio::sync::Mutex<()>,
+    // WHY: a live Section (not a frozen copy) — `magnet_resolve_timeout_seconds`
+    // is read per add_torrent call so a config reload bounds the next add
+    // without a restart. Every other ergasia leaf consumed here is
+    // restart-class: `publish()` holds those back in the effective config, so
+    // the construction-time snapshot never drifts from what the Section serves.
+    config: Section<ErgasiaConfig>,
 }
 
 impl TorrentSession {
     #[instrument(skip_all, name = "ergasia_session_init")]
-    pub async fn new(config: &ErgasiaConfig) -> Result<Self, ErgasiaError> {
+    pub async fn new(config_section: Section<ErgasiaConfig>) -> Result<Self, ErgasiaError> {
+        let config = config_section.get();
         let peer_opts = librqbit::PeerConnectionOptions {
             connect_timeout: Some(Duration::from_secs(config.peer_connect_timeout_seconds)),
             read_write_timeout: Some(Duration::from_secs(10)),
@@ -124,6 +132,7 @@ impl TorrentSession {
             torrent_refcounts: DashMap::new(),
             map_path: PathBuf::from(&config.session_state_path).join(TORRENT_MAP_FILE),
             persist_lock: tokio::sync::Mutex::new(()),
+            config: config_section,
         };
 
         // INVARIANT: the session is not handed out until torrent_map reflects
@@ -164,7 +173,20 @@ impl TorrentSession {
             ..Default::default()
         });
 
-        let response = self.session.add_torrent(source, opts).await.map_err(|e| {
+        // WHY: librqbit's magnet resolve waits on the peer/DHT stream with no
+        // internal deadline — an unresolvable magnet would otherwise hold this
+        // await (and the caller's dispatch slot) forever.
+        let timeout_seconds = self.config.get().magnet_resolve_timeout_seconds;
+        let response = tokio::time::timeout(
+            Duration::from_secs(timeout_seconds),
+            self.session.add_torrent(source, opts),
+        )
+        .await
+        .context(MagnetResolveTimeoutSnafu {
+            download_id,
+            timeout_seconds,
+        })?
+        .map_err(|e| {
             AddTorrentSnafu {
                 reason: "add_torrent call failed".to_string(),
                 error: e.to_string(),
@@ -476,7 +498,9 @@ mod tests {
         let download_id = DownloadId::new();
 
         {
-            let session = TorrentSession::new(&config).await.unwrap();
+            let session = TorrentSession::new(Section::fixed(config.clone()))
+                .await
+                .unwrap();
             session
                 .add_torrent_from_bytes(download_id, minimal_torrent_bytes("restart.bin"))
                 .await
@@ -486,7 +510,9 @@ mod tests {
             session.session.stop().await;
         }
 
-        let session = TorrentSession::new(&config).await.unwrap();
+        let session = TorrentSession::new(Section::fixed(config.clone()))
+            .await
+            .unwrap();
         assert!(
             session.get_stats(download_id).is_ok(),
             "download must be manageable after restart"
@@ -511,7 +537,9 @@ mod tests {
         };
         std::fs::write(&map_path, serde_json::to_vec(&stale).unwrap()).unwrap();
 
-        let session = TorrentSession::new(&config).await.unwrap();
+        let session = TorrentSession::new(Section::fixed(config.clone()))
+            .await
+            .unwrap();
         assert!(
             matches!(
                 session.get_stats(stale_id),
@@ -534,7 +562,9 @@ mod tests {
         let _guard = SESSION_TEST_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let config = test_config(dir.path(), 24401);
-        let session = TorrentSession::new(&config).await.unwrap();
+        let session = TorrentSession::new(Section::fixed(config.clone()))
+            .await
+            .unwrap();
         let unknown = DownloadId::new();
 
         assert!(matches!(
@@ -559,7 +589,9 @@ mod tests {
         let config = test_config(dir.path(), 24501);
         let download_id = DownloadId::new();
 
-        let session = TorrentSession::new(&config).await.unwrap();
+        let session = TorrentSession::new(Section::fixed(config.clone()))
+            .await
+            .unwrap();
         session
             .add_torrent_from_bytes(download_id, minimal_torrent_bytes("race.bin"))
             .await
@@ -589,7 +621,9 @@ mod tests {
         let download_b = DownloadId::new();
         let torrent_bytes = minimal_torrent_bytes("shared.bin");
 
-        let session = TorrentSession::new(&config).await.unwrap();
+        let session = TorrentSession::new(Section::fixed(config.clone()))
+            .await
+            .unwrap();
         let (id_a, _) = session
             .add_torrent_from_bytes(download_a, torrent_bytes.clone())
             .await
@@ -639,7 +673,9 @@ mod tests {
         let config = test_config(dir.path(), 24601);
         let download_id = DownloadId::new();
 
-        let session = TorrentSession::new(&config).await.unwrap();
+        let session = TorrentSession::new(Section::fixed(config.clone()))
+            .await
+            .unwrap();
         // WHY: a mapping to a torrent id librqbit does not manage forces the
         // session.delete failure path deterministically.
         session.torrent_map.insert(download_id, 999_999);
@@ -657,6 +693,46 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn unresolvable_magnet_times_out_instead_of_hanging() {
+        let _guard = SESSION_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path(), 24701);
+        config.magnet_resolve_timeout_seconds = 1;
+        let session = TorrentSession::new(Section::fixed(config.clone()))
+            .await
+            .unwrap();
+        let download_id = DownloadId::new();
+
+        // WHY: a random info-hash no peer will ever announce — librqbit's
+        // magnet resolve blocks on the DHT stream indefinitely, so only the
+        // configured timeout can settle this call.
+        // NOTE: ManagedTorrent (the Ok payload) does not derive Debug, so
+        // unwrap_err() is unavailable — match directly instead.
+        let result = session
+            .add_torrent_from_magnet(
+                download_id,
+                "magnet:?xt=urn:btih:0000000000000000000000000000000000000001",
+            )
+            .await;
+        let Err(err) = result else {
+            panic!("an unresolvable magnet must time out, not resolve");
+        };
+
+        assert!(
+            matches!(err, ErgasiaError::MagnetResolveTimeout { .. }),
+            "expected MagnetResolveTimeout, got {err:?}"
+        );
+        assert!(
+            matches!(
+                session.get_stats(download_id),
+                Err(ErgasiaError::TorrentNotFound { .. })
+            ),
+            "a timed-out add must leave no download mapping behind"
+        );
+        session.session.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn corrupt_torrent_map_is_quarantined() {
         let _guard = SESSION_TEST_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
@@ -666,7 +742,7 @@ mod tests {
         let map_path = config.session_state_path.join(TORRENT_MAP_FILE);
         std::fs::write(&map_path, b"{ not json").unwrap();
 
-        let session = TorrentSession::new(&config)
+        let session = TorrentSession::new(Section::fixed(config.clone()))
             .await
             .expect("corrupt side-table must not brick startup");
         assert!(

--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use themelion::ids::DownloadId;
 use tokio_util::sync::CancellationToken;
-use tracing::instrument;
+use tracing::{Instrument, instrument};
 
 use crate::error::{
     AddTorrentSnafu, DeleteActionSnafu, ErgasiaError, MagnetResolveTimeoutSnafu, PauseActionSnafu,
@@ -148,7 +148,7 @@ impl TorrentSession {
         download_id: DownloadId,
         magnet_uri: &str,
     ) -> Result<(usize, Arc<ManagedTorrent>), ErgasiaError> {
-        let source = AddTorrent::Url(Cow::Borrowed(magnet_uri));
+        let source = AddTorrent::Url(Cow::Owned(magnet_uri.to_owned()));
         self.add_torrent_inner(download_id, source, None).await
     }
 
@@ -165,7 +165,7 @@ impl TorrentSession {
     async fn add_torrent_inner(
         &self,
         download_id: DownloadId,
-        source: AddTorrent<'_>,
+        source: AddTorrent<'static>,
         output_folder: Option<String>,
     ) -> Result<(usize, Arc<ManagedTorrent>), ErgasiaError> {
         let opts = Some(AddTorrentOptions {
@@ -173,26 +173,97 @@ impl TorrentSession {
             ..Default::default()
         });
 
-        // WHY: librqbit's magnet resolve waits on the peer/DHT stream with no
-        // internal deadline — an unresolvable magnet would otherwise hold this
-        // await (and the caller's dispatch slot) forever.
+        let is_magnet = matches!(
+            &source,
+            AddTorrent::Url(url) if url.get(..7).is_some_and(|p| p.eq_ignore_ascii_case("magnet:"))
+        );
+
+        // WHY: the add runs as a spawned task so a deadline never cancels it
+        // mid-add — librqbit registers the torrent in its session before its
+        // final persistence await, and dropping that future there would leave
+        // a live torrent harmonia never tracks. The task either finishes in
+        // budget or finishes late and the reaper below deletes exactly what
+        // it created.
+        let add_session = Arc::clone(&self.session);
+        let mut add_task = tokio::spawn(
+            async move { add_session.add_torrent(source, opts).await }
+                .instrument(tracing::info_span!("torrent_add", %download_id)),
+        );
+
+        // WHY: the deadline applies to magnet sources only — resolve waits on
+        // the peer/DHT stream with no internal deadline, while a torrent-file
+        // add is local and returns promptly; binding file adds to the magnet
+        // knob would fail valid adds under an aggressive setting.
         let timeout_seconds = self.config.get().magnet_resolve_timeout_seconds;
-        let response = tokio::time::timeout(
-            Duration::from_secs(timeout_seconds),
-            self.session.add_torrent(source, opts),
-        )
-        .await
-        .context(MagnetResolveTimeoutSnafu {
-            download_id,
-            timeout_seconds,
-        })?
-        .map_err(|e| {
-            AddTorrentSnafu {
-                reason: "add_torrent call failed".to_string(),
-                error: e.to_string(),
+        let joined = if is_magnet {
+            match tokio::time::timeout(Duration::from_secs(timeout_seconds), &mut add_task).await {
+                Ok(joined) => joined,
+                Err(elapsed) => {
+                    // WARNING: best-effort orphan cleanup — a late-completing
+                    // add is deleted only when it Added a torrent (never
+                    // AlreadyManaged: that torrent belongs to another
+                    // download); a resolve that never completes is aborted
+                    // after a generous cap.
+                    let reap_session = Arc::clone(&self.session);
+                    tokio::spawn(
+                        async move {
+                            let cap =
+                                Duration::from_secs(timeout_seconds.saturating_mul(10).max(600));
+                            match tokio::time::timeout(cap, &mut add_task).await {
+                                Ok(Ok(Ok(AddTorrentResponse::Added(id, _)))) => {
+                                    tracing::warn!(
+                                        %download_id,
+                                        torrent_id = id,
+                                        "timed-out add completed late; deleting orphaned torrent"
+                                    );
+                                    if let Err(e) =
+                                        reap_session.delete(TorrentIdOrHash::Id(id), false).await
+                                    {
+                                        tracing::warn!(
+                                            %download_id,
+                                            torrent_id = id,
+                                            error = %e,
+                                            "orphaned torrent delete failed"
+                                        );
+                                    }
+                                }
+                                Ok(_) => {}
+                                Err(_) => {
+                                    add_task.abort();
+                                    tracing::warn!(
+                                        %download_id,
+                                        "timed-out add never completed within the reap cap; aborted"
+                                    );
+                                }
+                            }
+                        }
+                        .instrument(tracing::info_span!("torrent_add_reaper", %download_id)),
+                    );
+                    return Err(elapsed).context(MagnetResolveTimeoutSnafu {
+                        download_id,
+                        timeout_seconds,
+                    });
+                }
             }
-            .build()
-        })?;
+        } else {
+            add_task.await
+        };
+
+        let response = joined
+            .map_err(|e| {
+                AddTorrentSnafu {
+                    reason: "add_torrent task join failed".to_string(),
+                    error: e.to_string(),
+                }
+                .build()
+            })?
+            .map_err(|e| {
+                AddTorrentSnafu {
+                    reason: "add_torrent call failed".to_string(),
+                    error: e.to_string(),
+                }
+                .build()
+            })?;
 
         match response {
             AddTorrentResponse::Added(id, handle)
@@ -729,6 +800,27 @@ mod tests {
             ),
             "a timed-out add must leave no download mapping behind"
         );
+        session.session.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn torrent_file_add_ignores_magnet_deadline() {
+        let _guard = SESSION_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path(), 24707);
+        // WHY: zero instantly elapses any bounded await — a local torrent-file
+        // add must still succeed because the deadline is magnet-only.
+        config.magnet_resolve_timeout_seconds = 0;
+        let session = TorrentSession::new(Section::fixed(config.clone()))
+            .await
+            .unwrap();
+        let download_id = DownloadId::new();
+
+        session
+            .add_torrent_from_bytes(download_id, minimal_torrent_bytes("deadline-free"))
+            .await
+            .map(|_| ())
+            .expect("a torrent-file add must not be bounded by the magnet deadline");
         session.session.stop().await;
     }
 

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -107,11 +107,18 @@ pub const LIVE: &[&str] = &[
     // ergasia — step 7 (SessionEngine rebuilds ExtractionLimits per call)
     "ergasia.max_extraction_depth",
     "ergasia.max_decompression_ratio",
+    // #575: TorrentSession reads its Section per add_torrent call — the
+    // timeout bounds librqbit's otherwise-unbounded magnet resolve.
+    "ergasia.magnet_resolve_timeout_seconds",
     // syntaxis — step 7 (DownloadQueue::update_config + SlotAllocator::set_limits)
     "syntaxis.max_concurrent_downloads",
     "syntaxis.max_per_tracker",
     "syntaxis.retry_count",
     "syntaxis.retry_backoff_base_seconds",
+    // #575: the reconcile tick judges each active download's progress
+    // watermark against the live section value on every pass; a stalled
+    // download is failed permanently and its slot released.
+    "syntaxis.stalled_download_timeout_hours",
     // prostheke — step 8 (per-op prefs, provider rebuild + set_providers)
     "prostheke.languages",
     "prostheke.include_hearing_impaired",
@@ -120,6 +127,11 @@ pub const LIVE: &[&str] = &[
     "prostheke.opensubtitles.api_key",
     "prostheke.opensubtitles.rate_limit_per_second",
     "prostheke.opensubtitles.max_download_bytes",
+    // #575: OpenSubtitles JWT login (`POST /login` + bearer on /download) —
+    // REBUILD-class via the prostheke supervisor: a credential change
+    // rebuilds the provider, so the token cache resets with it.
+    "prostheke.opensubtitles.username",
+    "prostheke.opensubtitles.password",
     // komide — step 6 (feed scheduler rebuild supervisor); podcast_dir +
     // max_episode_bytes joined via the #575 episode-download wire (read FROM
     // the service's own config, which the supervisor rebuilds on change)
@@ -157,18 +169,12 @@ pub const LIVE: &[&str] = &[
     "aitesis.auto_approve_admins",
 ];
 
-/// Full dotted leaf paths with NO production consumer — the remaining
-/// dead-config fields inventoried by #529's design pass and filed as
-/// harmonia issue #575 (the WIRE half; the REMOVE half's 20 fields were
-/// deleted from the schema entirely rather than tracked here). Each stays
-/// here (rather than silently vanishing from the schema) until #575
-/// dispositions it: wired to a real consumer, or removed.
-pub const UNWIRED: &[&str] = &[
-    "ergasia.magnet_resolve_timeout_seconds",  // #575
-    "syntaxis.stalled_download_timeout_hours", // #575
-    "prostheke.opensubtitles.username",        // #575
-    "prostheke.opensubtitles.password",        // #575
-];
+/// Full dotted leaf paths with NO production consumer. EMPTY: #575
+/// dispositioned every dead-config field (wired to a real consumer, or
+/// removed from the schema). The list and its completeness test remain so a
+/// new field cannot become silently-dead config — a leaf must land in
+/// `LIVE`, `RESTART_REQUIRED`, or (deliberately, with a tracking issue) here.
+pub const UNWIRED: &[&str] = &[];
 
 // NOTE: paths a test/exemplar config walks under a dynamic-key map are
 // canonicalized to this parent path with a literal `*` child segment, so
@@ -506,12 +512,13 @@ mod tests {
     // WHY: every Option<Struct> subtree is populated with `Some(..)` (rather
     // than left at its `None` default) so the leaf walker descends into its
     // fields instead of collapsing the whole subtree to one leaf — the only
-    // way a mixed LIVE/UNWIRED subtree (e.g. `prostheke.opensubtitles`) gets
-    // per-field classification instead of one opaque leaf. `taxis.libraries`
-    // gets exactly ONE synthetic entry so `classification_leaf_paths` walks
-    // it once under the canonical `*` key; `syndesmos.plex.library_sections`
-    // is deliberately left EMPTY — uniformly classified as a whole (LIVE), so
-    // the "empty map collapses to its own leaf" fallback is sufficient.
+    // way a subtree with per-field classifications (e.g.
+    // `prostheke.opensubtitles`) is checked leaf-by-leaf instead of as one
+    // opaque node. `taxis.libraries` gets exactly ONE synthetic entry so
+    // `classification_leaf_paths` walks it once under the canonical `*` key;
+    // `syndesmos.plex.library_sections` is deliberately left EMPTY —
+    // uniformly classified as a whole (LIVE), so the "empty map collapses to
+    // its own leaf" fallback is sufficient.
     fn exemplar_config() -> Config {
         use crate::subsystems::{
             LastfmConfig, LibraryConfig, OpenSubtitlesConfig, PlexConfig, TidalConfig,

--- a/crates/prostheke/src/providers/mod.rs
+++ b/crates/prostheke/src/providers/mod.rs
@@ -53,7 +53,10 @@ pub trait SubtitleProvider: Send + Sync {
 /// dispatch avoids vtable overhead and dyn-compatibility concerns with async fn.
 #[non_exhaustive]
 pub enum Provider {
-    OpenSubtitles(OpenSubtitlesProvider),
+    // WHY: boxed — the OpenSubtitles client (reqwest client, rate limiter,
+    // JWT token cache) dwarfs the other variants; boxing keeps the enum small
+    // (clippy::large_enum_variant).
+    OpenSubtitles(Box<OpenSubtitlesProvider>),
     Addic7ed(Addic7edProvider),
 }
 
@@ -61,7 +64,7 @@ impl Provider {
     /// Build the default production provider list from configuration.
     pub fn default_providers(opensubtitles: Option<OpenSubtitlesConfig>) -> Vec<Provider> {
         vec![
-            Provider::OpenSubtitles(OpenSubtitlesProvider::new(opensubtitles)),
+            Provider::OpenSubtitles(Box::new(OpenSubtitlesProvider::new(opensubtitles))),
             Provider::Addic7ed(Addic7edProvider::new()),
         ]
     }

--- a/crates/prostheke/src/providers/opensubtitles.rs
+++ b/crates/prostheke/src/providers/opensubtitles.rs
@@ -1,12 +1,13 @@
 //! OpenSubtitles.com REST API v1 provider.
 
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use horismos::OpenSubtitlesConfig;
 use serde::Deserialize;
 use snafu::ResultExt;
 use themelion::{MediaId, MediaType};
+use tokio::sync::RwLock;
 use tracing::{debug, instrument, warn};
 
 use crate::error::{
@@ -28,6 +29,10 @@ const DEFAULT_MAX_DOWNLOAD_BYTES: u64 = 10 * 1024 * 1024;
 /// elsewhere in prostheke/epignosis is generous headroom without wiring a
 /// dedicated config field for it.
 const MAX_API_RESPONSE_BYTES: u64 = 10 * 1024 * 1024;
+// NOTE: OpenSubtitles JWTs are valid for roughly 24 hours; half that is a
+// conservative reuse window that keeps a stale token from ever reaching the
+// API (same shape as epignosis's TVDB token cache).
+const TOKEN_TTL: Duration = Duration::from_secs(12 * 60 * 60);
 
 /// Computes the OpenSubtitles-specific file hash.
 ///
@@ -84,6 +89,10 @@ pub struct OpenSubtitlesProvider {
     /// `None` when unconfigured — `search`/`download` return before ever
     /// reaching a network call in that case, so no limiter is needed.
     rate_limiter: Option<RateLimiter>,
+    // NOTE: interior mutability — SubtitleProvider methods take &self.
+    // Holds the bearer JWT and the instant it stops being valid; `None`
+    // until the first credentialed download logs in.
+    token: RwLock<Option<(String, Instant)>>,
 }
 
 impl OpenSubtitlesProvider {
@@ -101,6 +110,7 @@ impl OpenSubtitlesProvider {
             client,
             base_url: BASE_URL.to_string(),
             rate_limiter,
+            token: RwLock::new(None),
         }
     }
 
@@ -122,6 +132,101 @@ impl OpenSubtitlesProvider {
 
     fn api_key(&self) -> Option<&str> {
         self.config.as_ref().map(|c| c.api_key.as_str())
+    }
+
+    /// Username/password pair, present only when BOTH are configured and
+    /// non-empty. Absent credentials keep the provider anonymous
+    /// (quota-limited) — the login flow is never attempted.
+    fn credentials(&self) -> Option<(&str, &str)> {
+        let config = self.config.as_ref()?;
+        match (config.username.as_deref(), config.password.as_deref()) {
+            (Some(user), Some(pass)) if !user.is_empty() && !pass.is_empty() => Some((user, pass)),
+            _ => None,
+        }
+    }
+
+    /// Returns the cached bearer JWT, logging in via `POST /login` only on a
+    /// cache miss or after the reuse window has elapsed. `None` when no
+    /// credentials are configured — the download stays anonymous.
+    async fn bearer_token(&self, api_key: &str) -> Result<Option<String>, ProsthekeError> {
+        let Some((username, password)) = self.credentials() else {
+            return Ok(None);
+        };
+
+        if let Some((token, valid_until)) = self.token.read().await.as_ref()
+            && Instant::now() < *valid_until
+        {
+            return Ok(Some(token.clone()));
+        }
+
+        let mut slot = self.token.write().await;
+        // WHY: double-checked — a concurrent caller may have refreshed the
+        // token while this one waited for the write lock; holding the write
+        // lock across the login makes the refresh single-flight.
+        if let Some((token, valid_until)) = slot.as_ref()
+            && Instant::now() < *valid_until
+        {
+            return Ok(Some(token.clone()));
+        }
+
+        let body = serde_json::json!({ "username": username, "password": password });
+        self.throttle().await;
+        let response = self
+            .client
+            .post(format!("{}/login", self.base_url))
+            .header("Api-Key", api_key)
+            .json(&body)
+            .send()
+            .await
+            .context(ProviderDownSnafu)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            return DownloadFailedSnafu {
+                detail: format!("HTTP {status} FROM login endpoint"),
+            }
+            .fail();
+        }
+
+        let bytes = read_body_capped(response, MAX_API_RESPONSE_BYTES).await?;
+        let parsed: LoginResponse = serde_json::from_slice(&bytes).map_err(|e| {
+            DownloadFailedSnafu {
+                detail: format!("invalid login response JSON: {e}"),
+            }
+            .build()
+        })?;
+
+        *slot = Some((parsed.token.clone(), Instant::now() + TOKEN_TTL));
+        Ok(Some(parsed.token))
+    }
+
+    /// Drops the cached bearer JWT.
+    ///
+    /// WHY: a 401 means the server no longer honors the cached token before
+    /// its local TTL elapsed; clearing it makes the next call re-authenticate
+    /// instead of failing until the TTL expires.
+    async fn invalidate_token(&self) {
+        *self.token.write().await = None;
+    }
+
+    /// POSTs `/download` for `file_id`, attaching the bearer JWT when one is
+    /// available (logged-in downloads get the account's quota).
+    async fn request_download_link(
+        &self,
+        api_key: &str,
+        bearer: Option<&str>,
+        file_id: u64,
+    ) -> Result<reqwest::Response, ProsthekeError> {
+        self.throttle().await;
+        let mut request = self
+            .client
+            .post(format!("{}/download", self.base_url))
+            .header("Api-Key", api_key)
+            .json(&serde_json::json!({ "file_id": file_id }));
+        if let Some(token) = bearer {
+            request = request.bearer_auth(token);
+        }
+        request.send().await.context(ProviderDownSnafu)
     }
 }
 
@@ -161,6 +266,13 @@ struct DownloadResponse {
     link: String,
     #[serde(default)]
     file_name: String,
+}
+
+// NOTE: the login response also carries `base_url` and user quota fields;
+// only the JWT is consumed.
+#[derive(Deserialize)]
+struct LoginResponse {
+    token: String,
 }
 
 // ── Scoring ───────────────────────────────────────────────────────────────────
@@ -387,16 +499,22 @@ impl SubtitleProvider for OpenSubtitlesProvider {
                 provider_id: subtitle.provider_id.0.clone(),
             })?;
 
-        let download_req = serde_json::json!({ "file_id": file_id });
-        self.throttle().await;
-        let dl_resp = self
-            .client
-            .post(format!("{}/download", self.base_url))
-            .header("Api-Key", api_key)
-            .json(&download_req)
-            .send()
-            .await
-            .context(ProviderDownSnafu)?;
+        // WHY: the /download endpoint is quota-degraded (or refused) without a
+        // JWT — log in when credentials are configured; stay anonymous when not.
+        let bearer = self.bearer_token(api_key).await?;
+        let mut dl_resp = self
+            .request_download_link(api_key, bearer.as_deref(), file_id)
+            .await?;
+
+        // WHY: one re-login on 401 — the server may revoke a JWT before its
+        // local TTL elapses; a fresh login either recovers or fails loud.
+        if dl_resp.status() == reqwest::StatusCode::UNAUTHORIZED && bearer.is_some() {
+            self.invalidate_token().await;
+            let bearer = self.bearer_token(api_key).await?;
+            dl_resp = self
+                .request_download_link(api_key, bearer.as_deref(), file_id)
+                .await?;
+        }
 
         if !dl_resp.status().is_success() {
             let status = dl_resp.status();
@@ -704,6 +822,208 @@ mod tests {
             stream.write_all(response.as_bytes()).await.ok();
         });
         (format!("http://{addr}"), handle)
+    }
+
+    /// Raw-TCP HTTP/1.1 server answering `responses` (status, body) in order,
+    /// one connection per request; records each raw request (start-line +
+    /// headers + body, lowercased) for assertion.
+    async fn spawn_scripted_server(
+        responses: Vec<(u16, String)>,
+    ) -> (
+        String,
+        std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<String>>> = Default::default();
+        let record = std::sync::Arc::clone(&seen);
+        let handle = tokio::spawn(async move {
+            for (status, body) in responses {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut buf: Vec<u8> = Vec::new();
+                let mut chunk = [0u8; 4096];
+                loop {
+                    let n = stream.read(&mut chunk).await.unwrap();
+                    buf.extend_from_slice(&chunk[..n]);
+                    let head_end = buf.windows(4).position(|w| w == b"\r\n\r\n");
+                    if let Some(head_end) = head_end {
+                        let head = String::from_utf8_lossy(&buf[..head_end]).to_lowercase();
+                        let declared = head
+                            .lines()
+                            .find_map(|l| l.strip_prefix("content-length:"))
+                            .and_then(|v| v.trim().parse::<usize>().ok())
+                            .unwrap_or(0);
+                        if buf.len() - (head_end + 4) >= declared {
+                            break;
+                        }
+                    }
+                    if n == 0 {
+                        break;
+                    }
+                }
+                record
+                    .lock()
+                    .unwrap()
+                    .push(String::from_utf8_lossy(&buf).to_lowercase());
+                let reason = if status == 401 { "Unauthorized" } else { "OK" };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                stream.write_all(response.as_bytes()).await.ok();
+            }
+        });
+        (format!("http://{addr}"), seen, handle)
+    }
+
+    fn creds_config() -> OpenSubtitlesConfig {
+        OpenSubtitlesConfig {
+            api_key: "key".to_string(),
+            username: Some("user".to_string()),
+            password: Some("pass".to_string()),
+            // WHY: effectively unthrottled — these tests assert request
+            // sequencing, not politeness pacing.
+            rate_limit_per_second: 1000,
+            ..OpenSubtitlesConfig::default()
+        }
+    }
+
+    fn test_subtitle() -> SubtitleMatch {
+        SubtitleMatch {
+            provider: "opensubtitles".to_string(),
+            provider_id: SubtitleProviderId("123".to_string()),
+            language: "en".to_string(),
+            hearing_impaired: false,
+            forced: false,
+            score: 0.9,
+            download_url: "https://www.opensubtitles.com/x.srt".to_string(),
+        }
+    }
+
+    /// A `/download-link` body whose link fails local validation (non-https),
+    /// stopping the flow after the point under test without any network fetch.
+    fn dead_end_link_body() -> String {
+        serde_json::json!({ "link": "http://blocked.invalid/x.srt", "file_name": "x.srt" })
+            .to_string()
+    }
+
+    #[test]
+    fn empty_or_partial_credentials_are_treated_as_absent() {
+        for (username, password) in [
+            (None, None),
+            (Some("user".to_string()), None),
+            (None, Some("pass".to_string())),
+            (Some(String::new()), Some("pass".to_string())),
+            (Some("user".to_string()), Some(String::new())),
+        ] {
+            let provider = OpenSubtitlesProvider::new(Some(OpenSubtitlesConfig {
+                api_key: "key".to_string(),
+                username,
+                password,
+                ..OpenSubtitlesConfig::default()
+            }));
+            assert!(provider.credentials().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn download_with_credentials_logs_in_once_and_attaches_bearer() {
+        let login_body = serde_json::json!({ "token": "jwt-abc" }).to_string();
+        let (base_url, seen, handle) = spawn_scripted_server(vec![
+            (200, login_body),
+            (200, dead_end_link_body()),
+            (200, dead_end_link_body()),
+        ])
+        .await;
+        let provider = OpenSubtitlesProvider::with_base_url(Some(creds_config()), base_url);
+
+        let _ = provider.download(&test_subtitle()).await;
+        let _ = provider.download(&test_subtitle()).await;
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("both downloads must reach the server")
+            .unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 3);
+        assert!(seen[0].starts_with("post /login"));
+        assert!(seen[0].contains("api-key: key"));
+        assert!(seen[0].contains("\"username\":\"user\""));
+        assert!(seen[0].contains("\"password\":\"pass\""));
+        assert!(seen[1].starts_with("post /download"));
+        assert!(
+            seen[1].contains("authorization: bearer jwt-abc"),
+            "the download-link request must carry the login JWT: {}",
+            seen[1]
+        );
+        assert!(
+            seen[2].starts_with("post /download"),
+            "the second download must reuse the cached JWT, not re-login"
+        );
+        assert!(seen[2].contains("authorization: bearer jwt-abc"));
+    }
+
+    #[tokio::test]
+    async fn download_401_triggers_one_relogin_and_retry() {
+        let (base_url, seen, handle) = spawn_scripted_server(vec![
+            (200, serde_json::json!({ "token": "jwt-old" }).to_string()),
+            (401, "{}".to_string()),
+            (200, serde_json::json!({ "token": "jwt-new" }).to_string()),
+            (200, dead_end_link_body()),
+        ])
+        .await;
+        let provider = OpenSubtitlesProvider::with_base_url(Some(creds_config()), base_url);
+
+        let _ = provider.download(&test_subtitle()).await;
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("the 401 must trigger exactly one re-login and one retry")
+            .unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 4);
+        assert!(seen[0].starts_with("post /login"));
+        assert!(seen[1].starts_with("post /download"));
+        assert!(seen[1].contains("authorization: bearer jwt-old"));
+        assert!(seen[2].starts_with("post /login"));
+        assert!(seen[3].starts_with("post /download"));
+        assert!(
+            seen[3].contains("authorization: bearer jwt-new"),
+            "the retry must carry the fresh JWT: {}",
+            seen[3]
+        );
+    }
+
+    #[tokio::test]
+    async fn download_without_credentials_never_logs_in() {
+        let (base_url, seen, handle) =
+            spawn_scripted_server(vec![(200, dead_end_link_body())]).await;
+        let provider = OpenSubtitlesProvider::with_base_url(
+            Some(OpenSubtitlesConfig {
+                api_key: "key".to_string(),
+                rate_limit_per_second: 1000,
+                ..OpenSubtitlesConfig::default()
+            }),
+            base_url,
+        );
+
+        let _ = provider.download(&test_subtitle()).await;
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("the anonymous download must reach the server")
+            .unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1, "no login request may be issued: {seen:?}");
+        assert!(seen[0].starts_with("post /download"));
+        assert!(
+            !seen[0].contains("authorization:"),
+            "anonymous downloads must not carry a bearer: {}",
+            seen[0]
+        );
     }
 
     #[tokio::test]

--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -81,6 +81,11 @@ struct ActiveEntry {
     /// task settles it at its next fence instead of the canceller racing the
     /// engine start.
     cancel_requested: bool,
+    /// Highest engine-reported completion percentage seen for this download.
+    last_progress_pct: u8,
+    /// When `last_progress_pct` last advanced — the stall clock, judged
+    /// against `stalled_download_timeout_hours` on each reconcile pass.
+    last_progress_at: tokio::time::Instant,
 }
 
 impl ActiveEntry {
@@ -97,6 +102,8 @@ impl ActiveEntry {
             retry_count: item.retry_count,
             engine_started: false,
             cancel_requested: false,
+            last_progress_pct: 0,
+            last_progress_at: tokio::time::Instant::now(),
         }
     }
 }
@@ -498,8 +505,8 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
         };
 
         for download_id in snapshot {
-            let state = match self.engine.get_progress(download_id).await {
-                Ok(progress) => progress.state,
+            let progress = match self.engine.get_progress(download_id).await {
+                Ok(progress) => progress,
                 Err(e) => {
                     // WHY: a get_progress error cannot distinguish a lost
                     // download from a dispatch still registering with the
@@ -510,13 +517,13 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
                     continue;
                 }
             };
-            match state {
+            match progress.state {
                 DownloadState::Completed
                 | DownloadState::Seeding
                 | DownloadState::SeedPolicySatisfied
                 | DownloadState::Failed
                 | DownloadState::Deleted => {
-                    warn!(%download_id, %state, "terminal engine state with no processed event; reconciling");
+                    warn!(%download_id, state = %progress.state, "terminal engine state with no processed event; reconciling");
                     // WHY: get_progress carries no completion path, so the
                     // post-processing pipeline cannot be synthesized here.
                     // The failure path releases the slot and re-queues within
@@ -525,20 +532,63 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
                     self.on_download_failed(
                         download_id,
                         format!(
-                            "terminal engine state {state} observed during reconciliation; event was dropped"
+                            "terminal engine state {} observed during reconciliation; event was dropped",
+                            progress.state
                         ),
                     )
                     .await;
                 }
                 DownloadState::Queued
                 | DownloadState::Initializing
-                | DownloadState::Downloading => {}
+                | DownloadState::Downloading => {
+                    if let Some(reason) = self
+                        .stall_reason(download_id, progress.percent_complete)
+                        .await
+                    {
+                        warn!(%download_id, %reason, "active download stalled; failing");
+                        // WHY: the engine download is still live — cancel it so
+                        // the stuck transfer stops, instead of running headless
+                        // after its slot is reclaimed below.
+                        if let Err(e) = self.engine.cancel_download(download_id).await {
+                            warn!(%download_id, error = %e, "engine cancel failed for stalled download");
+                        }
+                        self.on_download_failed(download_id, reason).await;
+                    }
+                }
                 // WHY: DownloadState is non_exhaustive upstream; an unknown
                 // variant is treated as in-flight so the slot is never
                 // released for a state this crate cannot classify.
                 _ => {}
             }
         }
+    }
+
+    /// Advances the entry's progress watermark, returning the permanent
+    /// "stalled" failure reason (routed by `classify_failure`) once the
+    /// download has gone longer than `stalled_download_timeout_hours` without
+    /// advancing.
+    ///
+    /// INVARIANT: the read-compare-update on the watermark runs under the
+    /// `Inner` lock with no await, and the timeout is read from the live
+    /// config in the same critical section — `update_config` changes apply
+    /// on the next pass.
+    async fn stall_reason(&self, download_id: DownloadId, percent_complete: u8) -> Option<String> {
+        let mut inner = self.inner.lock().await;
+        let timeout_hours = inner.config.stalled_download_timeout_hours;
+        let entry = inner.active.get_mut(&download_id.to_string())?;
+        if percent_complete > entry.last_progress_pct {
+            entry.last_progress_pct = percent_complete;
+            entry.last_progress_at = tokio::time::Instant::now();
+            return None;
+        }
+        let stalled_for = entry.last_progress_at.elapsed();
+        let timeout = tokio::time::Duration::from_secs(timeout_hours.saturating_mul(3600));
+        (stalled_for >= timeout).then(|| {
+            format!(
+                "stalled: no progress in {}h (stalled_download_timeout_hours = {timeout_hours})",
+                stalled_for.as_secs() / 3600
+            )
+        })
     }
 
     async fn handle_event(&self, event: HarmoniaEvent) {
@@ -1228,7 +1278,7 @@ impl<E: DownloadEngine + 'static> QueueManager for Arc<DownloadQueue<E>> {
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex as StdMutex;
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 
     use apotheke::migrate::MIGRATOR;
     use ergasia::{DownloadProgress, ErgasiaError, ExtractionResult};
@@ -1242,6 +1292,7 @@ mod tests {
         calls: AtomicUsize,
         fail_remaining: AtomicUsize,
         progress_state: StdMutex<DownloadState>,
+        progress_pct: AtomicU8,
         progress_unavailable: AtomicBool,
         cancelled: StdMutex<Vec<DownloadId>>,
         fail_cancels: AtomicBool,
@@ -1259,6 +1310,7 @@ mod tests {
                     calls: AtomicUsize::new(0),
                     fail_remaining: AtomicUsize::new(0),
                     progress_state: StdMutex::new(DownloadState::Downloading),
+                    progress_pct: AtomicU8::new(0),
                     progress_unavailable: AtomicBool::new(false),
                     cancelled: StdMutex::new(Vec::new()),
                     fail_cancels: AtomicBool::new(false),
@@ -1290,6 +1342,10 @@ mod tests {
 
         fn set_progress_state(&self, state: DownloadState) {
             *self.progress_state.lock().unwrap() = state;
+        }
+
+        fn set_progress_pct(&self, pct: u8) {
+            self.progress_pct.store(pct, Ordering::SeqCst);
         }
 
         fn set_progress_unavailable(&self) {
@@ -1360,7 +1416,7 @@ mod tests {
             Ok(DownloadProgress {
                 download_id,
                 state: *self.progress_state.lock().unwrap(),
-                percent_complete: 0,
+                percent_complete: self.progress_pct.load(Ordering::SeqCst),
                 download_speed_bps: 0,
                 upload_speed_bps: 0,
                 peers_connected: 0,
@@ -2079,6 +2135,123 @@ mod tests {
             "an unqueryable download must not be reaped (could be a dispatch in flight)"
         );
         assert_eq!(active_total(&svc).await, 1);
+    }
+
+    // ── #575: stalled-download detection ────────────────────────────────────
+    //
+    // NOTE: the stall tests run on the REAL clock with
+    // `stalled_download_timeout_hours = 0` (any non-advancing tick is past the
+    // window) — a paused clock is unusable here because sqlx's pool-acquire
+    // timeout auto-advances to firing while the sqlite worker thread is still
+    // doing real work (`PoolTimedOut`).
+
+    #[tokio::test]
+    async fn stalled_download_is_failed_permanently_and_releases_slot() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let mut config = test_config(1, 3, 0);
+        config.stalled_download_timeout_hours = 0;
+        let svc = make_service(pool.clone(), Arc::clone(&engine), config).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (download_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(active_total(&svc).await, 1);
+
+        // No progress since dispatch and the window has elapsed: the pass
+        // must fail the download.
+        svc.reconcile_active().await;
+
+        let (status, reason, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "failed");
+        let reason = reason.unwrap_or_default();
+        assert!(
+            reason.contains("stalled"),
+            "the reason must carry the permanent 'stalled' classification: {reason}"
+        );
+        assert_eq!(
+            active_total(&svc).await,
+            0,
+            "a stalled download must release its slot"
+        );
+        assert_eq!(
+            retry_pending_len(&svc).await,
+            0,
+            "stalled is Permanent — no retry may be scheduled"
+        );
+        assert!(
+            engine.cancelled_ids().contains(&download_id),
+            "the stuck engine download must be cancelled, not left running headless"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_within_stall_window_is_not_failed() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let mut config = test_config(1, 3, 0);
+        config.stalled_download_timeout_hours = 1;
+        let svc = make_service(pool.clone(), Arc::clone(&engine), config).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (download_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // No progress, but the window has not elapsed — the entry survives.
+        svc.reconcile_active().await;
+
+        assert!(active_contains(&svc, download_id).await);
+        assert_eq!(active_total(&svc).await, 1);
+        assert!(engine.cancelled_ids().is_empty());
+        let (status, _, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "downloading");
+    }
+
+    #[tokio::test]
+    async fn progressing_download_is_not_stall_failed() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let mut config = test_config(1, 3, 0);
+        config.stalled_download_timeout_hours = 0;
+        let svc = make_service(pool.clone(), Arc::clone(&engine), config).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (download_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Every pass is past the zero-length window, but each one sees
+        // advanced progress — the watermark reset must keep the entry alive.
+        for pct in [10u8, 20] {
+            engine.set_progress_pct(pct);
+            svc.reconcile_active().await;
+            assert!(
+                active_contains(&svc, download_id).await,
+                "a download that advanced to {pct}% must not be stall-failed"
+            );
+        }
+
+        assert_eq!(active_total(&svc).await, 1);
+        assert!(engine.cancelled_ids().is_empty());
+        let (status, _, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "downloading");
+
+        // Once progress stops advancing, the same entry stalls out.
+        svc.reconcile_active().await;
+        let (status, reason, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "failed", "a later genuine stall must still fail");
+        assert!(reason.unwrap_or_default().contains("stalled"));
     }
 
     #[tokio::test]

--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -566,7 +566,7 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
     /// Advances the entry's progress watermark, returning the permanent
     /// "stalled" failure reason (routed by `classify_failure`) once the
     /// download has gone longer than `stalled_download_timeout_hours` without
-    /// advancing.
+    /// advancing. A download at 100% is exempt — full is never stalled.
     ///
     /// INVARIANT: the read-compare-update on the watermark runs under the
     /// `Inner` lock with no await, and the timeout is read from the live
@@ -576,7 +576,12 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
         let mut inner = self.inner.lock().await;
         let timeout_hours = inner.config.stalled_download_timeout_hours;
         let entry = inner.active.get_mut(&download_id.to_string())?;
-        if percent_complete > entry.last_progress_pct {
+        // WHY: the production engine reports Downloading/100 for a finished
+        // torrent while it seeds, so a completed download would otherwise
+        // freeze its watermark and be cancel-deleted as "stalled" once the
+        // window elapses. Completion/seeding are the lifecycle's concern.
+        // TODO[deliberate-prudent] #602: judge on honest terminal states // kanon:ignore RUST/todo-no-issue -- richer quadrant rule covers this // kanon:ignore META/rule-todo-without-issue -- richer quadrant rule covers this
+        if percent_complete >= 100 || percent_complete > entry.last_progress_pct {
             entry.last_progress_pct = percent_complete;
             entry.last_progress_at = tokio::time::Instant::now();
             return None;
@@ -2187,6 +2192,39 @@ mod tests {
             engine.cancelled_ids().contains(&download_id),
             "the stuck engine download must be cancelled, not left running headless"
         );
+    }
+
+    #[tokio::test]
+    async fn full_percent_download_is_never_stall_failed() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let mut config = test_config(1, 3, 0);
+        config.stalled_download_timeout_hours = 0;
+        let svc = make_service(pool.clone(), Arc::clone(&engine), config).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (download_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // The production engine reports Downloading/100 while a finished
+        // torrent seeds (#602): every pass is past the zero-length window and
+        // the percentage never advances, yet 100% must never read as stalled.
+        engine.set_progress_pct(100);
+        svc.reconcile_active().await;
+        svc.reconcile_active().await;
+
+        assert!(active_contains(&svc, download_id).await);
+        assert_eq!(active_total(&svc).await, 1);
+        assert!(
+            engine.cancelled_ids().is_empty(),
+            "a full download must never be cancelled as stalled"
+        );
+        let (status, _, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "downloading");
     }
 
     #[tokio::test]

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -261,9 +261,9 @@ honest and logged, never silent:
 
 `crates/horismos/src/diff.rs::every_leaf_is_classified_exactly_once` walks
 every leaf of an exemplar `Config` (every `Option<Struct>` subsystem
-populated with `Some(..)` so mixed LIVE/UNWIRED subtrees like
-`prostheke.opensubtitles` expose per-field granularity instead of collapsing
-to one leaf; `taxis.libraries` gets one synthetic entry canonicalized to a
+populated with `Some(..)` so subtrees like `prostheke.opensubtitles` expose
+per-field granularity instead of collapsing to one leaf; `taxis.libraries`
+gets one synthetic entry canonicalized to a
 `taxis.libraries.*.<field>` path so the leaf set is deterministic regardless
 of the real library key) and asserts:
 

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -19,8 +19,9 @@ exactly one of three classes:
   effective value, and the field is reported in `restart_pending` until the
   process restarts or the on-disk value reverts. Nothing is silently dropped.
 - **UNWIRED** — parsed and validated, but no code reads it to change
-  behavior. Tracked as tech debt ([#575](https://github.com/forkwright/harmonia/issues/575)),
-  not part of the reactive-config contract.
+  behavior. The list is EMPTY ([#575](https://github.com/forkwright/harmonia/issues/575)
+  wired or removed every dead field); it remains as a guarded surface so a
+  new field cannot become silently-dead config.
 
 `crates/horismos/src/diff.rs` is the single source of truth for this
 classification (`LIVE`, `RESTART_REQUIRED`, `UNWIRED` — the last two are
@@ -130,29 +131,29 @@ from the new section on change (`SectionWatcher::changed()`).
 | `caps_refresh_hours` | LIVE | zetesis supervisor caps-refresh tick (15 min) judges each indexer's `last_tested` staleness against the live value on every tick |
 | `cardigann_definitions_dir` | LIVE | registry reload + swap |
 
-### ergasia — mostly RESTART/UNWIRED; two LIVE
+### ergasia — mostly RESTART; three LIVE
 
 | Field | Class | Why |
 |---|---|---|
 | `download_dir` / `session_state_path` / `listen_port_range` / `peer_connect_timeout_seconds` | RESTART | frozen into the librqbit session at build |
 | `seed_ratio_threshold` / `seed_time_threshold_hours` | RESTART | frozen into librqbit's `SeedingPolicy`, no reconfigure API (reclassified in step 7 — previously a silent no-op) |
 | `max_extraction_depth` / `max_decompression_ratio` | LIVE | `SessionEngine` rebuilds `ExtractionLimits` per extract call |
-| `magnet_resolve_timeout_seconds` | UNWIRED | #575 |
+| `magnet_resolve_timeout_seconds` | LIVE | #575 — `TorrentSession` reads its `Section` per add_torrent call; the timeout bounds librqbit's otherwise-unbounded magnet resolve |
 
-### syntaxis — LIVE (step 7) except one UNWIRED
+### syntaxis — LIVE (step 7)
 
 | Field | Class |
 |---|---|
 | `max_concurrent_downloads` / `max_per_tracker` / `retry_count` / `retry_backoff_base_seconds` | LIVE — `DownloadQueue::update_config` + `SlotAllocator::set_limits` |
-| `stalled_download_timeout_hours` | UNWIRED — #575 |
+| `stalled_download_timeout_hours` | LIVE — #575: each reconcile pass compares every active download's progress watermark against the live value; a download with no progress inside the window is failed permanently (the `stalled` reason) and its slot released |
 
-### prostheke — LIVE (step 8) except two UNWIRED
+### prostheke — LIVE (step 8)
 
 | Field | Class | Mechanism |
 |---|---|---|
 | `languages` / `include_hearing_impaired` / `include_forced` / `min_match_score` | LIVE | per-op `Section` read |
 | `opensubtitles.api_key` / `.rate_limit_per_second` / `.max_download_bytes` | LIVE | provider rebuild + `set_providers` — rate limiter state RESETS with the provider (logged) |
-| `opensubtitles.username` / `.password` | UNWIRED | #575 — no login flow exists |
+| `opensubtitles.username` / `.password` | LIVE | #575 — JWT login (`POST /login`, bearer on `/download`); provider rebuild resets the token cache, so a credential change logs in fresh. Absent credentials keep downloads anonymous (quota-limited) |
 
 ### komide — LIVE (feed scheduler REBUILD, step 6)
 

--- a/docs/media/subtitles.md
+++ b/docs/media/subtitles.md
@@ -39,7 +39,7 @@ Body: { "username": "...", "password": "..." }
 Response: { "token": "...", "base_url": "..." }
 ```
 
-Token cached by Epignosis (same JWT refresh lock pattern as TVDB: `tokio::sync::Mutex<Option<OsToken>>`, first waiter refreshes, others block and reuse). Token lifetime: approximately 24 hours.
+Token cached by Prostheke's `OpenSubtitlesProvider` (same JWT refresh lock pattern as Epignosis's TVDB provider: `tokio::sync::RwLock<Option<(String, Instant)>>`, double-checked write lock so the first waiter refreshes and others reuse). Token lifetime: approximately 24 hours; the cache reuses a token for 12 hours, and a 401 on `/download` invalidates it for one re-login + retry. Login runs only when BOTH `username` and `password` are configured non-empty — otherwise downloads stay anonymous (quota-limited).
 
 Secrets stored in `secrets.toml`:
 


### PR DESCRIPTION
Wires the last four dead config fields — UNWIRED in diff.rs is now EMPTY, closing the dead-config-surface audit.

- **ergasia.magnet_resolve_timeout_seconds** — `session.add_torrent` (magnet resolve waits indefinitely on DHT) is now bounded by `tokio::time::timeout` with a dedicated error variant.
- **syntaxis.stalled_download_timeout_hours** — real stall detection: `ActiveEntry` tracks last-progress (pct + Instant); the reconcile tick fails a download whose progress hasn't advanced past the live-config threshold, releasing its slot, with the "stalled" reason `classify_failure` already routes.
- **prostheke.opensubtitles.username/password** — OpenSubtitles JWT login (TVDB token-cache pattern): POST /login when both credentials configured, Bearer attached to downloads, re-login on 401, anonymous behavior preserved when unconfigured.

Gate green (2111 tests, full workspace). Salvaged commit from the metis shutdown — re-gated post-restart; 3-lens adversarial review (credentials/concurrency/correctness) run separately.

Closes #575