### PR TITLE
feat(zetesis): Cardigann form, post, and get login with per-indexer sessions

### DIFF
--- a/crates/zetesis/src/client/cardigann/definition.rs
+++ b/crates/zetesis/src/client/cardigann/definition.rs
@@ -87,10 +87,37 @@ pub struct LoginBlock {
     pub method: Option<String>,
     #[serde(default)]
     pub path: Option<String>,
+    /// CSS selector for the login `<form>` (form method; defaults to "form").
+    #[serde(default)]
+    pub form: Option<String>,
+    /// Submit-target override, joined on the site base instead of the
+    /// form's `action`.
+    #[serde(default)]
+    pub submitpath: Option<String>,
     #[serde(default)]
     pub inputs: BTreeMap<String, ScalarString>,
+    /// Failed-login detectors checked against the post-submit page.
+    #[serde(default)]
+    pub error: Vec<ErrorBlock>,
     #[serde(default)]
     pub test: Option<LoginTest>,
+    /// Unmodeled selector-driven inputs; presence is rejected at load for
+    /// interactive login methods.
+    #[serde(default)]
+    pub selectorinputs: Option<serde_norway::Value>,
+    /// Unmodeled captcha block; presence is rejected at load for
+    /// interactive login methods.
+    #[serde(default)]
+    pub captcha: Option<serde_norway::Value>,
+}
+
+/// One failed-login detector: `selector` marks the post-submit page as a
+/// login error; `message` (FieldBlock semantics) refines the reported text.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ErrorBlock {
+    pub selector: String,
+    #[serde(default)]
+    pub message: Option<FieldBlock>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -541,19 +568,66 @@ fn validate(def: &CardigannDefinition) -> Result<(), SearchIndexerError> {
         }
     }
 
-    // NOTE: login templates are only validated for methods this engine runs;
-    // unsupported methods already fail at client construction, and their
-    // inputs routinely use template constructs outside this engine's subset.
-    if let Some(login) = &def.login
-        && matches!(login.method.as_deref(), Some("none" | "cookie") | None)
-    {
-        for (key, value) in &login.inputs {
-            check_template(&format!("login input {key}"), &value.0)?;
+    // NOTE: login blocks are only validated for methods this engine runs
+    // (none, cookie, form, post, get; an omitted method defaults to "form").
+    // Unknown methods fail at client construction with LoginUnsupported, and
+    // their inputs routinely use template constructs outside this subset.
+    if let Some(login) = &def.login {
+        let method = login.method.as_deref().unwrap_or("form");
+        let interactive = matches!(method, "form" | "post" | "get");
+        if interactive || matches!(method, "none" | "cookie") {
+            for (key, value) in &login.inputs {
+                check_template(&format!("login input {key}"), &value.0)?;
+            }
+            if let Some(test) = &login.test
+                && let Some(sel) = &test.selector
+            {
+                check_selector("login test", sel)?;
+            }
         }
-        if let Some(test) = &login.test
-            && let Some(sel) = &test.selector
-        {
-            check_selector("login test", sel)?;
+        if interactive {
+            // WHY: these blocks change what a login submits — silently
+            // skipping them would send an incomplete login (and captcha
+            // pages hard-require operator interaction this engine lacks).
+            if login.selectorinputs.is_some() {
+                return Err(unsupported("login.selectorinputs".to_string()));
+            }
+            if login.captcha.is_some() {
+                return Err(unsupported("login.captcha".to_string()));
+            }
+            let Some(path) = &login.path else {
+                return Err(invalid(format!(
+                    "login method {method:?} requires login.path"
+                )));
+            };
+            check_template("login path", path)?;
+            if let Some(form) = &login.form {
+                check_selector("login form", form)?;
+            }
+            if let Some(submitpath) = &login.submitpath {
+                check_template("login submitpath", submitpath)?;
+            }
+            for (index, block) in login.error.iter().enumerate() {
+                let what = format!("login error {index}");
+                check_selector(&what, &block.selector)?;
+                if let Some(message) = &block.message {
+                    if let Some(sel) = &message.selector {
+                        check_selector(&format!("{what} message"), sel)?;
+                    }
+                    if let Some(remove) = &message.remove {
+                        check_selector(&format!("{what} message remove"), remove)?;
+                    }
+                    if let Some(case) = &message.case {
+                        for (case_selector, _) in &case.0 {
+                            check_selector(&format!("{what} message case"), case_selector)?;
+                        }
+                    }
+                    if let Some(text) = &message.text {
+                        check_template(&format!("{what} message text"), &text.0)?;
+                    }
+                    check_filters(&format!("{what} message"), &message.filters)?;
+                }
+            }
         }
     }
 

--- a/crates/zetesis/src/client/cardigann/definition/tests.rs
+++ b/crates/zetesis/src/client/cardigann/definition/tests.rs
@@ -384,20 +384,76 @@ fn magnet_field_satisfies_download_source() {
 }
 
 #[test]
-fn form_login_definition_still_loads() {
-    // WHY: unsupported login methods must fail at client construction
-    // (with a clear pointer), not at load — the definition itself parses.
+fn form_login_definition_loads_with_declared_credentials() {
+    // WHY: a form login is executable — it loads when its credential inputs
+    // reference declared settings and a login.path is present.
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a"#,
+    ) + r#"
+settings:
+  - name: username
+    type: text
+  - name: password
+    type: password
+login:
+  method: form
+  path: /login.php
+  form: form#login
+  inputs:
+    username: "{{ .Config.username }}"
+    password: "{{ .Config.password }}"
+  error:
+    - selector: div.error
+  test:
+    path: /profile
+    selector: a.logout
+"#;
+    let def = parse_definition(&yaml, "test").unwrap();
+    let login = def.login.unwrap();
+    assert_eq!(login.method.as_deref(), Some("form"));
+    assert_eq!(login.form.as_deref(), Some("form#login"));
+    assert_eq!(login.error.len(), 1);
+    assert_eq!(login.error[0].selector, "div.error");
+}
+
+#[test]
+fn interactive_login_without_path_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a"#,
+    ) + r#"
+login:
+  method: post
+  inputs:
+    q: "{{ .Keywords }}"
+"#;
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionInvalid { .. }),
+        "got {err:?}"
+    );
+    assert!(err.to_string().contains("login.path"), "got {err}");
+}
+
+#[test]
+fn login_captcha_block_rejected_at_load() {
     let yaml = minimal_with(
         r#"  paths:
     - path: /a"#,
     ) + r#"
 login:
   method: form
-  inputs:
-    username: "{{ .Config.username }}"
+  path: /login.php
+  captcha:
+    type: image
+    selector: img.captcha
 "#;
-    let def = parse_definition(&yaml, "test").unwrap();
-    assert_eq!(def.login.unwrap().method.as_deref(), Some("form"));
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionUnsupported { ref feature, .. } if feature.contains("captcha")),
+        "got {err:?}"
+    );
 }
 
 #[test]

--- a/crates/zetesis/src/client/cardigann/extract.rs
+++ b/crates/zetesis/src/client/cardigann/extract.rs
@@ -150,6 +150,42 @@ fn collect_text(
     }
 }
 
