### PR TITLE
fix(ergasia,syntaxis,archon): honest download states and completion wiring

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -847,31 +847,14 @@ impl ergasia::DownloadEngine for SessionEngine {
         &self,
         download_id: themelion::ids::DownloadId,
     ) -> Result<ergasia::DownloadProgress, ergasia::ErgasiaError> {
-        let stats = self.session.get_stats(download_id)?;
-        let total = stats.total_bytes;
-        let downloaded = stats.progress_bytes;
-        let pct = if total > 0 {
-            ((downloaded as f64 / total as f64) * 100.0) as u8
-        } else {
-            0
-        };
-        let (dl_speed, ul_speed) = match &stats.live {
-            Some(live) => (
-                live.download_speed.mbps * 125_000.0,
-                live.upload_speed.mbps * 125_000.0,
-            ),
-            None => (0.0, 0.0),
-        };
-        Ok(ergasia::DownloadProgress {
-            download_id,
-            state: ergasia::DownloadState::Downloading,
-            percent_complete: pct,
-            download_speed_bps: dl_speed as u64,
-            upload_speed_bps: ul_speed as u64,
-            peers_connected: 0,
-            seeders: 0,
-            eta_seconds: None,
-        })
+        self.session.progress(download_id)
+    }
+
+    async fn content_path(
+        &self,
+        download_id: themelion::ids::DownloadId,
+    ) -> Result<PathBuf, ergasia::ErgasiaError> {
+        self.session.content_path(download_id)
     }
 
     async fn extract(
@@ -1125,12 +1108,12 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // `ergasia.magnet_resolve_timeout_seconds` a per-add live read; the
     // restart-class ergasia leaves are held back by `publish()`, so the
     // session's construction-time snapshot cannot drift from the effective
-    // config.
-    let ergasia_session = Arc::new(
-        TorrentSession::new(config_handle.section(|c| &c.ergasia))
+    // config. The event sender feeds the per-download lifecycle watchers
+    // that announce DownloadCompleted/DownloadFailed (#602).
+    let ergasia_session =
+        TorrentSession::new(config_handle.section(|c| &c.ergasia), event_tx.clone())
             .await
-            .context(DownloadEngineSnafu)?,
-    );
+            .context(DownloadEngineSnafu)?;
     info!("ergasia (download engine) initialized");
 
     // Layer 2: Syntaxis (queue orchestration, depends on ergasia)
@@ -2605,7 +2588,15 @@ mod service_adapter_tests {
                 peers_connected: 0,
                 seeders: 0,
                 eta_seconds: None,
+                error: None,
             })
+        }
+
+        async fn content_path(
+            &self,
+            _download_id: DownloadId,
+        ) -> Result<PathBuf, ergasia::ErgasiaError> {
+            Ok(PathBuf::from("/data/downloads/recorded"))
         }
 
         async fn extract(

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -343,6 +343,12 @@ impl<E: ergasia::DownloadEngine + 'static> DynQueueManager for QueueAdapter<E> {
 fn queue_error(error: syntaxis::SyntaxisError) -> ServiceError {
     match error {
         syntaxis::SyntaxisError::ItemNotFound { .. } => ServiceError::NotFound,
+        // WHY: cancelling a row whose import pipeline is in flight is a
+        // caller-visible conflict (the download already finished), never a
+        // server fault.
+        e @ syntaxis::SyntaxisError::CancelTooLate { .. } => {
+            ServiceError::InvalidInput(e.to_string())
+        }
         other => ServiceError::Internal(other.to_string()),
     }
 }

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -88,7 +88,15 @@ impl ergasia::DownloadEngine for MockEngine {
             peers_connected: 5,
             seeders: 10,
             eta_seconds: Some(300),
+            error: None,
         })
