### PR TITLE
docs: align architecture and download docs with the actual config schema

### DIFF
--- a/docs/architecture/communication.md
+++ b/docs/architecture/communication.md
@@ -35,19 +35,18 @@ This is the single most important communication design rule in Harmonia. Every n
 
 ## Channel topology
 
-Two tokio channel types are used:
+**`tokio::sync::broadcast`:** pub/sub events where multiple subscribers each react independently. Every subscriber receives a copy of the event. Buffer size: 1024 (configurable via Horismos under `[aggelia] buffer_size`). Used for all `HarmoniaEvent` variants — `create_event_bus(buffer_size)` (`themelion::aggelia`) wraps `broadcast::channel`, and it is the ONLY config-driven channel in the system.
 
-**`tokio::sync::broadcast`:** pub/sub events where multiple subscribers each react independently. Every subscriber receives a copy of the event. Buffer size: 1024 (configurable via Horismos under `[aggelia] buffer_size`). Used for all `HarmoniaEvent` variants.
-
-**`tokio::sync::mpsc`:** directed work queues where one consumer processes each item. Each message is consumed by exactly one receiver. Used for: download queue entries from Syntaxis to Ergasia (bounded, backpressure-aware). The channel is bounded; Syntaxis will block if Ergasia's queue is full, providing natural backpressure without event loss.
+Syntaxis → Ergasia is **not** a channel. There was a design for a bounded mpsc download queue (sized by an `aggelia.download_queue_size` field), but it never had a consumer and the field was removed from the schema (#598) — Syntaxis dispatches to Ergasia with a direct async trait call instead (`ergasia::DownloadEngine::start_download`, awaited from the dispatch task), which is the natural fit under this doc's own rule: Syntaxis needs the `Result<DownloadId, ErgasiaError>` to release or hold the slot it claimed. Concurrency is bounded by an in-process `SlotAllocator` (plain counters against `syntaxis.max_concurrent_downloads`/`.max_per_tracker`), not by channel capacity.
 
 | Communication Path | Channel Type | Rationale |
 |--------------------|-------------|-----------|
 | `ImportCompleted` event | `broadcast` | Syndesmos (Plex notify), Kritike (quality check), Prostheke (subtitle lookup) all react independently |
 | `QualityUpgradeTriggered` event | `broadcast` | Monitoring adapters may re-trigger acquisition; no guaranteed subscriber |
-| `DownloadProgress` event | `broadcast` | Web UI / API layer subscribes for real-time progress; Ergasia does not know who listens |
+| `DownloadProgress` event | `broadcast` | Defined on the enum for the web UI / API layer, but has no production emitter — nothing constructs and sends it today |
 | `DownloadCompleted` event | `broadcast` | Syntaxis triggers post-processing pipeline on completion |
 | `DownloadFailed` event | `broadcast` | Syntaxis handles retry or failure escalation |
+| `SeedPolicySatisfied` event | `broadcast` | Web UI may display seeding-complete status; the authoritative cleanup signal is a direct call to Kathodos, not this event |
 | `SearchCompleted` event | `broadcast` | Monitoring adapters may evaluate search results for acquisition decisions |
 | `PlexNotifyRequired` event | `broadcast` | Syndesmos is the sole consumer, but broadcast allows future subscribers |
 | `ScrobbleRequired` event | `broadcast` | Syndesmos is the sole consumer |
@@ -55,9 +54,11 @@ Two tokio channel types are used:
 | `MetadataEnriched` event | `broadcast` | Library indexing layer and web UI react to enrichment completion |
 | `LibraryScanCompleted` event | `broadcast` | Web UI and health reporting react to full scan completion |
 | `SubtitleAcquired` event | `broadcast` | Paroche reacts to new subtitle availability for active streams |
-| Syntaxis → Ergasia download queue | `mpsc` (bounded) | Single consumer; backpressure required to prevent queue overflow |
+| Syntaxis → Ergasia dispatch | direct call | Syntaxis needs the result to manage its slot — see above |
 
-All direct calls between subsystems (Paroche → Exousia, Kathodos → Epignosis, etc.) use synchronous trait method calls, not channels. Those paths are enumerated in `docs/architecture/subsystems.md`.
+All direct calls between subsystems (Paroche → Exousia, Kathodos → Epignosis, Syntaxis → Ergasia, etc.) use synchronous trait method calls, not channels. Those paths are enumerated in `docs/architecture/subsystems.md`.
+
+Two distinct `DownloadProgress` types exist and are easy to conflate: `themelion::HarmoniaEvent::DownloadProgress` (the broadcast event below — defined, never emitted) and `ergasia::DownloadProgress` (a different shape, returned by the `DownloadEngine::get_progress` polling call — see [download/torrent.md](../download/torrent.md)). Progress is available today only by polling the latter; there is no broadcast push.
 
 ---
 
@@ -108,6 +109,15 @@ pub enum HarmoniaEvent {
     DownloadFailed {
         download_id: DownloadId,
         reason: String,
+    },
+
+    /// Ergasia's seeding monitor determined ratio/time policy is satisfied.
+    /// Informational — the authoritative cleanup signal is a direct call to Kathodos.
+    /// Subscribers: web UI (display seeding completion status)
+    SeedPolicySatisfied {
+        download_id: DownloadId,
+        uploaded_bytes: u64,
+        downloaded_bytes: u64,
     },
 
     /// Zetesis completed a search against configured indexers.
@@ -177,53 +187,40 @@ pub enum HarmoniaEvent {
 archon creates all channels at startup and distributes handles via constructor injection. No subsystem imports a "bus crate"; this avoids the circular dependency pitfall described in `docs/architecture/cargo.md`.
 
 ```rust
-// In archon main()
-use tokio::sync::broadcast;
-use themelion::HarmoniaEvent;
+// In archon's serve.rs
+use themelion::create_event_bus;
 
-// Create broadcast channel — all HarmoniaEvent variants flow through this single sender
-let (event_tx, _) = broadcast::channel::<HarmoniaEvent>(config.aggelia.buffer_size);
-
-// Create mpsc download queue — Syntaxis sends, Ergasia receives
-let (download_tx, download_rx) = tokio::sync::mpsc::channel(config.aggelia.download_queue_size);
+// Create the broadcast bus — all HarmoniaEvent variants flow through this single sender
+let (event_tx, _event_rx) = create_event_bus(boot_config.aggelia.buffer_size);
 
 // Each subscribing subsystem gets a Receiver by calling .subscribe() on the Sender.
-// The initial _rx from broadcast::channel is discarded — it exists only to keep
-// the channel open until the first real subscriber subscribes.
+// The initial _event_rx is discarded — it exists only to keep the channel open
+// until the first real subscriber subscribes.
 let syndesmos_rx = event_tx.subscribe();
 let kritike_rx   = event_tx.subscribe();
 let prostheke_rx = event_tx.subscribe();
-let monitor_rx   = event_tx.subscribe();
 let paroche_rx   = event_tx.subscribe();
 // ... each subsystem that subscribes gets its own Receiver clone
 
-// Subsystems receive Sender clone (to emit) and their own Receiver (to subscribe)
-let kathodos = Kathodos::new(
-    config.taxis.clone(),
-    event_tx.clone(),  // to emit ImportCompleted, PlexNotifyRequired
-    // ...
-);
-
+// Subsystems receive a Sender clone (to emit) and their own Receiver (to subscribe)
 let syndesmos = Syndesmos::new(
-    config.syndesmos.clone(),
+    config_handle.section(|c| &c.syndesmos),
     event_tx.clone(),   // to emit TidalWantListSynced
-    syndesmos_rx,       // to receive PlexNotifyRequired, ScrobbleRequired, TidalWantListSynced
+    syndesmos_rx,       // to receive PlexNotifyRequired, ScrobbleRequired
     // ...
 );
 
-let ergasia = Ergasia::new(
-    config.ergasia.clone(),
-    event_tx.clone(),  // to emit DownloadProgress, DownloadCompleted, DownloadFailed
-    download_rx,       // receives work items from Syntaxis
-    // ...
-);
+// Syntaxis holds an Arc<dyn DownloadEngine> and calls it directly — there is
+// no channel between Syntaxis and Ergasia (see Channel topology above).
+let engine: Arc<dyn ergasia::DownloadEngine> = Arc::new(TorrentSession::new(&config.ergasia).await?);
+let syntaxis = DownloadQueue::new(pool.clone(), engine, event_tx.clone(), /* ... */);
 ```
 
 **Key points:**
-- `broadcast::channel::<HarmoniaEvent>(1024)` is created once in archon.
+- `create_event_bus(aggelia.buffer_size)` is created once in archon.
 - Each subsystem that emits events receives a `broadcast::Sender<HarmoniaEvent>` clone.
 - Each subsystem that subscribes calls `.subscribe()` to create its `broadcast::Receiver<HarmoniaEvent>`; this happens before the subsystems start processing, so no events are missed.
-- The mpsc channel for download queue entries is distinct from the broadcast channel.
+- Syntaxis → Ergasia dispatch does not go through this bus, or through any channel — it is a direct call (see Channel topology above).
 - No subsystem imports a crate to gain access to the bus. Handles are constructor-injected.
 
 ---

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -15,182 +15,253 @@ Horismos is the single source of truth for all system configuration. No other su
 
 ## Config file structure
 
-`harmonia.toml` at the workspace root (`harmonia/`). TOML format. One `[subsystem]` section per subsystem that has configurable values. Committed to version control with safe defaults; no secrets, no credentials.
+`harmonia.toml`, path given via `--config` (default `harmonia.toml` in the working directory). TOML format. One `[subsystem]` section per subsystem that has configurable values. Committed to version control with safe defaults; no secrets, no credentials.
 
 ```toml
 # harmonia.toml — committed, safe defaults only
 
-[zetesis]
-# Indexer search
-request_timeout_secs = 30
-max_results_per_indexer = 100
-max_response_body_bytes = 16777216   # 16 MiB cap on any single indexer response
-cloudflare_bypass_enabled = false
+[database]
+db_path = "harmonia.db"
+read_pool_size = 0                # 0 = auto-detect
+write_pool_max = 1
 
 [exousia]
-# Auth — JWT TTL values only; secrets come from secrets.toml or env vars
+# Auth — JWT TTL values only; the signing secret comes from secrets.toml or an env var
 access_token_ttl_secs = 900       # 15 minutes
 refresh_token_ttl_days = 30
 
 [paroche]
-# Media serving
-stream_buffer_kb = 256
-transcode_concurrency = 2
+# Media serving + renderer (KOSync/QUIC) registration
+listen_addr = "0.0.0.0"
+port = 8096
 opds_page_size = 50
+kosync_registration_enabled = true
+renderer_max_connections = 32
+renderer_session_init_timeout_secs = 10
+renderer_quic_port = 4433
+# renderer_api_key comes from secrets.toml — leaving it unset rejects every
+# renderer registration (fail closed)
 
-[ergasia]
-# Download execution
-download_dir = "/data/downloads"
-max_concurrent_downloads = 3
-seeding_ratio_limit = 2.0
-seeding_time_limit_hours = 168    # 7 days
+[taxis]
+# Library scanning — libraries themselves are named sub-tables, one per library
+watcher_debounce_ms = 500
+scan_concurrency = 4
 
-[aggelia]
-# Internal event bus
-buffer_size = 1024
-download_queue_size = 512
-
-[zetesis.indexers]
-# Indexer credentials live in secrets.toml, not here
-# This section contains protocol-level config only
-torznab_timeout_secs = 15
+[taxis.libraries.music]
+path = "/data/music"
+media_type = "music"              # "music" | "video" | "book"
+watcher_mode = "auto"              # "inotify" | "poll" | "auto"
+poll_interval_seconds = 300
+scan_interval_hours = 24
 
 [epignosis]
 # Metadata providers
 cache_ttl_secs = 86400            # 24 hours
-max_retries = 3
 provider_timeout_secs = 10
+fingerprint_accept_threshold = 0.8
+fingerprint_ambiguous_threshold = 0.5
 provider_response_max_bytes = 10485760  # cap on a buffered provider response
+# acoustid_key / tmdb_key / tvdb_key / comicvine_key / google_books_key come
+# from secrets.toml; an absent key degrades that provider (warning at
+# startup), it does not fail validation — see Validation rules below
 
 [kritike]
 # Quality curation
-scan_interval_hours = 24
 quality_check_concurrency = 4
+
+[aggelia]
+# Internal broadcast event bus
+buffer_size = 1024
+
+[zetesis]
+# Indexer search + Cloudflare bypass — see download/cloudflare.md
+request_timeout_secs = 30
+max_results_per_indexer = 100
+max_response_body_bytes = 16777216   # 16 MiB cap on any single indexer response
+cloudflare_bypass_enabled = false
+max_concurrent_searches = 10
+per_indexer_rate_limit_requests = 5
+per_indexer_rate_limit_window_seconds = 10
+caps_refresh_hours = 24
+search_timeout_seconds = 30
+# cf_proxy_url is REQUIRED when cloudflare_bypass_enabled = true (validation
+# error otherwise); cardigann_definitions_dir is optional
+cf_proxy_timeout_seconds = 60
+cf_cookie_refresh_minutes = 30
+
+[ergasia]
+# Torrent download execution (librqbit) — see download/torrent.md
+download_dir = "/data/downloads"
+session_state_path = "/data/downloads/.librqbit-state"
+listen_port_range = [6881, 6889]
+seed_ratio_threshold = 1.0
+seed_time_threshold_hours = 72
+peer_connect_timeout_seconds = 10
+magnet_resolve_timeout_seconds = 120
+max_extraction_depth = 3
+max_decompression_ratio = 100.0
+
+[syntaxis]
+# Download queue and post-processing — see download/orchestration.md
+max_concurrent_downloads = 5
+max_per_tracker = 3
+retry_count = 3
+retry_backoff_base_seconds = 30
+stalled_download_timeout_hours = 24
 
 [prostheke]
 # Subtitles
 languages = ["en", "de"]
-hearing_impaired = false
-provider_timeout_secs = 15
+include_hearing_impaired = false
+include_forced = true
+min_match_score = 0.7
+# prostheke.opensubtitles.api_key / username / password come from secrets.toml
 
-[taxis]
-# Library import and organization
-library_music_root = "/data/music"
-library_video_root = "/data/video"
-library_books_root = "/data/books"
-file_naming_dry_run = false
+[komide]
+# Podcasts and news feeds
+podcast_poll_interval_minutes = 30
+news_poll_interval_minutes = 15
+podcast_dir = "/data/podcasts"
+news_retention_days = 30
+news_retention_articles = 500
+auto_download_latest_n = 3
+fetch_timeout_secs = 30
+max_feed_bytes = 20971520
+max_episode_bytes = 1073741824
+max_backoff_minutes = 240
+jitter_percent = 10.0
 
-[syntaxis]
-# Queue management
-max_queue_size = 1000
-priority_strategy = "fifo"
+[syndesmos]
+# External integrations — Plex, Last.fm, Tidal are each optional sub-tables;
+# omitting one disables that integration. Credentials live in secrets.toml.
+circuit_break_minutes = 5
+circuit_break_failure_threshold = 5
 
 [aitesis]
 # Request management
-max_requests_per_user = 10
-request_auto_approve = false
+max_pending_per_user = 25
+max_requests_per_day = 10
+auto_approve_admins = true
 ```
 
 ---
 
 ## Secrets separation
 
-`secrets.toml` at the workspace root (`harmonia/`). Gitignored; never committed. Contains: JWT signing secret, API keys for external services (Plex, Last.fm, Tidal), indexer credentials. Same TOML structure as `harmonia.toml`; figment merges them transparently with `secrets.toml` taking precedence over `harmonia.toml`.
+`secrets.toml`, resolved as a sibling of the config file (same directory, filename `secrets.toml`). Gitignored; never committed. Contains: the JWT signing secret, the renderer registration key, metadata-provider API keys, subtitle-provider credentials, and the Plex/Last.fm/Tidal integration credentials. Same TOML structure as `harmonia.toml`; figment merges them transparently with `secrets.toml` taking precedence over `harmonia.toml`.
 
 ```toml
 # secrets.toml — gitignored, never committed
 
 [exousia]
-jwt_secret = "..."                # Required: min 32 bytes of entropy
+jwt_secret = "..."                 # Required: min 32 bytes of entropy
 
-[syndesmos]
-plex_token = "..."                # Required when plex feature is enabled
-lastfm_api_key = "..."            # Required when lastfm feature is enabled
-lastfm_api_secret = "..."
-tidal_client_id = "..."           # Required when tidal feature is enabled
-tidal_client_secret = "..."
+[paroche]
+renderer_api_key = "..."           # Unset = every renderer registration is rejected (fail closed)
 
-[zetesis.indexers.prowlarr]
+[epignosis]
+acoustid_key = "..."               # Optional — absent runs fingerprinting unauthenticated
+tmdb_key = "..."                   # Optional — absent disables movie/secondary-TV resolution
+tvdb_key = "..."                   # Optional — absent disables TV metadata resolution
+comicvine_key = "..."              # Optional — absent disables comic metadata resolution
+google_books_key = "..."           # Optional — absent runs the Google Books fallback unauthenticated
+
+[prostheke.opensubtitles]
 api_key = "..."
+username = "..."                   # Optional — enables the authenticated download quota
+password = "..."
 
-[zetesis.indexers.jackett]
+[syndesmos.plex]
+url = "http://localhost:32400"
+token = "..."
+
+[syndesmos.lastfm]
 api_key = "..."
+shared_secret = "..."
+
+[syndesmos.tidal]
+access_token = "..."               # OAuth2 access token; refreshed automatically when expired
 ```
 
-**CRITICAL: JWT secret validation.** The JWT secret must never come from `harmonia.toml` (committed). Horismos validates at startup that `exousia.jwt_secret` is not the compiled-in default value (`""` empty string or any placeholder like `"changeme"`). If the secret is the default, Horismos returns an error and the process exits before serving any requests. This prevents accidentally running with a known signing key.
+**CRITICAL: JWT secret validation.** The JWT secret must never come from `harmonia.toml` (committed). Horismos validates at startup that `exousia.jwt_secret` is not empty and not a placeholder value (`"changeme"` or `"default"`), and is at least 32 bytes. A failing check is a startup error — the process exits before serving any requests.
 
 ```rust
-// In Horismos validation — called during Config::load()
-fn validate_jwt_secret(config: &Config) -> Result<(), HorisomosError> {
+// crates/horismos/src/validation.rs
+fn validate_jwt_secret(config: &Config) -> Result<(), HorismosError> {
     let secret = &config.exousia.jwt_secret;
     if secret.is_empty() || secret == "changeme" || secret == "default" {
-        return Err(HorisomosError::InsecureDefault {
-            field: "exousia.jwt_secret".to_string(),
-            hint: "set via secrets.toml or HARMONIA__EXOUSIA__JWT_SECRET env var".to_string(),
-        });
+        return ValidationSnafu {
+            message: "exousia.jwt_secret must not be empty or a placeholder value — \
+                       set via secrets.toml or HARMONIA__EXOUSIA__JWT_SECRET".to_string(),
+        }
+        .fail();
     }
     if secret.len() < 32 {
-        return Err(HorisomosError::SecretTooShort {
-            field: "exousia.jwt_secret".to_string(),
-            minimum_bytes: 32,
-            actual_bytes: secret.len(),
-        });
+        return ValidationSnafu {
+            message: format!(
+                "exousia.jwt_secret is too short ({} bytes); minimum is 32 bytes",
+                secret.len()
+            ),
+        }
+        .fail();
     }
     Ok(())
 }
 ```
 
+Every validation failure — JWT secret included — returns the same `HorismosError::Validation { message }` variant; there is no per-check error type. See **Validation rules** below for the full check list.
+
 ---
 
 ## Figment layer order
 
-figment merges providers in order, with **later providers taking precedence**. The complete merge sequence:
+figment merges providers in order, with **later providers taking precedence**:
 
 | Order | Provider | Source | Notes |
 |-------|----------|--------|-------|
 | 1 (lowest) | `Serialized::defaults(Config::default())` | Compiled-in Rust defaults | Safe baseline; system must work with defaults alone (except secrets) |
-| 2 | `Toml::file("harmonia.toml")` | `harmonia/harmonia.toml` | User config; committed, no secrets |
-| 3 | `Toml::file("secrets.toml")` | `harmonia/secrets.toml` | Secret overrides; gitignored, optional file |
+| 2 | `Toml::file(config_path)` | The path given to `--config` (default `harmonia.toml`) | User config; committed, no secrets |
+| 3 (highest) | `Toml::file(secrets_path(config_path))` | `secrets.toml`, sibling of the config file | Secret overrides; gitignored, optional file |
 | 4 | `Env::prefixed("HARMONIA__").split("__")` | Environment variables | Container/CI deployment overrides |
-| 5 (highest) | `Serialized` of CLI args | `archon` startup args | Explicit runtime overrides |
 
 ```rust
-// In crates/horismos/src/lib.rs
-use figment::{Figment, providers::{Serialized, Toml, Env, Format}};
+// crates/horismos/src/lib.rs
+pub fn load_config(
+    config_path: Option<&Path>,
+) -> Result<(Config, Vec<ValidationWarning>), HorismosError> {
+    let config_path = config_path.unwrap_or_else(|| Path::new("harmonia.toml"));
 
-impl Config {
-    pub fn load() -> Result<Self, HorisomosError> {
-        let config: Config = Figment::from(Serialized::defaults(Config::default()))
-            .merge(Toml::file("harmonia.toml"))
-            .merge(Toml::file("secrets.toml"))  // optional — figment silently ignores missing files
-            .merge(Env::prefixed("HARMONIA__").split("__"))
-            .extract()
-            .context(ConfigExtractSnafu)?;
+    let figment = Figment::new()
+        .merge(Serialized::defaults(Config::default()))
+        .merge(Toml::file(config_path))
+        .merge(Toml::file(secrets_path(config_path)))
+        .merge(Env::prefixed("HARMONIA__").split("__"));
 
-        config.validate()?;
-        Ok(config)
-    }
+    let config: Config = figment.extract().context(ConfigParseSnafu)?;
+    let warnings = validate_config(&config)?;
+    Ok((config, warnings))
 }
 ```
 
+No figment layer carries CLI arguments. `archon`'s `--listen`/`--port` flags are the one CLI-driven override: `run_serve` calls `load_config()`, then mutates `config.paroche.listen_addr`/`.port` directly from the parsed args (not through figment), and records the same two values in a `ConfigOverrides` struct so a later `SIGHUP` reload re-applies them — otherwise a reload would silently drop a `--port` override back to the on-disk value.
+
 ### Double-underscore separator: critical detail
 
-figment's `Env::split("__")` uses double underscore as the nesting level separator. This is not optional; single underscore `split("_")` has a known ambiguity with snake_case field names (figment issue #12).
+figment's `Env::split("__")` uses double underscore as the nesting level separator. This is not optional; single underscore `split("_")` has a known ambiguity with snake_case field names.
 
-**How it works:** figment replaces the split string with `.` to form a dotted key path. `HARMONIA__ZETESIS__TIMEOUT` becomes `zetesis.timeout`, which maps to `Config.zetesis.timeout`. The prefix `HARMONIA__` is stripped first, then each `__` becomes a nesting level.
+**How it works:** figment replaces the split string with `.` to form a dotted key path. `HARMONIA__ZETESIS__REQUEST_TIMEOUT_SECS` becomes `zetesis.request_timeout_secs`, which maps to `Config.zetesis.request_timeout_secs`. The prefix `HARMONIA__` is stripped first, then each `__` becomes a nesting level.
 
 | Env Var | Maps To | Why |
 |---------|---------|-----|
-| `HARMONIA__ZETESIS__TIMEOUT` | `[zetesis] timeout` | `__` splits nesting levels: `zetesis` → `timeout` |
-| `HARMONIA__EXOUSIA__SECRET_KEY` | `[exousia] secret_key` | single `_` in `secret_key` is preserved as part of the field name |
-| `HARMONIA__ERGASIA__MAX_CONCURRENT_DOWNLOADS` | `[ergasia] max_concurrent_downloads` | underscores within a key name are preserved |
-| `HARMONIA__PAROCHE__STREAM_BUFFER_KB` | `[paroche] stream_buffer_kb` | same; field name contains underscores, preserved |
-| `HARMONIA__EXOUSIA__JWT_SECRET` | `[exousia] jwt_secret` | correct way to set JWT secret in container environments |
+| `HARMONIA__ZETESIS__REQUEST_TIMEOUT_SECS` | `[zetesis] request_timeout_secs` | `__` splits nesting levels: `zetesis` → `request_timeout_secs` |
+| `HARMONIA__EXOUSIA__JWT_SECRET` | `[exousia] jwt_secret` | correct way to set the JWT secret in container environments |
+| `HARMONIA__SYNTAXIS__MAX_CONCURRENT_DOWNLOADS` | `[syntaxis] max_concurrent_downloads` | underscores within a field name are preserved |
+| `HARMONIA__PAROCHE__RENDERER_MAX_CONNECTIONS` | `[paroche] renderer_max_connections` | same; field name contains underscores, preserved |
 
 **WRONG: why `split("_")` fails:**
 
 `Env::prefixed("HARMONIA_").split("_")` would replace every `_` with `.`:
-- `HARMONIA_SECRET_KEY` → `secret.key`: is this `[secret] key` (nested) or `secret_key` (flat field)? Ambiguous.
+- `HARMONIA_JWT_SECRET` → `jwt.secret`: is this `[jwt] secret` (nested) or `jwt_secret` (flat field)? Ambiguous.
 - `HARMONIA_MAX_CONCURRENT_DOWNLOADS` → `max.concurrent.downloads`: three nesting levels instead of one field name.
 
 Always use `Env::prefixed("HARMONIA__").split("__")`, double underscore for both prefix and separator.
@@ -199,52 +270,41 @@ Always use `Env::prefixed("HARMONIA__").split("__")`, double underscore for both
 
 ## Config struct layout
 
-The top-level `Config` struct in `crates/horismos/`. One field per subsystem that has configurable values.
+The top-level `Config` struct in `crates/horismos/src/config.rs`. One field per subsystem that has configurable values:
 
 ```rust
 // crates/horismos/src/config.rs
-
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
-    pub zetesis: ZetesisConfig,
-    pub exousia: ExousiaConfig,
-    pub paroche: ParocheConfig,
-    pub ergasia: ErgasiaConfig,
-    pub syntaxis: SyntaxisConfig,
-    pub taxis: TaxisConfig,
-    pub kritike: KritikeConfig,
-    pub prostheke: ProsthekeConfig,
-    pub epignosis: EpignosisConfig,
-    pub aitesis: AitesisConfig,
-    pub syndesmos: SyndesmosConfig,
-    pub aggelia: AggeliaConfig,
+    #[serde(default)] pub database: DatabaseConfig,
+    #[serde(default)] pub exousia: ExousiaConfig,
+    #[serde(default)] pub paroche: ParocheConfig,
+    #[serde(default)] pub taxis: TaxisConfig,
+    #[serde(default)] pub epignosis: EpignosisConfig,
+    #[serde(default)] pub kritike: KritikeConfig,
+    #[serde(default)] pub aggelia: AggeliaConfig,
+    #[serde(default)] pub zetesis: SearchSubsystemConfig,
+    #[serde(default)] pub ergasia: ErgasiaConfig,
+    #[serde(default)] pub syntaxis: SyntaxisConfig,
+    #[serde(default)] pub prostheke: ProsthekeConfig,
+    #[serde(default)] pub komide: KomideConfig,
+    #[serde(default)] pub syndesmos: SyndesmosConfig,
+    #[serde(default)] pub aitesis: AitesisConfig,
 }
+```
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            zetesis: ZetesisConfig::default(),
-            exousia: ExousiaConfig::default(),
-            paroche: ParocheConfig::default(),
-            ergasia: ErgasiaConfig::default(),
-            syntaxis: SyntaxisConfig::default(),
-            taxis: TaxisConfig::default(),
-            kritike: KritikeConfig::default(),
-            prostheke: ProsthekeConfig::default(),
-            epignosis: EpignosisConfig::default(),
-            aitesis: AitesisConfig::default(),
-            syndesmos: SyndesmosConfig::default(),
-            aggelia: AggeliaConfig::default(),
-        }
-    }
-}
+Note the TOML section key (`zetesis`) does not always match the Rust struct name (`SearchSubsystemConfig`) — the struct name reflects what it configures, the field name is the stable section key.
 