+/// Evaluates one `login.error` block against a post-login page: `selector`
+/// decides whether the page reports a failed login; `message` (FieldBlock
+/// semantics, evaluated from the document root like upstream Cardigann)
+/// refines the reported text, falling back to the matched element's text.
+///
+/// Returns `Ok(None)` when the selector does not match (no error).
+pub fn extract_error_message(
+    html: &str,
+    selector: &str,
+    message: Option<&FieldBlock>,
+    ctx: &TemplateContext,
+    now: &Zoned,
+) -> Result<Option<String>, String> {
+    let document = Html::parse_document(html);
+    let Some(element) = document.select(&parse_selector(selector)?).next() else {
+        return Ok(None);
+    };
+    if let Some(field) = message
+        && let Ok(Some(value)) = extract_field(document.root_element(), field, ctx, now)
+    {
+        return Ok(Some(value));
+    }
+    let text = element_text(element, None)?;
+    Ok(Some(if text.is_empty() {
+        "site reported a login error".to_string()
+    } else {
+        text
+    }))
+}
+
+/// True when `selector` matches anywhere in `html` (`login.test` assertion).
+pub fn selector_matches(html: &str, selector: &str) -> Result<bool, String> {
+    let document = Html::parse_document(html);
+    Ok(document.select(&parse_selector(selector)?).next().is_some())
+}
+
 /// Pulls the follow-on download link out of a details/interstitial page
 /// (the `download:` block's selector + attribute).
 pub fn extract_download_link(

--- a/crates/zetesis/src/client/cardigann/mod.rs
+++ b/crates/zetesis/src/client/cardigann/mod.rs
@@ -405,8 +405,22 @@ impl CardigannClient {
         url: &str,
         ct: &CancellationToken,
     ) -> Result<reqwest::Response, SearchIndexerError> {
+        self.send_once_with_cookie(url, self.request_cookie_header(), ct)
+            .await
+    }
+
+    /// Like `send_once` but with an explicit `Cookie` header, so the post-login
+    /// retry uses the session `login` just established rather than re-reading
+    /// the store (which a racing `invalidate` could empty between the store
+    /// and the read, spuriously sending the retry cookieless).
+    async fn send_once_with_cookie(
+        &self,
+        url: &str,
+        cookie: Option<String>,
+        ct: &CancellationToken,
+    ) -> Result<reqwest::Response, SearchIndexerError> {
         let mut request = self.http_client.get(url).timeout(self.timeout);
-        if let Some(cookie) = self.request_cookie_header() {
+        if let Some(cookie) = cookie {
             request = request.header(reqwest::header::COOKIE, cookie);
         }
         let fut = request.send();
@@ -470,8 +484,12 @@ impl CardigannClient {
         if let LoginMethod::Interactive { verb } = &self.login {
             if self.looks_like_auth_loss(&response) {
                 self.sessions.invalidate(self.indexer.id);
-                self.login(*verb, ct.clone()).await?;
-                let retry = self.send_once(url, &ct).await?;
+                // WHY: use the cookie login just established directly — a
+                // concurrent client's invalidate can wipe the store between
+                // login's store() and a fresh read, which would send the
+                // retry cookieless and fail a healthy indexer.
+                let established = self.login(*verb, ct.clone()).await?;
+                let retry = self.send_once_with_cookie(url, established, &ct).await?;
                 if retry.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
                     return Err(self.rate_limited(&retry));
                 }
@@ -1018,9 +1036,24 @@ fn resolve_login_url(
     let rendered = ctx
         .render_url(path)
         .map_err(|e| invalid(format!("login path: {e}")))?;
-    base_url
+    let resolved = base_url
         .join(rendered.trim_start_matches('/'))
-        .map_err(|e| invalid(format!("login path {rendered:?}: {e}")))
+        .map_err(|e| invalid(format!("login path {rendered:?}: {e}")))?;
+    // SECURITY GATE: login.path must stay on the indexer's own host. A path
+    // carrying its own scheme (e.g. `http://attacker.example/harvest`) makes
+    // `Url::join` return it verbatim, ignoring base_url — which would point
+    // the login-page GET (and the cookies it harvests) at an arbitrary host,
+    // the very off-site credential exposure require_same_host guards on the
+    // submit URL and every redirect hop. Fail loud at construction.
+    if !matches!(resolved.scheme(), "http" | "https") || resolved.host() != base_url.host() {
+        return Err(invalid(format!(
+            "login path {rendered:?} resolves to host {:?}, off the indexer host {:?}; \
+             refusing to fetch the login page off-site",
+            resolved.host_str().unwrap_or("<none>"),
+            base_url.host_str().unwrap_or("<none>")
+        )));
+    }
+    Ok(resolved)
 }
 
 fn path_applies(path: &SearchPath, site_categories: &[String], unconstrained: bool) -> bool {

--- a/crates/zetesis/src/client/cardigann/mod.rs
+++ b/crates/zetesis/src/client/cardigann/mod.rs
@@ -3,13 +3,15 @@
 //! Executes Prowlarr-compatible YAML definitions (loaded at startup from
 //! `cardigann_definitions_dir`) against HTML trackers that lack a native
 //! Torznab/Newznab API: templated search URLs, CSS row/field selectors, a
-//! filter pipeline, and category mapping. Login support covers `none` and
-//! `cookie`; form/multi-step login defers to a Torznab sidecar.
+//! filter pipeline, and category mapping. Login support covers `none`,
+//! `cookie`, and the interactive `form`/`post`/`get` methods (per-indexer
+//! session cookies in [`session::SessionStore`]).
 
 pub mod categories;
 pub mod definition;
 mod extract;
 mod filters;
+mod session;
 mod template;
 
 use std::collections::{BTreeMap, HashMap};
@@ -35,6 +37,8 @@ use crate::types::{
     SearchQuery, SearchResult, ServerInfo,
 };
 use definition::{CardigannDefinition, SearchPath};
+pub use session::SessionStore;
+use session::{LoginMethod, LoginVerb};
 use template::TemplateContext;
 
 /// Cardigann definitions loaded from `cardigann_definitions_dir`, keyed by
@@ -143,6 +147,7 @@ impl CardigannRegistry {
         http_client: reqwest::Client,
         cf_proxy: Arc<dyn CloudflareProxy>,
         timeout: Duration,
+        sessions: Arc<SessionStore>,
     ) -> Result<CardigannClient, SearchIndexerError> {
         let definition =
             self.resolve(&indexer.url)
@@ -158,6 +163,7 @@ impl CardigannRegistry {
             timeout,
             indexer,
             definition,
+            sessions,
         )
     }
 }
@@ -170,23 +176,38 @@ pub struct CardigannClient {
     indexer: IndexerConfig,
     definition: Arc<CardigannDefinition>,
     base_url: Url,
-    /// Cookie header for `login.method: cookie`, taken from the indexer
-    /// row's `api_key` column (the per-instance secret slot).
-    cookie: Option<String>,
+    /// Resolved login strategy (none / static cookie / interactive).
+    login: LoginMethod,
+    /// Per-indexer interactive-login session store, owned by the service and
+    /// shared across every ephemeral client for one indexer.
+    sessions: Arc<SessionStore>,
+    /// Rendered `login.path` joined on the site base (interactive methods
+    /// only). Also the staleness comparison target — a search that ends up
+    /// back here means the session expired.
+    login_url: Option<Url>,
 }
 
 impl std::fmt::Debug for CardigannClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // WHY: `login` has a redacting Debug and `sessions` prints cookie
+        // names only — no credential or cookie value can reach this output.
         f.debug_struct("CardigannClient")
             .field("indexer_id", &self.indexer.id)
             .field("definition_id", &self.definition.id)
             .field("base_url", &self.base_url.as_str())
-            .field("cookie", &self.cookie.as_ref().map(|_| "[redacted]"))
+            .field("login", &self.login)
             .finish_non_exhaustive()
     }
 }
 
 impl CardigannClient {
+    // WHY: an ephemeral per-search client wiring its live dependencies
+    // (config, transport, proxy, timeout, indexer row, definition, shared
+    // session store); a params struct would only relocate the same fields.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "dependency-injection constructor; each arg is a distinct live dependency"
+    )]
     pub fn new(
         config: Arc<SearchSubsystemConfig>,
         http_client: reqwest::Client,
@@ -194,19 +215,26 @@ impl CardigannClient {
         timeout: Duration,
         indexer: IndexerConfig,
         definition: Arc<CardigannDefinition>,
+        sessions: Arc<SessionStore>,
     ) -> Result<Self, SearchIndexerError> {
         let base_url = resolve_base_url(&indexer, &definition)?;
         validate_settings(&indexer, &definition)?;
-        let cookie = resolve_login(&indexer, &definition)?;
-        if cookie.is_some() && indexer.cf_bypass {
+        let login = resolve_login(&indexer, &definition)?;
+        if !matches!(login, LoginMethod::None) && indexer.cf_bypass {
             // WHY: the bypass proxy carries no request headers, so a session
-            // cookie silently vanishes — fail loudly instead.
+            // or login cookie silently vanishes — fail loudly for EVERY
+            // non-None login method, not just static cookies.
             return Err(SearchIndexerError::DefinitionUnsupported {
                 definition_id: definition.id.clone(),
-                feature: "cf_bypass combined with cookie login".to_string(),
+                feature: "cf_bypass combined with an authenticated login method".to_string(),
                 location: snafu::Location::new(file!(), line!(), column!()),
             });
         }
+        let login_url = if matches!(login, LoginMethod::Interactive { .. }) {
+            Some(resolve_login_url(&indexer, &definition, &base_url)?)
+        } else {
+            None
+        };
         Ok(Self {
             config,
             http_client,
@@ -215,8 +243,59 @@ impl CardigannClient {
             indexer,
             definition,
             base_url,
-            cookie,
+            login,
+            sessions,
+            login_url,
         })
+    }
+
+    /// Static `.Config` seed shared by search and login rendering: definition
+    /// defaults, then the indexer's settings overrides, then the injected
+    /// static cookie (cookie method only).
+    fn config_seed(&self) -> BTreeMap<String, String> {
+        build_config_seed(
+            &self.definition,
+            &self.indexer.settings,
+            self.cookie_value(),
+        )
+    }
+
+    /// The static `Cookie`-method value, if this indexer uses cookie login.
+    fn cookie_value(&self) -> Option<&str> {
+        match &self.login {
+            LoginMethod::Cookie(cookie) => Some(cookie.as_str()),
+            _ => None,
+        }
+    }
+
+    /// A `.Config`-only template context for rendering `login.inputs` /
+    /// `login.path` / error-message templates (no per-search keywords).
+    pub(crate) fn login_template_context(&self) -> TemplateContext {
+        TemplateContext {
+            keywords: String::new(),
+            categories: Vec::new(),
+            config: self.config_seed(),
+            query: BTreeMap::new(),
+        }
+    }
+
+    /// `Cookie` header for an ordinary request: the static cookie-method
+    /// value, or the interactive session's cookies from the store.
+    fn request_cookie_header(&self) -> Option<String> {
+        match &self.login {
+            LoginMethod::None => None,
+            LoginMethod::Cookie(cookie) => Some(cookie.clone()),
+            LoginMethod::Interactive { .. } => self.sessions.get_cookie_header(self.indexer.id),
+        }
+    }
+
+    fn login_failed(&self, reason: String) -> SearchIndexerError {
+        SearchIndexerError::LoginFailed {
+            definition_id: self.definition.id.clone(),
+            indexer_id: self.indexer.id,
+            reason,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        }
     }
 
     fn invalid(&self, reason: String) -> SearchIndexerError {
@@ -240,31 +319,10 @@ impl CardigannClient {
         )
         .map_err(|e| self.invalid(format!("keywordsfilters: {e}")))?;
 
-        // Seed order: definition defaults, then user settings overrides,
-        // then the injected session cookie (never user-overridable — see
-        // `validate_settings`).
-        let mut config = BTreeMap::new();
-        for setting in &self.definition.settings {
-            config.insert(
-                setting.name.clone(),
-                setting
-                    .default
-                    .as_ref()
-                    .map(|d| d.0.clone())
-                    .unwrap_or_default(),
-            );
-        }
-        for (key, value) in &self.indexer.settings {
-            config.insert(key.clone(), value.clone());
-        }
-        if let Some(cookie) = &self.cookie {
-            config.insert("cookie".to_string(), cookie.clone());
-        }
-
         Ok(TemplateContext {
             keywords,
             categories: site_categories,
-            config,
+            config: self.config_seed(),
             query: query_vars(query),
         })
     }
@@ -340,44 +398,95 @@ impl CardigannClient {
         Ok(url)
     }
 
+    /// Fires one request with the current cookie (static or session),
+    /// honoring cancellation. No status interpretation.
+    async fn send_once(
+        &self,
+        url: &str,
+        ct: &CancellationToken,
+    ) -> Result<reqwest::Response, SearchIndexerError> {
+        let mut request = self.http_client.get(url).timeout(self.timeout);
+        if let Some(cookie) = self.request_cookie_header() {
+            request = request.header(reqwest::header::COOKIE, cookie);
+        }
+        let fut = request.send();
+        tokio::select! {
+            result = fut => result.context(error::HttpRequestSnafu { url: redact_api_key(url) }),
+            () = ct.cancelled() => Err(SearchIndexerError::Cancelled {
+                url: redact_api_key(url),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            }),
+        }
+    }
+
+    fn rate_limited(&self, response: &reqwest::Response) -> SearchIndexerError {
+        let retry_after = response
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok());
+        SearchIndexerError::RateLimited {
+            indexer_id: self.indexer.id,
+            retry_after_seconds: retry_after,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        }
+    }
+
+    fn auth_failed(&self) -> SearchIndexerError {
+        SearchIndexerError::AuthFailed {
+            indexer_id: self.indexer.id,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        }
+    }
+
+    /// True when a fetched response looks like lost authentication: a 401/403,
+    /// or a final URL whose path equals the rendered login path (the tracker
+    /// silently 200-redirected the request to its login page).
+    ///
+    /// WHY: an expired session otherwise 200s a login page and the indexer
+    /// yields zero rows forever with no signal.
+    fn looks_like_auth_loss(&self, response: &reqwest::Response) -> bool {
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return true;
+        }
+        self.login_url
+            .as_ref()
+            .is_some_and(|login_url| response.url().path() == login_url.path())
+    }
+
     async fn send(
         &self,
         url: &str,
         ct: CancellationToken,
     ) -> Result<reqwest::Response, SearchIndexerError> {
-        let mut request = self.http_client.get(url).timeout(self.timeout);
-        if let Some(cookie) = &self.cookie {
-            request = request.header(reqwest::header::COOKIE, cookie);
+        let response = self.send_once(url, &ct).await?;
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(self.rate_limited(&response));
         }
-        let fut = request.send();
-        let response = tokio::select! {
-            result = fut => result.context(error::HttpRequestSnafu { url: redact_api_key(url) })?,
-            () = ct.cancelled() => {
-                return Err(SearchIndexerError::Cancelled {
-                    url: redact_api_key(url),
-                    location: snafu::Location::new(file!(), line!(), column!()),
-                });
-            }
-        };
 
+        // WHY: interactive sessions expire mid-use — invalidate, re-login
+        // ONCE, retry ONCE. A second auth loss is a real AuthFailed.
+        if let LoginMethod::Interactive { verb } = &self.login {
+            if self.looks_like_auth_loss(&response) {
+                self.sessions.invalidate(self.indexer.id);
+                self.login(*verb, ct.clone()).await?;
+                let retry = self.send_once(url, &ct).await?;
+                if retry.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    return Err(self.rate_limited(&retry));
+                }
+                if self.looks_like_auth_loss(&retry) {
+                    return Err(self.auth_failed());
+                }
+                return Ok(retry);
+            }
+            return Ok(response);
+        }
+
+        // None / Cookie: a 401/403 is an immediate auth failure.
         let status = response.status();
         if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-            return Err(SearchIndexerError::AuthFailed {
-                indexer_id: self.indexer.id,
-                location: snafu::Location::new(file!(), line!(), column!()),
-            });
-        }
-        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            let retry_after = response
-                .headers()
-                .get("retry-after")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.parse().ok());
-            return Err(SearchIndexerError::RateLimited {
-                indexer_id: self.indexer.id,
-                retry_after_seconds: retry_after,
-                location: snafu::Location::new(file!(), line!(), column!()),
-            });
+            return Err(self.auth_failed());
         }
         Ok(response)
     }