+    }
+
+    async fn content_path(
+        &self,
+        _download_id: DownloadId,
+    ) -> Result<std::path::PathBuf, ErgasiaError> {
+        Ok(std::path::PathBuf::from("/data/downloads/mock"))
     }
 
     async fn extract(

--- a/crates/ergasia/src/error.rs
+++ b/crates/ergasia/src/error.rs
@@ -64,6 +64,14 @@ pub enum ErgasiaError {
         location: snafu::Location,
     },
 
+    #[snafu(display("cannot resolve content path for {download_id}: {reason}"))]
+    ContentPath {
+        download_id: DownloadId,
+        reason: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("failed to open archive at {}", path.display()))]
     OpenArchive {
         path: PathBuf,

--- a/crates/ergasia/src/lib.rs
+++ b/crates/ergasia/src/lib.rs
@@ -6,7 +6,7 @@ pub mod session;
 pub mod state;
 
 use std::future::Future;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub use error::ErgasiaError;
 pub use extract::{
@@ -15,7 +15,7 @@ pub use extract::{
 pub use progress::DownloadProgress;
 pub use seeding::{SeedingPolicy, TrackerSeedPolicy};
 pub use session::TorrentSession;
-pub use state::{DownloadEntry, DownloadState};
+pub use state::{DownloadEntry, DownloadState, map_torrent_stats};
 use themelion::ids::{DownloadId, WantId};
 
 pub struct DownloadRequest {
@@ -46,6 +46,14 @@ pub trait DownloadEngine: Send + Sync {
         &self,
         download_id: DownloadId,
     ) -> impl Future<Output = Result<DownloadProgress, ErgasiaError>> + Send;
+
+    /// Resolves the on-disk path holding the download's content: the
+    /// containing directory for a multi-file download, the file itself for a
+    /// single-file one.
+    fn content_path(
+        &self,
+        download_id: DownloadId,
+    ) -> impl Future<Output = Result<PathBuf, ErgasiaError>> + Send;
 
     fn extract(
         &self,

--- a/crates/ergasia/src/progress.rs
+++ b/crates/ergasia/src/progress.rs
@@ -1,7 +1,13 @@
+use librqbit::TorrentStats;
 use serde::{Deserialize, Serialize};
 use themelion::ids::DownloadId;
 
-use crate::state::DownloadState;
+use crate::state::{DownloadState, map_torrent_stats};
+
+// WHY: librqbit's `Speed.mbps` is bytes/s divided by 1024^2 — MiB/s despite
+// the name (librqbit-core speed_estimator.rs `mbps()`); converting back with
+// the same factor keeps the reported bytes/s honest.
+const MIB_PER_SECOND_TO_BPS: f64 = 1024.0 * 1024.0;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DownloadProgress {
@@ -13,11 +19,95 @@ pub struct DownloadProgress {
     pub peers_connected: u32,
     pub seeders: u32,
     pub eta_seconds: Option<u64>,
+    /// Engine-reported failure detail; `Some` only when `state` is `Failed`.
+    pub error: Option<String>,
+}
+
+impl DownloadProgress {
+    /// Assembles a progress report from a librqbit stats snapshot.
+    pub fn from_stats(download_id: DownloadId, stats: &TorrentStats) -> Self {
+        let (download_speed_bps, upload_speed_bps, peers_connected) = match &stats.live {
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "speeds are non-negative and far below u64::MAX"
+            )]
+            Some(live) => (
+                (live.download_speed.mbps * MIB_PER_SECOND_TO_BPS) as u64,
+                (live.upload_speed.mbps * MIB_PER_SECOND_TO_BPS) as u64,
+                u32::try_from(live.snapshot.peer_stats.live).unwrap_or(u32::MAX),
+            ),
+            None => (0, 0, 0),
+        };
+
+        let remaining = stats.total_bytes.saturating_sub(stats.progress_bytes);
+        // WHY: recomputed from remaining/speed — librqbit's own estimate
+        // (`LiveStats.time_remaining`) wraps a Duration that is private to
+        // the crate, so it cannot be read back here.
+        let eta_seconds = if stats.finished || download_speed_bps == 0 {
+            None
+        } else {
+            Some(remaining / download_speed_bps)
+        };
+
+        Self {
+            download_id,
+            state: map_torrent_stats(stats),
+            percent_complete: percent_complete(
+                stats.progress_bytes,
+                stats.total_bytes,
+                stats.finished,
+            ),
+            download_speed_bps,
+            upload_speed_bps,
+            peers_connected,
+            // NOTE: librqbit exposes no per-torrent seeder count; 0 is the
+            // honest value, not a fabricated one.
+            seeders: 0,
+            eta_seconds,
+            error: stats.error.clone(),
+        }
+    }
+}
+
+fn percent_complete(progress: u64, total: u64, finished: bool) -> u8 {
+    if finished {
+        100
+    } else if total > 0 {
+        // SAFETY: progress <= total keeps the ratio in [0, 100]; floor of a
+        // value in that range always fits u8.
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "floored ratio is bounded to [0, 100]"
+        )]
+        {
+            ((progress as f64 / total as f64) * 100.0).floor() as u8
+        }
+    } else {
+        0
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use librqbit::TorrentStatsState;
+    use librqbit::api::LiveStats;
+
     use super::*;
+
+    fn stats(state: TorrentStatsState, finished: bool) -> TorrentStats {
+        TorrentStats {
+            state,
+            file_progress: Vec::new(),
+            error: None,
+            progress_bytes: 0,
+            uploaded_bytes: 0,
+            total_bytes: 0,
+            finished,
+            live: None,
+        }
+    }
 
     #[test]
     fn download_progress_serde_roundtrip() {
@@ -30,10 +120,85 @@ mod tests {
             peers_connected: 10,
             seeders: 5,
             eta_seconds: Some(300),
+            error: None,
         };
         let json = serde_json::to_string(&progress).unwrap();
         let recovered: DownloadProgress = serde_json::from_str(&json).unwrap();
         assert_eq!(recovered.percent_complete, 42);
         assert_eq!(recovered.download_speed_bps, 1_000_000);
+        assert!(recovered.error.is_none());
+    }
+
+    #[test]
+    fn percent_is_zero_when_total_unknown() {
+        assert_eq!(percent_complete(0, 0, false), 0);
+        assert_eq!(percent_complete(500, 0, false), 0);
+    }
+
+    #[test]
+    fn percent_is_hundred_when_finished_regardless_of_bytes() {
+        assert_eq!(percent_complete(0, 0, true), 100);
+        assert_eq!(percent_complete(50, 100, true), 100);
+    }
+
+    #[test]
+    fn percent_floors_the_ratio() {
+        assert_eq!(percent_complete(999, 1000, false), 99);
+        assert_eq!(percent_complete(1, 3, false), 33);
+        assert_eq!(percent_complete(1000, 1000, false), 100);
+    }
+
+    #[test]
+    fn from_stats_propagates_engine_error() {
+        let mut s = stats(TorrentStatsState::Error, false);
+        s.error = Some("disk gone".to_string());
+        let progress = DownloadProgress::from_stats(DownloadId::new(), &s);
+        assert_eq!(progress.state, DownloadState::Failed);
+        assert_eq!(progress.error.as_deref(), Some("disk gone"));
+    }
+
+    #[test]
+    fn from_stats_reads_live_speeds_and_peers() {
+        let mut live = LiveStats {
+            download_speed: 2.0.into(),
+            upload_speed: 0.5.into(),
+            ..LiveStats::default()
+        };
+        live.snapshot.peer_stats.live = 7;
+        let mut s = stats(TorrentStatsState::Live, false);
+        s.progress_bytes = 25;
+        s.total_bytes = 100;
+        s.live = Some(live);
+
+        let progress = DownloadProgress::from_stats(DownloadId::new(), &s);
+        assert_eq!(progress.state, DownloadState::Downloading);
+        assert_eq!(progress.percent_complete, 25);
+        assert_eq!(progress.download_speed_bps, 2 * 1024 * 1024);
+        assert_eq!(progress.upload_speed_bps, 512 * 1024);
+        assert_eq!(progress.peers_connected, 7);
+        assert_eq!(progress.seeders, 0);
+        // 75 remaining bytes at 2 MiB/s floors to 0 seconds.
+        assert_eq!(progress.eta_seconds, Some(0));
+    }
+
+    #[test]
+    fn from_stats_eta_absent_when_finished_or_idle() {
+        let mut s = stats(TorrentStatsState::Live, true);
+        s.progress_bytes = 100;
+        s.total_bytes = 100;
+        s.live = Some(LiveStats::default());
+        let progress = DownloadProgress::from_stats(DownloadId::new(), &s);
+        assert_eq!(progress.state, DownloadState::Seeding);
+        assert_eq!(progress.percent_complete, 100);
+        assert_eq!(progress.eta_seconds, None);
+
+        let mut idle = stats(TorrentStatsState::Live, false);
+        idle.total_bytes = 100;
+        idle.live = Some(LiveStats::default());
+        let progress = DownloadProgress::from_stats(DownloadId::new(), &idle);
+        assert_eq!(
+            progress.eta_seconds, None,
+            "zero speed must not fabricate an ETA"
+        );
     }
 }

--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -71,6 +71,27 @@ pub struct TorrentSession {
     event_tx: EventSender,
 }
 
+/// Mirrors librqbit's `get_default_subfolder_for_torrent` name resolution
+/// (librqbit-8.1.1 session.rs:988-1030) tier for tier: the info-dict name if
+/// non-empty, else the magnet display name if non-empty, else the largest
+/// file's stem. `None` only when all three are unavailable.
+///
+/// NOTE: librqbit additionally path-validates tiers 1-2 at add time — a live
+/// torrent's name already passed that check, so only emptiness is re-guarded
+/// here (upstream guards `!s.is_empty()` but `TorrentMetadata::new` does not,
+/// so an empty info name IS observable through metadata).
+fn resolve_multi_file_subfolder(
+    meta_name: Option<&str>,
+    handle_name: Option<&str>,
+    largest_stem: Option<&std::ffi::OsStr>,
+) -> Option<PathBuf> {
+    meta_name
+        .filter(|n| !n.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| handle_name.filter(|n| !n.is_empty()).map(PathBuf::from))
+        .or_else(|| largest_stem.filter(|s| !s.is_empty()).map(PathBuf::from))
+}
+
 impl TorrentSession {
     // WHY: returns Arc<Self> — every successful add (and every restored
     // torrent) spawns a lifecycle watcher that holds the session, so
@@ -343,16 +364,22 @@ impl TorrentSession {
     /// output_folder join) — the resolved folder is pub(crate) upstream, so
     /// it cannot be read back. `download_dir` is restart-class config
     /// (`publish()` holds changes back), so the recomputation cannot drift
-    /// within a process lifetime.
+    /// within a process lifetime. Name resolution mirrors librqbit's three
+    /// tiers via `resolve_multi_file_subfolder`.
     pub fn content_path(&self, download_id: DownloadId) -> Result<PathBuf, ErgasiaError> {
         let handle = self.get_torrent(download_id)?;
         let download_dir = self.config.get().download_dir.clone();
-        let (file_count, meta_name, first_file) = handle
+        let (file_count, meta_name, first_file, largest_stem) = handle
             .with_metadata(|m| {
                 (
                     m.file_infos.len(),
                     m.name.clone(),
                     m.file_infos.first().map(|f| f.relative_filename.clone()),
+                    m.file_infos
+                        .iter()
+                        .max_by_key(|f| f.len)
+                        .and_then(|f| f.relative_filename.file_stem())
+                        .map(|s| s.to_os_string()),
                 )
             })
             .map_err(|e| {
@@ -366,15 +393,23 @@ impl TorrentSession {
             })?;
 
         if file_count >= 2 {
-            match meta_name.or_else(|| handle.name()) {
-                Some(name) => Ok(download_dir.join(name)),
-                None => {
-                    tracing::warn!(
-                        %download_id,
-                        "multi-file torrent carries no name; falling back to the download dir"
-                    );
-                    Ok(download_dir)
+            match resolve_multi_file_subfolder(
+                meta_name.as_deref(),
+                handle.name().as_deref(),
+                largest_stem.as_deref(),
+            ) {
+                Some(subfolder) => Ok(download_dir.join(subfolder)),
+                // WHY: an unresolvable name must be an ERROR, never the bare
+                // download_dir — that is the session-wide shared root, and
+                // handing it to the completion pipeline would extract and
+                // import every sibling download's files as this release.
+                None => Err(ContentPathSnafu {
+                    download_id,
+                    reason: "multi-file torrent has no resolvable name \
+                             (no info name, magnet name, or file stem)"
+                        .to_string(),
                 }
+                .build()),
             }
         } else {
             first_file
@@ -451,6 +486,12 @@ impl TorrentSession {
                         }
                     }
                 }
+                // WHY: self-cleanup on every exit path — a download_id that
+                // is never deleted (e.g. the pre-restart id of a row that
+                // recovery re-queued under a fresh id) would otherwise leak
+                // its seed_tracker entry forever. Removing an already-removed
+                // key (the delete_torrent path) is a no-op.
+                session.seed_tracker.remove(&download_id);
             }
             .instrument(tracing::info_span!("torrent_lifecycle", %download_id)),
         );
@@ -1087,7 +1128,54 @@ mod tests {
             config.download_dir.join("payload.bin"),
             "single-file content path must be the file itself"
         );
+
+        // The watcher removes its own seed_tracker entry on exit — a
+        // download_id that is never explicitly deleted must not leak one.
+        let mut cleaned = false;
+        for _ in 0..100 {
+            if !session.seed_tracker.contains_key(&download_id) {
+                cleaned = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            cleaned,
+            "the lifecycle watcher must self-remove its seed_tracker entry"
+        );
         session.session.stop().await;
+    }
+
+    #[test]
+    fn multi_file_subfolder_resolution_mirrors_librqbit_tiers() {
+        use std::ffi::OsStr;
+        let stem = Some(OsStr::new("largest-file"));
+        // Tier 1: non-empty info name wins.
+        assert_eq!(
+            resolve_multi_file_subfolder(Some("info-name"), Some("magnet-name"), stem),
+            Some(PathBuf::from("info-name"))
+        );
+        // Empty info name falls through to the handle (magnet) name.
+        assert_eq!(
+            resolve_multi_file_subfolder(Some(""), Some("magnet-name"), stem),
+            Some(PathBuf::from("magnet-name"))
+        );
+        // Absent/empty names fall through to the largest file's stem.
+        assert_eq!(
+            resolve_multi_file_subfolder(None, None, stem),
+            Some(PathBuf::from("largest-file"))
+        );
+        assert_eq!(
+            resolve_multi_file_subfolder(Some(""), Some(""), stem),
+            Some(PathBuf::from("largest-file"))
+        );
+        // Nothing resolvable: None — the caller must error, never hand back
+        // the shared download_dir root.
+        assert_eq!(resolve_multi_file_subfolder(None, None, None), None);
+        assert_eq!(
+            resolve_multi_file_subfolder(Some(""), None, Some(OsStr::new(""))),
+            None
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/ergasia/src/session.rs
+++ b/crates/ergasia/src/session.rs
@@ -14,13 +14,15 @@ use librqbit::{
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use themelion::ids::DownloadId;
+use themelion::{EventSender, HarmoniaEvent};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, instrument};
 
 use crate::error::{
-    AddTorrentSnafu, DeleteActionSnafu, ErgasiaError, MagnetResolveTimeoutSnafu, PauseActionSnafu,
-    SessionInitSnafu, TorrentMapPersistenceSnafu, TorrentNotFoundSnafu,
+    AddTorrentSnafu, ContentPathSnafu, DeleteActionSnafu, ErgasiaError, MagnetResolveTimeoutSnafu,
+    PauseActionSnafu, SessionInitSnafu, TorrentMapPersistenceSnafu, TorrentNotFoundSnafu,
 };
+use crate::progress::DownloadProgress;
 use crate::seeding::SeedingPolicy;
 
 const TORRENT_MAP_FILE: &str = "harmonia-torrent-map.json";
@@ -63,11 +65,21 @@ pub struct TorrentSession {
     // restart-class: `publish()` holds those back in the effective config, so
     // the construction-time snapshot never drifts from what the Section serves.
     config: Section<ErgasiaConfig>,
+    // WHY: completion is push-based — a lifecycle watcher per download emits
+    // DownloadCompleted/DownloadFailed on this bus so syntaxis settles the
+    // queue row and runs the import pipeline in production (#602).
+    event_tx: EventSender,
 }
 
 impl TorrentSession {
+    // WHY: returns Arc<Self> — every successful add (and every restored
+    // torrent) spawns a lifecycle watcher that holds the session, so
+    // construction must already own the Arc the watchers clone.
     #[instrument(skip_all, name = "ergasia_session_init")]
-    pub async fn new(config_section: Section<ErgasiaConfig>) -> Result<Self, ErgasiaError> {
+    pub async fn new(
+        config_section: Section<ErgasiaConfig>,
+        event_tx: EventSender,
+    ) -> Result<Arc<Self>, ErgasiaError> {
         let config = config_section.get();
         let peer_opts = librqbit::PeerConnectionOptions {
             connect_timeout: Some(Duration::from_secs(config.peer_connect_timeout_seconds)),
@@ -124,7 +136,7 @@ impl TorrentSession {
             time_threshold: Duration::from_secs(config.seed_time_threshold_hours * 3600),
         };
 
-        let torrent_session = Self {
+        let torrent_session = Arc::new(Self {
             session,
             policy,
             seed_tracker: Arc::new(DashMap::new()),
@@ -133,7 +145,8 @@ impl TorrentSession {
             map_path: PathBuf::from(&config.session_state_path).join(TORRENT_MAP_FILE),
             persist_lock: tokio::sync::Mutex::new(()),
             config: config_section,
-        };
+            event_tx,
+        });
 
         // INVARIANT: the session is not handed out until torrent_map reflects
         // every torrent librqbit restored from persisted state.
@@ -144,7 +157,7 @@ impl TorrentSession {
 
     #[instrument(skip(self, magnet_uri), fields(download_id = %download_id))]
     pub async fn add_torrent_from_magnet(
-        &self,
+        self: &Arc<Self>,
         download_id: DownloadId,
         magnet_uri: &str,
     ) -> Result<(usize, Arc<ManagedTorrent>), ErgasiaError> {
@@ -154,7 +167,7 @@ impl TorrentSession {
 
     #[instrument(skip(self, torrent_bytes), fields(download_id = %download_id))]
     pub async fn add_torrent_from_bytes(
-        &self,
+        self: &Arc<Self>,
         download_id: DownloadId,
         torrent_bytes: bytes::Bytes,
     ) -> Result<(usize, Arc<ManagedTorrent>), ErgasiaError> {
@@ -163,13 +176,18 @@ impl TorrentSession {
     }
 
     async fn add_torrent_inner(
-        &self,
+        self: &Arc<Self>,
         download_id: DownloadId,
         source: AddTorrent<'static>,
         output_folder: Option<String>,
     ) -> Result<(usize, Arc<ManagedTorrent>), ErgasiaError> {
         let opts = Some(AddTorrentOptions {
             output_folder,
+            // WHY: librqbit's own session restore sets overwrite
+            // (session_persistence/mod.rs `into_add_torrent`) — existing data
+            // is hash-checked, never blindly trusted, so this enables
+            // retry-over-kept-files and completion via hash check alone.
+            overwrite: true,
             ..Default::default()
         });
 
@@ -280,6 +298,7 @@ impl TorrentSession {
                     self.release_torrent_ref(id);
                     return Err(persist_err);
                 }
+                self.spawn_lifecycle_watcher(download_id, Arc::clone(&handle), true);
                 Ok((id, handle))
             }
             AddTorrentResponse::ListOnly(_) => Err(AddTorrentSnafu {
@@ -310,6 +329,142 @@ impl TorrentSession {
         Ok(handle.stats())
     }
 
+    /// Reports honest, engine-derived progress for a download.
+    pub fn progress(&self, download_id: DownloadId) -> Result<DownloadProgress, ErgasiaError> {
+        let stats = self.get_stats(download_id)?;
+        Ok(DownloadProgress::from_stats(download_id, &stats))
+    }
+
+    /// Resolves the on-disk content path: the containing directory for a
+    /// multi-file download, the file itself for a single-file one.
+    ///
+    /// WHY: this recomputes what librqbit resolved at add time (session.rs
+    /// `get_default_subfolder_for_torrent` + `add_torrent_internal`'s
+    /// output_folder join) — the resolved folder is pub(crate) upstream, so
+    /// it cannot be read back. `download_dir` is restart-class config
+    /// (`publish()` holds changes back), so the recomputation cannot drift
+    /// within a process lifetime.
+    pub fn content_path(&self, download_id: DownloadId) -> Result<PathBuf, ErgasiaError> {
+        let handle = self.get_torrent(download_id)?;
+        let download_dir = self.config.get().download_dir.clone();
+        let (file_count, meta_name, first_file) = handle
+            .with_metadata(|m| {
+                (
+                    m.file_infos.len(),
+                    m.name.clone(),
+                    m.file_infos.first().map(|f| f.relative_filename.clone()),
+                )
+            })
+            .map_err(|e| {
+                // WHY: metadata is None only while a magnet resolves — the
+                // caller (reconcile / lifecycle watcher) retries later.
+                ContentPathSnafu {
+                    download_id,
+                    reason: e.to_string(),
+                }
+                .build()
+            })?;
+
+        if file_count >= 2 {
+            match meta_name.or_else(|| handle.name()) {
+                Some(name) => Ok(download_dir.join(name)),
+                None => {
+                    tracing::warn!(
+                        %download_id,
+                        "multi-file torrent carries no name; falling back to the download dir"
+                    );
+                    Ok(download_dir)
+                }
+            }
+        } else {
+            first_file
+                .map(|relative| download_dir.join(relative))
+                .ok_or_else(|| {
+                    ContentPathSnafu {
+                        download_id,
+                        reason: "torrent metadata lists no files".to_string(),
+                    }
+                    .build()
+                })
+        }
+    }
+
+    /// Spawns the per-download lifecycle watcher that turns librqbit's
+    /// completion signal into a bus event.
+    ///
+    /// `announce_completion` is false for torrents restored from persisted
+    /// state: they exist for seed continuity (PR-2 of #602), while completion
+    /// for re-queued rows flows through their new download_ids — announcing
+    /// here would replay stale completions on every restart.
+    fn spawn_lifecycle_watcher(
+        self: &Arc<Self>,
+        download_id: DownloadId,
+        handle: Arc<ManagedTorrent>,
+        announce_completion: bool,
+    ) {
+        // WHY: wait_until_completed never resolves for a paused torrent
+        // (librqbit torrent_state/mod.rs loops while Paused) — a watcher
+        // would pin the session Arc forever. Only restored torrents can be
+        // paused (librqbit persists is_paused); PR-2's seed monitor owns
+        // those.
+        if handle.is_paused() {
+            return;
+        }
+
+        let cancel = CancellationToken::new();
+        self.seed_tracker.insert(
+            download_id,
+            SeedHandle {
+                cancel: cancel.clone(),
+            },
+        );
+        let session = Arc::clone(self);
+        tokio::spawn(
+            async move {
+                tokio::select! {
+                    _ = cancel.cancelled() => {}
+                    result = handle.wait_until_completed() => {
+                        match result {
+                            Ok(()) if announce_completion => {
+                                match session.content_path(download_id) {
+                                    Ok(path) => session.emit(HarmoniaEvent::DownloadCompleted {
+                                        download_id,
+                                        path,
+                                    }),
+                                    // WHY: warn and stand down — the syntaxis
+                                    // reconcile pass observes the terminal
+                                    // state and retries the path resolution.
+                                    Err(e) => tracing::warn!(
+                                        %download_id,
+                                        error = %e,
+                                        "download finished but its content path did not resolve"
+                                    ),
+                                }
+                            }
+                            Err(e) if announce_completion => {
+                                session.emit(HarmoniaEvent::DownloadFailed {
+                                    download_id,
+                                    reason: e.to_string(),
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            .instrument(tracing::info_span!("torrent_lifecycle", %download_id)),
+        );
+    }
+
+    fn emit(&self, event: HarmoniaEvent) {
+        // WHY: a send error only means no live receivers (broadcast
+        // semantics) — nothing to recover, but worth a trace for tests and
+        // shutdown windows.
+        if self.event_tx.send(event).is_err() {
+            tracing::debug!("event bus has no receivers; lifecycle event dropped");
+        }
+    }
+
     pub async fn pause_torrent(&self, download_id: DownloadId) -> Result<(), ErgasiaError> {
         let handle = self.get_torrent(download_id)?;
         self.session.pause(&handle).await.map_err(|e| {
@@ -330,6 +485,15 @@ impl TorrentSession {
             .torrent_map
             .remove(&download_id)
             .ok_or_else(|| TorrentNotFoundSnafu { download_id }.build())?;
+
+        // WHY: the lifecycle watcher must not announce completion for a
+        // download being deleted; cancel it under the claim that won the map
+        // entry. NOTE: a failed librqbit delete below restores the mapping
+        // but not the watcher — the syntaxis reconcile pass still observes
+        // terminal states for the restored entry.
+        if let Some((_, seed_handle)) = self.seed_tracker.remove(&download_id) {
+            seed_handle.cancel.cancel();
+        }
 
         // WHY: librqbit dedups a duplicate info-hash onto one torrent_id shared
         // by two DownloadIds (AlreadyManaged) — only the last DownloadId still
@@ -388,19 +552,16 @@ impl TorrentSession {
         }
     }
 
-    async fn reconcile_persisted_torrents(&self) -> Result<(), ErgasiaError> {
+    async fn reconcile_persisted_torrents(self: &Arc<Self>) -> Result<(), ErgasiaError> {
         let persisted = self.load_torrent_map().await?;
 
         let mut restored = 0usize;
         let mut dropped = 0usize;
         for entry in persisted {
-            if self
-                .session
-                .get(TorrentIdOrHash::Id(entry.torrent_id))
-                .is_some()
-            {
+            if let Some(handle) = self.session.get(TorrentIdOrHash::Id(entry.torrent_id)) {
                 self.torrent_map.insert(entry.download_id, entry.torrent_id);
                 self.acquire_torrent_ref(entry.torrent_id);
+                self.spawn_lifecycle_watcher(entry.download_id, handle, false);
                 restored += 1;
             } else {
                 tracing::warn!(
@@ -530,6 +691,10 @@ mod tests {
         }
     }
 
+    fn test_event_tx() -> EventSender {
+        themelion::create_event_bus(64).0
+    }
+
     fn minimal_torrent_bytes(name: &str) -> bytes::Bytes {
         let mut buf = Vec::new();
         buf.extend_from_slice(b"d4:infod6:lengthi11e4:name");
@@ -569,7 +734,7 @@ mod tests {
         let download_id = DownloadId::new();
 
         {
-            let session = TorrentSession::new(Section::fixed(config.clone()))
+            let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
                 .await
                 .unwrap();
             session
@@ -581,7 +746,7 @@ mod tests {
             session.session.stop().await;
         }
 
-        let session = TorrentSession::new(Section::fixed(config.clone()))
+        let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
             .await
             .unwrap();
         assert!(
@@ -608,7 +773,7 @@ mod tests {
         };
         std::fs::write(&map_path, serde_json::to_vec(&stale).unwrap()).unwrap();
 
-        let session = TorrentSession::new(Section::fixed(config.clone()))
+        let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
             .await
             .unwrap();
         assert!(
@@ -633,7 +798,7 @@ mod tests {
         let _guard = SESSION_TEST_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let config = test_config(dir.path(), 24401);
-        let session = TorrentSession::new(Section::fixed(config.clone()))
+        let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
             .await
             .unwrap();
         let unknown = DownloadId::new();
@@ -660,7 +825,7 @@ mod tests {
         let config = test_config(dir.path(), 24501);
         let download_id = DownloadId::new();
 
-        let session = TorrentSession::new(Section::fixed(config.clone()))
+        let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
             .await
             .unwrap();
         session
@@ -692,7 +857,7 @@ mod tests {
         let download_b = DownloadId::new();
         let torrent_bytes = minimal_torrent_bytes("shared.bin");
 
-        let session = TorrentSession::new(Section::fixed(config.clone()))
+        let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
             .await
             .unwrap();
         let (id_a, _) = session
@@ -744,7 +909,7 @@ mod tests {
         let config = test_config(dir.path(), 24601);
         let download_id = DownloadId::new();
 
-        let session = TorrentSession::new(Section::fixed(config.clone()))
+        let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
             .await
             .unwrap();
         // WHY: a mapping to a torrent id librqbit does not manage forces the
@@ -769,7 +934,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path(), 24701);
         config.magnet_resolve_timeout_seconds = 1;
-        let session = TorrentSession::new(Section::fixed(config.clone()))
+        let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
             .await
             .unwrap();
         let download_id = DownloadId::new();
@@ -811,7 +976,7 @@ mod tests {
         // WHY: zero instantly elapses any bounded await — a local torrent-file
         // add must still succeed because the deadline is magnet-only.
         config.magnet_resolve_timeout_seconds = 0;
-        let session = TorrentSession::new(Section::fixed(config.clone()))
+        let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
             .await
             .unwrap();
         let download_id = DownloadId::new();
@@ -834,13 +999,205 @@ mod tests {
         let map_path = config.session_state_path.join(TORRENT_MAP_FILE);
         std::fs::write(&map_path, b"{ not json").unwrap();
 
-        let session = TorrentSession::new(Section::fixed(config.clone()))
+        let session = TorrentSession::new(Section::fixed(config.clone()), test_event_tx())
             .await
             .expect("corrupt side-table must not brick startup");
         assert!(
             map_path.with_extension("json.corrupt").exists(),
             "corrupt map must be quarantined for forensics"
         );
+        session.session.stop().await;
+    }
+
+    // ── #602: lifecycle watcher announces honest terminal states ───────────
+
+    /// Writes `payload` into the download dir and returns torrent bytes whose
+    /// hash check will pass against it — a deterministic completed download
+    /// with zero peers.
+    async fn single_file_fixture(download_dir: &Path, name: &str, payload: &[u8]) -> bytes::Bytes {
+        std::fs::create_dir_all(download_dir).unwrap();
+        let file_path = download_dir.join(name);
+        std::fs::write(&file_path, payload).unwrap();
+        let created =
+            librqbit::create_torrent(&file_path, librqbit::CreateTorrentOptions::default())
+                .await
+                .unwrap();
+        created.as_bytes().unwrap()
+    }
+
+    /// Two-file directory fixture; librqbit derives the multi-file subfolder
+    /// from the torrent name (the directory basename).
+    async fn multi_file_fixture(download_dir: &Path, dir_name: &str) -> bytes::Bytes {
+        let content_dir = download_dir.join(dir_name);
+        std::fs::create_dir_all(&content_dir).unwrap();
+        std::fs::write(content_dir.join("a.bin"), b"first payload").unwrap();
+        std::fs::write(content_dir.join("b.bin"), b"second payload").unwrap();
+        let created =
+            librqbit::create_torrent(&content_dir, librqbit::CreateTorrentOptions::default())
+                .await
+                .unwrap();
+        created.as_bytes().unwrap()
+    }
+
+    async fn recv_completion(
+        rx: &mut themelion::EventReceiver,
+        download_id: DownloadId,
+    ) -> PathBuf {
+        tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                match rx.recv().await {
+                    Ok(HarmoniaEvent::DownloadCompleted {
+                        download_id: id,
+                        path,
+                    }) if id == download_id => return path,
+                    Ok(_) => continue,
+                    Err(e) => panic!("event bus closed before completion arrived: {e}"),
+                }
+            }
+        })
+        .await
+        .expect("DownloadCompleted must arrive for a hash-complete torrent")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn completed_fixture_announces_completion_with_single_file_path() {
+        let _guard = SESSION_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path(), 24801);
+        let torrent_bytes = single_file_fixture(
+            &config.download_dir,
+            "payload.bin",
+            b"deterministic fixture payload",
+        )
+        .await;
+
+        let (event_tx, mut event_rx) = themelion::create_event_bus(64);
+        let session = TorrentSession::new(Section::fixed(config.clone()), event_tx)
+            .await
+            .unwrap();
+        let download_id = DownloadId::new();
+        session
+            .add_torrent_from_bytes(download_id, torrent_bytes)
+            .await
+            .unwrap();
+
+        let path = recv_completion(&mut event_rx, download_id).await;
+        assert_eq!(
+            path,
+            config.download_dir.join("payload.bin"),
+            "single-file content path must be the file itself"
+        );
+        session.session.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn multi_file_completion_path_is_download_dir_joined_with_name() {
+        let _guard = SESSION_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path(), 24901);
+        let torrent_bytes = multi_file_fixture(&config.download_dir, "album").await;
+
+        let (event_tx, mut event_rx) = themelion::create_event_bus(64);
+        let session = TorrentSession::new(Section::fixed(config.clone()), event_tx)
+            .await
+            .unwrap();
+        let download_id = DownloadId::new();
+        session
+            .add_torrent_from_bytes(download_id, torrent_bytes)
+            .await
+            .unwrap();
+
+        let path = recv_completion(&mut event_rx, download_id).await;
+        assert_eq!(
+            path,
+            config.download_dir.join("album"),
+            "multi-file content path must be the torrent-name directory"
+        );
+        assert_eq!(
+            session.content_path(download_id).unwrap(),
+            config.download_dir.join("album"),
+            "content_path must agree with the announced path"
+        );
+        session.session.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn restored_watcher_does_not_reannounce_completion() {
+        let _guard = SESSION_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path(), 25001);
+        let torrent_bytes =
+            single_file_fixture(&config.download_dir, "restart.bin", b"restart payload").await;
+        let download_id = DownloadId::new();
+
+        {
+            let (event_tx, mut event_rx) = themelion::create_event_bus(64);
+            let session = TorrentSession::new(Section::fixed(config.clone()), event_tx)
+                .await
+                .unwrap();
+            session
+                .add_torrent_from_bytes(download_id, torrent_bytes)
+                .await
+                .unwrap();
+            recv_completion(&mut event_rx, download_id).await;
+            wait_for_session_state(&config.session_state_path).await;
+            session.session.stop().await;
+        }
+
+        let (event_tx, mut event_rx) = themelion::create_event_bus(64);
+        let session = TorrentSession::new(Section::fixed(config.clone()), event_tx)
+            .await
+            .unwrap();
+        assert!(
+            session.get_stats(download_id).is_ok(),
+            "precondition: the download must be restored"
+        );
+        // WHY: restored watchers run with announce_completion = false; a
+        // bounded quiet window proves no stale completion replays on restart.
+        let replay = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                match event_rx.recv().await {
+                    Ok(HarmoniaEvent::DownloadCompleted { .. }) => return,
+                    Ok(_) => continue,
+                    Err(_) => std::future::pending::<()>().await,
+                }
+            }
+        })
+        .await;
+        assert!(
+            replay.is_err(),
+            "a restored finished torrent must not re-announce DownloadCompleted"
+        );
+        session.session.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn progress_reports_seeding_for_completed_fixture() {
+        let _guard = SESSION_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path(), 25101);
+        let torrent_bytes =
+            single_file_fixture(&config.download_dir, "seeded.bin", b"seeded payload").await;
+
+        let (event_tx, mut event_rx) = themelion::create_event_bus(64);
+        let session = TorrentSession::new(Section::fixed(config.clone()), event_tx)
+            .await
+            .unwrap();
+        let download_id = DownloadId::new();
+        session
+            .add_torrent_from_bytes(download_id, torrent_bytes)
+            .await
+            .unwrap();
+        recv_completion(&mut event_rx, download_id).await;
+
+        let progress = session.progress(download_id).unwrap();
+        assert_eq!(
+            progress.state,
+            crate::state::DownloadState::Seeding,
+            "a finished live torrent must report Seeding, never Downloading"
+        );
+        assert_eq!(progress.percent_complete, 100);
+        assert!(progress.error.is_none());
         session.session.stop().await;
     }
 }

--- a/crates/ergasia/src/state.rs
+++ b/crates/ergasia/src/state.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+use librqbit::{TorrentStats, TorrentStatsState};
 use serde::{Deserialize, Serialize};
 use snafu::ensure;
 use themelion::ids::{DownloadId, WantId};
@@ -14,11 +15,35 @@ pub enum DownloadState {
     Queued,
     Initializing,
     Downloading,
+    Paused,
     Completed,
     Seeding,
     SeedPolicySatisfied,
     Failed,
     Deleted,
+}
+
+/// Maps a librqbit stats snapshot onto the honest harmonia download state.
+///
+/// WHY: librqbit reports a coarse engine state (`initializing`/`live`/
+/// `paused`/`error`) plus a `finished` flag; harmonia's lifecycle needs the
+/// cross product spelled out so completion, seeding, and failure each surface
+/// as themselves instead of a hardcoded `Downloading` (#602).
+pub fn map_torrent_stats(stats: &TorrentStats) -> DownloadState {
+    match (stats.state, stats.finished) {
+        // WHY: librqbit folds its internal `None` state into `Error` with a
+        // diagnostic message (torrent_state/mod.rs `stats()`), so this arm
+        // covers both.
+        (TorrentStatsState::Error, _) => DownloadState::Failed,
+        (TorrentStatsState::Initializing, _) => DownloadState::Initializing,
+        (TorrentStatsState::Live, false) => DownloadState::Downloading,
+        (TorrentStatsState::Live, true) => DownloadState::Seeding,
+        // NOTE: the only production pauser is the seed monitor (PR-2 of
+        // #602); librqbit persists `is_paused`, so a restored paused+finished
+        // torrent still reads as seed-policy-satisfied after a restart.
+        (TorrentStatsState::Paused, true) => DownloadState::SeedPolicySatisfied,
+        (TorrentStatsState::Paused, false) => DownloadState::Paused,
+    }
 }
 
 impl DownloadState {
@@ -47,6 +72,7 @@ impl std::fmt::Display for DownloadState {
             Self::Queued => "queued",
             Self::Initializing => "initializing",
             Self::Downloading => "downloading",
+            Self::Paused => "paused",
             Self::Completed => "completed",
             Self::Seeding => "seeding",
             Self::SeedPolicySatisfied => "seed_policy_satisfied",
@@ -153,9 +179,53 @@ mod tests {
     fn display_state() {
         assert_eq!(DownloadState::Queued.to_string(), "queued");
         assert_eq!(DownloadState::Downloading.to_string(), "downloading");
+        assert_eq!(DownloadState::Paused.to_string(), "paused");
         assert_eq!(
             DownloadState::SeedPolicySatisfied.to_string(),
             "seed_policy_satisfied"
         );
+    }
+
+    fn stats(state: TorrentStatsState, finished: bool, error: Option<&str>) -> TorrentStats {
+        TorrentStats {
+            state,
+            file_progress: Vec::new(),
+            error: error.map(str::to_owned),
+            progress_bytes: 0,
+            uploaded_bytes: 0,
+            total_bytes: 0,
+            finished,
+            live: None,
+        }
+    }
+
+    #[test]
+    fn map_torrent_stats_covers_every_engine_state() {
+        use TorrentStatsState as S;
+        let cases = [
+            (S::Error, false, None, DownloadState::Failed),
+            (S::Error, true, None, DownloadState::Failed),
+            // WHY: librqbit's internal None state surfaces as Error + message.
+            (
+                S::Error,
+                false,
+                Some("bug: torrent in broken \"None\" state"),
+                DownloadState::Failed,
+            ),
+            (S::Initializing, false, None, DownloadState::Initializing),
+            (S::Initializing, true, None, DownloadState::Initializing),
+            (S::Live, false, None, DownloadState::Downloading),
+            (S::Live, true, None, DownloadState::Seeding),
+            (S::Paused, true, None, DownloadState::SeedPolicySatisfied),
+            (S::Paused, false, None, DownloadState::Paused),
+        ];
+
+        for (state, finished, error, expected) in cases {
+            let mapped = map_torrent_stats(&stats(state, finished, error));
+            assert_eq!(
+                mapped, expected,
+                "({state:?}, finished={finished}) must map to {expected:?}"
+            );
+        }
     }
 }

--- a/crates/syntaxis/src/error.rs
+++ b/crates/syntaxis/src/error.rs
@@ -28,6 +28,15 @@ pub enum SyntaxisError {
         location: snafu::Location,
     },
 
+    #[snafu(display(
+        "queue item {id} already finished downloading; post-processing is in flight and cannot be cancelled"
+    ))]
+    CancelTooLate {
+        id: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("post-processing pipeline aborted: {reason}"))]
     PipelineAborted {
         reason: String,

--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -13,7 +13,7 @@ pub(crate) mod recovery;
 pub(crate) mod repo;
 pub(crate) mod retry;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use ergasia::{DownloadEngine, DownloadState, ErgasiaError};
@@ -154,6 +154,11 @@ struct Inner {
     /// sleep an item is in neither `queue` nor `active`; this map makes the
     /// window visible so a cancel can abort the sleeping task.
     retry_pending: HashMap<uuid::Uuid, tokio::task::AbortHandle>,
+    /// Queue rows whose post-processing pipeline is in flight. A row in this
+    /// set is past the point of no return — its content is being extracted
+    /// and imported by a detached task — so a cancel must fail loudly rather
+    /// than delete the row while the import proceeds anyway.
+    completing: HashSet<uuid::Uuid>,
     config: SyntaxisConfig,
 }
 
@@ -189,6 +194,7 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
             allocator,
             active: HashMap::new(),
             retry_pending: HashMap::new(),
+            completing: HashSet::new(),
             config,
         }));
 
@@ -337,6 +343,17 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
 
         let removed_in_memory = {
             let mut inner = self.inner.lock().await;
+            // WHY: a row whose pipeline is in flight is past cancellation —
+            // deleting it here would report success while the detached task
+            // imports the content anyway (and its status writes no-op against
+            // the deleted row). Checked under the same lock the completion
+            // claim inserts the marker in, so no window exists between them.
+            if inner.completing.contains(&queue_id) {
+                return Err(SyntaxisError::CancelTooLate {
+                    id: queue_id.to_string(),
+                    location: snafu::location!(),
+                });
+            }
             let removed_from_queue = inner.queue.remove(queue_id).is_some();
             // WHY: a retry sleeping out its backoff holds the item in neither
             // `queue` nor `active`; aborting it here prevents the task from
@@ -673,6 +690,11 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
             let key = download_id.to_string();
             if let Some(entry) = inner.active.remove(&key) {
                 inner.allocator.release(entry.protocol, entry.tracker_id);
+                // INVARIANT: the completing-marker insert shares the claim's
+                // critical section — a concurrent cancel observes either the
+                // active entry or the marker, never neither, so it can never
+                // delete the row out from under the pipeline task.
+                inner.completing.insert(entry.queue_id);
                 Some(entry)
             } else {
                 // WHY: debug, not warn — the completion event and the
@@ -692,6 +714,8 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
             let pool = self.pool.clone();
             let engine = Arc::clone(&self.engine);
             let import_svc = Arc::clone(&self.import_svc);
+            let inner = Arc::clone(&self.inner);
+            let queue_id = entry.queue_id;
             let span = tracing::Span::current();
 
             tokio::spawn(
@@ -714,6 +738,7 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
                     {
                         error!(error = %e, "post-processing pipeline failed");
                     }
+                    inner.lock().await.completing.remove(&queue_id);
                 }
                 .instrument(span),
             );
@@ -2227,6 +2252,83 @@ mod tests {
             engine.cancelled_ids().is_empty(),
             "completion must never cancel the engine download"
         );
+    }
+
+    #[tokio::test]
+    async fn cancel_during_post_processing_is_too_late_and_keeps_the_row() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 0, 0)).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (dl_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // The cancel race window, reproduced deterministically: completion
+        // has claimed the active entry and set the completing marker, and the
+        // detached pipeline has not yet finished.
+        {
+            let mut inner = svc.inner.lock().await;
+            let entry = inner.active.remove(&dl_id.to_string()).unwrap();
+            inner.allocator.release(entry.protocol, entry.tracker_id);
+            inner.completing.insert(queue_id);
+        }
+
+        let err = svc.cancel_by_queue_id(queue_id).await.unwrap_err();
+        assert!(
+            matches!(err, SyntaxisError::CancelTooLate { .. }),
+            "expected CancelTooLate, got {err:?}"
+        );
+        let (status, _, _) = row_state(&pool, queue_id).await;
+        assert_eq!(
+            status, "downloading",
+            "a too-late cancel must leave the row to the pipeline"
+        );
+    }
+
+    #[tokio::test]
+    async fn completing_marker_set_by_claim_and_cleared_by_pipeline() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let import = CountingImportService::create();
+        let svc = make_service_with_import(
+            pool.clone(),
+            Arc::clone(&engine),
+            test_config(2, 0, 0),
+            Arc::clone(&import) as Arc<dyn ImportService>,
+        )
+        .await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (dl_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        engine.set_content_path("/data/downloads/album");
+        engine.set_progress_state(DownloadState::Seeding);
+        svc.reconcile_active().await;
+
+        settle_until(|| import.import_count() == 1).await;
+        let mut cleared = false;
+        for _ in 0..200 {
+            if !svc.inner.lock().await.completing.contains(&queue_id) {
+                cleared = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            cleared,
+            "the pipeline must clear the completing marker when it finishes"
+        );
+        let _ = dl_id;
     }
 
     #[tokio::test]

--- a/crates/syntaxis/src/lib.rs
+++ b/crates/syntaxis/src/lib.rs
@@ -16,7 +16,7 @@ pub(crate) mod retry;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use ergasia::{DownloadEngine, DownloadState};
+use ergasia::{DownloadEngine, DownloadState, ErgasiaError};
 pub use error::SyntaxisError;
 use horismos::SyntaxisConfig;
 pub use pipeline::ImportService;
@@ -25,7 +25,7 @@ use themelion::ids::DownloadId;
 use themelion::{EventReceiver, HarmoniaEvent};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, error, info, instrument, warn};
+use tracing::{Instrument, debug, error, info, instrument, warn};
 pub use types::{CompletedDownload, DownloadProtocol, QueueItem, QueuePosition, QueueSnapshot};
 
 use crate::dispatch::SlotAllocator;
@@ -38,6 +38,15 @@ use crate::retry::{FailureKind, backoff_seconds, classify_failure};
 /// WHY: broadcast `Lagged` detection alone can miss a terminal event that
 /// races the lag window; a periodic pass bounds any slot leak to one interval.
 const RECONCILE_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(60);
+
+/// Consecutive reconcile passes tolerating `TorrentNotFound` for an
+/// engine-acknowledged download before it is failed.
+///
+/// WHY: a single missing pass can race a dispatch still registering with the
+/// engine or a transient map inconsistency; three consecutive passes (with
+/// the counter reset on any successful poll) mean the engine has genuinely
+/// forgotten the download and its slot must be reclaimed.
+const MISSING_PASS_LIMIT: u8 = 3;
 
 /// Public trait surface for queue management.
 pub trait QueueManager: Send + Sync {
@@ -86,6 +95,10 @@ struct ActiveEntry {
     /// When `last_progress_pct` last advanced — the stall clock, judged
     /// against `stalled_download_timeout_hours` on each reconcile pass.
     last_progress_at: tokio::time::Instant,
+    /// Consecutive reconcile passes on which the engine reported
+    /// `TorrentNotFound` for this started download; reset on any successful
+    /// poll, escalated to failure at `MISSING_PASS_LIMIT`.
+    missing_passes: u8,
 }
 
 impl ActiveEntry {
@@ -104,6 +117,7 @@ impl ActiveEntry {
             cancel_requested: false,
             last_progress_pct: 0,
             last_progress_at: tokio::time::Instant::now(),
+            missing_passes: 0,
         }
     }
 }
@@ -494,10 +508,10 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
 
     /// Reconciles in-memory active entries against engine-reported state.
     ///
-    /// Any download the engine reports as terminal while still registered as
-    /// active has lost its completion/failure event; it is routed through the
-    /// failure path so its slot is released and its retry budget decides
-    /// between re-queue and permanent failure.
+    /// A completed/seeding download whose event was lost is completed
+    /// directly (content path re-resolved from the engine); a failed or
+    /// deleted one is routed through the failure path so its slot is released
+    /// and its retry budget decides between re-queue and permanent failure.
     async fn reconcile_active(&self) {
         let snapshot: Vec<DownloadId> = {
             let inner = self.inner.lock().await;
@@ -506,52 +520,61 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
 
         for download_id in snapshot {
             let progress = match self.engine.get_progress(download_id).await {
-                Ok(progress) => progress,
+                Ok(progress) => {
+                    let mut inner = self.inner.lock().await;
+                    if let Some(entry) = inner.active.get_mut(&download_id.to_string()) {
+                        entry.missing_passes = 0;
+                    }
+                    progress
+                }
                 Err(e) => {
-                    // WHY: a get_progress error cannot distinguish a lost
-                    // download from a dispatch still registering with the
-                    // engine; reaping here could kill a healthy in-flight
-                    // dispatch. Keep the entry; a later pass or a real event
-                    // settles it.
-                    warn!(%download_id, error = %e, "reconciliation could not query engine state");
+                    self.note_missing_download(download_id, &e).await;
                     continue;
                 }
             };
             match progress.state {
                 DownloadState::Completed
                 | DownloadState::Seeding
-                | DownloadState::SeedPolicySatisfied
-                | DownloadState::Failed
-                | DownloadState::Deleted => {
-                    warn!(%download_id, state = %progress.state, "terminal engine state with no processed event; reconciling");
-                    // WHY: get_progress carries no completion path, so the
-                    // post-processing pipeline cannot be synthesized here.
-                    // The failure path releases the slot and re-queues within
-                    // the retry budget; an engine-side resume of a finished
-                    // download then re-emits the real completion event.
+                | DownloadState::SeedPolicySatisfied => {
+                    match self.engine.content_path(download_id).await {
+                        Ok(path) => {
+                            warn!(%download_id, state = %progress.state, "terminal engine state with no processed event; completing");
+                            self.on_download_completed(download_id, path).await;
+                        }
+                        Err(e) => {
+                            // WHY: mirrors the get_progress error handling
+                            // above — an unresolvable path (e.g. metadata
+                            // still loading) must not fail a finished
+                            // download; the next pass retries.
+                            warn!(%download_id, error = %e, "reconciliation could not resolve content path");
+                        }
+                    }
+                }
+                DownloadState::Failed => {
+                    let reason = progress
+                        .error
+                        .clone()
+                        .unwrap_or_else(|| "engine reported failure without detail".to_string());
+                    warn!(%download_id, %reason, "failed engine state with no processed event; reconciling");
+                    self.on_download_failed(download_id, reason).await;
+                }
+                DownloadState::Deleted => {
+                    warn!(%download_id, "engine reports download deleted; reconciling");
                     self.on_download_failed(
                         download_id,
-                        format!(
-                            "terminal engine state {} observed during reconciliation; event was dropped",
-                            progress.state
-                        ),
+                        "engine reports download deleted".to_string(),
                     )
                     .await;
                 }
                 DownloadState::Queued
                 | DownloadState::Initializing
-                | DownloadState::Downloading => {
+                | DownloadState::Downloading
+                | DownloadState::Paused => {
                     if let Some(reason) = self
                         .stall_reason(download_id, progress.percent_complete)
                         .await
                     {
                         warn!(%download_id, %reason, "active download stalled; failing");
-                        // WHY: the engine download is still live — cancel it so
-                        // the stuck transfer stops, instead of running headless
-                        // after its slot is reclaimed below.
-                        if let Err(e) = self.engine.cancel_download(download_id).await {
-                            warn!(%download_id, error = %e, "engine cancel failed for stalled download");
-                        }
                         self.on_download_failed(download_id, reason).await;
                     }
                 }
@@ -563,10 +586,48 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
         }
     }
 
+    /// Records a `TorrentNotFound` pass for a started download and fails it
+    /// once `MISSING_PASS_LIMIT` consecutive passes agree the engine no
+    /// longer tracks it.
+    async fn note_missing_download(&self, download_id: DownloadId, error: &ErgasiaError) {
+        // WHY: a single get_progress error cannot distinguish a lost download
+        // from a dispatch still registering with the engine; reaping on one
+        // pass could kill a healthy in-flight dispatch. Only consecutive
+        // TorrentNotFound passes for an engine-acknowledged download qualify.
+        let escalate = if matches!(error, ErgasiaError::TorrentNotFound { .. }) {
+            let mut inner = self.inner.lock().await;
+            match inner.active.get_mut(&download_id.to_string()) {
+                Some(entry) if entry.engine_started => {
+                    entry.missing_passes = entry.missing_passes.saturating_add(1);
+                    entry.missing_passes >= MISSING_PASS_LIMIT
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+
+        if escalate {
+            warn!(%download_id, passes = MISSING_PASS_LIMIT, "engine no longer tracks download; failing");
+            self.on_download_failed(download_id, "engine no longer tracks download".to_string())
+                .await;
+        } else {
+            warn!(%download_id, error = %error, "reconciliation could not query engine state");
+        }
+    }
+
     /// Advances the entry's progress watermark, returning the permanent
     /// "stalled" failure reason (routed by `classify_failure`) once the
     /// download has gone longer than `stalled_download_timeout_hours` without
-    /// advancing. A download at 100% is exempt — full is never stalled.
+    /// advancing.
+    ///
+    /// Judged states are Queued/Initializing/Downloading/Paused — honest
+    /// terminal states route to completion before the stall clock, so no
+    /// finished download can reach here. Initializing is judged deliberately
+    /// (checked bytes advance the watermark; a wedged hash check is a stalled
+    /// slot-holder), as is an incomplete Paused (nothing pauses mid-download
+    /// in production, and an incomplete pause would otherwise pin a slot
+    /// forever).
     ///
     /// INVARIANT: the read-compare-update on the watermark runs under the
     /// `Inner` lock with no await, and the timeout is read from the live
@@ -576,12 +637,7 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
         let mut inner = self.inner.lock().await;
         let timeout_hours = inner.config.stalled_download_timeout_hours;
         let entry = inner.active.get_mut(&download_id.to_string())?;
-        // WHY: the production engine reports Downloading/100 for a finished
-        // torrent while it seeds, so a completed download would otherwise
-        // freeze its watermark and be cancel-deleted as "stalled" once the
-        // window elapses. Completion/seeding are the lifecycle's concern.
-        // TODO[deliberate-prudent] #602: judge on honest terminal states // kanon:ignore RUST/todo-no-issue -- richer quadrant rule covers this // kanon:ignore META/rule-todo-without-issue -- richer quadrant rule covers this
-        if percent_complete >= 100 || percent_complete > entry.last_progress_pct {
+        if percent_complete > entry.last_progress_pct {
             entry.last_progress_pct = percent_complete;
             entry.last_progress_at = tokio::time::Instant::now();
             return None;
@@ -619,7 +675,12 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
                 inner.allocator.release(entry.protocol, entry.tracker_id);
                 Some(entry)
             } else {
-                warn!(%download_id, "DownloadCompleted for unknown download_id");
+                // WHY: debug, not warn — the completion event and the
+                // reconcile pass both deliver this notice; whichever arrives
+                // second finds the entry already claimed. The `active.remove`
+                // above is the idempotence guard: one claim, one slot
+                // release, one pipeline run.
+                debug!(%download_id, "DownloadCompleted for unknown or already-settled download_id");
                 None
             }
         };
@@ -678,11 +739,25 @@ impl<E: DownloadEngine + 'static> DownloadQueue<E> {
             // the settle; retrying would resurrect a download the user
             // cancelled. The canceller already settled the row (deleted or
             // failed); re-mark in case the dispatch's own status write
-            // overwrote it.
+            // overwrote it. The canceller also settles the engine, so no
+            // cleanup cancel is issued here.
             info!(%download_id, "ignoring failure event for cancelled dispatch");
             Self::mark_cancelled_row(&self.pool, entry.queue_id).await;
             self.try_dispatch_next().await;
             return;
+        }
+
+        // WHY: the single failure-cleanup site — the engine may still hold
+        // the torrent (errored, stalled, or a lost-event terminal state);
+        // deleting it stops a stuck transfer and clears the way for a retry
+        // to re-add over kept files. Best-effort: an engine that already
+        // forgot the download is the desired end state.
+        if let Err(e) = self.engine.cancel_download(download_id).await {
+            if matches!(e, ErgasiaError::TorrentNotFound { .. }) {
+                debug!(%download_id, "engine already dropped the download before failure cleanup");
+            } else {
+                warn!(%download_id, error = %e, "engine cleanup failed for failed download");
+            }
         }
 
         match classify_failure(&reason) {
@@ -1298,7 +1373,9 @@ mod tests {
         fail_remaining: AtomicUsize,
         progress_state: StdMutex<DownloadState>,
         progress_pct: AtomicU8,
+        progress_error: StdMutex<Option<String>>,
         progress_unavailable: AtomicBool,
+        content_path: StdMutex<Option<std::path::PathBuf>>,
         cancelled: StdMutex<Vec<DownloadId>>,
         fail_cancels: AtomicBool,
         hold_next_start: AtomicBool,
@@ -1316,7 +1393,11 @@ mod tests {
                     fail_remaining: AtomicUsize::new(0),
                     progress_state: StdMutex::new(DownloadState::Downloading),
                     progress_pct: AtomicU8::new(0),
+                    progress_error: StdMutex::new(None),
                     progress_unavailable: AtomicBool::new(false),
+                    content_path: StdMutex::new(Some(std::path::PathBuf::from(
+                        "/data/downloads/mock",
+                    ))),
                     cancelled: StdMutex::new(Vec::new()),
                     fail_cancels: AtomicBool::new(false),
                     hold_next_start: AtomicBool::new(false),
@@ -1353,8 +1434,24 @@ mod tests {
             self.progress_pct.store(pct, Ordering::SeqCst);
         }
 
+        fn set_progress_error(&self, error: &str) {
+            *self.progress_error.lock().unwrap() = Some(error.to_string());
+        }
+
         fn set_progress_unavailable(&self) {
             self.progress_unavailable.store(true, Ordering::SeqCst);
+        }
+
+        fn set_progress_available(&self) {
+            self.progress_unavailable.store(false, Ordering::SeqCst);
+        }
+
+        fn set_content_path(&self, path: &str) {
+            *self.content_path.lock().unwrap() = Some(std::path::PathBuf::from(path));
+        }
+
+        fn fail_content_path(&self) {
+            *self.content_path.lock().unwrap() = None;
         }
 
         fn start_calls(&self) -> usize {
@@ -1427,7 +1524,22 @@ mod tests {
                 peers_connected: 0,
                 seeders: 0,
                 eta_seconds: None,
+                error: self.progress_error.lock().unwrap().clone(),
             })
+        }
+
+        async fn content_path(
+            &self,
+            download_id: DownloadId,
+        ) -> Result<std::path::PathBuf, ErgasiaError> {
+            self.content_path
+                .lock()
+                .unwrap()
+                .clone()
+                .ok_or_else(|| ErgasiaError::TorrentNotFound {
+                    download_id,
+                    location: snafu::location!(),
+                })
         }
 
         async fn extract(
@@ -1447,6 +1559,42 @@ mod tests {
             _completed: CompletedDownload,
         ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>>
         {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    /// Records every import so tests can assert the pipeline ran exactly once
+    /// and with the expected content path.
+    struct CountingImportService {
+        count: AtomicUsize,
+        paths: StdMutex<Vec<std::path::PathBuf>>,
+    }
+
+    impl CountingImportService {
+        fn create() -> Arc<Self> {
+            Arc::new(Self {
+                count: AtomicUsize::new(0),
+                paths: StdMutex::new(Vec::new()),
+            })
+        }
+
+        fn import_count(&self) -> usize {
+            self.count.load(Ordering::SeqCst)
+        }
+
+        fn imported_paths(&self) -> Vec<std::path::PathBuf> {
+            self.paths.lock().unwrap().clone()
+        }
+    }
+
+    impl ImportService for CountingImportService {
+        fn import(
+            &self,
+            completed: CompletedDownload,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>>
+        {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            self.paths.lock().unwrap().push(completed.download_path);
             Box::pin(async { Ok(()) })
         }
     }
@@ -1488,7 +1636,15 @@ mod tests {
         engine: Arc<MockEngine>,
         config: SyntaxisConfig,
     ) -> Arc<DownloadQueue<MockEngine>> {
-        let import_svc: Arc<dyn ImportService> = Arc::new(NoopImportService);
+        make_service_with_import(pool, engine, config, Arc::new(NoopImportService)).await
+    }
+
+    async fn make_service_with_import(
+        pool: SqlitePool,
+        engine: Arc<MockEngine>,
+        config: SyntaxisConfig,
+        import_svc: Arc<dyn ImportService>,
+    ) -> Arc<DownloadQueue<MockEngine>> {
         Arc::new(
             DownloadQueue::new(pool, engine, import_svc, config)
                 .await
@@ -2024,14 +2180,20 @@ mod tests {
         );
     }
 
-    // ── #426: dropped events no longer leak slots ───────────────────────────
+    // ── #426 + #602: lost terminal events reconcile to their honest end ────
 
     #[tokio::test]
-    async fn reconcile_releases_slot_for_terminal_state() {
+    async fn reconcile_seeding_completes_runs_pipeline_and_frees_slot() {
         let pool = test_pool().await;
         let (engine, mut started_rx) = MockEngine::create();
-        // Retry budget 0: the synthesized failure exhausts immediately.
-        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 0, 0)).await;
+        let import = CountingImportService::create();
+        let svc = make_service_with_import(
+            pool.clone(),
+            Arc::clone(&engine),
+            test_config(2, 0, 0),
+            Arc::clone(&import) as Arc<dyn ImportService>,
+        )
+        .await;
 
         let item = make_item(DownloadProtocol::Torrent, 2);
         let queue_id = item.id;
@@ -2042,25 +2204,102 @@ mod tests {
             .unwrap();
         assert_eq!(active_total(&svc).await, 1);
 
-        engine.set_progress_state(DownloadState::Completed);
+        engine.set_content_path("/data/downloads/album");
+        engine.set_progress_state(DownloadState::Seeding);
+        engine.set_progress_pct(100);
         svc.reconcile_active().await;
 
+        let (status, _, _) = wait_for_status(&pool, queue_id, "completed").await;
+        assert_eq!(status, "completed");
         assert_eq!(
             active_total(&svc).await,
             0,
-            "the leaked slot must be reclaimed"
+            "the completed download must free its slot"
         );
         assert!(!active_contains(&svc, dl_id).await);
-        let (status, reason, _) = row_state(&pool, queue_id).await;
-        assert_eq!(status, "failed");
+        settle_until(|| import.import_count() == 1).await;
+        assert_eq!(
+            import.imported_paths(),
+            vec![std::path::PathBuf::from("/data/downloads/album")],
+            "the pipeline must import the engine-resolved content path"
+        );
         assert!(
-            reason.unwrap_or_default().contains("reconciliation"),
-            "the failure reason must name the reconciliation origin"
+            engine.cancelled_ids().is_empty(),
+            "completion must never cancel the engine download"
         );
     }
 
     #[tokio::test]
-    async fn reconcile_requeues_terminal_download_within_budget() {
+    async fn reconcile_keeps_finished_download_when_content_path_unresolved() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 0, 0)).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (dl_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        engine.fail_content_path();
+        engine.set_progress_state(DownloadState::Seeding);
+        svc.reconcile_active().await;
+
+        assert!(
+            active_contains(&svc, dl_id).await,
+            "an unresolvable content path must leave the entry for the next pass"
+        );
+        assert_eq!(active_total(&svc).await, 1);
+        let (status, _, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "downloading", "the row must not fail spuriously");
+    }
+
+    #[tokio::test]
+    async fn completion_event_then_reconcile_imports_exactly_once() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let import = CountingImportService::create();
+        let svc = make_service_with_import(
+            pool.clone(),
+            Arc::clone(&engine),
+            test_config(2, 3, 0),
+            Arc::clone(&import) as Arc<dyn ImportService>,
+        )
+        .await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (dl_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // The completion event lands first; the reconcile pass then observes
+        // the same terminal state — the second notice must find the entry
+        // already claimed and start no second pipeline.
+        svc.on_download_completed(dl_id, std::path::PathBuf::from("/data/downloads/album"))
+            .await;
+        engine.set_progress_state(DownloadState::Seeding);
+        svc.reconcile_active().await;
+
+        wait_for_status(&pool, queue_id, "completed").await;
+        settle_until(|| import.import_count() == 1).await;
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            import.import_count(),
+            1,
+            "event + reconcile must import exactly once"
+        );
+        assert_eq!(active_total(&svc).await, 0);
+    }
+
+    #[tokio::test]
+    async fn reconcile_requeues_failed_download_within_budget() {
         let pool = test_pool().await;
         let (engine, mut started_rx) = MockEngine::create();
         let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 3, 0)).await;
@@ -2074,6 +2313,7 @@ mod tests {
             .unwrap();
 
         engine.set_progress_state(DownloadState::Failed);
+        engine.set_progress_error("connection reset by peer");
         svc.reconcile_active().await;
 
         let (second_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
@@ -2088,8 +2328,46 @@ mod tests {
             1,
             "release + re-acquire must not leak or double-count"
         );
+        assert!(
+            engine.cancelled_ids().contains(&first_id),
+            "failure cleanup must delete the failed engine download before the retry"
+        );
         let (_, _, retry_count) = row_state(&pool, queue_id).await;
         assert_eq!(retry_count, 1);
+    }
+
+    #[tokio::test]
+    async fn reconcile_failed_download_carries_engine_error_into_the_row() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        // Retry budget 0: the reconciled failure exhausts immediately.
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 0, 0)).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (dl_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        engine.set_progress_state(DownloadState::Failed);
+        engine.set_progress_error("tracker rejected the announce");
+        svc.reconcile_active().await;
+
+        let (status, reason, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "failed");
+        assert!(
+            reason
+                .unwrap_or_default()
+                .contains("tracker rejected the announce"),
+            "the engine-reported error must reach the persisted failure reason"
+        );
+        assert!(
+            engine.cancelled_ids().contains(&dl_id),
+            "failure cleanup must delete the failed engine download"
+        );
+        assert_eq!(active_total(&svc).await, 0);
     }
 
     #[tokio::test]
@@ -2195,7 +2473,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn full_percent_download_is_never_stall_failed() {
+    async fn seeding_download_completes_and_never_stalls() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let mut config = test_config(1, 3, 0);
+        config.stalled_download_timeout_hours = 0;
+        let svc = make_service(pool.clone(), Arc::clone(&engine), config).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // A finished torrent reports Seeding (honest states, #602): every
+        // pass is past the zero-length stall window and the percentage never
+        // advances, yet the download must complete, never stall.
+        engine.set_progress_state(DownloadState::Seeding);
+        engine.set_progress_pct(100);
+        svc.reconcile_active().await;
+        svc.reconcile_active().await;
+
+        let (status, _, _) = wait_for_status(&pool, queue_id, "completed").await;
+        assert_eq!(status, "completed");
+        assert_eq!(active_total(&svc).await, 0);
+        assert!(
+            engine.cancelled_ids().is_empty(),
+            "a finished download must never be cancelled as stalled"
+        );
+    }
+
+    #[tokio::test]
+    async fn paused_incomplete_download_stalls_out() {
         let pool = test_pool().await;
         let (engine, mut started_rx) = MockEngine::create();
         let mut config = test_config(1, 3, 0);
@@ -2210,21 +2521,95 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // The production engine reports Downloading/100 while a finished
-        // torrent seeds (#602): every pass is past the zero-length window and
-        // the percentage never advances, yet 100% must never read as stalled.
-        engine.set_progress_pct(100);
+        // WHY: nothing pauses mid-download in production — an incomplete
+        // Paused would pin its slot forever, so the stall clock judges it.
+        engine.set_progress_state(DownloadState::Paused);
+        engine.set_progress_pct(40);
         svc.reconcile_active().await;
         svc.reconcile_active().await;
 
-        assert!(active_contains(&svc, download_id).await);
-        assert_eq!(active_total(&svc).await, 1);
+        let (status, reason, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "failed");
+        assert!(reason.unwrap_or_default().contains("stalled"));
+        assert_eq!(active_total(&svc).await, 0);
         assert!(
-            engine.cancelled_ids().is_empty(),
-            "a full download must never be cancelled as stalled"
+            engine.cancelled_ids().contains(&download_id),
+            "the stalled paused download must be cleaned off the engine"
         );
-        let (status, _, _) = row_state(&pool, queue_id).await;
-        assert_eq!(status, "downloading");
+    }
+
+    // ── #602: consecutive TorrentNotFound passes reap forgotten downloads ──
+
+    #[tokio::test]
+    async fn torrent_not_found_three_passes_fails_download() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 0, 0)).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        let queue_id = item.id;
+        svc.enqueue(item).await.unwrap();
+        let (download_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        // WHY: only engine-acknowledged downloads escalate — pin the entry
+        // past the post-start fence first.
+        settle_until(|| engine_started_now(&svc, download_id)).await;
+
+        engine.set_progress_unavailable();
+        svc.reconcile_active().await;
+        svc.reconcile_active().await;
+        assert!(
+            active_contains(&svc, download_id).await,
+            "two missing passes must not reap the download"
+        );
+
+        svc.reconcile_active().await;
+        assert!(!active_contains(&svc, download_id).await);
+        assert_eq!(active_total(&svc).await, 0);
+        let (status, reason, _) = row_state(&pool, queue_id).await;
+        assert_eq!(status, "failed");
+        assert!(
+            reason
+                .unwrap_or_default()
+                .contains("engine no longer tracks download"),
+            "the failure reason must name the missing-download escalation"
+        );
+    }
+
+    #[tokio::test]
+    async fn torrent_not_found_counter_resets_on_successful_poll() {
+        let pool = test_pool().await;
+        let (engine, mut started_rx) = MockEngine::create();
+        let svc = make_service(pool.clone(), Arc::clone(&engine), test_config(2, 0, 0)).await;
+
+        let item = make_item(DownloadProtocol::Torrent, 2);
+        svc.enqueue(item).await.unwrap();
+        let (download_id, _) = tokio::time::timeout(RECV_TIMEOUT, started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        settle_until(|| engine_started_now(&svc, download_id)).await;
+
+        engine.set_progress_unavailable();
+        svc.reconcile_active().await;
+        svc.reconcile_active().await;
+
+        // A successful poll resets the consecutive-miss counter…
+        engine.set_progress_available();
+        svc.reconcile_active().await;
+
+        // …so two further missing passes stay below the limit.
+        engine.set_progress_unavailable();
+        svc.reconcile_active().await;
+        svc.reconcile_active().await;
+
+        assert!(
+            active_contains(&svc, download_id).await,
+            "non-consecutive missing passes must never escalate"
+        );
+        assert_eq!(active_total(&svc).await, 1);
     }
 
     #[tokio::test]
@@ -2322,8 +2707,7 @@ mod tests {
         let shutdown = CancellationToken::new();
         let listener = svc.start(event_rx, shutdown.clone());
 
-        let (_, reason, _) = wait_for_status(&pool, queue_id, "failed").await;
-        assert!(reason.unwrap_or_default().contains("reconciliation"));
+        wait_for_status(&pool, queue_id, "completed").await;
         assert_eq!(
             active_total(&svc).await,
             0,
@@ -2365,12 +2749,12 @@ mod tests {
         tokio::time::advance(RECONCILE_INTERVAL + tokio::time::Duration::from_secs(1)).await;
         tokio::time::resume();
 
-        let (_, reason, _) = wait_for_status(&pool, queue_id, "failed").await;
-        assert!(
-            reason.unwrap_or_default().contains("reconciliation"),
+        wait_for_status(&pool, queue_id, "completed").await;
+        assert_eq!(
+            active_total(&svc).await,
+            0,
             "the periodic pass must reconcile without a Lagged signal"
         );
-        assert_eq!(active_total(&svc).await, 0);
         shutdown.cancel();
         listener.await.unwrap();
     }

--- a/crates/syntaxis/src/pipeline.rs
+++ b/crates/syntaxis/src/pipeline.rs
@@ -19,6 +19,11 @@ use crate::types::{CompletedDownload, DownloadProtocol};
 
 /// Trait boundary for the Taxis import service. Wired in P3-08.
 ///
+/// Implementations must be idempotent per item: a restart mid-pipeline
+/// re-runs the whole pipeline for the same download, so a repeated `import`
+/// of an already-imported item must succeed without duplicating library
+/// state.
+///
 /// Uses `Pin<Box<dyn Future>>` for dyn compatibility — callers can store
 /// `Arc<dyn ImportService>` without the object-safety issues of native async fn.
 pub trait ImportService: Send + Sync {
@@ -197,6 +202,9 @@ mod tests {
         async fn get_progress(&self, _id: DownloadId) -> Result<DownloadProgress, ErgasiaError> {
             unimplemented!()
         }
+        async fn content_path(&self, _id: DownloadId) -> Result<PathBuf, ErgasiaError> {
+            Ok(PathBuf::from("/data/downloads/album"))
+        }
         async fn extract(
             &self,
             _path: &Path,
@@ -219,6 +227,9 @@ mod tests {
         }
         async fn get_progress(&self, _id: DownloadId) -> Result<DownloadProgress, ErgasiaError> {
             unimplemented!()
+        }
+        async fn content_path(&self, _id: DownloadId) -> Result<PathBuf, ErgasiaError> {
+            Ok(PathBuf::from("/data/downloads/album"))
         }
         async fn extract(
             &self,


### PR DESCRIPTION
PR 1 of the #602 download-lifecycle fix (PR 2 — live seed enforcement — closes #602 and #590).

- **Honest state mapping**: pure `map_torrent_stats` (librqbit → DownloadState): Error→Failed, Initializing→Initializing, Live+!finished→Downloading, Live+finished→Seeding, Paused+finished→SeedPolicySatisfied, Paused+!finished→new Paused variant. `SessionEngine::get_progress` delegates — the hardcoded `Downloading` is gone. `DownloadProgress` gains `error`; honest peers/eta; `seeders` stays 0 with a NOTE (librqbit exposes no seeder count).
- **Completion propagation, both paths**: ergasia lifecycle watcher per download (wait_until_completed → emit `DownloadCompleted`/`DownloadFailed`; is_paused early-exit; cancelled on delete; restored watchers don't announce) AND the reconcile terminal branch now completes via `engine.content_path()` → `on_download_completed`. Idempotent via the existing active-map claim — no new state.
- **content_path** trait method recomputes librqbit's layout (its output_folder is pub(crate)); `overwrite: true` on adds (librqbit's own restore posture; hash-checked, enables retry-over-kept-files).
- **Failure handling**: consolidated engine-cancel in `on_download_failed`; TorrentNotFound escalation (3 consecutive passes → failed) closes a pre-existing slot leak.
- **Stall detector**: the percent>=100 exemption is deleted — finished torrents route to completion before the stall clock.

Downloads now complete → import → (still seed unbounded until PR 2, status quo). Gate green (full workspace). 3-lens adversarial review run separately.

Part of #602