### PR TITLE
feat(zetesis,apotheke,paroche): per-indexer Cardigann settings override

### DIFF
--- a/crates/apotheke/migrations/013_indexer_settings.sql
+++ b/crates/apotheke/migrations/013_indexer_settings.sql
@@ -1,0 +1,5 @@
+-- Per-indexer settings override storage (Cardigann `settings:` fields).
+-- JSON object string (setting name -> value), nullable — absent means "use
+-- every definition default." Same treatment as caps_json in 004.
+
+ALTER TABLE indexers ADD COLUMN settings_json TEXT;

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -4252,6 +4252,7 @@ mod rebuild_supervisor_tests {
                 api_key: None,
                 cf_bypass: false,
                 priority: 10,
+                settings_json: None,
             },
         )
         .await
@@ -4265,6 +4266,7 @@ mod rebuild_supervisor_tests {
                 api_key: None,
                 cf_bypass: false,
                 priority: 20,
+                settings_json: None,
             },
         )
         .await

--- a/crates/paroche/src/routes/indexer.rs
+++ b/crates/paroche/src/routes/indexer.rs
@@ -1,4 +1,6 @@
 /// Indexer management endpoints.
+use std::collections::BTreeMap;
+
 use axum::{
     Json,
     extract::{Path, Query, State},
@@ -43,6 +45,7 @@ struct IndexerRow {
     _caps_json: Option<String>,
     priority: i64,
     added_at: String,
+    settings_json: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -58,10 +61,18 @@ pub struct IndexerResponse {
     pub last_tested: Option<String>,
     pub priority: i64,
     pub added_at: String,
+    /// Configured setting names only — never values (may carry passwords).
+    pub settings_keys: Vec<String>,
 }
 
 impl From<IndexerRow> for IndexerResponse {
     fn from(r: IndexerRow) -> Self {
+        let settings_keys = r
+            .settings_json
+            .as_deref()
+            .and_then(|json| serde_json::from_str::<BTreeMap<String, String>>(json).ok())
+            .map(|settings| settings.into_keys().collect())
+            .unwrap_or_default();
         Self {
             id: r.id,
             name: r.name,
@@ -74,6 +85,7 @@ impl From<IndexerRow> for IndexerResponse {
             last_tested: r.last_tested,
             priority: r.priority,
             added_at: r.added_at,
+            settings_keys,
         }
     }
 }
@@ -89,6 +101,8 @@ pub struct CreateIndexerRequest {
     pub cf_bypass: bool,
     #[serde(default = "default_priority")]
     pub priority: i64,
+    #[serde(default)]
+    pub settings: Option<BTreeMap<String, String>>,
 }
 fn default_protocol() -> String {
     "torznab".to_string()
@@ -106,6 +120,8 @@ pub struct UpdateIndexerRequest {
     pub cf_bypass: Option<bool>,
     pub enabled: Option<bool>,
     pub priority: Option<i64>,
+    #[serde(default)]
+    pub settings: Option<BTreeMap<String, String>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -114,7 +130,7 @@ pub struct UpdateIndexerRequest {
 
 const SELECT_INDEXER: &str = "\
     SELECT id, name, url, protocol, api_key, enabled, cf_bypass, \
-           status, last_tested, caps_json, priority, added_at \
+           status, last_tested, caps_json, priority, added_at, settings_json \
     FROM indexers";
 
 // ---------------------------------------------------------------------------
@@ -180,10 +196,19 @@ pub async fn create_indexer(
     }
 
     let now = crate::routes::music::chrono_now_pub();
+    let settings_json = body
+        .settings
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|_| ParocheError::Internal)?;
 
+    // NOTE: 'unknown' violates the indexers.status CHECK (active/degraded/
+    // failed) — a newly created indexer starts 'active' until the next
+    // caps/test probe says otherwise, same as zetesis::repo::insert_indexer.
     let result = sqlx::query(
-        "INSERT INTO indexers (name, url, protocol, api_key, cf_bypass, enabled, status, priority, added_at) \
-         VALUES (?, ?, ?, ?, ?, 1, 'unknown', ?, ?)",
+        "INSERT INTO indexers (name, url, protocol, api_key, cf_bypass, enabled, status, priority, added_at, settings_json) \
+         VALUES (?, ?, ?, ?, ?, 1, 'active', ?, ?, ?)",
     )
     .bind(&body.name)
     .bind(&body.url)
@@ -192,6 +217,7 @@ pub async fn create_indexer(
     .bind(body.cf_bypass)
     .bind(body.priority)
     .bind(&now)
+    .bind(&settings_json)
     .execute(&state.db.write)
     .await
     .map_err(|_| ParocheError::Internal)?;
@@ -228,10 +254,16 @@ pub async fn update_indexer(
     let cf_bypass = body.cf_bypass.unwrap_or(existing.cf_bypass);
     let enabled = body.enabled.unwrap_or(existing.enabled);
     let priority = body.priority.unwrap_or(existing.priority);
+    let settings_json = match body.settings {
+        Some(settings) => {
+            Some(serde_json::to_string(&settings).map_err(|_| ParocheError::Internal)?)
+        }
+        None => existing.settings_json,
+    };
 
     sqlx::query(
         "UPDATE indexers SET name = ?, url = ?, protocol = ?, api_key = ?, \
-         cf_bypass = ?, enabled = ?, priority = ? WHERE id = ?",
+         cf_bypass = ?, enabled = ?, priority = ?, settings_json = ? WHERE id = ?",
     )
     .bind(&name)
     .bind(&url)
@@ -240,6 +272,7 @@ pub async fn update_indexer(
     .bind(cf_bypass)
     .bind(enabled)
     .bind(priority)
+    .bind(&settings_json)
     .bind(id)
     .execute(&state.db.write)
     .await
@@ -340,4 +373,144 @@ pub fn indexer_routes() -> axum::Router<AppState> {
         )
         .route("/{id}/test", post(test_indexer))
         .route("/{id}/caps", post(refresh_caps))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helpers::{admin_token, test_state};
+
+    async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_indexer_persists_settings_and_response_carries_keys_only() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+        let pool = state.db.read.clone();
+        let app = indexer_routes().with_state(state);
+
+        let request_body = serde_json::json!({
+            "name": "Cardigann Sample",
+            "url": "sample-tracker",
+            "protocol": "cardigann",
+            "settings": {"sort": "hunter2secret"},
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let bytes_resp = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let raw = String::from_utf8(bytes_resp.to_vec()).unwrap();
+        assert!(
+            !raw.contains("hunter2secret"),
+            "settings value leaked into response: {raw}"
+        );
+        let payload: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            payload["data"]["settings_keys"],
+            serde_json::json!(["sort"])
+        );
+        assert!(payload["data"].get("settings").is_none());
+
+        let id = payload["data"]["id"].as_i64().unwrap();
+        let settings_json: Option<String> =
+            sqlx::query_scalar("SELECT settings_json FROM indexers WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            settings_json.as_deref(),
+            Some(r#"{"sort":"hunter2secret"}"#)
+        );
+    }
+
+    #[tokio::test]
+    async fn update_indexer_persists_settings_and_response_carries_keys_only() {
+        let (state, auth) = test_state().await;
+        let token = admin_token(&auth).await;
+        let pool = state.db.read.clone();
+        let app = indexer_routes().with_state(state);
+
+        let create_body = serde_json::json!({
+            "name": "Plain",
+            "url": "https://example.com/api",
+            "protocol": "torznab",
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(create_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let created = body_json(resp).await;
+        let id = created["data"]["id"].as_i64().unwrap();
+        assert_eq!(created["data"]["settings_keys"], serde_json::json!([]));
+
+        let update_body = serde_json::json!({
+            "settings": {"password": "supersecretvalue"},
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/{id}"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(update_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes_resp = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let raw = String::from_utf8(bytes_resp.to_vec()).unwrap();
+        assert!(
+            !raw.contains("supersecretvalue"),
+            "settings value leaked into response: {raw}"
+        );
+        let payload: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            payload["data"]["settings_keys"],
+            serde_json::json!(["password"])
+        );
+
+        let settings_json: Option<String> =
+            sqlx::query_scalar("SELECT settings_json FROM indexers WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            settings_json.as_deref(),
+            Some(r#"{"password":"supersecretvalue"}"#)
+        );
+    }
 }

--- a/crates/zetesis/src/client/cardigann/mod.rs
+++ b/crates/zetesis/src/client/cardigann/mod.rs
@@ -196,6 +196,7 @@ impl CardigannClient {
         definition: Arc<CardigannDefinition>,
     ) -> Result<Self, SearchIndexerError> {
         let base_url = resolve_base_url(&indexer, &definition)?;
+        validate_settings(&indexer, &definition)?;
         let cookie = resolve_login(&indexer, &definition)?;
         if cookie.is_some() && indexer.cf_bypass {
             // WHY: the bypass proxy carries no request headers, so a session
@@ -239,9 +240,9 @@ impl CardigannClient {
         )
         .map_err(|e| self.invalid(format!("keywordsfilters: {e}")))?;
 
-        // NOTE: per-indexer `settings:` overrides are not plumbed yet —
-        // `.Config.<key>` always resolves to the definition's YAML
-        // `default:` (plus the injected session cookie).
+        // Seed order: definition defaults, then user settings overrides,
+        // then the injected session cookie (never user-overridable — see
+        // `validate_settings`).
         let mut config = BTreeMap::new();
         for setting in &self.definition.settings {
             config.insert(
@@ -252,6 +253,9 @@ impl CardigannClient {
                     .map(|d| d.0.clone())
                     .unwrap_or_default(),
             );
+        }
+        for (key, value) in &self.indexer.settings {
+            config.insert(key.clone(), value.clone());
         }
         if let Some(cookie) = &self.cookie {
             config.insert("cookie".to_string(), cookie.clone());
@@ -688,6 +692,68 @@ fn parse_absolute_http(raw: &str) -> Option<Url> {
     Url::parse(raw)
         .ok()
         .filter(|url| matches!(url.scheme(), "http" | "https"))
+}
+
+/// Rejects an indexer row's `settings` overrides that the definition does not
+/// declare, or whose value does not fit the declared `type`.
+///
+/// WHY: `cookie` is always sourced from the row's `api_key` — accepting it
+/// here would let a settings override silently shadow the real session
+/// cookie the login flow depends on.
+fn validate_settings(
+    indexer: &IndexerConfig,
+    definition: &CardigannDefinition,
+) -> Result<(), SearchIndexerError> {
+    let invalid = |reason: String| SearchIndexerError::SettingsInvalid {
+        definition_id: definition.id.clone(),
+        indexer_id: indexer.id,
+        reason,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    };
+
+    for (key, value) in &indexer.settings {
+        if key == "cookie" {
+            return Err(invalid(
+                "\"cookie\" is a reserved setting name sourced from the indexer's \
+                 api_key field, not overridable via settings"
+                    .to_string(),
+            ));
+        }
+        let Some(field) = definition.settings.iter().find(|s| &s.name == key) else {
+            return Err(invalid(format!(
+                "unknown setting {key:?} (not declared in this definition's settings)"
+            )));
+        };
+        match field.field_type.as_deref() {
+            Some("select") => {
+                let known = field
+                    .options
+                    .as_ref()
+                    .is_some_and(|options| options.keys().any(|opt| &opt.0 == value));
+                if !known {
+                    return Err(invalid(format!(
+                        "setting {key:?} value {value:?} is not one of the declared options"
+                    )));
+                }
+            }
+            Some("checkbox") => {
+                if value != "true" && value != "false" {
+                    return Err(invalid(format!(
+                        "setting {key:?} is a checkbox; value must be \"true\" or \"false\", \
+                         got {value:?}"
+                    )));
+                }
+            }
+            Some("info") => {
+                return Err(invalid(format!(
+                    "setting {key:?} is type \"info\" and cannot be overridden"
+                )));
+            }
+            // WHY: text/password/absent-type settings accept any string.
+            None | Some(_) => {}
+        }
+    }
+    Ok(())
 }
 
 /// Resolves the login block to an optional Cookie header value.

--- a/crates/zetesis/src/client/cardigann/tests.rs
+++ b/crates/zetesis/src/client/cardigann/tests.rs
@@ -23,6 +23,12 @@ settings:
   - name: sort
     type: select
     default: created
+    options:
+      created: Created
+      size: Size
+  - name: freeleech_only
+    type: checkbox
+    default: "false"
 search:
   paths:
     - path: /browse
@@ -106,6 +112,15 @@ fn client(
     url: String,
     api_key: Option<&str>,
 ) -> Result<CardigannClient, SearchIndexerError> {
+    client_with_settings(yaml, url, api_key, BTreeMap::new())
+}
+
+fn client_with_settings(
+    yaml: &str,
+    url: String,
+    api_key: Option<&str>,
+    settings: BTreeMap<String, String>,
+) -> Result<CardigannClient, SearchIndexerError> {
     CardigannClient::new(
         Arc::new(SearchSubsystemConfig::default()),
         reqwest::Client::new(),
@@ -117,6 +132,7 @@ fn client(
             url,
             api_key: api_key.map(str::to_string),
             cf_bypass: false,
+            settings,
         },
         definition(yaml),
     )
@@ -183,7 +199,106 @@ async fn search_extracts_rows_fields_and_maps_categories() {
     );
     assert!(request_line.contains("q=test.query"), "got: {request_line}");
     assert!(request_line.contains("cats=6%2C7"), "got: {request_line}");
+    // WHY: no settings override was supplied — the definition's `default:`
+    // value must be what reaches the request.
     assert!(request_line.contains("sort=created"), "got: {request_line}");
+}
+
+// ── settings overrides ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn settings_override_reaches_the_request() {
+    let (url, server) = spawn_one_shot_http(200, "OK", &[], SAMPLE_HTML).await;
+    let settings = BTreeMap::from([("sort".to_string(), "size".to_string())]);
+    client_with_settings(SAMPLE_DEF, url, None, settings)
+        .unwrap()
+        .search(&movie_query(), CancellationToken::new())
+        .await
+        .unwrap();
+
+    let request_head = server.await.unwrap();
+    let request_line = request_head.lines().next().unwrap_or_default().to_string();
+    assert!(request_line.contains("sort=size"), "got: {request_line}");
+    assert!(
+        !request_line.contains("sort=created"),
+        "got: {request_line}"
+    );
+}
+
+#[test]
+fn settings_unknown_key_is_rejected() {
+    let settings = BTreeMap::from([("nope".to_string(), "x".to_string())]);
+    let err = client_with_settings(
+        SAMPLE_DEF,
+        "http://127.0.0.1:9/".to_string(),
+        None,
+        settings,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::SettingsInvalid { ref reason, .. } if reason.contains("unknown setting")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn settings_select_out_of_options_is_rejected() {
+    let settings = BTreeMap::from([("sort".to_string(), "nonexistent".to_string())]);
+    let err = client_with_settings(
+        SAMPLE_DEF,
+        "http://127.0.0.1:9/".to_string(),
+        None,
+        settings,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::SettingsInvalid { ref reason, .. } if reason.contains("not one of the declared options")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn settings_checkbox_non_boolean_is_rejected() {
+    let settings = BTreeMap::from([("freeleech_only".to_string(), "yes".to_string())]);
+    let err = client_with_settings(
+        SAMPLE_DEF,
+        "http://127.0.0.1:9/".to_string(),
+        None,
+        settings,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::SettingsInvalid { ref reason, .. } if reason.contains("checkbox")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn settings_checkbox_boolean_string_is_accepted() {
+    let settings = BTreeMap::from([("freeleech_only".to_string(), "true".to_string())]);
+    client_with_settings(
+        SAMPLE_DEF,
+        "http://127.0.0.1:9/".to_string(),
+        None,
+        settings,
+    )
+    .unwrap();
+}
+
+#[test]
+fn settings_cookie_key_is_rejected() {
+    let settings = BTreeMap::from([("cookie".to_string(), "sneaky=1".to_string())]);
+    let err = client_with_settings(
+        SAMPLE_DEF,
+        "http://127.0.0.1:9/".to_string(),
+        None,
+        settings,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::SettingsInvalid { ref reason, .. } if reason.contains("reserved")),
+        "got {err:?}"
+    );
 }
 
 const PATH_TEMPLATE_DEF: &str = r#"---
@@ -589,6 +704,7 @@ fn registry_client_for_unknown_url_errors() {
                 url: "no-such-definition".to_string(),
                 api_key: None,
                 cf_bypass: false,
+                settings: BTreeMap::new(),
             },
             reqwest::Client::new(),
             Arc::new(NoProxy),

--- a/crates/zetesis/src/client/mod.rs
+++ b/crates/zetesis/src/client/mod.rs
@@ -3,6 +3,7 @@ pub mod newznab;
 pub mod torznab;
 pub mod xml;
 
+use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use futures::StreamExt;
@@ -90,6 +91,9 @@ pub struct IndexerConfig {
     pub url: String,
     pub api_key: Option<String>,
     pub cf_bypass: bool,
+    /// Per-indexer Cardigann `settings:` overrides (setting name -> value);
+    /// empty for non-Cardigann protocols.
+    pub settings: BTreeMap<String, String>,
 }
 
 pub(crate) fn build_search_url(config: &IndexerConfig, query: &SearchQuery) -> String {
@@ -394,6 +398,7 @@ mod tests {
             url: "https://example.com/api".to_string(),
             api_key: Some("abc123".to_string()),
             cf_bypass: false,
+            settings: BTreeMap::new(),
         };
         let query = SearchQuery {
             query_text: Some("test query".to_string()),
@@ -417,6 +422,7 @@ mod tests {
             url: "https://example.com/api/".to_string(),
             api_key: None,
             cf_bypass: false,
+            settings: BTreeMap::new(),
         };
         let query = SearchQuery {
             media_type: SearchMediaType::Tv,
@@ -443,6 +449,7 @@ mod tests {
             url: "https://example.com/api".to_string(),
             api_key: Some("key123".to_string()),
             cf_bypass: false,
+            settings: BTreeMap::new(),
         };
 
         let url = build_caps_url(&config);

--- a/crates/zetesis/src/client/newznab.rs
+++ b/crates/zetesis/src/client/newznab.rs
@@ -229,6 +229,7 @@ mod tests {
                 url,
                 api_key: api_key.map(str::to_string),
                 cf_bypass: false,
+                settings: std::collections::BTreeMap::new(),
             },
             reqwest::Client::new(),
             Arc::new(NoProxy),

--- a/crates/zetesis/src/client/torznab.rs
+++ b/crates/zetesis/src/client/torznab.rs
@@ -243,6 +243,7 @@ mod tests {
                 url,
                 api_key: api_key.map(str::to_string),
                 cf_bypass: false,
+                settings: std::collections::BTreeMap::new(),
             },
             reqwest::Client::new(),
             Arc::new(NoProxy),

--- a/crates/zetesis/src/error.rs
+++ b/crates/zetesis/src/error.rs
@@ -170,4 +170,24 @@ pub enum SearchIndexerError {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    #[snafu(display("indexer {indexer_id} settings_json is not valid JSON: {reason}"))]
+    SettingsJsonInvalid {
+        indexer_id: i64,
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display(
+        "indexer {indexer_id} settings override rejected for Cardigann definition \
+         {definition_id}: {reason}"
+    ))]
+    SettingsInvalid {
+        definition_id: String,
+        indexer_id: i64,
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }

--- a/crates/zetesis/src/repo.rs
+++ b/crates/zetesis/src/repo.rs
@@ -19,6 +19,9 @@ pub struct IndexerRow {
     pub caps_json: Option<String>,
     pub priority: i32,
     pub added_at: String,
+    /// JSON object string of per-indexer `settings:` overrides. May carry a
+    /// password-typed setting — redacted in Debug, same as `api_key`.
+    pub settings_json: Option<String>,
 }
 impl std::fmt::Debug for IndexerRow {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -35,6 +38,10 @@ impl std::fmt::Debug for IndexerRow {
             .field("caps_json", &self.caps_json)
             .field("priority", &self.priority)
             .field("added_at", &self.added_at)
+            .field(
+                "settings_json",
+                &self.settings_json.as_ref().map(|_| "[redacted]"),
+            )
             .finish()
     }
 }
@@ -52,6 +59,7 @@ pub struct InsertIndexerParams<'a> {
     pub api_key: Option<&'a str>,
     pub cf_bypass: bool,
     pub priority: i32,
+    pub settings_json: Option<&'a str>,
 }
 
 pub async fn insert_indexer(
@@ -65,10 +73,11 @@ pub async fn insert_indexer(
         api_key,
         cf_bypass,
         priority,
+        settings_json,
     } = params;
     let result = sqlx::query_scalar::<_, i64>(
-        "INSERT INTO indexers (name, url, protocol, api_key, cf_bypass, priority)
-         VALUES (?, ?, ?, ?, ?, ?)
+        "INSERT INTO indexers (name, url, protocol, api_key, cf_bypass, priority, settings_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
          RETURNING id",
     )
     .bind(name)
@@ -77,6 +86,7 @@ pub async fn insert_indexer(
     .bind(api_key)
     .bind(cf_bypass)
     .bind(priority)
+    .bind(settings_json)
     .fetch_one(pool)
     .await
     .context(QuerySnafu { table: "indexers" })?;
@@ -236,6 +246,7 @@ mod tests {
             api_key: Some("key"),
             cf_bypass,
             priority: 50,
+            settings_json: None,
         }
     }
 
@@ -516,5 +527,41 @@ mod tests {
         assert_eq!(untouched.status, "degraded");
         let still_failed = get_indexer(&pool, cf_failed).await.unwrap().unwrap();
         assert_eq!(still_failed.status, "failed");
+    }
+
+    #[tokio::test]
+    async fn insert_indexer_persists_settings_json() {
+        let pool = setup().await;
+        let id = insert_indexer(
+            &pool,
+            InsertIndexerParams {
+                settings_json: Some(r#"{"sort":"size"}"#),
+                ..params("Settings", false)
+            },
+        )
+        .await
+        .unwrap();
+
+        let row = get_indexer(&pool, id).await.unwrap().unwrap();
+        assert_eq!(row.settings_json.as_deref(), Some(r#"{"sort":"size"}"#));
+    }
+
+    #[tokio::test]
+    async fn indexer_row_debug_hides_settings_json() {
+        let pool = setup().await;
+        let id = insert_indexer(
+            &pool,
+            InsertIndexerParams {
+                settings_json: Some(r#"{"password":"hunter2"}"#),
+                ..params("Redacted", false)
+            },
+        )
+        .await
+        .unwrap();
+
+        let row = get_indexer(&pool, id).await.unwrap().unwrap();
+        let debug = format!("{row:?}");
+        assert!(!debug.contains("hunter2"), "leaked: {debug}");
+        assert!(debug.contains("[redacted]"), "got: {debug}");
     }
 }

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -444,13 +444,16 @@ impl SearchIndexerService {
             // neither says the indexer itself is unhealthy.
             SearchIndexerError::Cancelled { .. } | SearchIndexerError::RateLimited { .. } => None,
             // WHY: a missing/unsupported/misconfigured Cardigann definition
-            // fails every search identically until the operator intervenes.
+            // (or a corrupt/invalid settings override) fails every search
+            // identically until the operator intervenes.
             SearchIndexerError::DefinitionNotFound { .. }
             | SearchIndexerError::DefinitionLoad { .. }
             | SearchIndexerError::DefinitionInvalid { .. }
             | SearchIndexerError::DefinitionUnsupported { .. }
             | SearchIndexerError::LoginUnsupported { .. }
-            | SearchIndexerError::CookieAuthRequired { .. } => Some("failed"),
+            | SearchIndexerError::CookieAuthRequired { .. }
+            | SearchIndexerError::SettingsJsonInvalid { .. }
+            | SearchIndexerError::SettingsInvalid { .. } => Some("failed"),
             _ => None,
         };
 
@@ -559,12 +562,26 @@ fn make_client(
     max_body_bytes: u64,
     cardigann: &CardigannRegistry,
 ) -> Result<Box<dyn DynIndexerClient>, SearchIndexerError> {
+    // WHY: a corrupt settings_json blob must fail loud — silently falling
+    // back to defaults would mask the row that just lost its overrides.
+    let settings: BTreeMap<String, String> = match indexer.settings_json.as_deref() {
+        Some(json) => {
+            serde_json::from_str(json).map_err(|e| SearchIndexerError::SettingsJsonInvalid {
+                indexer_id: indexer.id,
+                reason: e.to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?
+        }
+        None => BTreeMap::new(),
+    };
+
     let config = IndexerConfig {
         id: indexer.id,
         name: indexer.name.clone(),
         url: indexer.url.clone(),
         api_key: indexer.api_key.clone(),
         cf_bypass: indexer.cf_bypass,
+        settings,
     };
 
     Ok(match indexer.protocol.as_str() {

--- a/crates/zetesis/src/search/tests.rs
+++ b/crates/zetesis/src/search/tests.rs
@@ -130,6 +130,7 @@ fn filter_capability_any_includes_all() {
         caps_json: None,
         priority: 50,
         added_at: "2024-01-01T00:00:00Z".to_string(),
+        settings_json: None,
     }];
 
     let query = SearchQuery {
@@ -156,6 +157,7 @@ fn filter_capability_typed_excludes_no_caps() {
         caps_json: None,
         priority: 50,
         added_at: "2024-01-01T00:00:00Z".to_string(),
+        settings_json: None,
     }];
 
     let query = SearchQuery {
@@ -195,6 +197,7 @@ fn filter_capability_typed_includes_supported() {
         caps_json: Some(serde_json::to_string(&caps).unwrap()),
         priority: 50,
         added_at: "2024-01-01T00:00:00Z".to_string(),
+        settings_json: None,
     }];
 
     let query = SearchQuery {
@@ -250,6 +253,7 @@ async fn seed_indexer(pool: &SqlitePool, url: &str) -> IndexerRow {
             api_key: Some("key"),
             cf_bypass: false,
             priority: 50,
+            settings_json: None,
         },
     )
     .await
@@ -518,6 +522,7 @@ async fn cardigann_search_end_to_end_through_dispatch() {
             api_key: None,
             cf_bypass: false,
             priority: 50,
+            settings_json: None,
         },
     )
     .await
@@ -560,6 +565,37 @@ async fn cardigann_row_without_definition_marks_failed() {
             api_key: None,
             cf_bypass: false,
             priority: 50,
+            settings_json: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let results = service
+        .search(SearchQuery::new(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert!(results.is_empty());
+
+    let row = repo::get_indexer(&pool, indexer_id).await.unwrap().unwrap();
+    assert_eq!(row.status, "failed");
+}
+
+#[tokio::test]
+async fn corrupt_settings_json_is_a_hard_error_not_silent_defaults() {
+    // WHY: a corrupt settings_json blob must fail loud at make_client — it
+    // must never silently fall back to the definition's plain defaults.
+    let (service, pool) = make_service().await;
+    let indexer_id = repo::insert_indexer(
+        &pool,
+        InsertIndexerParams {
+            name: "Corrupt Settings",
+            url: "https://example.com/api",
+            protocol: "torznab",
+            api_key: None,
+            cf_bypass: false,
+            priority: 50,
+            settings_json: Some("not json"),
         },
     )
     .await
@@ -792,6 +828,7 @@ async fn refresh_stale_caps_continues_past_a_failing_indexer() {
             api_key: None,
             cf_bypass: false,
             priority: 10,
+            settings_json: None,
         },
     )
     .await
@@ -806,6 +843,7 @@ async fn refresh_stale_caps_continues_past_a_failing_indexer() {
             api_key: None,
             cf_bypass: false,
             priority: 90,
+            settings_json: None,
         },
     )
     .await
@@ -996,6 +1034,7 @@ async fn cf_proxy_swap_turns_a_no_proxy_service_into_a_proxied_one() {
             api_key: None,
             cf_bypass: true,
             priority: 50,
+            settings_json: None,
         },
     )
     .await

--- a/docs/download/indexer-protocol.md
+++ b/docs/download/indexer-protocol.md
@@ -174,23 +174,23 @@ pub trait IndexerClient: Send + Sync {
         &self,
         query: &SearchQuery,
         ct: CancellationToken,
-    ) -> Result<Vec<SearchResult>, ZetesisError>;
+    ) -> Result<Vec<SearchResult>, SearchIndexerError>;
 
     async fn caps(
         &self,
         ct: CancellationToken,
-    ) -> Result<IndexerCaps, ZetesisError>;
+    ) -> Result<IndexerCaps, SearchIndexerError>;
 
     async fn test(
         &self,
         ct: CancellationToken,
-    ) -> Result<IndexerStatus, ZetesisError>;
+    ) -> Result<IndexerStatus, SearchIndexerError>;
 
     async fn download(
         &self,
         url: &str,
         ct: CancellationToken,
-    ) -> Result<DownloadResponse, ZetesisError>;
+    ) -> Result<DownloadResponse, SearchIndexerError>;
 }
 ```
 
@@ -415,7 +415,7 @@ Indexer rows select the client with `protocol = 'cardigann'`; the row's `url` co
 | Filter chains | Common set | `regexp`, `re_replace`, `replace`, `split`, `trim`, `prepend`, `append`, `tolower`, `toupper`, `querystring`, `dateparse`, `timeago` (best-effort); unknown filters rejected at load |
 | `download` | `selector`/`attribute`/filters | `before` pre-requests and `infohash` fallback warned and ignored |
 | `login` | `none`, `cookie` | Form/post/get/oneurl fail at client construction with a clear error |
-| `settings` | Defaults only | `.Config.<key>` always resolves to the definition's `default:` value; per-indexer overrides are not plumbed yet (deferred) |
+| `settings` | Yes | Per-indexer overrides stored on the indexer row (`settings_json`), validated at client construction against the declared `settings:` fields, and overlaid onto `.Config.<key>` (definition `default:` → user override → injected `cookie`). `checkbox` values render as the literal strings `"true"`/`"false"`; `{{ if .Config.x }}` conditionals stay rejected at load (this engine's template subset has no `if`) |
 | `ratio` | No | Deferred |
 
 **Definition source**: Harmonia reads Prowlarr-compatible YAML definitions from `config.zetesis.cardigann_definitions_dir`, one indexer per `.yml`/`.yaml` file, at startup (`SearchIndexerService::new` → `CardigannRegistry::load`). Definitions that fail validation are skipped with a warning naming the unsupported construct. Third-party definitions are not vendored into the repo.
@@ -426,69 +426,22 @@ Indexer rows select the client with `protocol = 'cardigann'`; the row's `url` co
 
 ## Error handling
 
-`ZetesisError` uses snafu per `standards/RUST.md`:
-
-```rust
-#[derive(Debug, Snafu)]
-pub enum ZetesisError {
-    #[snafu(display("HTTP request to indexer {url} failed"))]
-    HttpRequest {
-        url: String,
-        source: reqwest::Error,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-
-    #[snafu(display("failed to parse Torznab/Newznab XML response from {url}"))]
-    ParseResponse {
-        url: String,
-        source: quick_xml::DeError,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-
-    #[snafu(display("indexer {indexer_id} returned auth failure (bad API key)"))]
-    AuthFailed {
-        indexer_id: i64,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-
-    #[snafu(display("indexer {indexer_id} rate limited — retry after {retry_after_seconds}s"))]
-    RateLimited {
-        indexer_id: i64,
-        retry_after_seconds: Option<u64>,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-
-    #[snafu(display("indexer {indexer_id} requires Cloudflare bypass but Byparr sidecar is unavailable"))]
-    NoCfBypass {
-        indexer_id: i64,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-
-    #[snafu(display("caps negotiation failed for indexer {indexer_id}"))]
-    CapsUnavailable {
-        indexer_id: i64,
-        source: Box<ZetesisError>,
-        #[snafu(implicit)]
-        location: snafu::Location,
-    },
-}
-```
+`SearchIndexerError` (`crates/zetesis/src/error.rs`) is one `#[non_exhaustive]` snafu enum shared by every indexer client (Torznab, Newznab, Cardigann) and the search-dispatch service, per `standards/RUST.md`. Every variant carries a `#[snafu(implicit)] location`; read the enum directly for the current, full variant list rather than a doc snapshot — it grows as new client/definition/settings failure modes are added. Broad categories: transport (`HttpRequest`, `Cancelled`, `ResponseTooLarge`, `UnsafeUrl`), indexer-reported (`AuthFailed`, `RateLimited`), Cloudflare-bypass (`NoCfBypass`, `CfProxyTimeout`, `CfProxyError`, `CfCookieExpired`), persistence (`Database`, `IndexerNotFound`), response parsing (`ParseResponse`, `CapsUnavailable`), and Cardigann configuration (`DefinitionLoad`, `DefinitionInvalid`, `DefinitionUnsupported`, `DefinitionNotFound`, `LoginUnsupported`, `CookieAuthRequired`, `SettingsJsonInvalid`, `SettingsInvalid`).
 
 ### Error → status transitions
+
+`SearchIndexerService::handle_search_error` (`crates/zetesis/src/search.rs`) maps a subset of variants to an indexer status change; every other variant leaves status untouched.
 
 | Error | Indexer Status Transition | Notes |
 |-------|--------------------------|-------|
 | `AuthFailed` | → `failed` | Bad API key requires user intervention |
-| `HttpRequest` (repeated) | → `degraded` then `failed` | 3 consecutive failures → failed |
+| `HttpRequest` (repeated) | → `degraded` then `failed` | Second consecutive failure while already `degraded` → `failed` |
 | `RateLimited` | No status change | Back off per `Retry-After` header; resume normally |
-| `NoCfBypass` | → `degraded` | Degraded (not failed); recoverable when Byparr starts |
+| `Cancelled` | No status change | Caller intent, not indexer failure |
+| `NoCfBypass`, `CfProxyTimeout`, `CfProxyError` | → `degraded` | Recoverable when Byparr becomes available |
 | `CapsUnavailable` | → `degraded` | Can still serve cached caps; retry on schedule |
-| `ParseResponse` | → `degraded` | Malformed response; may recover on next request |
+| `ParseResponse`, `ResponseTooLarge` | → `degraded` | Malformed/oversized response; may recover on next request |
+| `DefinitionNotFound`, `DefinitionLoad`, `DefinitionInvalid`, `DefinitionUnsupported`, `LoginUnsupported`, `CookieAuthRequired`, `SettingsJsonInvalid`, `SettingsInvalid` | → `failed` | Misconfiguration (definition, login, or settings override) fails every search identically until the operator intervenes |
 
 ### Rate limiting
 
@@ -530,38 +483,24 @@ max_results_per_indexer = 100
 cloudflare_bypass_enabled = false
 ```
 
-`ZetesisConfig` struct additions in `crates/horismos/src/config.rs`:
+`SearchSubsystemConfig` in `crates/horismos/src/subsystems.rs` (not `ZetesisConfig` — that name never shipped):
 
 ```rust
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ZetesisConfig {
-    // Existing fields:
+pub struct SearchSubsystemConfig {
     pub request_timeout_secs: u64,
     pub max_results_per_indexer: usize,
+    pub max_response_body_bytes: u64,
     pub cloudflare_bypass_enabled: bool,
-
-    // New fields from this design:
-    pub max_concurrent_searches: usize,                  // default: 10
-    pub per_indexer_rate_limit_requests: u32,            // default: 5
-    pub per_indexer_rate_limit_window_seconds: u64,      // default: 10
-    pub caps_refresh_hours: u64,                         // default: 24
-    pub search_timeout_seconds: u64,                     // default: 30
-    pub cardigann_definitions_dir: Option<PathBuf>,      // default: None
-}
-
-impl Default for ZetesisConfig {
-    fn default() -> Self {
-        Self {
-            request_timeout_secs: 30,
-            max_results_per_indexer: 100,
-            cloudflare_bypass_enabled: false,
-            max_concurrent_searches: 10,
-            per_indexer_rate_limit_requests: 5,
-            per_indexer_rate_limit_window_seconds: 10,
-            caps_refresh_hours: 24,
-            search_timeout_seconds: 30,
-            cardigann_definitions_dir: None,
-        }
-    }
+    pub max_concurrent_searches: usize,
+    pub per_indexer_rate_limit_requests: u32,
+    pub per_indexer_rate_limit_window_seconds: u64,
+    pub caps_refresh_hours: u64,
+    pub search_timeout_seconds: u64,
+    pub cardigann_definitions_dir: Option<PathBuf>,
+    pub cf_proxy_url: Option<String>,
+    pub cf_proxy_timeout_seconds: u64,
+    pub cf_cookie_refresh_minutes: u64,
 }
 ```
+
+Field defaults live in `SearchSubsystemConfig`'s `Default` impl alongside the struct — read it directly rather than a doc snapshot.


### PR DESCRIPTION
PR 1 of the #513 Cardigann coverage extension: definitions declare `settings:` fields, but user values had nowhere to live — `.Config.<key>` always resolved to the YAML default. This adds the store and overlay; PR 2 (form login) builds on it, with credentials as settings.

- **Storage**: `indexers.settings_json` (nullable TEXT, migration 013; JSON string→string, `caps_json` precedent).
- **Overlay order**: definition defaults → user settings → `cookie` from api_key (reserved key, rejected as a setting).
- **Validation** at client construction: unknown keys, out-of-options selects, non-boolean checkboxes, info overrides → new `SettingsInvalid` error. Corrupt `settings_json` is a hard error, never silent defaults.
- **Secret posture**: repo Debug redacts `settings_json`; the API returns `settings_keys` (presence-only, never values); text/password values never reach an error reason or log; `TemplateContext` Debug already redacts.
- **Inline fix**: `create_indexer` always wrote `status='unknown'`, violating the indexers.status CHECK constraint — zero prior coverage; now `'active'` with tests.
- Docs: settings support row + two stale-name drifts in indexer-protocol.md (`ZetesisConfig`→`SearchSubsystemConfig`, the fictional 6-variant error enum).

Gate green (2114 tests; 24 new).

Part of #513