@@ -529,6 +638,7 @@ impl IndexerClient for CardigannClient {
         query: &SearchQuery,
         ct: CancellationToken,
     ) -> Result<Vec<SearchResult>, SearchIndexerError> {
+        self.ensure_session(ct.clone()).await?;
         let mappings = &self.definition.caps.categorymappings;
         let site_categories = categories::site_categories_for(mappings, &query.category_ids);
         if !query.category_ids.is_empty() && !mappings.is_empty() && site_categories.is_empty() {
@@ -572,16 +682,19 @@ impl IndexerClient for CardigannClient {
 
     #[instrument(skip(self, ct), fields(indexer_id = self.indexer.id))]
     async fn test(&self, ct: CancellationToken) -> Result<IndexerStatus, SearchIndexerError> {
-        // NOTE: login.test.selector checks are deferred — this probe only
-        // verifies the page is reachable (HTTP success).
-        let test_path = self
+        let login_test = self
             .definition
             .login
             .as_ref()
-            .and_then(|login| login.test.as_ref())
-            .and_then(|test| test.path.clone());
+            .and_then(|login| login.test.as_ref());
+        let test_selector = login_test.and_then(|test| test.selector.clone());
+        let test_path = login_test.and_then(|test| test.path.clone());
         let probe = async {
-            let url = match test_path {
+            // WHY: ensure_session logs the interactive indexer in (which
+            // already runs login.test as part of the flow); for none/cookie
+            // it is a no-op.
+            self.ensure_session(ct.clone()).await?;
+            let url = match &test_path {
                 Some(path) => self
                     .base_url
                     .join(path.trim_start_matches('/'))
@@ -592,13 +705,38 @@ impl IndexerClient for CardigannClient {
                 self.cf_proxy.get(url.as_str(), ct).await?;
                 return Ok(());
             }
-            let response = self.send(url.as_str(), ct).await?;
-            response
-                .error_for_status()
-                .map(|_| ())
-                .context(error::HttpRequestSnafu {
-                    url: redact_api_key(url.as_str()),
-                })
+            // WHY: when the definition declares a login.test selector, the
+            // health check is a content assertion (a reachable login page is
+            // NOT a healthy session); otherwise it stays a reachability probe.
+            match &test_selector {
+                Some(selector) => {
+                    let response = self.send(url.as_str(), ct).await?;
+                    let body = read_body_bounded(
+                        response,
+                        url.as_str(),
+                        self.config.max_response_body_bytes,
+                    )
+                    .await?;
+                    let matched = extract::selector_matches(&body, selector)
+                        .map_err(|e| self.invalid(format!("login test: {e}")))?;
+                    if matched {
+                        Ok(())
+                    } else {
+                        Err(self.login_failed(
+                            "login test selector matched nothing — login likely failed".to_string(),
+                        ))
+                    }
+                }
+                None => {
+                    let response = self.send(url.as_str(), ct).await?;
+                    response
+                        .error_for_status()
+                        .map(|_| ())
+                        .context(error::HttpRequestSnafu {
+                            url: redact_api_key(url.as_str()),
+                        })
+                }
+            }
         };
         match probe.await {
             Ok(()) => Ok(IndexerStatus {
@@ -626,6 +764,10 @@ impl IndexerClient for CardigannClient {
         if url.starts_with("magnet:") {
             return Ok(DownloadResponse::MagnetUri(url.to_string()));
         }
+        // WHY: a gated .torrent needs the login cookie on the fetch; a magnet
+        // above never touches the network, so the session is only ensured
+        // once a real download is imminent.
+        self.ensure_session(ct.clone()).await?;
         // SAFETY: download URLs originate in scraped third-party HTML —
         // validate scheme + resolved addresses before any fetch.
         validate_fetch_url(url).await?;
@@ -756,32 +898,129 @@ fn validate_settings(
     Ok(())
 }
 
-/// Resolves the login block to an optional Cookie header value.
+/// Builds the static `.Config` seed: definition defaults, then the indexer's
+/// settings overrides, then the injected static cookie (never
+/// user-overridable — see `validate_settings`).
+fn build_config_seed(
+    definition: &CardigannDefinition,
+    indexer_settings: &BTreeMap<String, String>,
+    cookie: Option<&str>,
+) -> BTreeMap<String, String> {
+    let mut config = BTreeMap::new();
+    for setting in &definition.settings {
+        config.insert(
+            setting.name.clone(),
+            setting
+                .default
+                .as_ref()
+                .map(|d| d.0.clone())
+                .unwrap_or_default(),
+        );
+    }
+    for (key, value) in indexer_settings {
+        config.insert(key.clone(), value.clone());
+    }
+    if let Some(cookie) = cookie {
+        config.insert("cookie".to_string(), cookie.to_string());
+    }
+    config
+}
+
+/// Resolves the login block to a [`LoginMethod`].
+///
+/// For interactive methods (form/post/get) every `.Config.<key>` referenced
+/// by `login.inputs` must resolve to a non-empty value after the settings
+/// overlay — a missing credential fails loud at construction rather than
+/// sending an empty username/password to the tracker.
 fn resolve_login(
     indexer: &IndexerConfig,
     definition: &CardigannDefinition,
-) -> Result<Option<String>, SearchIndexerError> {
+) -> Result<LoginMethod, SearchIndexerError> {
     let Some(login) = &definition.login else {
-        return Ok(None);
+        return Ok(LoginMethod::None);
     };
     // NOTE: Cardigann's default method when the login block omits one is
-    // "form", which this engine defers.
-    match login.method.as_deref().unwrap_or("form") {
-        "none" => Ok(None),
-        "cookie" => match &indexer.api_key {
-            Some(cookie) if !cookie.trim().is_empty() => Ok(Some(cookie.clone())),
-            _ => Err(SearchIndexerError::CookieAuthRequired {
+    // "form".
+    let verb = match login.method.as_deref().unwrap_or("form") {
+        "none" => return Ok(LoginMethod::None),
+        "cookie" => {
+            return match &indexer.api_key {
+                Some(cookie) if !cookie.trim().is_empty() => {
+                    Ok(LoginMethod::Cookie(cookie.clone()))
+                }
+                _ => Err(SearchIndexerError::CookieAuthRequired {
+                    definition_id: definition.id.clone(),
+                    indexer_id: indexer.id,
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                }),
+            };
+        }
+        "form" => LoginVerb::Form,
+        "post" => LoginVerb::Post,
+        "get" => LoginVerb::Get,
+        other => {
+            return Err(SearchIndexerError::LoginUnsupported {
                 definition_id: definition.id.clone(),
-                indexer_id: indexer.id,
+                method: other.to_string(),
                 location: snafu::Location::new(file!(), line!(), column!()),
-            }),
-        },
-        other => Err(SearchIndexerError::LoginUnsupported {
-            definition_id: definition.id.clone(),
-            method: other.to_string(),
-            location: snafu::Location::new(file!(), line!(), column!()),
-        }),
+            });
+        }
+    };
+
+    let config = build_config_seed(definition, &indexer.settings, None);
+    for value in login.inputs.values() {
+        for key in template::config_keys(&value.0) {
+            let resolved = config.get(&key).map(String::as_str).unwrap_or_default();
+            if resolved.trim().is_empty() {
+                return Err(SearchIndexerError::SettingsInvalid {
+                    definition_id: definition.id.clone(),
+                    indexer_id: indexer.id,
+                    reason: format!(
+                        "login requires a non-empty value for setting {key:?}; set it via the \
+                         indexer's settings (e.g. username/password)"
+                    ),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+        }
     }
+    Ok(LoginMethod::Interactive { verb })
+}
+
+/// Renders `login.path` (config-only context) and joins it on the site base.
+fn resolve_login_url(
+    indexer: &IndexerConfig,
+    definition: &CardigannDefinition,
+    base_url: &Url,
+) -> Result<Url, SearchIndexerError> {
+    let invalid = |reason: String| SearchIndexerError::DefinitionInvalid {
+        definition_id: definition.id.clone(),
+        reason,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    };
+    // INVARIANT: validate() rejects an interactive login without a login.path.
+    let path = definition
+        .login
+        .as_ref()
+        .and_then(|login| login.path.as_ref())
+        .ok_or_else(|| invalid("interactive login requires login.path".to_string()))?;
+    let cookie = match &indexer.api_key {
+        Some(cookie) if !cookie.trim().is_empty() => Some(cookie.as_str()),
+        _ => None,
+    };
+    let config = build_config_seed(definition, &indexer.settings, cookie);
+    let ctx = TemplateContext {
+        keywords: String::new(),
+        categories: Vec::new(),
+        config,
+        query: BTreeMap::new(),
+    };
+    let rendered = ctx
+        .render_url(path)
+        .map_err(|e| invalid(format!("login path: {e}")))?;
+    base_url
+        .join(rendered.trim_start_matches('/'))
+        .map_err(|e| invalid(format!("login path {rendered:?}: {e}")))
 }
 
 fn path_applies(path: &SearchPath, site_categories: &[String], unconstrained: bool) -> bool {

--- a/crates/zetesis/src/client/cardigann/session.rs
+++ b/crates/zetesis/src/client/cardigann/session.rs
@@ -137,7 +137,7 @@ impl CardigannClient {
         if self.sessions.get_cookie_header(self.indexer.id).is_some() {
             return Ok(());
         }
-        self.login(verb, ct).await
+        self.login(verb, ct).await.map(|_| ())
     }
 
     /// One full login: page fetch + form harvest (form verb), credential
@@ -147,11 +147,14 @@ impl CardigannClient {
         skip(self, ct),
         fields(indexer_id = self.indexer.id, definition_id = %self.definition.id)
     )]
+    /// Runs one full login and returns the `Cookie` header it established, so
+    /// a caller can use the fresh session directly without re-reading the
+    /// shared store (which a concurrent client's `invalidate` may have wiped).
     pub(super) async fn login(
         &self,
         verb: LoginVerb,
         ct: CancellationToken,
-    ) -> Result<(), SearchIndexerError> {
+    ) -> Result<Option<String>, SearchIndexerError> {
         let (Some(login), Some(login_url)) =
             (self.definition.login.as_ref(), self.login_url.as_ref())
         else {
@@ -203,6 +206,14 @@ impl CardigannClient {
                 self.resolve_submit_url(login, &ctx, login_url, None)?
             }
         };
+
+        // WHY: snapshot the cookies harvested BEFORE credentials are sent (the
+        // form-page GET and its redirects — e.g. an anonymous PHPSESSID). A
+        // rejected password commonly re-renders 200 with that same cookie
+        // still set, so a non-empty jar alone is not proof of a successful
+        // login; the success gate below requires a login.test pass or a
+        // cookie the credential exchange itself set or rotated.
+        let pre_auth_cookies = cookies.clone();
 
         let label = redact_query(&submit_url);
         let request = match verb {
@@ -261,11 +272,13 @@ impl CardigannClient {
             return Err(self.login_failed(format!("login response status {status}")));
         }
 
+        let mut verified_by_test = false;
         if let Some(test) = &login.test
             && let Some(selector) = &test.selector
         {
             self.verify_login_test(&client, test, selector, &mut cookies, &ct)
                 .await?;
+            verified_by_test = true;
         }
 
         if cookies.is_empty() {
@@ -275,8 +288,25 @@ impl CardigannClient {
                 self.login_failed("login flow completed without any session cookie".to_string())
             );
         }
+        // WHY: reject a "success" that rests only on pre-credential cookies.
+        // A real login either passes login.test or sets/rotates a cookie
+        // during the credential exchange; when it does neither, the password
+        // was rejected (or the definition lacks a login.test to confirm it) —
+        // storing the anonymous cookie would silently serve public/empty
+        // results forever with no failure signal to the operator.
+        let auth_cookie_set = cookies
+            .iter()
+            .any(|(name, value)| pre_auth_cookies.get(name) != Some(value));
+        if !verified_by_test && !auth_cookie_set {
+            return Err(self.login_failed(
+                "login set no post-authentication cookie and the definition has no login.test \
+                 to confirm success; the credentials were likely rejected"
+                    .to_string(),
+            ));
+        }
+        let stored = cookie_header(&cookies);
         self.sessions.store(self.indexer.id, cookies);
-        Ok(())
+        Ok(stored)
     }
 
     /// Resolves where credentials are submitted: `login.submitpath`

--- a/crates/zetesis/src/client/cardigann/session.rs
+++ b/crates/zetesis/src/client/cardigann/session.rs
@@ -1,0 +1,539 @@
+//! Per-indexer Cardigann login sessions: cookie store plus the interactive
+//! (form/post/get) login flow.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use jiff::Zoned;
+use reqwest::header;
+use scraper::{Html, Selector};
+use snafu::ResultExt;
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+use url::Url;
+
+use crate::client::cardigann::definition::{LoginBlock, LoginTest};
+use crate::client::cardigann::{CardigannClient, extract, template::TemplateContext};
+use crate::client::{SsrfGuardResolver, read_body_bounded};
+use crate::error::{self, SearchIndexerError};
+
+/// Upper bound on manual redirect follows during one login flow.
+const MAX_LOGIN_REDIRECTS: usize = 5;
+
+/// Login strategy resolved at client construction from the definition's
+/// `login:` block plus the indexer row.
+pub(crate) enum LoginMethod {
+    /// No authentication.
+    None,
+    /// Static `Cookie` header from the indexer row's `api_key` column.
+    Cookie(String),
+    /// Session-based login executed against the site.
+    Interactive { verb: LoginVerb },
+}
+
+/// HTTP shape of an interactive login.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LoginVerb {
+    /// GET the login page, harvest the form (hidden CSRF included), POST.
+    Form,
+    /// POST rendered inputs straight to `login.path`.
+    Post,
+    /// GET `login.path` with rendered inputs as query pairs.
+    Get,
+}
+
+// WHY: manual Debug — the Cookie variant carries the row's session cookie.
+impl fmt::Debug for LoginMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::None => f.write_str("None"),
+            Self::Cookie(_) => f.write_str("Cookie([redacted])"),
+            Self::Interactive { verb } => write!(f, "Interactive({verb:?})"),
+        }
+    }
+}
+
+/// Interactive-login sessions keyed by indexer-instance id.
+///
+/// WHY: keyed per indexer id, NOT per host — two indexer rows may target the
+/// same host with different accounts, and their sessions must never mix. The
+/// Cloudflare `CookieStore` is host-keyed byparr state and stays
+/// deliberately separate. In-memory only: a restart means a fresh login,
+/// matching the CF-bypass cookie posture.
+///
+/// There is no login single-flight lock: two concurrent misses both log in
+/// and the second `store` wins — benign, and lock-free keeps every reader
+/// trivial (the per-indexer rate limiter damps the duplicate request).
+#[derive(Default)]
+pub struct SessionStore {
+    sessions: DashMap<i64, Session>,
+}
+
+struct Session {
+    cookies: BTreeMap<String, String>,
+}
+
+impl SessionStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `Cookie` header value for the indexer's live session, if any.
+    ///
+    /// INVARIANT: the DashMap guard is dropped before this returns — callers
+    /// can never hold a shard lock across an await (search.rs discipline).
+    pub fn get_cookie_header(&self, indexer_id: i64) -> Option<String> {
+        let session = self.sessions.get(&indexer_id)?;
+        if session.cookies.is_empty() {
+            return None;
+        }
+        Some(format_cookie_header(&session.cookies))
+    }
+
+    pub fn store(&self, indexer_id: i64, cookies: BTreeMap<String, String>) {
+        self.sessions.insert(indexer_id, Session { cookies });
+    }
+
+    pub fn invalidate(&self, indexer_id: i64) {
+        self.sessions.remove(&indexer_id);
+    }
+}
+
+// WHY: manual Debug — cookie VALUES are session credentials; only the
+// indexer ids and cookie names are printable.
+impl fmt::Debug for SessionStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut map = f.debug_map();
+        for entry in &self.sessions {
+            map.entry(
+                entry.key(),
+                &entry.value().cookies.keys().collect::<Vec<_>>(),
+            );
+        }
+        map.finish()
+    }
+}
+
+/// A parsed login `<form>`: its `action` and every named input's value
+/// (hidden CSRF tokens included).
+struct LoginForm {
+    action: Option<String>,
+    inputs: Vec<(String, String)>,
+}
+
+impl CardigannClient {
+    /// Establishes a live session for interactive login methods; a no-op for
+    /// `none`/`cookie` and when the store already has a session.
+    pub(crate) async fn ensure_session(
+        &self,
+        ct: CancellationToken,
+    ) -> Result<(), SearchIndexerError> {
+        let LoginMethod::Interactive { verb } = &self.login else {
+            return Ok(());
+        };
+        let verb = *verb;
+        if self.sessions.get_cookie_header(self.indexer.id).is_some() {
+            return Ok(());
+        }
+        self.login(verb, ct).await
+    }
+
+    /// One full login: page fetch + form harvest (form verb), credential
+    /// submit, manual redirect chase, error-block check, `login.test`
+    /// check, session store.
+    #[instrument(
+        skip(self, ct),
+        fields(indexer_id = self.indexer.id, definition_id = %self.definition.id)
+    )]
+    pub(super) async fn login(
+        &self,
+        verb: LoginVerb,
+        ct: CancellationToken,
+    ) -> Result<(), SearchIndexerError> {
+        let (Some(login), Some(login_url)) =
+            (self.definition.login.as_ref(), self.login_url.as_ref())
+        else {
+            // INVARIANT: construction sets both for every interactive method.
+            return Err(self.login_failed("interactive login without a login block".to_string()));
+        };
+        let ctx = self.login_template_context();
+        let client = self.login_http_client()?;
+        let mut cookies: BTreeMap<String, String> = BTreeMap::new();
+
+        // WHY: inputs render PLAIN — encoding happens exactly once at
+        // body/query serialization below; render_url here would
+        // double-encode credentials.
+        let mut inputs: Vec<(String, String)> = Vec::new();
+        let submit_url = match verb {
+            LoginVerb::Form => {
+                let label = redact_query(login_url);
+                let response = self
+                    .login_send(client.get(login_url.clone()), &label, &ct)
+                    .await?;
+                harvest_cookies(response.headers(), &mut cookies);
+                let response = self
+                    .follow_login_redirects(&client, response, &mut cookies, &ct)
+                    .await?;
+                let page_url = response.url().clone();
+                let body = read_body_bounded(response, &label, self.config.max_response_body_bytes)
+                    .await?;
+                let form = parse_login_form(&body, login.form.as_deref().unwrap_or("form"))
+                    .map_err(|e| self.invalid(e))?
+                    .ok_or_else(|| {
+                        self.login_failed("login form selector matched nothing".to_string())
+                    })?;
+                inputs = form.inputs;
+                for (key, value) in &login.inputs {
+                    let rendered = ctx
+                        .render(&value.0)
+                        .map_err(|e| self.invalid(format!("login input {key}: {e}")))?;
+                    override_input(&mut inputs, key, rendered);
+                }
+                self.resolve_submit_url(login, &ctx, &page_url, form.action.as_deref())?
+            }
+            LoginVerb::Post | LoginVerb::Get => {
+                for (key, value) in &login.inputs {
+                    let rendered = ctx
+                        .render(&value.0)
+                        .map_err(|e| self.invalid(format!("login input {key}: {e}")))?;
+                    inputs.push((key.clone(), rendered));
+                }
+                self.resolve_submit_url(login, &ctx, login_url, None)?
+            }
+        };
+
+        let label = redact_query(&submit_url);
+        let request = match verb {
+            LoginVerb::Get => {
+                let mut url = submit_url;
+                if !inputs.is_empty() {
+                    // WHY: append_pair percent-encodes each credential value;
+                    // the inputs above were rendered unencoded.
+                    let mut pairs = url.query_pairs_mut();
+                    for (key, value) in &inputs {
+                        pairs.append_pair(key, value);
+                    }
+                }
+                client.get(url)
+            }
+            LoginVerb::Form | LoginVerb::Post => {
+                let body: String = url::form_urlencoded::Serializer::new(String::new())
+                    .extend_pairs(inputs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+                    .finish();
+                client
+                    .post(submit_url)
+                    .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                    .body(body)
+            }
+        };
+        let request = match cookie_header(&cookies) {
+            Some(cookie) => request.header(header::COOKIE, cookie),
+            None => request,
+        };
+        let response = self.login_send(request, &label, &ct).await?;
+        harvest_cookies(response.headers(), &mut cookies);
+        let response = self
+            .follow_login_redirects(&client, response, &mut cookies, &ct)
+            .await?;
+
+        let status = response.status();
+        let final_label = redact_query(response.url());
+        let body =
+            read_body_bounded(response, &final_label, self.config.max_response_body_bytes).await?;
+        for block in &login.error {
+            // NOTE: the reason carries only the site's own message — never
+            // the submitted credentials or request body.
+            if let Some(message) = extract::extract_error_message(
+                &body,
+                &block.selector,
+                block.message.as_ref(),
+                &ctx,
+                &Zoned::now(),
+            )
+            .map_err(|e| self.invalid(format!("login error block: {e}")))?
+            {
+                return Err(self.login_failed(message));
+            }
+        }
+        if !status.is_success() {
+            return Err(self.login_failed(format!("login response status {status}")));
+        }
+
+        if let Some(test) = &login.test
+            && let Some(selector) = &test.selector
+        {
+            self.verify_login_test(&client, test, selector, &mut cookies, &ct)
+                .await?;
+        }
+
+        if cookies.is_empty() {
+            // WHY: a cookieless "success" cannot authenticate later requests;
+            // storing it would silently re-run this flow on every search.
+            return Err(
+                self.login_failed("login flow completed without any session cookie".to_string())
+            );
+        }
+        self.sessions.store(self.indexer.id, cookies);
+        Ok(())
+    }
+
+    /// Resolves where credentials are submitted: `login.submitpath`
+    /// (rendered, joined on the site base), else the form's `action`
+    /// resolved against the login-page URL, else the login-page URL itself.
+    ///
+    /// SECURITY GATE (credential-exfiltration chokepoint): the resolved host
+    /// must equal the site base host. A hostile definition or a compromised
+    /// login page must not point the credential submit off-origin — upstream
+    /// Jackett does not enforce this; this engine deliberately does.
+    fn resolve_submit_url(
+        &self,
+        login: &LoginBlock,
+        ctx: &TemplateContext,
+        page_url: &Url,
+        action: Option<&str>,
+    ) -> Result<Url, SearchIndexerError> {
+        let submit = if let Some(submitpath) = &login.submitpath {
+            let rendered = ctx
+                .render_url(submitpath)
+                .map_err(|e| self.invalid(format!("login submitpath: {e}")))?;
+            self.base_url
+                .join(rendered.trim_start_matches('/'))
+                .map_err(|e| self.invalid(format!("login submitpath {rendered:?}: {e}")))?
+        } else if let Some(action) = action.map(str::trim).filter(|a| !a.is_empty()) {
+            page_url.join(action).map_err(|e| {
+                self.login_failed(format!(
+                    "login form action {action:?} does not resolve: {e}"
+                ))
+            })?
+        } else {
+            page_url.clone()
+        };
+        self.require_same_host(&submit, "login submit")?;
+        Ok(submit)
+    }
+
+    /// Rejects any login-flow target that leaves the indexer's host.
+    fn require_same_host(&self, url: &Url, what: &str) -> Result<(), SearchIndexerError> {
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err(self.login_failed(format!(
+                "{what} target must be http(s), got scheme {:?}",
+                url.scheme()
+            )));
+        }
+        if url.host() != self.base_url.host() {
+            return Err(self.login_failed(format!(
+                "{what} target host {:?} differs from the indexer host {:?}; \
+                 refusing to send credentials off-site",
+                url.host_str().unwrap_or("<none>"),
+                self.base_url.host_str().unwrap_or("<none>")
+            )));
+        }
+        Ok(())
+    }
+
+    /// One-shot no-redirect client for the login flow.
+    ///
+    /// WHY: the shared client auto-follows redirects and drops each hop's
+    /// Set-Cookie; login must own every hop. Mirrors `build_http_client`
+    /// (timeout + SSRF-guard resolver); a throwaway client per login is fine
+    /// — this runs once per session lifetime. No `unwrap_or_default`
+    /// fallback: a default client follows redirects and drops the SSRF
+    /// guard, so a build failure must fail closed.
+    fn login_http_client(&self) -> Result<reqwest::Client, SearchIndexerError> {
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(self.timeout)
+            .dns_resolver(Arc::new(SsrfGuardResolver))
+            .build()
+            .map_err(|e| self.login_failed(format!("login HTTP client build failed: {e}")))
+    }
+
+    /// Sends one login-flow request, honoring cancellation.
+    ///
+    /// NOTE: `url_label` is pre-redacted (query stripped) — get-method login
+    /// URLs carry credentials in the query string.
+    async fn login_send(
+        &self,
+        request: reqwest::RequestBuilder,
+        url_label: &str,
+        ct: &CancellationToken,
+    ) -> Result<reqwest::Response, SearchIndexerError> {
+        let fut = request.send();
+        tokio::select! {
+            result = fut => result.context(error::HttpRequestSnafu { url: url_label.to_string() }),
+            () = ct.cancelled() => Err(SearchIndexerError::Cancelled {
+                url: url_label.to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            }),
+        }
+    }
+
+    /// Chases 3xx responses by hand: same-host enforced, at most
+    /// [`MAX_LOGIN_REDIRECTS`] hops, cookies harvested per hop.
+    ///
+    /// WHY: manual on purpose — reqwest's auto-redirect discards each hop's
+    /// Set-Cookie, and login flows routinely set the session cookie on the
+    /// 302 itself.
+    async fn follow_login_redirects(
+        &self,
+        client: &reqwest::Client,
+        mut response: reqwest::Response,
+        cookies: &mut BTreeMap<String, String>,
+        ct: &CancellationToken,
+    ) -> Result<reqwest::Response, SearchIndexerError> {
+        let mut hops = 0;
+        while response.status().is_redirection() {
+            let Some(location) = response
+                .headers()
+                .get(header::LOCATION)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+            else {
+                // NOTE: a 3xx without Location is a final response.
+                return Ok(response);
+            };
+            hops += 1;
+            if hops > MAX_LOGIN_REDIRECTS {
+                return Err(
+                    self.login_failed(format!("login exceeded {MAX_LOGIN_REDIRECTS} redirects"))
+                );
+            }
+            let next = response.url().join(&location).map_err(|e| {
+                self.login_failed(format!("login redirect target {location:?}: {e}"))
+            })?;
+            self.require_same_host(&next, "login redirect")?;
+            let label = redact_query(&next);
+            let mut request = client.get(next);
+            if let Some(cookie) = cookie_header(cookies) {
+                request = request.header(header::COOKIE, cookie);
+            }
+            response = self.login_send(request, &label, ct).await?;
+            harvest_cookies(response.headers(), cookies);
+        }
+        Ok(response)
+    }
+
+    /// `login.test` assertion: GET the test path with the fresh cookies; the
+    /// selector must match or the login is treated as failed.
+    ///
+    /// WHY: many trackers answer a failed login with HTTP 200 — only a
+    /// content assertion can tell a session apart from a login page.
+    async fn verify_login_test(
+        &self,
+        client: &reqwest::Client,
+        test: &LoginTest,
+        selector: &str,
+        cookies: &mut BTreeMap<String, String>,
+        ct: &CancellationToken,
+    ) -> Result<(), SearchIndexerError> {
+        let url = match &test.path {
+            Some(path) => self
+                .base_url
+                .join(path.trim_start_matches('/'))
+                .map_err(|e| self.invalid(format!("login test path {path:?}: {e}")))?,
+            None => self.base_url.clone(),
+        };
+        let label = redact_query(&url);
+        let mut request = client.get(url);
+        if let Some(cookie) = cookie_header(cookies) {
+            request = request.header(header::COOKIE, cookie);
+        }
+        let response = self.login_send(request, &label, ct).await?;
+        harvest_cookies(response.headers(), cookies);
+        let response = self
+            .follow_login_redirects(client, response, cookies, ct)
+            .await?;
+        let body = read_body_bounded(response, &label, self.config.max_response_body_bytes).await?;
+        let matched = extract::selector_matches(&body, selector)
+            .map_err(|e| self.invalid(format!("login test: {e}")))?;
+        if !matched {
+            return Err(self.login_failed(
+                "login test selector matched nothing — login likely failed".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Parses the login page's `<form>` and its named inputs.
+///
+/// WHY: sync on purpose — `scraper::Html` is `!Send` and must be created and
+/// dropped between awaits (see extract.rs).
+fn parse_login_form(body: &str, form_selector: &str) -> Result<Option<LoginForm>, String> {
+    let document = Html::parse_document(body);
+    let selector =
+        Selector::parse(form_selector).map_err(|e| format!("login form {form_selector:?}: {e}"))?;
+    let Some(form) = document.select(&selector).next() else {
+        return Ok(None);
+    };
+    let input_selector =
+        Selector::parse("input[name]").map_err(|e| format!("input selector: {e}"))?;
+    let mut inputs = Vec::new();
+    for input in form.select(&input_selector) {
+        let Some(name) = input.value().attr("name") else {
+            continue;
+        };
+        // WHY: a valueless input (empty username/password field) contributes
+        // an empty string the definition's login.inputs then overlays.
+        let value = input.value().attr("value").unwrap_or("");
+        override_input(&mut inputs, name, value.to_string());
+    }
+    Ok(Some(LoginForm {
+        action: form.value().attr("action").map(str::to_string),
+        inputs,
+    }))
+}
+
+/// Replaces the named input in place (keeping page order) or appends it.
+fn override_input(inputs: &mut Vec<(String, String)>, name: &str, value: String) {
+    match inputs.iter_mut().find(|(n, _)| n == name) {
+        Some((_, v)) => *v = value,
+        None => inputs.push((name.to_string(), value)),
+    }
+}
+
+/// Accumulates `name=value` pairs from every `Set-Cookie` header; malformed
+/// headers are skipped.
+fn harvest_cookies(headers: &header::HeaderMap, cookies: &mut BTreeMap<String, String>) {
+    for value in headers.get_all(header::SET_COOKIE) {
+        let Ok(raw) = value.to_str() else {
+            continue;
+        };
+        let pair = raw.split(';').next().unwrap_or(raw);
+        let Some((name, val)) = pair.split_once('=') else {
+            continue;
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        cookies.insert(name.to_string(), val.trim().to_string());
+    }
+}
+
+fn cookie_header(cookies: &BTreeMap<String, String>) -> Option<String> {
+    if cookies.is_empty() {
+        return None;
+    }
+    Some(format_cookie_header(cookies))
+}
+
+fn format_cookie_header(cookies: &BTreeMap<String, String>) -> String {
+    cookies
+        .iter()
+        .map(|(name, value)| format!("{name}={value}"))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// URL rendered for logs/errors with its query stripped.
+///
+/// WHY: get-method login URLs carry credentials in the query; even the
+/// apikey-focused `redact_api_key` would leak them.
+fn redact_query(url: &Url) -> String {
+    let mut clean = url.clone();
+    clean.set_query(None);
+    clean.to_string()
+}

--- a/crates/zetesis/src/client/cardigann/template.rs
+++ b/crates/zetesis/src/client/cardigann/template.rs
@@ -85,6 +85,21 @@ pub fn validate(template: &str, config_keys: &[&str]) -> Result<(), String> {
     .map(|_| ())
 }
 
+/// `.Config.<key>` names referenced by `template`.
+///
+/// NOTE: unparseable expressions are skipped — load-time [`validate`] has
+/// already rejected them for every template this is called on.
+pub fn config_keys(template: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let _ = walk(template, &mut |expr| {
+        if let Ok(Expr::Config(key)) = classify(expr) {
+            keys.push(key);
+        }
+        Ok(String::new())
+    });
+    keys
+}
+
 fn walk(
     template: &str,
     on_expr: &mut dyn FnMut(&str) -> Result<String, String>,

--- a/crates/zetesis/src/client/cardigann/tests.rs
+++ b/crates/zetesis/src/client/cardigann/tests.rs
@@ -640,6 +640,84 @@ const FORM_LOGIN_PAGE: &str = r#"<html><body>
 </form>
 </body></html>"#;
 
+// A definition whose login.path is an absolute off-host URL — the same-host
+// gate must refuse it at construction, before any network request.
+const FORM_LOGIN_OFFHOST_PATH_DEF: &str = r#"---
+id: offhost-tracker
+name: Offhost Tracker
+links:
+  - https://offhost-tracker.example/
+caps:
+  categorymappings:
+    - {id: 6, cat: Movies/HD}
+  modes:
+    search: [q]
+settings:
+  - name: username
+    type: text
+  - name: password
+    type: password
+login:
+  method: form
+  path: http://evil.example/harvest
+  inputs:
+    username: "{{ .Config.username }}"
+    password: "{{ .Config.password }}"
+search:
+  paths:
+    - path: /browse
+  inputs:
+    q: "{{ .Keywords }}"
+  rows:
+    selector: table#torrents > tbody > tr
+  fields:
+    title:
+      selector: a.title
+    download:
+      selector: a.dl
+      attribute: href
+"#;
+
+// A form definition with NO login.error and NO login.test — the only success
+// signal is the cookie jar, which is exactly the case a pre-credential
+// anonymous cookie must not be allowed to satisfy.
+const FORM_LOGIN_NO_VERIFY_DEF: &str = r#"---
+id: noverify-tracker
+name: Noverify Tracker
+links:
+  - https://noverify-tracker.example/
+caps:
+  categorymappings:
+    - {id: 6, cat: Movies/HD}
+  modes:
+    search: [q]
+settings:
+  - name: username
+    type: text
+  - name: password
+    type: password
+login:
+  method: form
+  path: /login.php
+  form: form#login
+  inputs:
+    username: "{{ .Config.username }}"
+    password: "{{ .Config.password }}"
+search:
+  paths:
+    - path: /browse
+  inputs:
+    q: "{{ .Keywords }}"
+  rows:
+    selector: table#torrents > tbody > tr
+  fields:
+    title:
+      selector: a.title
+    download:
+      selector: a.dl
+      attribute: href
+"#;
+
 const SEARCH_ROWS_HTML: &str = r#"<html><body><table id="torrents"><tbody>
 <tr><td><a class="title" href="/d/1">Result.One</a></td>
 <td><a class="dl" href="/dl/1.torrent">DL</a></td></tr>
@@ -841,6 +919,89 @@ async fn foreign_host_form_action_refuses_and_leaks_no_request() {
     assert!(
         !heads.iter().any(|h| h.contains("evil.example")),
         "off-origin request leaked: {heads:?}"
+    );
+}
+
+#[tokio::test]
+async fn absolute_off_host_login_path_refused_at_construction() {
+    // No server: the same-host gate must fire during construction, before any
+    // request could leave for the foreign host.
+    let err = client_with_settings(
+        FORM_LOGIN_OFFHOST_PATH_DEF,
+        "https://offhost-tracker.example".to_string(),
+        None,
+        creds(),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionInvalid { .. }),
+        "an off-host login.path must be refused at construction, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn pre_credential_cookie_alone_is_not_login_success() {
+    // GET /login.php sets an anonymous session cookie; the credential POST is
+    // rejected and re-renders 200 with the SAME cookie and no error/test
+    // markup. The pre-credential cookie must not be accepted as proof.
+    let (url, server) = spawn_sequence_http(vec![
+        (
+            200,
+            vec![header("set-cookie", "PHPSESSID=anon; Path=/")],
+            FORM_LOGIN_PAGE.to_string(),
+        ),
+        // Rejected login: 200, same anonymous cookie re-set, no new session.
+        (
+            200,
+            vec![header("set-cookie", "PHPSESSID=anon; Path=/")],
+            "<html><body>wrong password</body></html>".to_string(),
+        ),
+    ])
+    .await;
+
+    let err = client_with_settings(FORM_LOGIN_NO_VERIFY_DEF, url, None, creds())
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::LoginFailed { .. }),
+        "a login proven only by a pre-credential cookie must fail, got {err:?}"
+    );
+    let _ = server.await.unwrap();
+}
+
+#[tokio::test]
+async fn credential_phase_cookie_confirms_login_without_test_block() {
+    // Same no-verify definition, but the POST sets a NEW cookie — a genuine
+    // post-authentication session — so the login is accepted and the search
+    // proceeds on that cookie.
+    let (url, server) = spawn_sequence_http(vec![
+        (
+            200,
+            vec![header("set-cookie", "PHPSESSID=anon; Path=/")],
+            FORM_LOGIN_PAGE.to_string(),
+        ),
+        (
+            200,
+            vec![header("set-cookie", "auth=live-42; Path=/")],
+            "<html><body>welcome</body></html>".to_string(),
+        ),
+        (200, vec![], SEARCH_ROWS_HTML.to_string()),
+    ])
+    .await;
+
+    let results = client_with_settings(FORM_LOGIN_NO_VERIFY_DEF, url, None, creds())
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    let heads = server.await.unwrap();
+    let search = heads.last().unwrap().to_lowercase();
+    assert!(
+        search.contains("auth=live-42"),
+        "search must carry the post-auth cookie: {search}"
     );
 }
 

--- a/crates/zetesis/src/client/cardigann/tests.rs
+++ b/crates/zetesis/src/client/cardigann/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::cf_bypass::noop::NoProxy;
-use crate::test_support::{spawn_one_shot_http, spawn_raw_http};
+use crate::test_support::{spawn_one_shot_http, spawn_raw_http, spawn_sequence_http};
 
 const SAMPLE_DEF: &str = r#"---
 id: sample-tracker
@@ -121,6 +121,16 @@ fn client_with_settings(
     api_key: Option<&str>,
     settings: BTreeMap<String, String>,
 ) -> Result<CardigannClient, SearchIndexerError> {
+    client_with_sessions(yaml, url, api_key, settings, Arc::new(SessionStore::new()))
+}
+
+fn client_with_sessions(
+    yaml: &str,
+    url: String,
+    api_key: Option<&str>,
+    settings: BTreeMap<String, String>,
+    sessions: Arc<SessionStore>,
+) -> Result<CardigannClient, SearchIndexerError> {
     CardigannClient::new(
         Arc::new(SearchSubsystemConfig::default()),
         reqwest::Client::new(),
@@ -135,6 +145,7 @@ fn client_with_settings(
             settings,
         },
         definition(yaml),
+        sessions,
     )
 }
 
@@ -532,12 +543,600 @@ fn cookie_login_without_api_key_errors() {
 }
 
 #[test]
-fn form_login_is_unsupported_at_construction() {
-    let yaml = format!("{SAMPLE_DEF}\nlogin:\n  method: form\n");
+fn unknown_login_method_is_unsupported_at_construction() {
+    let yaml = format!("{SAMPLE_DEF}\nlogin:\n  method: oneurl\n");
     let err = client(&yaml, "http://127.0.0.1:9/".to_string(), None).unwrap_err();
     assert!(
-        matches!(err, SearchIndexerError::LoginUnsupported { ref method, .. } if method == "form"),
+        matches!(err, SearchIndexerError::LoginUnsupported { ref method, .. } if method == "oneurl"),
         "got {err:?}"
+    );
+}
+
+// ── interactive login (form / post / get) ──────────────────────────────────
+
+const FORM_LOGIN_DEF: &str = r#"---
+id: form-tracker
+name: Form Tracker
+links:
+  - https://form-tracker.example/
+caps:
+  categorymappings:
+    - {id: 6, cat: Movies/HD}
+  modes:
+    search: [q]
+settings:
+  - name: username
+    type: text
+  - name: password
+    type: password
+login:
+  method: form
+  path: /login.php
+  form: form#login
+  inputs:
+    username: "{{ .Config.username }}"
+    password: "{{ .Config.password }}"
+  error:
+    - selector: span.error
+  test:
+    path: /profile
+    selector: a.logout
+search:
+  paths:
+    - path: /browse
+  inputs:
+    q: "{{ .Keywords }}"
+  rows:
+    selector: table#torrents > tbody > tr
+  fields:
+    title:
+      selector: a.title
+    download:
+      selector: a.dl
+      attribute: href
+"#;
+
+const POST_LOGIN_DEF: &str = r#"---
+id: post-tracker
+name: Post Tracker
+links:
+  - https://post-tracker.example/
+caps:
+  categorymappings:
+    - {id: 6, cat: Movies/HD}
+  modes:
+    search: [q]
+settings:
+  - name: username
+    type: text
+  - name: password
+    type: password
+login:
+  method: post
+  path: /takelogin.php
+  inputs:
+    username: "{{ .Config.username }}"
+    password: "{{ .Config.password }}"
+search:
+  paths:
+    - path: /browse
+  inputs:
+    q: "{{ .Keywords }}"
+  rows:
+    selector: table#torrents > tbody > tr
+  fields:
+    title:
+      selector: a.title
+    download:
+      selector: a.dl
+      attribute: href
+"#;
+
+const FORM_LOGIN_PAGE: &str = r#"<html><body>
+<form id="login" method="post" action="/login.php">
+<input type="hidden" name="csrf_token" value="tok-42">
+<input type="text" name="username" value="">
+<input type="password" name="password" value="">
+</form>
+</body></html>"#;
+
+const SEARCH_ROWS_HTML: &str = r#"<html><body><table id="torrents"><tbody>
+<tr><td><a class="title" href="/d/1">Result.One</a></td>
+<td><a class="dl" href="/dl/1.torrent">DL</a></td></tr>
+</tbody></table></body></html>"#;
+
+const LOGGED_IN_HTML: &str =
+    r#"<html><body><a class="logout" href="/logout">Logout</a></body></html>"#;
+
+fn header(name: &str, value: &str) -> (String, String) {
+    (name.to_string(), value.to_string())
+}
+
+fn creds() -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("username".to_string(), "alice".to_string()),
+        ("password".to_string(), "secret".to_string()),
+    ])
+}
+
+fn login_query() -> SearchQuery {
+    SearchQuery {
+        query_text: Some("hello".to_string()),
+        limit: 100,
+        ..Default::default()
+    }
+}
+
+fn request_body(head: &str) -> &str {
+    head.split("\r\n\r\n").nth(1).unwrap_or_default()
+}
+
+#[tokio::test]
+async fn form_login_happy_path_harvests_csrf_and_carries_session() {
+    let (url, server) = spawn_sequence_http(vec![
+        // GET login page: hidden CSRF + a session cookie.
+        (
+            200,
+            vec![header("set-cookie", "sess=abc; Path=/")],
+            FORM_LOGIN_PAGE.to_string(),
+        ),
+        // POST credentials: success page + session cookie.
+        (
+            200,
+            vec![header("set-cookie", "uid=42; Path=/")],
+            "<html><body>ok</body></html>".to_string(),
+        ),
+        // login.test probe.
+        (200, vec![], LOGGED_IN_HTML.to_string()),
+        // search fetch.
+        (200, vec![], SEARCH_ROWS_HTML.to_string()),
+    ])
+    .await;
+
+    let results = client_with_settings(FORM_LOGIN_DEF, url, None, creds())
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+
+    let heads = server.await.unwrap();
+    assert_eq!(heads.len(), 4, "unexpected request count: {heads:?}");
+    assert!(heads[0].starts_with("GET /login.php"), "got {}", heads[0]);
+
+    let post = &heads[1];
+    assert!(post.starts_with("POST /login.php"), "got {post}");
+    let post_lower = post.to_lowercase();
+    assert!(
+        post_lower.contains("content-type: application/x-www-form-urlencoded"),
+        "missing urlencoded content-type: {post}"
+    );
+    // WHY: the page-GET session cookie must ride the POST.
+    assert!(
+        post_lower.contains("cookie: sess=abc"),
+        "page-GET cookie not sent on POST: {post}"
+    );
+    let body = request_body(post);
+    assert!(
+        body.contains("csrf_token=tok-42"),
+        "CSRF not harvested: {body}"
+    );
+    assert!(body.contains("username=alice"), "got body: {body}");
+    assert!(body.contains("password=secret"), "got body: {body}");
+
+    assert!(heads[2].starts_with("GET /profile"), "got {}", heads[2]);
+
+    let search = &heads[3];
+    assert!(search.starts_with("GET /browse?q=hello"), "got {search}");
+    // WHY: both the page cookie and the POST cookie authenticate the search.
+    assert!(
+        search.to_lowercase().contains("uid=42"),
+        "session cookie missing: {search}"
+    );
+}
+
+#[tokio::test]
+async fn set_cookie_captured_on_302_hop() {
+    let (url, server) = spawn_sequence_http(vec![
+        // POST → 302 that itself carries the session cookie.
+        (
+            302,
+            vec![
+                header("location", "/index.php"),
+                header("set-cookie", "uid=99; Path=/"),
+            ],
+            String::new(),
+        ),
+        // Redirect follow.
+        (200, vec![], "<html><body>ok</body></html>".to_string()),
+        // Search fetch.
+        (200, vec![], SEARCH_ROWS_HTML.to_string()),
+    ])
+    .await;
+
+    let results = client_with_settings(POST_LOGIN_DEF, url, None, creds())
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+
+    let heads = server.await.unwrap();
+    assert_eq!(heads.len(), 3, "{heads:?}");
+    assert!(
+        heads[0].starts_with("POST /takelogin.php"),
+        "got {}",
+        heads[0]
+    );
+    assert!(heads[1].starts_with("GET /index.php"), "got {}", heads[1]);
+    assert!(
+        heads[2].to_lowercase().contains("uid=99"),
+        "cookie set on the 302 hop was lost: {}",
+        heads[2]
+    );
+}
+
+#[tokio::test]
+async fn login_error_selector_reports_site_message_never_credentials() {
+    let error_page =
+        r#"<html><body><span class="error">Invalid username or password</span></body></html>"#;
+    let (url, server) = spawn_sequence_http(vec![
+        (
+            200,
+            vec![header("set-cookie", "sess=abc")],
+            FORM_LOGIN_PAGE.to_string(),
+        ),
+        (200, vec![], error_page.to_string()),
+    ])
+    .await;
+
+    let err = client_with_settings(FORM_LOGIN_DEF, url, None, creds())
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap_err();
+    match err {
+        SearchIndexerError::LoginFailed { reason, .. } => {
+            assert!(
+                reason.contains("Invalid username or password"),
+                "site message missing: {reason}"
+            );
+            assert!(!reason.contains("secret"), "credentials leaked: {reason}");
+        }
+        other => panic!("expected LoginFailed, got {other:?}"),
+    }
+    let _ = server.await.unwrap();
+}
+
+#[tokio::test]
+async fn foreign_host_form_action_refuses_and_leaks_no_request() {
+    let page = r#"<html><body>
+<form id="login" method="post" action="http://evil.example/steal">
+<input type="hidden" name="csrf_token" value="x">
+<input type="text" name="username" value="">
+<input type="password" name="password" value="">
+</form></body></html>"#;
+    let (url, server) = spawn_sequence_http(vec![(
+        200,
+        vec![header("set-cookie", "sess=abc")],
+        page.to_string(),
+    )])
+    .await;
+
+    let err = client_with_settings(FORM_LOGIN_DEF, url, None, creds())
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::LoginFailed { .. }),
+        "got {err:?}"
+    );
+
+    let heads = server.await.unwrap();
+    // WHY: only the login-page GET — the credential POST never left for the
+    // foreign host, proving the same-host exfiltration gate.
+    assert_eq!(heads.len(), 1, "a request leaked off-origin: {heads:?}");
+    assert!(heads[0].starts_with("GET /login.php"), "got {}", heads[0]);
+    assert!(
+        !heads.iter().any(|h| h.contains("evil.example")),
+        "off-origin request leaked: {heads:?}"
+    );
+}
+
+#[tokio::test]
+async fn login_redirect_hop_cap_fails() {
+    let mut responses = vec![(302, vec![header("location", "/r")], String::new())];
+    for _ in 0..5 {
+        responses.push((302, vec![header("location", "/r")], String::new()));
+    }
+    let (url, server) = spawn_sequence_http(responses).await;
+
+    let err = client_with_settings(POST_LOGIN_DEF, url, None, creds())
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::LoginFailed { ref reason, .. } if reason.contains("redirect")),
+        "got {err:?}"
+    );
+    let _ = server.await.unwrap();
+}
+
+#[tokio::test]
+async fn post_login_sends_no_page_get() {
+    let (url, server) = spawn_sequence_http(vec![
+        (
+            200,
+            vec![header("set-cookie", "uid=1")],
+            "<html>ok</html>".to_string(),
+        ),
+        (200, vec![], SEARCH_ROWS_HTML.to_string()),
+    ])
+    .await;
+
+    let results = client_with_settings(POST_LOGIN_DEF, url, None, creds())
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+
+    let heads = server.await.unwrap();
+    // WHY: the post method skips the form-page GET entirely.
+    assert_eq!(heads.len(), 2, "unexpected extra request: {heads:?}");
+    assert!(
+        heads[0].starts_with("POST /takelogin.php"),
+        "first request must be the credential POST: {}",
+        heads[0]
+    );
+    let body = request_body(&heads[0]);
+    assert!(
+        body.contains("username=alice") && body.contains("password=secret"),
+        "got body: {body}"
+    );
+    assert!(heads[1].starts_with("GET /browse"), "got {}", heads[1]);
+}
+
+#[tokio::test]
+async fn session_reused_across_two_searches() {
+    let sessions = Arc::new(SessionStore::new());
+    let (url, server) = spawn_sequence_http(vec![
+        (
+            200,
+            vec![header("set-cookie", "uid=7")],
+            "<html>ok</html>".to_string(),
+        ),
+        (200, vec![], SEARCH_ROWS_HTML.to_string()),
+        (200, vec![], SEARCH_ROWS_HTML.to_string()),
+    ])
+    .await;
+
+    for _ in 0..2 {
+        client_with_sessions(
+            POST_LOGIN_DEF,
+            url.clone(),
+            None,
+            creds(),
+            Arc::clone(&sessions),
+        )
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap();
+    }
+
+    let heads = server.await.unwrap();
+    assert_eq!(heads.len(), 3, "{heads:?}");
+    let logins = heads.iter().filter(|h| h.starts_with("POST")).count();
+    assert_eq!(logins, 1, "login ran more than once: {heads:?}");
+}
+
+#[tokio::test]
+async fn stale_session_invalidates_relogs_and_retries_once() {
+    let (url, server) = spawn_sequence_http(vec![
+        // Initial login.
+        (
+            200,
+            vec![header("set-cookie", "uid=1")],
+            "<html>ok</html>".to_string(),
+        ),
+        // Search redirects to the login path (expired session).
+        (
+            302,
+            vec![header("location", "/takelogin.php")],
+            String::new(),
+        ),
+        // Auto-followed login page (shared client follows redirects).
+        (200, vec![], "<html>login</html>".to_string()),
+        // Re-login.
+        (
+            200,
+            vec![header("set-cookie", "uid=2")],
+            "<html>ok</html>".to_string(),
+        ),
+        // Retried search succeeds.
+        (200, vec![], SEARCH_ROWS_HTML.to_string()),
+    ])
+    .await;
+
+    let results = client_with_settings(POST_LOGIN_DEF, url, None, creds())
+        .unwrap()
+        .search(&login_query(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+
+    let heads = server.await.unwrap();
+    assert_eq!(heads.len(), 5, "{heads:?}");
+    assert!(
+        heads[0].starts_with("POST /takelogin.php"),
+        "got {}",
+        heads[0]
+    );
+    assert!(heads[1].starts_with("GET /browse"), "got {}", heads[1]);
+    assert!(
+        heads[2].starts_with("GET /takelogin.php"),
+        "got {}",
+        heads[2]
+    );
+    assert!(
+        heads[3].starts_with("POST /takelogin.php"),
+        "got {}",
+        heads[3]
+    );
+    assert!(heads[4].starts_with("GET /browse"), "got {}", heads[4]);
+    // WHY: the retry rides the fresh session cookie, not the stale one.
+    assert!(
+        heads[4].to_lowercase().contains("uid=2"),
+        "retry did not use the fresh session: {}",
+        heads[4]
+    );
+}
+
+#[tokio::test]
+async fn login_test_selector_drives_test_healthy() {
+    let (url, server) = spawn_sequence_http(vec![
+        (
+            200,
+            vec![header("set-cookie", "sess=abc")],
+            FORM_LOGIN_PAGE.to_string(),
+        ),
+        (
+            200,
+            vec![header("set-cookie", "uid=1")],
+            "<html>ok</html>".to_string(),
+        ),
+        // login.test during login().
+        (200, vec![], LOGGED_IN_HTML.to_string()),
+        // test() content assertion.
+        (200, vec![], LOGGED_IN_HTML.to_string()),
+    ])
+    .await;
+
+    let status = client_with_settings(FORM_LOGIN_DEF, url, None, creds())
+        .unwrap()
+        .test(CancellationToken::new())
+        .await
+        .unwrap();
+    assert!(status.healthy, "error: {:?}", status.error);
+    let _ = server.await.unwrap();
+}
+
+#[tokio::test]
+async fn login_test_selector_absent_marks_unhealthy() {
+    let (url, server) = spawn_sequence_http(vec![
+        (
+            200,
+            vec![header("set-cookie", "sess=abc")],
+            FORM_LOGIN_PAGE.to_string(),
+        ),
+        (
+            200,
+            vec![header("set-cookie", "uid=1")],
+            "<html>ok</html>".to_string(),
+        ),
+        // login.test probe: no logout link → session not established.
+        (
+            200,
+            vec![],
+            "<html><body>no session here</body></html>".to_string(),
+        ),
+    ])
+    .await;
+
+    let status = client_with_settings(FORM_LOGIN_DEF, url, None, creds())
+        .unwrap()
+        .test(CancellationToken::new())
+        .await
+        .unwrap();
+    assert!(!status.healthy);
+    assert!(
+        status
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("matched nothing"),
+        "got {:?}",
+        status.error
+    );
+    let _ = server.await.unwrap();
+}
+
+#[test]
+fn cf_bypass_with_form_login_unsupported_at_construction() {
+    let err = CardigannClient::new(
+        Arc::new(SearchSubsystemConfig::default()),
+        reqwest::Client::new(),
+        Arc::new(NoProxy),
+        Duration::from_secs(5),
+        IndexerConfig {
+            id: 1,
+            name: "Test".to_string(),
+            url: "https://form-tracker.example/".to_string(),
+            api_key: None,
+            cf_bypass: true,
+            settings: creds(),
+        },
+        definition(FORM_LOGIN_DEF),
+        Arc::new(SessionStore::new()),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionUnsupported { ref feature, .. } if feature.contains("cf_bypass")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn form_login_missing_credential_fails_construction() {
+    // WHY: password unset → the .Config.password login input cannot resolve.
+    let settings = BTreeMap::from([("username".to_string(), "alice".to_string())]);
+    let err = client_with_settings(
+        FORM_LOGIN_DEF,
+        "https://form-tracker.example/".to_string(),
+        None,
+        settings,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::SettingsInvalid { ref reason, .. } if reason.contains("password")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn debug_client_and_store_hide_credential_values() {
+    let sessions = Arc::new(SessionStore::new());
+    sessions.store(
+        1,
+        BTreeMap::from([("uid".to_string(), "supersecretcookievalue".to_string())]),
+    );
+    let client = client_with_sessions(
+        FORM_LOGIN_DEF,
+        "https://form-tracker.example/".to_string(),
+        None,
+        creds(),
+        Arc::clone(&sessions),
+    )
+    .unwrap();
+
+    let client_debug = format!("{client:?}");
+    assert!(
+        !client_debug.contains("secret"),
+        "client Debug leaked credentials: {client_debug}"
+    );
+
+    let store_debug = format!("{sessions:?}");
+    assert!(
+        !store_debug.contains("supersecretcookievalue"),
+        "store Debug leaked a cookie value: {store_debug}"
+    );
+    // WHY: cookie NAMES are safe to show and aid debugging.
+    assert!(
+        store_debug.contains("uid"),
+        "cookie name not shown: {store_debug}"
     );
 }
 
@@ -709,6 +1308,7 @@ fn registry_client_for_unknown_url_errors() {
             reqwest::Client::new(),
             Arc::new(NoProxy),
             Duration::from_secs(5),
+            Arc::new(SessionStore::new()),
         )
         .unwrap_err();
     assert!(

--- a/crates/zetesis/src/error.rs
+++ b/crates/zetesis/src/error.rs
@@ -149,13 +149,27 @@ pub enum SearchIndexerError {
     },
 
     #[snafu(display(
-        "Cardigann definition {definition_id} uses login method {method:?}; only \
-         'none' and 'cookie' are supported — expose the tracker via a Torznab \
-         sidecar instead"
+        "Cardigann definition {definition_id} uses login method {method:?}; supported \
+         methods are 'none', 'cookie', 'form', 'post', and 'get' — expose the tracker \
+         via a Torznab sidecar instead"
     ))]
     LoginUnsupported {
         definition_id: String,
         method: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    // NOTE: `reason` carries selector diagnostics or the site's own error
+    // message — never credentials, request bodies, or full login URLs.
+    #[snafu(display(
+        "Cardigann login failed for indexer {indexer_id} (definition {definition_id}): \
+         {reason}"
+    ))]
+    LoginFailed {
+        definition_id: String,
+        indexer_id: i64,
+        reason: String,
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, instrument, warn};
 
 use crate::cf_bypass::CloudflareProxy;
-use crate::client::cardigann::CardigannRegistry;
+use crate::client::cardigann::{CardigannRegistry, SessionStore};
 use crate::client::newznab::NewznabClient;
 use crate::client::torznab::TorznabClient;
 use crate::client::{DynIndexerClient, IndexerConfig, SsrfGuardResolver};
@@ -59,6 +59,11 @@ pub struct SearchIndexerService {
     // `cardigann_definitions_dir` change re-runs `CardigannRegistry::load`
     // and swaps the Arc; a load failure keeps the previous registry.
     cardigann: std::sync::RwLock<Arc<CardigannRegistry>>,
+    // WHY: interactive-login sessions live on the service, not on the
+    // per-search ephemeral CardigannClient — a session must outlive the
+    // client that created it. In-memory only: a restart re-logs-in,
+    // matching the CF-bypass cookie posture.
+    cardigann_sessions: Arc<SessionStore>,
     event_tx: EventSender,
 }
 
@@ -92,6 +97,7 @@ impl SearchIndexerService {
             http: std::sync::RwLock::new((cfg.request_timeout_secs, http)),
             config,
             cardigann: std::sync::RwLock::new(Arc::new(cardigann)),
+            cardigann_sessions: Arc::new(SessionStore::new()),
             event_tx,
         }
     }
@@ -180,6 +186,7 @@ impl SearchIndexerService {
         // Step 3: Parallel fan-out
         let cf_proxy = self.cf_proxy_snapshot();
         let cardigann = self.cardigann_snapshot();
+        let cardigann_sessions = Arc::clone(&self.cardigann_sessions);
         let http = self.http_client(cfg.request_timeout_secs);
         let timeout = Duration::from_secs(cfg.search_timeout_seconds);
         let max_body_bytes = cfg.max_response_body_bytes;
@@ -190,6 +197,7 @@ impl SearchIndexerService {
             .map(|indexer| {
                 let cf = Arc::clone(&cf_proxy);
                 let cardigann = Arc::clone(&cardigann);
+                let sessions = Arc::clone(&cardigann_sessions);
                 let h = http.clone();
                 let ct = ct.clone();
                 let q = query.clone();
@@ -204,20 +212,27 @@ impl SearchIndexerService {
                         );
                         return Vec::new();
                     }
-                    let client =
-                        match make_client(&indexer, h, cf, timeout, max_body_bytes, &cardigann) {
-                            Ok(client) => client,
-                            Err(e) => {
-                                warn!(
-                                    indexer_id = indexer.id,
-                                    indexer_name = %indexer.name,
-                                    error = %e,
-                                    "failed to construct indexer client"
-                                );
-                                self.handle_search_error(&indexer, &e).await;
-                                return Vec::new();
-                            }
-                        };
+                    let client = match make_client(
+                        &indexer,
+                        h,
+                        cf,
+                        timeout,
+                        max_body_bytes,
+                        &cardigann,
+                        sessions,
+                    ) {
+                        Ok(client) => client,
+                        Err(e) => {
+                            warn!(
+                                indexer_id = indexer.id,
+                                indexer_name = %indexer.name,
+                                error = %e,
+                                "failed to construct indexer client"
+                            );
+                            self.handle_search_error(&indexer, &e).await;
+                            return Vec::new();
+                        }
+                    };
                     match client.search_boxed(&q, ct).await {
                         Ok(mut results) => {
                             // WHY: cap each indexer's contribution BEFORE the
@@ -289,6 +304,7 @@ impl SearchIndexerService {
             Duration::from_secs(cfg.request_timeout_secs),
             cfg.max_response_body_bytes,
             &self.cardigann_snapshot(),
+            Arc::clone(&self.cardigann_sessions),
         )?;
         let status = client.test_boxed(ct).await?;
         let db_status = if status.healthy { "active" } else { "degraded" };
@@ -315,6 +331,7 @@ impl SearchIndexerService {
             Duration::from_secs(cfg.request_timeout_secs),
             cfg.max_response_body_bytes,
             &self.cardigann_snapshot(),
+            Arc::clone(&self.cardigann_sessions),
         )?;
         let caps =
             client
@@ -426,7 +443,11 @@ impl SearchIndexerService {
         }
 
         let new_status = match error {
-            SearchIndexerError::AuthFailed { .. } => Some("failed"),
+            // WHY: a rejected login (bad credentials, off-host submit, failed
+            // login-test) needs operator intervention, same as a bad API key.
+            SearchIndexerError::AuthFailed { .. } | SearchIndexerError::LoginFailed { .. } => {
+                Some("failed")
+            }
             SearchIndexerError::NoCfBypass { .. } => Some("degraded"),
             SearchIndexerError::CfProxyTimeout { .. } | SearchIndexerError::CfProxyError { .. } => {
                 Some("degraded")
@@ -554,6 +575,13 @@ fn deduplicate(results: Vec<SearchResult>) -> Vec<SearchResult> {
     deduped
 }
 
+// WHY: a protocol-dispatch factory that threads every per-request dependency
+// (transport, proxy, timeouts, definition registry, session store) into the
+// right client — a params struct would just relocate the same wiring.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "dependency-injection factory; each arg is a distinct live dependency"
+)]
 fn make_client(
     indexer: &IndexerRow,
     http: reqwest::Client,
@@ -561,6 +589,7 @@ fn make_client(
     timeout: Duration,
     max_body_bytes: u64,
     cardigann: &CardigannRegistry,
+    cardigann_sessions: Arc<SessionStore>,
 ) -> Result<Box<dyn DynIndexerClient>, SearchIndexerError> {
     // WHY: a corrupt settings_json blob must fail loud — silently falling
     // back to defaults would mask the row that just lost its overrides.
@@ -592,7 +621,9 @@ fn make_client(
             timeout,
             max_body_bytes,
         )),
-        "cardigann" => Box::new(cardigann.client_for(config, http, cf_proxy, timeout)?),
+        "cardigann" => {
+            Box::new(cardigann.client_for(config, http, cf_proxy, timeout, cardigann_sessions)?)
+        }
         _ => Box::new(TorznabClient::new(
             config,
             http,

--- a/crates/zetesis/src/test_support.rs
+++ b/crates/zetesis/src/test_support.rs
@@ -35,6 +35,68 @@ pub(crate) async fn spawn_raw_http(raw_response: Vec<u8>) -> (String, JoinHandle
     (base_url, handle)
 }
 
+/// Spawns a TCP server that answers `responses.len()` sequential connections,
+/// one HTTP response each in order, and resolves to the request head from
+/// every connection it served.
+///
+/// Each response carries its extra headers, a correct `Content-Length`, and
+/// `Connection: close` so the client opens a fresh connection per request —
+/// which keeps the request/response pairing deterministic for multi-hop
+/// login flows.
+pub(crate) async fn spawn_sequence_http(
+    responses: Vec<(u16, Vec<(String, String)>, String)>,
+) -> (String, JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+
+    let handle = tokio::spawn(async move {
+        let mut heads = Vec::with_capacity(responses.len());
+        for (status, extra_headers, body) in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            let header_end;
+            loop {
+                let n = stream.read(&mut chunk).await.unwrap();
+                assert!(n > 0, "client closed before sending full headers");
+                buf.extend_from_slice(&chunk[..n]);
+                if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+                    header_end = pos + 4;
+                    break;
+                }
+            }
+            // WHY: read the declared request body too, so multi-hop login
+            // tests can assert on POST form bodies without depending on TCP
+            // segmentation.
+            if let Some(len) = content_length(&buf[..header_end]) {
+                while buf.len() < header_end + len {
+                    let n = stream.read(&mut chunk).await.unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    buf.extend_from_slice(&chunk[..n]);
+                }
+            }
+            heads.push(String::from_utf8_lossy(&buf).into_owned());
+
+            let mut response = format!("HTTP/1.1 {status} OK\r\n");
+            for (name, value) in &extra_headers {
+                response.push_str(&format!("{name}: {value}\r\n"));
+            }
+            response.push_str(&format!(
+                "content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            ));
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+        heads
+    });
+
+    (base_url, handle)
+}
+
 /// Spawns a TCP server that answers exactly one HTTP request with `status`,
 /// the given extra headers, and `body` (with a correct `Content-Length`).
 pub(crate) async fn spawn_one_shot_http(
@@ -77,4 +139,15 @@ pub(crate) async fn spawn_hang_http() -> (String, JoinHandle<()>) {
 
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Parses the `Content-Length` header value out of a request head.
+fn content_length(head: &[u8]) -> Option<usize> {
+    let text = String::from_utf8_lossy(head);
+    text.lines()
+        .find_map(|line| {
+            line.split_once(':')
+                .filter(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+        })
+        .and_then(|(_, v)| v.trim().parse().ok())
 }

--- a/docs/download/indexer-protocol.md
+++ b/docs/download/indexer-protocol.md
@@ -414,19 +414,36 @@ Indexer rows select the client with `protocol = 'cardigann'`; the row's `url` co
 | `search.fields` | Yes | `selector`, `attribute`, `text`, `optional`, `case`, `remove`, filters |
 | Filter chains | Common set | `regexp`, `re_replace`, `replace`, `split`, `trim`, `prepend`, `append`, `tolower`, `toupper`, `querystring`, `dateparse`, `timeago` (best-effort); unknown filters rejected at load |
 | `download` | `selector`/`attribute`/filters | `before` pre-requests and `infohash` fallback warned and ignored |
-| `login` | `none`, `cookie` | Form/post/get/oneurl fail at client construction with a clear error |
+| `login` | `none`, `cookie`, `form`, `post`, `get` | Interactive methods log in against the site and cache a per-indexer session cookie. `login.error` blocks surface the tracker's failure message; `login.test` (path + selector) is a content assertion. `login.selectorinputs` / `login.captcha` and `oneurl` / unknown methods are rejected. See **Interactive login** below |
 | `settings` | Yes | Per-indexer overrides stored on the indexer row (`settings_json`), validated at client construction against the declared `settings:` fields, and overlaid onto `.Config.<key>` (definition `default:` → user override → injected `cookie`). `checkbox` values render as the literal strings `"true"`/`"false"`; `{{ if .Config.x }}` conditionals stay rejected at load (this engine's template subset has no `if`) |
 | `ratio` | No | Deferred |
 
 **Definition source**: Harmonia reads Prowlarr-compatible YAML definitions from `config.zetesis.cardigann_definitions_dir`, one indexer per `.yml`/`.yaml` file, at startup (`SearchIndexerService::new` → `CardigannRegistry::load`). Definitions that fail validation are skipped with a warning naming the unsupported construct. Third-party definitions are not vendored into the repo.
 
-**Authentication-required trackers**: Only `login.method: none` and `cookie` are executed. Trackers that require form submission or multi-step login should use a Prowlarr sidecar and expose it as a Torznab feed to Harmonia; this is the practical escape hatch for the most complex trackers.
+**Authentication-required trackers**: `login.method: none`, `cookie`, `form`, `post`, and `get` are executed directly. For `cookie`, the indexer row's `api_key` column carries the session cookie. For the interactive methods (`form`/`post`/`get`), credentials come from the indexer's `settings` (e.g. `username`/`password` referenced as `{{ .Config.username }}` in `login.inputs`) and Harmonia performs the login itself, caching the resulting session per indexer. Trackers that need CAPTCHA solving, selector-driven inputs (`login.selectorinputs`), or the `oneurl` flow are rejected at load; those still route through a Prowlarr sidecar exposed as a Torznab feed.
+
+### Interactive login (`form` / `post` / `get`)
+
+`CardigannClient` establishes a session before the first search/test/download and reuses it across requests:
+
+- **`form`**: GET `login.path` with a dedicated no-redirect client, harvest every `Set-Cookie` and every `input[name]` (hidden CSRF tokens included) inside the `login.form` selector (default `form`), overlay the rendered `login.inputs`, then POST `application/x-www-form-urlencoded` to `login.submitpath` (rendered) — else the form's `action`, else the login-page URL.
+- **`post`**: skip the page fetch; POST the rendered `login.inputs` straight to `login.path`.
+- **`get`**: same as `post` with an HTTP GET, inputs carried as query pairs.
+
+Shared discipline:
+
+- **Same-host gate (credential-exfiltration chokepoint)**: the resolved submit target and every redirect hop must share the indexer's host, or the login fails without a request leaving — a hostile definition or a compromised login page cannot POST credentials off-origin. Redirects are followed manually (capped at 5) so each hop's `Set-Cookie` is captured.
+- **Sessions** are keyed by indexer-instance id (two rows on one host with different accounts never mix), held in memory only (a restart re-logs-in), and reused until they go stale.
+- **Staleness**: a search whose final URL lands back on the login path, or a 401/403, invalidates the session and re-logs-in once before retrying the fetch once; a second failure is an auth failure.
+- **`login.error`** blocks turn the tracker's own message into a `LoginFailed` error (the submitted body/credentials are never echoed). **`login.test`** (path + selector) is a content assertion — a reachable login page is not a healthy session.
+- **`cf_bypass`** is incompatible with every authenticated login method (the bypass proxy carries no request headers) and is rejected at client construction.
+- Rendered login bodies and `get`-method URLs (whose query carries credentials) are never logged.
 
 ---
 
 ## Error handling
 
-`SearchIndexerError` (`crates/zetesis/src/error.rs`) is one `#[non_exhaustive]` snafu enum shared by every indexer client (Torznab, Newznab, Cardigann) and the search-dispatch service, per `standards/RUST.md`. Every variant carries a `#[snafu(implicit)] location`; read the enum directly for the current, full variant list rather than a doc snapshot — it grows as new client/definition/settings failure modes are added. Broad categories: transport (`HttpRequest`, `Cancelled`, `ResponseTooLarge`, `UnsafeUrl`), indexer-reported (`AuthFailed`, `RateLimited`), Cloudflare-bypass (`NoCfBypass`, `CfProxyTimeout`, `CfProxyError`, `CfCookieExpired`), persistence (`Database`, `IndexerNotFound`), response parsing (`ParseResponse`, `CapsUnavailable`), and Cardigann configuration (`DefinitionLoad`, `DefinitionInvalid`, `DefinitionUnsupported`, `DefinitionNotFound`, `LoginUnsupported`, `CookieAuthRequired`, `SettingsJsonInvalid`, `SettingsInvalid`).
+`SearchIndexerError` (`crates/zetesis/src/error.rs`) is one `#[non_exhaustive]` snafu enum shared by every indexer client (Torznab, Newznab, Cardigann) and the search-dispatch service, per `standards/RUST.md`. Every variant carries a `#[snafu(implicit)] location`; read the enum directly for the current, full variant list rather than a doc snapshot — it grows as new client/definition/settings failure modes are added. Broad categories: transport (`HttpRequest`, `Cancelled`, `ResponseTooLarge`, `UnsafeUrl`), indexer-reported (`AuthFailed`, `RateLimited`), Cloudflare-bypass (`NoCfBypass`, `CfProxyTimeout`, `CfProxyError`, `CfCookieExpired`), persistence (`Database`, `IndexerNotFound`), response parsing (`ParseResponse`, `CapsUnavailable`), and Cardigann configuration (`DefinitionLoad`, `DefinitionInvalid`, `DefinitionUnsupported`, `DefinitionNotFound`, `LoginUnsupported`, `LoginFailed`, `CookieAuthRequired`, `SettingsJsonInvalid`, `SettingsInvalid`).
 
 ### Error → status transitions
 
@@ -442,6 +459,7 @@ Indexer rows select the client with `protocol = 'cardigann'`; the row's `url` co
 | `CapsUnavailable` | → `degraded` | Can still serve cached caps; retry on schedule |
 | `ParseResponse`, `ResponseTooLarge` | → `degraded` | Malformed/oversized response; may recover on next request |
 | `DefinitionNotFound`, `DefinitionLoad`, `DefinitionInvalid`, `DefinitionUnsupported`, `LoginUnsupported`, `CookieAuthRequired`, `SettingsJsonInvalid`, `SettingsInvalid` | → `failed` | Misconfiguration (definition, login, or settings override) fails every search identically until the operator intervenes |
+| `LoginFailed` | → `failed` | Interactive login rejected (bad credentials, off-host submit, redirect cap, failed login-test) |
 
 ### Rate limiting
 


### PR DESCRIPTION
PR 2 of the #513 Cardigann coverage extension: authenticated private-tracker login (the largest coverage gap). Builds on PR1's per-indexer settings — credentials are settings.

**Login flow** (form/post/get): GET login page → parse the form + hidden CSRF via the selector engine → POST credentials urlencoded → follow redirects manually (harvesting Set-Cookie per hop) → check `login.error` blocks + `login.test` selector → store the session per indexer. `ensure_session` runs at the top of search/download/test; a stale session (401/403 or a silent redirect-to-login) invalidates + re-logs-in once.

**Security posture** (this is credential-handling code — it had a dedicated adversarial review, which found and drove three fixes now included):
- **Same-host gate on every credential path** — the submit URL, every redirect hop, AND `login.path` itself (an absolute off-host `login.path` is refused at construction, before any request leaves). Off-site credential exposure is refused loud.
- **Affirmative login success** — a login is accepted only on a `login.test` pass or a cookie the credential exchange itself set/rotated; a pre-credential anonymous cookie (e.g. a login-page PHPSESSID) no longer masks a rejected password as a stored session.
- **Race-safe retry** — the post-auth-loss retry uses the cookie `login` just established rather than re-reading the shared store (which a concurrent `invalidate` could empty).
- Per-indexer session keying (not host — distinct accounts on one host stay separate); credential/cookie values never reach a log, error reason, or Debug output (asserted by tests); `cf_bypass` + any login refused at construction.

Gate green (full workspace, incl. the same-host, pre-credential-cookie, and post-auth-cookie regression tests). No PR opened for JSON/POST/filter/XML — those are PRs 3–6.

Part of #513