-// Each SubsystemConfig is a plain data struct — no logic, no external deps
-#[derive(Debug, Clone, Deserialize, Serialize)]
+**Config structs are plain data.** No methods beyond `Default` (and a redacting `Debug` impl for any struct holding a secret). No logic. No external dependencies. They are deserialization targets; figment fills them; subsystems read them. `ExousiaConfig` is the smallest complete example of the pattern:
+
+```rust
+// crates/horismos/src/subsystems.rs
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct ExousiaConfig {
-    pub access_token_ttl_secs: u64,    // default: 900 (15 min)
-    pub refresh_token_ttl_days: u64,   // default: 30
-    pub jwt_secret: String,            // MUST NOT be empty or default at runtime
+    pub access_token_ttl_secs: u64,
+    pub refresh_token_ttl_days: u64,
+    pub jwt_secret: String,
 }
 
 impl Default for ExousiaConfig {
@@ -252,98 +312,29 @@ impl Default for ExousiaConfig {
         Self {
             access_token_ttl_secs: 900,
             refresh_token_ttl_days: 30,
-            jwt_secret: String::new(),  // intentionally invalid default — validation rejects it
+            jwt_secret: String::new(), // intentionally invalid — validation rejects it
         }
     }
 }
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ZetesisConfig {
-    pub request_timeout_secs: u64,         // default: 30
-    pub max_results_per_indexer: usize,    // default: 100
-    pub max_response_body_bytes: u64,      // default: 16 MiB
-    pub cloudflare_bypass_enabled: bool,   // default: false
-}
-
-impl Default for ZetesisConfig {
-    fn default() -> Self {
-        Self {
-            request_timeout_secs: 30,
-            max_results_per_indexer: 100,
-            max_response_body_bytes: 16 * 1024 * 1024,
-            cloudflare_bypass_enabled: false,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ErgasiaConfig {
-    pub download_dir: PathBuf,
-    pub max_concurrent_downloads: usize,
-    pub seeding_ratio_limit: f64,
-    pub seeding_time_limit_hours: u64,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct TaxisConfig {
-    pub library_music_root: PathBuf,
-    pub library_video_root: PathBuf,
-    pub library_books_root: PathBuf,
-    pub file_naming_dry_run: bool,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct AggeliaConfig {
-    pub buffer_size: usize,          // default: 1024 — broadcast channel buffer
-    pub download_queue_size: usize,  // default: 512 — mpsc channel for download queue
-}
-
-impl Default for AggeliaConfig {
-    fn default() -> Self {
-        Self {
-            buffer_size: 1024,
-            download_queue_size: 512,
-        }
-    }
-}
-
-// ... one struct per subsystem following the same pattern
 ```
 
-**Config structs are plain data.** No methods beyond `Default`. No logic. No external dependencies. They are deserialization targets; figment fills them; subsystems read them.
+This document does not duplicate the full per-subsystem field list — that drifts. `crates/horismos/src/subsystems.rs` is the source of truth for every field, its type, and its default; `config-reload.md` is the source of truth for which fields are LIVE, RESTART-required, or UNWIRED.
+
+Every subsystem config carries `#[serde(deny_unknown_fields)]`: a config file setting a field that does not exist (removed, renamed, or never real) fails to parse at startup rather than being silently ignored.
 
 ---
 
 ## Config distribution
 
-archon calls `Config::load()` once at startup. The resulting `Config` is split into per-subsystem `Arc<SubsystemConfig>` references and passed to each subsystem's constructor.
+archon calls `horismos::load_config()` once at startup, splits the resulting `Config` into per-subsystem slices, and constructs each subsystem. Fields classified LIVE (see [config-reload.md](config-reload.md)) are handed a `Section<T>`/`SectionWatcher<T>` off the shared `ConfigHandle` instead of a frozen clone, so a later `SIGHUP` reaches them without a restart; RESTART-class fields are read once at construction, matching the "held-back" contract.
 
 ```rust
-// In archon main()
-let config = Config::load().expect("configuration load failed");
+// crates/archon/src/serve.rs (shape, not verbatim)
+let (config, warnings) = horismos::load_config(Some(args.config.as_path()))?;
+// ... apply --listen/--port CLI overrides directly on `config` ...
+let (config_manager, config_handle) = ConfigManager::new(config.clone(), config_path, overrides);
 
-// Each subsystem receives only its own config slice — not the full Config.
-// Arc<_> avoids copying the config data; subsystems store the Arc and clone it as needed.
-let exousia = Exousia::new(Arc::new(config.exousia.clone()), /* other deps */);
-let zetesis  = Zetesis::new(Arc::new(config.zetesis.clone()), /* other deps */);
-let kathodos = Kathodos::new(Arc::new(config.taxis.clone()),  /* other deps */);
-// ...
-```
-
-**Subsystem storage pattern:**
-
-```rust
-// In crates/zetesis/src/lib.rs
-pub struct ZetesisService {
-    config: Arc<ZetesisConfig>,
-    // ... other fields
-}
-
-impl ZetesisService {
-    pub fn new(config: Arc<ZetesisConfig>, /* ... */) -> Self {
-        Self { config, /* ... */ }
-    }
-}
+let auth = ExousiaServiceImpl::new(db.clone(), config_handle.section(|c| &c.exousia));
 ```
 
 **Runtime config reload exists (#529).** `SIGHUP` re-reads and applies config changes without a restart, for every field classified LIVE. A field classified RESTART-required is held back (the running process keeps its old effective value) and reported in `restart_pending` until the process restarts or the on-disk value reverts — nothing is silently dropped either way. See [config-reload.md](config-reload.md) for the mechanism and the full field classification.
@@ -352,51 +343,46 @@ impl ZetesisService {
 
 ## Validation rules
 
-Horismos validates the merged config before returning it. Validation runs after all providers are merged, against the final resolved values.
+`validate_config(&Config) -> Result<Vec<ValidationWarning>, HorismosError>` (`crates/horismos/src/validation.rs`) runs after all providers are merged, against the final resolved values. It either returns `Err` (a hard startup failure) or `Ok(warnings)` — non-fatal degraded-capability notices logged and, for `restart_pending`-adjacent surfacing, echoed by the admin diagnostic endpoint.
 
-```rust
-impl Config {
-    fn validate(&self) -> Result<(), HorisomosError> {
-        // 1. JWT secret must not be the default value
-        self.validate_jwt_secret()?;
+**Hard errors (reject startup):**
 
-        // 2. Library root paths must exist and be writable
-        self.validate_library_paths()?;
+| Check | Rule |
+|---|---|
+| `exousia.jwt_secret` | Not empty, not `"changeme"`/`"default"`, at least 32 bytes |
+| `exousia.access_token_ttl_secs` | Greater than 0 |
+| `exousia.refresh_token_ttl_days` | Between 1 and 36,500 (100 years — catches a typo'd unit, not a policy choice) |
+| `paroche.port` / `paroche.renderer_quic_port` | Each ≥ 1024 (Harmonia must not run as root); the two must differ |
+| `zetesis.request_timeout_secs` | Greater than 0 |
+| `zetesis.max_response_body_bytes` | Greater than 0 |
+| `zetesis.cf_proxy_url` | Required when `zetesis.cloudflare_bypass_enabled = true` |
+| `epignosis.provider_timeout_secs` | Greater than 0 |
+| `prostheke.min_match_score` | Between 0.0 and 1.0 |
+| `taxis.scan_concurrency` | Greater than 0 (sizes a semaphore; 0 permits blocks the first scan forever) |
+| `kritike.quality_check_concurrency` | Greater than 0 |
+| `database.write_pool_max` | Greater than 0 |
 
-        // 3. Port numbers must be in valid range
-        self.validate_ports()?;
+**Warnings (logged, never fatal):**
 
-        // 4. Required API keys must be present when their feature flag is enabled
-        self.validate_feature_keys()?;
+| Check | Behavior |
+|---|---|
+| `epignosis.{acoustid,tmdb,tvdb,comicvine,google_books}_key` | Absent → warning naming the degraded capability (keyless operation is a legitimate posture). An explicitly-set placeholder (empty string, `"changeme"`, `"default"`) is still a hard error — that can only come from a botched edit, never from omitting the field. |
+| `taxis.libraries.<name>.path` | Not accessible at startup → warning per library. Not a startup error — a library can be created or remounted after Harmonia starts. |
 
-        Ok(())
-    }
-}
-```
-
-**Rule 1, JWT secret:** `exousia.jwt_secret` must not be empty, `"changeme"`, or any compiled-in placeholder. Must be at least 32 bytes. Enforced regardless of feature flags; JWT auth is always active.
-
-**Rule 2, library paths:** `taxis.library_music_root`, `taxis.library_video_root`, `taxis.library_books_root` must exist as directories and be writable by the Harmonia process. A missing or read-only library root is a startup error; the system cannot import media without it. Ergasia's `download_dir` is validated the same way.
-
-**Rule 3, port ranges:** Any configured port number must be in the range `1024..=65535`. Ports below 1024 require elevated privileges; Harmonia must not run as root. If a port falls below 1024, Horismos returns a config error that names the field.
-
-**Rule 4, feature key presence:** When a feature flag is enabled, its required credentials must be present:
-- `plex` feature → `syndesmos.plex_token` must not be empty
-- `lastfm` feature → `syndesmos.lastfm_api_key` and `syndesmos.lastfm_api_secret` must not be empty
-- `tidal` feature → `syndesmos.tidal_client_id` and `syndesmos.tidal_client_secret` must not be empty
-
-Feature flags that are not enabled skip their credential validation; a system running without Tidal need not supply Tidal credentials.
+No credential-presence check gates `syndesmos.plex`/`.lastfm`/`.tidal`: each is an `Option<...>`, and simply being absent (`None`) disables that integration. No separate "feature flag" layer gates them.
 
 ---
 
 ## Anti-patterns
 
-**No subsystem reads environment variables directly.** Only Horismos calls figment. If a subsystem needs a value from an env var, that env var must be declared in the figment Env provider (with the `HARMONIA__` prefix), reflected in the TOML schema, and surfaced via the `SubsystemConfig` struct. Bypassing Horismos to call `std::env::var()` directly creates an undocumented, untested configuration path.
+**No subsystem reads environment variables directly.** Only Horismos calls figment. If a subsystem needs a value from an env var, that env var must be declared in the figment `Env` provider (with the `HARMONIA__` prefix), reflected in the TOML schema, and surfaced via the `SubsystemConfig` struct. Bypassing Horismos to call `std::env::var()` directly creates an undocumented, untested configuration path.
 
 **No hardcoded values that should be configurable.** File paths, timeouts, buffer sizes, API endpoints, retry limits; if the value might need to differ between development, staging, and production, it belongs in the config struct. The test for "should this be configurable" is: "would a user ever need to change this?" Timeouts, limits, paths, and URLs always qualify.
 
 **No direct config mutation.** Subsystems never hold `&mut SubsystemConfig` or write to a config struct in place. A LIVE field changes only by publishing a whole new validated `Config` through `ConfigManager` (`SIGHUP` or `.replace()`) — see [config-reload.md](config-reload.md). Dynamic values that change at runtime (download progress, queue depth, session state) belong in subsystem-internal state, not in config.
 
-**No full Config passed to subsystems.** Each subsystem receives only its own `Arc<SubsystemConfig>` slice. Passing the full `Config` to subsystems couples every subsystem's constructor to the full config shape; adding a field to any subsystem's config would recompile all of them. The slice boundary also prevents a subsystem from accidentally reading another subsystem's credentials.
+**No full Config passed to subsystems.** Each subsystem receives only its own config slice (`Section<T>` for LIVE fields, a frozen clone for RESTART-class ones). Passing the full `Config` to subsystems couples every subsystem's constructor to the full config shape; adding a field to any subsystem's config would recompile all of them. The slice boundary also prevents a subsystem from accidentally reading another subsystem's credentials.
 
 **No secrets in `harmonia.toml`.** The file is committed. Any value that provides access to external services (API keys, JWT signing secrets, database credentials) must live in `secrets.toml` (gitignored) or in a `HARMONIA__{SUBSYSTEM}__{KEY}` environment variable. The `harmonia.toml` file should be safe to publish; containing it in a public repository must not compromise the running system.
+
+**Config structs are never hand-copied into other docs.** A doc that needs to reference a field cites `crates/horismos/src/subsystems.rs` (schema) and [config-reload.md](config-reload.md) (LIVE/RESTART/UNWIRED classification) rather than re-listing the struct — a copy drifts the moment the struct changes.

--- a/docs/data/storage.md
+++ b/docs/data/storage.md
@@ -194,29 +194,32 @@ Database path and pool sizes are Horismos-configurable via a `[database]` sectio
 ```toml
 # harmonia.toml — safe committed defaults
 [database]
-path = "data/harmonia.db"
-read_pool_size = 0          # 0 = auto (num_cpus); set explicitly to override
+db_path = "harmonia.db"
+read_pool_size = 0          # 0 = auto-detect; set explicitly to override
+write_pool_max = 1
 ```
 
 ```rust
-// crates/horismos/src/config.rs — addition
-#[derive(Debug, Clone, Deserialize, Serialize)]
+// crates/horismos/src/subsystems.rs
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DatabaseConfig {
-    pub path: PathBuf,          // default: "data/harmonia.db"
-    pub read_pool_size: u32,    // default: 0 (= num_cpus at runtime)
+    pub db_path: PathBuf,
+    pub read_pool_size: u32,
+    pub write_pool_max: u32,
 }
 
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            path: PathBuf::from("data/harmonia.db"),
-            read_pool_size: 0,
+            db_path: PathBuf::from("harmonia.db"),
+            read_pool_size: 0, // 0 = auto-detect
+            write_pool_max: 1,
         }
     }
 }
 ```
 
-Override via environment: `HARMONIA__DATABASE__PATH=/mnt/data/harmonia.db` or `HARMONIA__DATABASE__READ_POOL_SIZE=8`.
+All three fields are RESTART-class — sqlx pool sizing is fixed at connect, with no resize API (see [architecture/config-reload.md](../architecture/config-reload.md)). Override via environment: `HARMONIA__DATABASE__DB_PATH=/mnt/data/harmonia.db` or `HARMONIA__DATABASE__READ_POOL_SIZE=8`.
 
 ---
 

--- a/docs/download/archive.md
+++ b/docs/download/archive.md
@@ -134,21 +134,11 @@ extract(download_path, depth=0)
 
 ## Extraction output
 
-Extracted files land in a per-download temp directory:
+Extraction is in-place: `DownloadEngine::extract(download_path, output_dir)` is called with `output_dir == download_path` — there is no separate staging directory. #529's original design called for one (`extraction_temp_dir`, with an `extraction_cleanup_hours` janitor), but neither field ever had a reader and both were removed from the schema (#598).
 
-```
-{config.ergasia.extraction_temp_dir}/{download_id}/
-```
+Extracted files therefore land directly alongside the original archive files in the download directory. The `extracted_path` on `ExtractionResult` is that same directory; it replaces `download_path` in the `CompletedDownload` struct passed to Kathodos for import.
 
-`extraction_temp_dir` defaults to `{download_dir}/.extraction/`.
-
-The `extracted_path` from `ExtractionResult` replaces the original `download_path` in the `CompletedDownload` struct passed to Kathodos for import.
-
-**Cleanup policy:**
-
-- After successful Kathodos import: delete `{extraction_temp_dir}/{download_id}/` immediately
-- After failed import: retain for debugging. A periodic janitor task deletes directories older than `extraction_cleanup_hours` (default: 48 hours)
-- Archives in the original download path are never deleted by Ergasia; that is Kathodos's responsibility after hardlink/move
+**Cleanup**: there is no extraction-specific cleanup step. The archive files and the extracted output live in the same download directory Kathodos already owns cleanup of after hardlink/move and after seed-policy-complete — see [download/orchestration.md](orchestration.md) (hardlink/move import strategy).
 
 ---
 
@@ -156,10 +146,10 @@ The `extracted_path` from `ExtractionResult` replaces the original `download_pat
 
 Before any extraction begins:
 
-1. Calculate `archive_size` (sum of all archive file sizes in the download directory)
-2. Check available space on the extraction temp dir filesystem
-3. Required space: `archive_size * 1.1` (10% overhead for filesystem metadata)
-4. If insufficient: emit `ErgasiaError::InsufficientDiskSpace`, do not attempt partial extraction
+1. Sum each archive's **declared uncompressed size** (not its on-disk compressed size) across every archive found — this is the same figure the decompression-ratio guard checks
+2. Check available space on the download directory's filesystem (extraction is in-place, so this is the download directory itself)
+3. Required space: declared-uncompressed total `* 1.1` (10% headroom)
+4. If insufficient: `ErgasiaError::InsufficientDiskSpace`, no partial extraction attempted
 
 For Usenet downloads: extraction may follow PAR2 repair, which also requires temporary space. The space check accounts for the post-repair file sizes, not the original segment sizes.
 
@@ -244,21 +234,16 @@ pub enum ErgasiaError {
 
 ## Horismos configuration
 
-`[ergasia]` additions in `harmonia.toml`:
+`[ergasia]` fields that gate extraction:
 
 ```toml
 [ergasia]
-# Temporary directory for archive extraction. Defaults to {download_dir}/.extraction/
-# Must be on the same filesystem as download_dir for efficient cleanup.
-extraction_temp_dir = "/data/downloads/.extraction"
-
 # Maximum nested archive depth. Prevents zip bombs and infinite recursion.
 max_extraction_depth = 3
 
 # Maximum declared-uncompressed to compressed size ratio. Archives declaring
 # more than this ratio are rejected before any extraction write occurs.
 max_decompression_ratio = 100.0
-
-# How long to retain failed extraction directories before cleanup (hours).
-extraction_cleanup_hours = 48
 ```
+
+Both are LIVE — `SessionEngine` rebuilds `ExtractionLimits` from the current config on every extract call (no restart needed to change either). See [architecture/config-reload.md](../architecture/config-reload.md).

--- a/docs/download/cloudflare.md
+++ b/docs/download/cloudflare.md
@@ -187,11 +187,11 @@ Per the locked decision: CF-protected indexers become `degraded`, not `failed`, 
 
 ### Startup
 
-1. If `[zetesis] cf_proxy_url` is set:
-   - POST health check to `{cf_proxy_url}/v1` with dummy URL (`http://localhost`)
-   - If Byparr responds with any non-connection-error: inject `ByparrProxy`
-   - If connection refused or timeout: log warning, inject `NoProxy`
-2. If `cf_proxy_url` is not configured: inject `NoProxy`, log info (not warning, as this is a deliberate choice)
+`build_cf_proxy(&config)` (archon) decides synchronously — there is no startup health-check probe:
+
+1. `zetesis.cloudflare_bypass_enabled = false` → inject `NoProxy`.
+2. `cloudflare_bypass_enabled = true` and `cf_proxy_url` is set (non-blank) → construct `ByparrProxy` directly. No request is made to Byparr before injection; the first real `.get()` call is the first contact.
+3. `cloudflare_bypass_enabled = true` and `cf_proxy_url` is absent or blank → **validation error at startup** (`zetesis.cloudflare_bypass_enabled requires zetesis.cf_proxy_url`), not a silent fall-through to `NoProxy` — silently degrading would turn every CF-bypass indexer into an unexplained failure.
 
 ### Per-search degradation
 
@@ -215,17 +215,7 @@ proxy.get(url, ct)
 
 The monitoring layer receives empty results from degraded indexers and proceeds with results from active indexers. The degraded indexer does not surface as an error to the user; it appears only as a status indicator in the indexer list UI.
 
-### Periodic recovery
-
-A background task runs every `cf_health_check_interval_minutes` (default: 5):
-
-1. If current proxy is `ByparrProxy`: no action
-2. If current proxy is `NoProxy` and `cf_proxy_url` is configured:
-   - Attempt health check
-   - If Byparr is now healthy:
-     - Replace `NoProxy` with `ByparrProxy` (via `ArcSwap<dyn CloudflareProxy>`)
-     - `UPDATE indexers SET status = 'active' WHERE status = 'degraded' AND cf_bypass = TRUE`
-     - Log info: Byparr reconnected, X indexers restored
+No periodic recovery task exists. A design for one (polling on `cf_health_check_interval_minutes`, promoting `NoProxy` back to `ByparrProxy` once healthy) never had a reader — `ByparrProxy::health_check` had zero callers and was deleted along with the config field (#598). Recovery today is config-reload-driven: `zetesis.cf_proxy_url` is LIVE — setting or changing it swaps the proxy on the next `SIGHUP` (see [architecture/config-reload.md](../architecture/config-reload.md)), it just does not self-heal on a timer.
 
 ---
 
@@ -277,7 +267,10 @@ pub enum ZetesisError {
 
 ```toml
 [zetesis]
-# CF bypass endpoint. If absent, CF bypass is disabled and CF-protected indexers become degraded.
+# Master switch. Requires cf_proxy_url to be set (validation error otherwise).
+cloudflare_bypass_enabled = false
+
+# CF bypass endpoint.
 cf_proxy_url = "http://localhost:8191"
 
 # Byparr challenge timeout in seconds. Cloudflare challenges can be slow on first solve.
@@ -285,9 +278,6 @@ cf_proxy_timeout_seconds = 60
 
 # How many minutes before cookie expiry to proactively refresh via Byparr.
 cf_cookie_refresh_minutes = 30
-
-# How often to re-check Byparr health when it was previously unavailable.
-cf_health_check_interval_minutes = 5
 ```
 
 Example Docker Compose entry for Byparr sidecar:

--- a/docs/download/orchestration.md
+++ b/docs/download/orchestration.md
@@ -1,13 +1,13 @@
 # Download orchestration: Syntaxis queue, post-processing, and import pipeline
 
 > Syntaxis owns the download queue, priority rules, concurrency control, and post-processing pipeline. Kathodos owns library import, hardlink/move strategy, and file cleanup.
-> Cross-references: [architecture/subsystems.md](../architecture/subsystems.md) (Syntaxis + Kathodos ownership), [architecture/communication.md](../architecture/communication.md) (mpsc channel + events), [download/torrent.md](torrent.md) (Ergasia state machine + DownloadCompleted), [download/archive.md](archive.md) (extraction step), [download/usenet.md](usenet.md) (Usenet pipeline), [data/want-release.md](../data/want-release.md) (releases + haves tables).
+> Cross-references: [architecture/subsystems.md](../architecture/subsystems.md) (Syntaxis + Kathodos ownership), [architecture/communication.md](../architecture/communication.md) (event bus + the direct-call rule), [download/torrent.md](torrent.md) (Ergasia state machine + DownloadCompleted), [download/archive.md](archive.md) (extraction step), [download/usenet.md](usenet.md) (Usenet pipeline), [data/want-release.md](../data/want-release.md) (releases + haves tables).
 
 ---
 
 ## Queue architecture
 
-Syntaxis owns the download queue. Items arrive from the monitoring layer via direct call and are dispatched to Ergasia via mpsc channel.
+Syntaxis owns the download queue. Items arrive from the monitoring layer via direct call, and are dispatched to Ergasia via a direct call too — `ergasia::DownloadEngine::start_download`, awaited from the dispatch task. There is no channel between Syntaxis and Ergasia.
 
 ### `QueueItem` type
 
@@ -36,16 +36,16 @@ The monitoring layer (or UI) calls Syntaxis.enqueue(item)
     |
 Syntaxis inserts row into download_queue (status = 'queued')
     |
-Priority 4 (interactive)? → bypass queue, send directly to Ergasia mpsc
+Priority 4 (interactive)? → bypass the wait, dispatch as soon as a slot is free
     |
 Otherwise: wait for capacity slot (max_concurrent_downloads, max_per_tracker)
     |
 Slot available → update download_queue status to 'downloading'
               → set releases.grabbed_at = now()
-              → send QueueItem to Ergasia via mpsc
+              → dispatch task calls engine.start_download(request).await directly
 ```
 
-**Ergasia mpsc channel:** bounded, capacity = `config.aggelia.download_queue_size` (default 512). When full, Syntaxis blocks on send; backpressure propagates to monitoring enqueue calls. This is intentional: the queue does not grow without bound.
+**Syntaxis → Ergasia dispatch:** a direct async call to `ergasia::DownloadEngine::start_download`, not a channel. `SlotAllocator` (in-process counters, not a channel) tracks `active_total`/`active_per_tracker` against `max_concurrent_downloads`/`max_per_tracker` and gates whether a dispatch is attempted; the actual handoff is one `.await` on the engine trait, so Syntaxis gets `Result<DownloadId, ErgasiaError>` back and can roll back the slot claim on failure. There is no bounded mpsc queue here, and no `aggelia.download_queue_size` field — that field never had a consumer and was removed (#598). Aggelia's `buffer_size` config sizes only the unrelated `HarmoniaEvent` broadcast channel (see [architecture/communication.md](../architecture/communication.md)).
 
 ---
 
@@ -55,7 +55,7 @@ Higher number = processed first. Within the same tier, FIFO order is preserved.
 
 | Priority | Tier | Trigger | Behavior |
 |----------|------|---------|----------|
-| 4 | Interactive | User-initiated from UI | Bypass queue entirely; sent directly to Ergasia mpsc |
+| 4 | Interactive | User-initiated from UI | Bypass the wait — dispatched to Ergasia as soon as a slot is free |
 | 3 | Wanted-missing | Monitoring triggered | Item in want list with no matching have |
 | 2 | Quality-upgrade | Kritike triggered | Better version available; current have below quality ceiling |
 | 1 | Routine-check | Scheduled RSS monitoring | Background acquisition from RSS/schedule |
@@ -96,7 +96,7 @@ Step 1: Scan download path for archive files
     - If no archives: skip to Step 3
     |
 Step 2: Extract archives
-    - Call Ergasia.extract(download_path)
+    - Call Ergasia.extract(download_path, download_path) -- in-place, no staging dir (see archive.md)
     - Receive ExtractionResult { extracted_path, files, archive_format, nested_levels }
     - Update working path to extracted_path
     - On extraction failure: mark queue item 'failed', do NOT retry
@@ -117,7 +117,8 @@ Step 4: Post-import bookkeeping
 Step 5: Cleanup coordination
     - Torrent: seeding continues from original download_path
       (hardlink means library copy is independent — no action needed)
-    - Usenet: no seeding — Kathodos moves files and deletes extraction temp dir
+    - Usenet: no seeding — Kathodos moves files, download_path (archives + in-place
+      extraction output) is removed with it
     - SeedPolicySatisfied (Ergasia → Kathodos direct call): Kathodos deletes download copy
 ```
 
@@ -208,8 +209,8 @@ Syntaxis receives `DownloadFailed { download_id, reason }` from Ergasia.
 | Error Class | Retry Strategy |
 |------------|----------------|
 | Transient (network error, tracker timeout) | 3 retries: 30s, 2m, 10m exponential backoff |
-| Permanent (no seeders after `stalled_download_timeout_hours`, corrupt torrent) | Mark `download_queue.status = 'failed'`, update `releases.rejected_reason` |
-| Stalled (no progress for `stalled_download_timeout_hours`) | Treated as permanent failure; no retry |
+| Permanent (corrupt torrent, unsupported protocol) | Mark `download_queue.status = 'failed'`, update `releases.rejected_reason` |
+| Stalled (no progress for `syntaxis.stalled_download_timeout_hours`) | A periodic reconciliation pass (every `RECONCILE_INTERVAL`, 60s) compares each active download's engine-reported progress against its last-seen watermark; once stalled past the threshold, the entry is cancelled via `engine.cancel_download()` and failed — `classify_failure` routes it to `Permanent`, releasing the slot. |
 
 After retry budget exhausted: `download_queue.status = 'failed'`, `releases.rejected_reason = <reason>`.
 

--- a/docs/download/torrent.md
+++ b/docs/download/torrent.md
@@ -20,7 +20,7 @@ pub struct ErgasiaSession {
 ```
 
 - `session`: the librqbit `Session`, shared across all torrents via `Arc`
-- `policy`: default seeding policy for this instance; per-tracker overrides consulted at seed time
+- `policy`: the single seeding policy for this instance (`ergasia.seed_ratio_threshold` / `.seed_time_threshold_hours`) — there is no per-tracker override
 - `seed_tracker`: live handles for active seeding monitor tasks, keyed by `DownloadId`
 
 ### Session initialization
@@ -36,7 +36,7 @@ let opts = SessionOptions {
     listen_port_range: Some(config.listen_port_range.clone()),
     enable_upnp_port_forwarding: false,
     // peer opts:
-    peer_connect_timeout: Some(config.peer_connect_timeout),
+    peer_connect_timeout: Some(config.peer_connect_timeout_seconds),
     peer_read_write_timeout: Some(Duration::from_secs(10)),
     ..Default::default()
 };
@@ -48,7 +48,7 @@ Key guarantees:
 - **DHT enabled**: default peer discovery. PEX enabled by librqbit defaults.
 - **Fast resume**: `persistence` enabled. librqbit persists piece completion state to `session_state_path`. After restart, torrents resume without re-verifying all pieces.
 - **Single session**: Ergasia does NOT expose librqbit's built-in HTTP API. All external access to download state goes through Ergasia's own trait surface (`start_download`, `cancel_download`, `get_progress`).
-- **Connection limits**: `peer_connect_timeout` is configurable via `[ergasia]`. Max connections per torrent defaults to librqbit's internal limit; Horismos can override via `max_connections_per_torrent`.
+- **Connection limits**: `peer_connect_timeout_seconds` is configurable via `[ergasia]`. Max connections per torrent is not configurable — librqbit 8.1.1 has no such knob, and Horismos does not carry a field for it.
 
 ---
 
@@ -72,9 +72,9 @@ Ergasia maintains its own download state on top of librqbit's internal tracking.
 
 | State | Description | Ergasia Action |
 |-------|-------------|----------------|
-| `Queued` | Work item received via mpsc from Syntaxis. Not yet handed to librqbit. | Waits for capacity slot (`max_concurrent_downloads`). |
+| `Queued` | Work item dispatched via a direct `ergasia::DownloadEngine::start_download` call from Syntaxis (not a channel — see [architecture/communication.md](../architecture/communication.md)). Not yet handed to librqbit. | Waits for a capacity slot (`syntaxis.max_concurrent_downloads` / `.max_per_tracker`). |
 | `Initializing` | librqbit resolving metadata: magnet link DHT lookup, piece map construction, integrity check on previously downloaded data. | Monitors `TorrentStats` for transition to downloading. |
-| `Downloading` | Active piece download. `TorrentStats.state` is `Downloading`. | Polls `api_stats_v1` every 2 seconds. Emits `DownloadProgress` events (throttled). |
+| `Downloading` | Active piece download. `TorrentStats.state` is `Downloading`. | `get_progress()` reads `api_stats_v1` on demand — see **Progress tracking** below; there is no periodic push. |
 | `Completed` | All pieces verified. `TorrentStats.finished = true`. | Emits `DownloadCompleted` event. Signals Syntaxis. Spawns seeding monitor task. |
 | `Seeding` | Post-completion upload. Torrent continues seeding from `config.download_dir`. Kathodos has already hardlinked the files to the library. | Seeding monitor task polls every 60 seconds. |
 | `SeedPolicySatisfied` | Seeding monitor determined policy threshold met (ratio OR time). | Pauses torrent via `api_torrent_action_pause`. Calls `Kathodos::on_seed_complete(download_id)` directly. Emits `SeedPolicySatisfied` event for observability. |
@@ -123,23 +123,7 @@ impl SeedingPolicy {
 }
 ```
 
-**Default policy** (from locked decisions): 1.0x ratio OR 72 hours, whichever is met first.
-
-### Per-tracker overrides
-
-Private trackers often require higher ratios or longer seed times. The `[ergasia]` config section carries a `tracker_seed_policies` map:
-
-```toml
-[ergasia]
-seed_ratio_threshold = 1.0
-seed_time_threshold_hours = 72
-
-[ergasia.tracker_seed_policies]
-"tracker.alpharatio.cc" = { ratio_threshold = 2.0, time_threshold_hours = 168 }
-"tracker.btn.ag" = { ratio_threshold = 1.5, time_threshold_hours = 120 }
-```
-
-When a seeding monitor task starts, it queries the torrent's tracker URL list and checks `tracker_seed_policies` for an override. The most restrictive matching policy wins: if multiple tracker URLs match, use the highest `ratio_threshold` and longest `time_threshold`.
+**Default policy**: 1.0x ratio OR 72 hours, whichever is met first (`ergasia.seed_ratio_threshold` / `.seed_time_threshold_hours`). There is no per-tracker override — a `tracker_seed_policies` map was designed in #529's pass but never had a reader; it was removed from the schema entirely (#598), not merely deferred.
 
 ### Monitor task
 
@@ -205,37 +189,7 @@ async fn run_seeding_monitor(
 
 ## Progress tracking
 
-### `DownloadProgress` event emission
-
-Ergasia emits `DownloadProgress` events during the `Downloading` state. To avoid flooding the broadcast channel:
-
-- **Throttle**: max 1 event per 2 seconds per download (`config.progress_throttle_seconds`, default 2)
-- **Delta filter**: only emit if `percent` changed by >= 1% since the last emission
-- **Poll interval**: Ergasia polls `api_stats_v1` every 2 seconds during active download, every 60 seconds during seeding
-
-```rust
-struct ProgressThrottle {
-    last_emit: Instant,
-    last_percent: u8,
-    throttle_duration: Duration,
-}
-
-impl ProgressThrottle {
-    fn should_emit(&mut self, percent: u8) -> bool {
-        let now = Instant::now();
-        let elapsed = now.duration_since(self.last_emit);
-        let delta = percent.abs_diff(self.last_percent);
-
-        if elapsed >= self.throttle_duration && delta >= 1 {
-            self.last_emit = now;
-            self.last_percent = percent;
-            true
-        } else {
-            false
-        }
-    }
-}
-```
+`DownloadProgress` (the type) has no bus emitter — there is no throttled `HarmoniaEvent::DownloadProgress` broadcast in production, and the `progress_throttle_seconds` field a throttle struct would have read was never wired and was removed from the schema (#598). Progress is a pull, not a push: callers poll it on demand.
 
 ### Stats exposed
 
@@ -254,7 +208,7 @@ pub struct DownloadProgress {
 }
 ```
 
-All fields sourced from `TorrentStats` returned by `api_stats_v1`.
+All fields sourced from `TorrentStats` returned by `api_stats_v1`. `get_progress()` is part of the `DownloadEngine` trait — Syntaxis (or any caller) reads it on demand; nothing subscribes to it as an event.
 
 ---
 
@@ -330,97 +284,32 @@ pub enum ErgasiaError {
 | Network errors (connection refused, timeout) | 3 retries with exponential backoff: 5s, 25s, 125s. After 3 failures → `Failed` state. |
 | Tracker errors (tracker unreachable) | 3 retries. Private trackers may be momentarily down. |
 | Invalid torrent / corrupt data | Fail immediately; no retry. Record reason in `DownloadFailed` event. |
-| Magnet URI resolution timeout | Fail after configurable timeout (`magnet_resolve_timeout_secs`, default 120s). |
+| Magnet URI resolution timeout | `session.add_torrent()` is wrapped in `tokio::time::timeout(magnet_resolve_timeout_seconds)` (a per-add live config read, default 120s); an unresolvable magnet returns `MagnetResolveTimeout` instead of holding the await — and its dispatch slot — forever. |
 | Already exists in session | Not an error; log and return existing `DownloadId`. |
 
 Errors are logged where they are handled (at the retry boundary or at final failure), not where they originate. This follows the snafu pattern: propagate with `.context()`, log at the decision point.
 
 ---
 
-## Proposed new HarmoniaEvent variants
+## HarmoniaEvent variants used here
 
-The following variants should be added to `HarmoniaEvent` in `themelion`:
-
-```rust
-/// Ergasia's seeding monitor determined ratio/time policy is satisfied.
-/// Informational — the authoritative cleanup signal is the direct call to Kathodos.
-/// Subscribers: web UI (display seeding completion status)
-SeedPolicySatisfied {
-    download_id: DownloadId,
-    uploaded_bytes: u64,
-    downloaded_bytes: u64,
-},
-```
-
-Note: `DownloadFailed` is already defined in `communication.md`. No addition needed.
+`SeedPolicySatisfied { download_id, uploaded_bytes, downloaded_bytes }` and `DownloadFailed { download_id, reason }` are both already defined in `themelion::aggelia::events::HarmoniaEvent` — see [architecture/communication.md](../architecture/communication.md) for the full enum.
 
 ---
 
 ## Horismos configuration: `[ergasia]` section
 
-Full config additions for this document's design:
-
 ```toml
 [ergasia]
-# Base path where librqbit writes downloaded files
 download_dir = "/data/downloads"
-
-# librqbit session persistence — fast resume state
 session_state_path = "/data/downloads/.librqbit-state"
-
-# Port range for BitTorrent protocol (TCP + UDP)
 listen_port_range = [6881, 6889]
-
-# Maximum simultaneous active downloads (Queued torrents wait for a slot)
-max_concurrent_downloads = 5
-
-# Default seeding policy — applies to all torrents unless tracker override matches
 seed_ratio_threshold = 1.0
 seed_time_threshold_hours = 72
-
-# Per-tracker seeding policy overrides
-# Tracker URL substring match — most restrictive policy wins if multiple match
-[ergasia.tracker_seed_policies]
-# "tracker.example.com" = { ratio_threshold = 2.0, time_threshold_hours = 168 }
-
-# How often to emit DownloadProgress events (minimum seconds between emissions)
-progress_throttle_seconds = 2
-
-# Staging area for archive extraction (before move to download_dir final location)
-extraction_temp_dir = "/data/downloads/.extract-staging"
-
-# Peer connection timeout in seconds
 peer_connect_timeout_seconds = 10
-
-# Maximum peer connections per torrent (0 = librqbit default)
-max_connections_per_torrent = 0
-
-# Magnet URI DHT resolution timeout in seconds
 magnet_resolve_timeout_seconds = 120
+max_extraction_depth = 3
+max_decompression_ratio = 100.0
 ```
 
-Corresponding `ErgasiaConfig` struct additions in `crates/horismos/src/config.rs`:
-
-```rust
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ErgasiaConfig {
-    pub download_dir: PathBuf,
-    pub session_state_path: PathBuf,
-    pub listen_port_range: [u16; 2],
-    pub max_concurrent_downloads: usize,          // default: 5
-    pub seed_ratio_threshold: f64,                // default: 1.0
-    pub seed_time_threshold_hours: u64,           // default: 72
-    pub tracker_seed_policies: HashMap<String, TrackerSeedPolicy>,
-    pub progress_throttle_seconds: u64,           // default: 2
-    pub extraction_temp_dir: PathBuf,
-    pub peer_connect_timeout_seconds: u64,        // default: 10
-    pub max_connections_per_torrent: u32,         // default: 0 (librqbit default)
-    pub magnet_resolve_timeout_seconds: u64,      // default: 120
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct TrackerSeedPolicy {
-    pub ratio_threshold: f64,
-    pub time_threshold_hours: u64,
-}
-```
+`max_concurrent_downloads` lives under `[syntaxis]`, not `[ergasia]` — see [download/orchestration.md](orchestration.md). `max_extraction_depth`/`max_decompression_ratio` gate archive extraction — see [download/archive.md](archive.md). The full `ErgasiaConfig` field list is `crates/horismos/src/subsystems.rs`; LIVE/RESTART/UNWIRED classification is [architecture/config-reload.md](../architecture/config-reload.md).

--- a/docs/media/scanner.md
+++ b/docs/media/scanner.md
@@ -97,9 +97,9 @@ Auto mode (`watcher_mode = "auto"`) checks `/proc/mounts` to determine whether t
 ```rust
 fn detect_watcher_mode(lib: &LibraryConfig) -> WatcherMode {
     match lib.watcher_mode {
-        WatcherModeConfig::Inotify => WatcherMode::Inotify,
-        WatcherModeConfig::Poll    => WatcherMode::Poll,
-        WatcherModeConfig::Auto    => {
+        WatcherMode::Inotify => WatcherMode::Inotify,
+        WatcherMode::Poll    => WatcherMode::Poll,
+        WatcherMode::Auto    => {
             if is_network_mount(&lib.path) {
                 tracing::info!(library = %lib.name, "NFS mount detected; using PollWatcher");
                 WatcherMode::Poll
@@ -332,10 +332,7 @@ Per-file errors are logged at `warn` level and the scan continues. `WatcherInit`
 scan_concurrency = 4
 
 # Debounce window for real-time watcher events (milliseconds)
-event_debounce_ms = 500
-
-# Whether to auto-detect NFS mounts and use PollWatcher
-nfs_detection = true
+watcher_debounce_ms = 500
 
 [taxis.libraries.music]
 path = "/media/music"
@@ -347,24 +344,24 @@ scan_interval_hours = 6
 # Additional libraries follow the same pattern
 ```
 
-`TaxisConfig` struct in `crates/horismos/src/config.rs`:
+`TaxisConfig` in `crates/horismos/src/subsystems.rs`:
 
 ```rust
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TaxisConfig {
-    pub scan_concurrency: usize,        // default: 4
-    pub event_debounce_ms: u64,         // default: 500
-    pub nfs_detection: bool,            // default: true
     pub libraries: HashMap<String, LibraryConfig>,
+    pub watcher_debounce_ms: u64,   // default: 500
+    pub scan_concurrency: usize,    // default: 4
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LibraryConfig {
     pub path: PathBuf,
     pub media_type: MediaType,
-    pub watcher_mode: WatcherModeConfig, // Auto | Inotify | Poll
-    pub poll_interval_seconds: u64,      // default: 30
-    pub scan_interval_hours: u64,        // default: 6
-    pub naming_template: Option<String>, // overrides default template
+    pub watcher_mode: WatcherMode,  // Auto | Inotify | Poll
+    pub poll_interval_seconds: u64, // default: 300
+    pub scan_interval_hours: u64,   // default: 24
 }
 ```
+
+No `nfs_detection` field exists — NFS/network-mount detection is not a separate toggle, it is inherent to `watcher_mode = "auto"` (see **NFS detection** below). `LibraryConfig` carries no `naming_template` field either; see [media/import-rename.md](import-rename.md) for the caveat on that document's naming-template claims.


### PR DESCRIPTION
Fixes the #597 drift classes across the architecture/download docs, verified field-by-field against `crates/horismos/src/subsystems.rs`:

- **Removed-field references** (post-#598): stream_buffer_kb, transcode_concurrency, max_retries, download_queue_size, extraction_temp_dir/cleanup, max_connections_per_torrent, cf_health_check_interval_minutes, tracker_seed_policies, and the fabricated `[zetesis.indexers]` block.
- **Fabricated current-state narrative** cut or reduced to reality: the invented 5-layer config figment stack, hand-invented validate() rules, the extraction staging-dir + janitor, the CF startup probe + periodic-recovery task, and the syntaxis→ergasia "bounded mpsc" (real mechanism: direct `DownloadEngine::start_download` gated by `SlotAllocator`).
- **Wrong names** corrected everywhere (seeding_ratio_limit→seed_ratio_threshold, magnet_resolve_timeout_secs→..._seconds, event_debounce_ms→watcher_debounce_ms, db path→db_path, ...).
- **Out-of-flagged-scope catches**: docs/data/storage.md, docs/media/scanner.md (fabricated nfs_detection/naming_template fields).
- configuration.md's exhaustive struct dump replaced with one accurate example + a pointer to subsystems.rs, so it cannot re-drift the same way.

Two whole fabricated-feature documents (docs/download/irc.md, docs/media/import-rename.md) are the same class at document scale — filed separately rather than folded in here.

Gate green (2103 tests).

Closes #597