### PR TITLE
fix(archon,kathodos): wire production ImportService (real library import)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ STATE.md tracks that desktop port as the remaining Phase 3.5 scope.
 
 ### Capability status
 
-- **Shipped / wired to routes:** auth, library scan/import (kathodos), feed scheduler (komide), torrent download engine (ergasia), queue orchestration (syntaxis), HTTP/OpenSubsonic API (paroche), external integrations (syndesmos), QUIC renderer transport (syndesis), audio pipeline (akouo-core).
+- **Shipped / wired to routes:** auth, library scan/import (kathodos), feed scheduler (komide), torrent download engine (ergasia), queue orchestration (syntaxis), HTTP/OpenSubsonic API (paroche), external integrations (syndesmos), QUIC renderer transport (syndesis), audio pipeline (akouo-core), post-download import (`archon::ImportAdapter` - a completed download lands in the library for music/movie/book wants; audiobook/comic/podcast/tv_series wants have no library type yet and are deferred, forkwright/harmonia#612).
 - **Initialized, adapter-backed or fallback-only at HTTP layer:** the live `serve` path wires adapter structs for search, download execution, queue management, requests, external integrations, subtitles, and renderer registry. It still uses 2 null placeholders for metadata resolution and curation. The fallback/test `AppState::with_stubs` path defines 9 `Null*` service implementations.
-- **Stubbed:** syntaxis post-download import pipeline (`StubImportService` - downloads complete but are not auto-imported).
 
 For current planning, blockers, and phase status, see the canonical project state maintained with the internal planning records.
 

--- a/crates/apotheke/migrations/014_haves_upgraded_from_soft_reference.sql
+++ b/crates/apotheke/migrations/014_haves_upgraded_from_soft_reference.sql
@@ -1,0 +1,71 @@
+-- Drop the live FK on haves.upgraded_from_id.
+--
+-- WHY: the import finalize path's upgrade sequence (archon::ImportAdapter,
+-- forkwright/harmonia#602 keystone) must DELETE the have row it is replacing
+-- (idx_haves_file_path is UNCONDITIONAL UNIQUE — the old and new row can
+-- never coexist for a Music album directory) while the NEW row's
+-- upgraded_from_id records that deleted row's former id. A hard
+-- `REFERENCES haves(id)` cannot express this: SQLite validates the FK
+-- immediately against live table state, so an INSERT whose upgraded_from_id
+-- points at an id already removed in the same transaction is rejected —
+-- verified empirically, including with `PRAGMA defer_foreign_keys = ON`
+-- (deferred-to-COMMIT still fails, because the referenced row genuinely
+-- does not exist in the final state; there is no ordering of
+-- DELETE-then-INSERT vs INSERT-then-DELETE that satisfies a live FK here).
+-- upgraded_from_id is lineage metadata (which prior have this one
+-- replaced), not a referential-integrity link to a still-present row, so it
+-- stays a plain BLOB — informational, unenforced.
+--
+-- WHY the rebuild: SQLite cannot drop a column's REFERENCES clause in place.
+
+CREATE TABLE haves_backup (
+    id               BLOB NOT NULL PRIMARY KEY,
+    want_id          BLOB NOT NULL,
+    release_id       BLOB,
+    media_type       TEXT NOT NULL,
+    media_type_id    BLOB NOT NULL,
+    quality_score    INTEGER NOT NULL,
+    file_path        TEXT NOT NULL,
+    file_size_bytes  INTEGER NOT NULL,
+    status           TEXT NOT NULL,
+    imported_at      TEXT NOT NULL,
+    upgraded_from_id BLOB
+) STRICT;
+
+INSERT INTO haves_backup
+    (id, want_id, release_id, media_type, media_type_id, quality_score,
+     file_path, file_size_bytes, status, imported_at, upgraded_from_id)
+SELECT id, want_id, release_id, media_type, media_type_id, quality_score,
+       file_path, file_size_bytes, status, imported_at, upgraded_from_id
+FROM haves;
+
+DROP TABLE haves;
+
+CREATE TABLE haves (
+    id               BLOB NOT NULL PRIMARY KEY,
+    want_id          BLOB NOT NULL REFERENCES wants(id),
+    release_id       BLOB REFERENCES releases(id),
+    media_type       TEXT NOT NULL,
+    media_type_id    BLOB NOT NULL,
+    quality_score    INTEGER NOT NULL,
+    file_path        TEXT NOT NULL,
+    file_size_bytes  INTEGER NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'pending' CHECK(status IN (
+                         'pending', 'downloading', 'importing', 'complete', 'failed'
+                     )),
+    imported_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    upgraded_from_id BLOB
+) STRICT;
+
+INSERT INTO haves
+    (id, want_id, release_id, media_type, media_type_id, quality_score,
+     file_path, file_size_bytes, status, imported_at, upgraded_from_id)
+SELECT id, want_id, release_id, media_type, media_type_id, quality_score,
+       file_path, file_size_bytes, status, imported_at, upgraded_from_id
+FROM haves_backup;
+
+DROP TABLE haves_backup;
+
+CREATE INDEX idx_haves_want ON haves(want_id);
+CREATE INDEX idx_haves_type_id ON haves(media_type, media_type_id);
+CREATE UNIQUE INDEX idx_haves_file_path ON haves(file_path);

--- a/crates/apotheke/src/repo/want.rs
+++ b/crates/apotheke/src/repo/want.rs
@@ -189,17 +189,23 @@ pub async fn list_wants_by_type_and_status(
     .context(QuerySnafu { table: "wants" })
 }
 
-pub async fn update_want_status(
-    pool: &SqlitePool,
+// NOTE: executor-generic so the import finalize path can fulfil the want in
+// the same `BEGIN IMMEDIATE` transaction as its have write — see
+// `insert_have`.
+pub async fn update_want_status<'e, E>(
+    executor: E,
     id: &[u8],
     status: &str,
     fulfilled_at: Option<&str>,
-) -> Result<(), DbError> {
+) -> Result<(), DbError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     let result = sqlx::query("UPDATE wants SET status = ?, fulfilled_at = ? WHERE id = ?")
         .bind(status)
         .bind(fulfilled_at)
         .bind(id)
-        .execute(pool)
+        .execute(executor)
         .await
         .context(QuerySnafu { table: "wants" })?;
     super::require_affected(result, "wants", super::id_hex(id))
@@ -317,7 +323,14 @@ pub async fn delete_release(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError>
 
 // --- haves ---
 
-pub async fn insert_have(pool: &SqlitePool, have: &Have) -> Result<(), DbError> {
+// NOTE: executor-generic so the import finalize path (archon::ImportAdapter)
+// can run its check-delete-insert-fulfil sequence inside one `BEGIN
+// IMMEDIATE` transaction (`&mut *tx`), instead of racing across pools —
+// same idiom as `user::insert_refresh_token`.
+pub async fn insert_have<'e, E>(executor: E, have: &Have) -> Result<(), DbError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     sqlx::query(
         "INSERT INTO haves
          (id, want_id, release_id, media_type, media_type_id, quality_score,
@@ -335,7 +348,7 @@ pub async fn insert_have(pool: &SqlitePool, have: &Have) -> Result<(), DbError> 
     .bind(&have.status)
     .bind(&have.imported_at)
     .bind(&have.upgraded_from_id)
-    .execute(pool)
+    .execute(executor)
     .await
     .context(QuerySnafu { table: "haves" })?;
     Ok(())
@@ -349,6 +362,38 @@ pub async fn get_have(pool: &SqlitePool, id: &[u8]) -> Result<Option<Have>, DbEr
     )
     .bind(id)
     .fetch_optional(pool)
+    .await
+    .context(QuerySnafu { table: "haves" })
+}
+
+/// Looks up a have by its library location.
+///
+/// `file_path` is the natural collision key against `idx_haves_file_path`
+/// (a UNCONDITIONAL UNIQUE index): for Music it is the want-derived album
+/// directory, identical across releases of the same album, so this is how
+/// the import finalize path detects a same-release retry OR a
+/// different-release quality upgrade landing at the same library location
+/// (`release_id` alone cannot see the upgrade case). The caller deletes the
+/// found row and carries its id forward as the new have's
+/// `upgraded_from_id` — see migration 014: that column is a soft/unenforced
+/// reference for exactly this reason (a hard FK cannot point at a row
+/// deleted in the same transaction that inserts the reference).
+///
+/// NOTE: executor-generic — see `insert_have`.
+pub async fn get_have_by_file_path<'e, E>(
+    executor: E,
+    file_path: &str,
+) -> Result<Option<Have>, DbError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
+    sqlx::query_as::<_, Have>(
+        "SELECT id, want_id, release_id, media_type, media_type_id, quality_score,
+                file_path, file_size_bytes, status, imported_at, upgraded_from_id
+         FROM haves WHERE file_path = ?",
+    )
+    .bind(file_path)
+    .fetch_optional(executor)
     .await
     .context(QuerySnafu { table: "haves" })
 }
@@ -375,10 +420,14 @@ pub async fn update_have_status(pool: &SqlitePool, id: &[u8], status: &str) -> R
     super::require_affected(result, "haves", super::id_hex(id))
 }
 
-pub async fn delete_have(pool: &SqlitePool, id: &[u8]) -> Result<(), DbError> {
+// NOTE: executor-generic — see `insert_have`.
+pub async fn delete_have<'e, E>(executor: E, id: &[u8]) -> Result<(), DbError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     let result = sqlx::query("DELETE FROM haves WHERE id = ?")
         .bind(id)
-        .execute(pool)
+        .execute(executor)
         .await
         .context(QuerySnafu { table: "haves" })?;
     super::require_affected(result, "haves", super::id_hex(id))
@@ -674,5 +723,115 @@ mod tests {
 
         let haves = list_haves_for_want(&pool, &want_id).await.unwrap();
         assert_eq!(haves.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_have_by_file_path_finds_by_location_not_id() {
+        let pool = setup().await;
+        let profile_id = insert_test_profile(&pool).await;
+
+        let want_id = make_id();
+        insert_want(
+            &pool,
+            &Want {
+                id: want_id.clone(),
+                media_type: "music_album".to_string(),
+                title: "Some Album".to_string(),
+                registry_id: None,
+                quality_profile_id: profile_id,
+                status: "searching".to_string(),
+                source: None,
+                source_ref: None,
+                added_at: now(),
+                fulfilled_at: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let have_id = make_id();
+        let have = Have {
+            id: have_id.clone(),
+            want_id: want_id.clone(),
+            release_id: None,
+            media_type: "music_album".to_string(),
+            media_type_id: make_id(),
+            quality_score: 80,
+            file_path: "/music/Some Album".to_string(),
+            file_size_bytes: 1000,
+            status: "complete".to_string(),
+            imported_at: now(),
+            upgraded_from_id: None,
+        };
+        insert_have(&pool, &have).await.unwrap();
+
+        let found = get_have_by_file_path(&pool, "/music/Some Album")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.id, have_id);
+
+        assert!(
+            get_have_by_file_path(&pool, "/music/No Such Album")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_have_by_file_path_works_inside_a_transaction() {
+        let pool = setup().await;
+        let profile_id = insert_test_profile(&pool).await;
+
+        let want_id = make_id();
+        insert_want(
+            &pool,
+            &Want {
+                id: want_id.clone(),
+                media_type: "movie".to_string(),
+                title: "Some Movie".to_string(),
+                registry_id: None,
+                quality_profile_id: profile_id,
+                status: "searching".to_string(),
+                source: None,
+                source_ref: None,
+                added_at: now(),
+                fulfilled_at: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let have_id = make_id();
+        insert_have(
+            &pool,
+            &Have {
+                id: have_id.clone(),
+                want_id: want_id.clone(),
+                release_id: None,
+                media_type: "movie".to_string(),
+                media_type_id: make_id(),
+                quality_score: 70,
+                file_path: "/movies/some-movie.mkv".to_string(),
+                file_size_bytes: 5000,
+                status: "complete".to_string(),
+                imported_at: now(),
+                upgraded_from_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut tx = pool.begin().await.unwrap();
+        let found = get_have_by_file_path(&mut *tx, "/movies/some-movie.mkv")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.id, have_id);
+        delete_have(&mut *tx, &found.id).await.unwrap();
+        tx.commit().await.unwrap();
+
+        assert!(get_have(&pool, &have_id).await.unwrap().is_none());
     }
 }

--- a/crates/archon/Cargo.toml
+++ b/crates/archon/Cargo.toml
@@ -6,6 +6,14 @@ license.workspace = true
 publish = false
 description = "Binary entry point — assembles all subsystems"
 
+[lib]
+# WHY: a minimal lib surface so `tests/` integration crates can reach
+# internals (e.g. `import::ImportAdapter`) that a bin-only crate cannot
+# expose. `main.rs` depends on this lib crate exactly like an external
+# consumer would (auto-linked by matching package/lib name).
+name = "archon"
+path = "src/lib.rs"
+
 [[bin]]
 name = "harmonia"
 path = "src/main.rs"

--- a/crates/archon/src/import.rs
+++ b/crates/archon/src/import.rs
@@ -1,0 +1,1055 @@
+//! Production `syntaxis::ImportService`: wires a completed download into the library via kathodos. // kanon:ignore STORAGE/no-migration-checksum -- false positive: this module runs ordinary apotheke::repo CRUD (insert_have/update_want_status), not schema migration code
+
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+
+use apotheke::repo::want::{Have, Release, Want};
+use apotheke::repo::{registry, want};
+use apotheke::{DbError, begin_immediate, commit_tx};
+use horismos::{LibraryConfig, Section, TaxisConfig};
+use kathodos::import::identify::resolve_media_type;
+use kathodos::import::tags::{FileTags, read_tags};
+use kathodos::scanner::filter::is_supported_extension;
+use kathodos::scanner::walk::walk_library;
+use kathodos::{EpignosisError, ImportOrigin, ImportPipeline, ImportSource, MetadataResolver};
+use snafu::{OptionExt, ResultExt, Snafu};
+use sqlx::SqlitePool;
+use syntaxis::{CompletedDownload, ImportService};
+use themelion::{EventSender, MediaType, ReleaseId, WantId};
+use tokio::sync::Semaphore;
+use tracing::{info, instrument, warn};
+
+/// Want media types with a real library mapping today (`horismos::MediaType`
+/// only distinguishes Music/Video/Book — see `kathodos::import::identify::resolve_media_type`).
+/// The remaining CHECK values (`audiobook`, `comic`, `podcast`, `tv_series`)
+/// have no library type to land in; see `UnsupportedWantMediaType` below.
+const SUPPORTED_WANT_MEDIA_TYPES: [MediaType; 3] =
+    [MediaType::Music, MediaType::Movie, MediaType::Book];
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum ImportAdapterError {
+    #[snafu(display("database error: {source}"))]
+    Database {
+        source: DbError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("want {want_id} not found"))]
+    WantNotFound {
+        want_id: WantId,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("release {release_id} not found"))]
+    ReleaseNotFound {
+        release_id: ReleaseId,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("unknown want media_type '{media_type}'"))]
+    UnknownWantMediaType {
+        media_type: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    // TODO[deliberate-prudent] #612: extend horismos::MediaType past Music/Video/Book so audiobook/comic/podcast/tv_series wants can resolve a library // kanon:ignore RUST/todo-no-issue -- richer quadrant rule covers this // kanon:ignore META/rule-todo-without-issue -- richer quadrant rule covers this
+    #[snafu(display(
+        "no library type for '{media_type}'  -  horismos::MediaType only supports Music/Video/Book today (forkwright/harmonia#612)"
+    ))]
+    UnsupportedWantMediaType {
+        media_type: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("no configured library maps to media_type {media_type}"))]
+    NoMatchingLibrary {
+        media_type: MediaType,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("cannot stat download path {path:?}: {source}"))]
+    Stat {
+        path: PathBuf,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("library scan failed at {path:?}: {source}"))]
+    Walk {
+        path: PathBuf,
+        #[snafu(source(from(kathodos::error::TaxisError, Box::new)))]
+        source: Box<kathodos::error::TaxisError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("no importable files found at {path:?}"))]
+    NoFiles {
+        path: PathBuf,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("unsupported file for media_type {media_type}: {path:?}"))]
+    UnsupportedFile {
+        path: PathBuf,
+        media_type: MediaType,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("import failed for {path:?}: {source}"))]
+    Pipeline {
+        path: PathBuf,
+        #[snafu(source(from(kathodos::error::TaxisError, Box::new)))]
+        source: Box<kathodos::error::TaxisError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Wires a `syntaxis::CompletedDownload` into the library via kathodos'
+/// `ImportPipeline`. The honest name for what #300 falsely closed without
+/// building — see `syntaxis::ImportService`'s idempotency contract, which
+/// this adapter and `kathodos::import::fileops::same_file` jointly satisfy.
+///
+/// `pub`, not `pub(crate)`: this crate is bin-only otherwise, and the
+/// `tests/acquisition_integration` integration suite needs a real
+/// `ImportAdapter` (not a mock) to exercise the full completion→import→have
+/// flow — see `crates/archon/src/lib.rs`.
+pub struct ImportAdapter {
+    read_pool: SqlitePool,
+    write_pool: SqlitePool,
+    taxis: Section<TaxisConfig>,
+    event_tx: EventSender,
+}
+
+impl ImportAdapter {
+    pub fn new(
+        read_pool: SqlitePool,
+        write_pool: SqlitePool,
+        taxis: Section<TaxisConfig>,
+        event_tx: EventSender,
+    ) -> Self {
+        Self {
+            read_pool,
+            write_pool,
+            taxis,
+            event_tx,
+        }
+    }
+
+    #[instrument(skip(self, completed), fields(want_id = %completed.want_id, release_id = %completed.release_id))]
+    async fn import_inner(&self, completed: CompletedDownload) -> Result<(), ImportAdapterError> {
+        let want_id_bytes = completed.want_id.as_bytes().to_vec();
+        let release_id_bytes = completed.release_id.as_bytes().to_vec();
+
+        // 1. want / release
+        let want = want::get_want(&self.read_pool, &want_id_bytes)
+            .await
+            .context(DatabaseSnafu)?
+            .context(WantNotFoundSnafu {
+                want_id: completed.want_id,
+            })?;
+        let release = want::get_release(&self.read_pool, &release_id_bytes)
+            .await
+            .context(DatabaseSnafu)?
+            .context(ReleaseNotFoundSnafu {
+                release_id: completed.release_id,
+            })?;
+
+        // 2. media type mapping
+        let mapped_media_type =
+            MediaType::parse_want_str(&want.media_type).context(UnknownWantMediaTypeSnafu {
+                media_type: want.media_type.clone(),
+            })?;
+        if !SUPPORTED_WANT_MEDIA_TYPES.contains(&mapped_media_type) {
+            return UnsupportedWantMediaTypeSnafu {
+                media_type: want.media_type.clone(),
+            }
+            .fail();
+        }
+
+        // 3. library selection — deterministic lexicographic pick among matches
+        let taxis = self.taxis.get();
+        let mut candidates: Vec<(&String, &LibraryConfig)> = taxis
+            .libraries
+            .iter()
+            .filter(|(_, lib)| resolve_media_type(&lib.media_type) == mapped_media_type)
+            .collect();
+        candidates.sort_by(|a, b| a.0.cmp(b.0));
+        let (library_name, library_cfg) = candidates
+            .first()
+            .map(|(name, cfg)| ((*name).clone(), (*cfg).clone()))
+            .context(NoMatchingLibrarySnafu {
+                media_type: mapped_media_type,
+            })?;
+
+        // 4. haves short-circuit — idempotent no-op if a complete have for
+        // this exact (want, release) still points at a present target on
+        // disk. This is a fast-path optimization only, keyed on release_id
+        // (the durable idempotency + upgrade logic lives in the
+        // file_path-keyed transactional finalize at step 7/8 below, which
+        // covers the case this fast path cannot see: a different release
+        // resolving to the same library location).
+        let now = jiff::Timestamp::now().to_string();
+        let existing_haves = want::list_haves_for_want(&self.read_pool, &want_id_bytes)
+            .await
+            .context(DatabaseSnafu)?;
+        let matching_have = existing_haves
+            .into_iter()
+            .find(|h| h.release_id.as_deref() == Some(release_id_bytes.as_slice()));
+        if let Some(have) = &matching_have
+            && have.status == "complete"
+        {
+            // WHY: for Music `have.file_path` is the album DIRECTORY — a
+            // directory existing is not proof it holds anything (an empty
+            // or partially-cleaned dir must fall through to re-import).
+            // Movie/Book already point at the single file itself.
+            let present = if mapped_media_type == MediaType::Music {
+                directory_contains_media(&have.file_path, mapped_media_type).await
+            } else {
+                tokio::fs::try_exists(&have.file_path)
+                    .await
+                    .unwrap_or(false)
+            };
+            if present {
+                info!(file_path = %have.file_path, "have already complete on disk  -  import is a no-op");
+                // WHY: a complete have with files present must never return
+                // Ok while leaving the want un-fulfilled — otherwise a
+                // crash between a prior insert_have and update_want_status
+                // (or a recovery::reload_queue replay) permanently strands
+                // the want. update_want_status is idempotent.
+                want::update_want_status(&self.write_pool, &want_id_bytes, "fulfilled", Some(&now))
+                    .await
+                    .context(DatabaseSnafu)?;
+                return Ok(());
+            }
+            warn!(file_path = %have.file_path, "recorded have file missing or empty on disk  -  reimporting");
+        }
+
+        // 5. enumerate source files
+        let files = enumerate_files(&completed.download_path, mapped_media_type).await?;
+
+        // 6. per-file import through the shared kathodos pipeline
+        let registry_display_name = match &want.registry_id {
+            Some(id) => registry::get_registry_entry(&self.read_pool, id)
+                .await
+                .context(DatabaseSnafu)?
+                .map(|entry| entry.display_name),
+            None => None,
+        };
+        let resolver = DownloadResolver::new(&want, &release, registry_display_name);
+        let pipeline = ImportPipeline::new(resolver, self.event_tx.clone());
+        let mut results = Vec::with_capacity(files.len());
+        for file in files {
+            let source = ImportSource {
+                path: file.clone(),
+                library_name: library_name.clone(),
+                media_type: mapped_media_type,
+                origin: ImportOrigin::Download {
+                    want_id: completed.want_id,
+                    release_id: completed.release_id,
+                },
+                naming_template: None,
+                library_root: library_cfg.path.clone(),
+            };
+            let result = pipeline
+                .process(source)
+                .await
+                .context(PipelineSnafu { path: file })?;
+            results.push(result);
+        }
+        // WHY: enumerate_files errors on zero files, so `results` is never
+        // empty here — the .first() unwrap surface is a defensive Option
+        // rather than a real reachable branch.
+        let Some(first) = results.first() else {
+            return NoFilesSnafu {
+                path: completed.download_path.clone(),
+            }
+            .fail();
+        };
+
+        // 7+8. finalize atomically: land the have row and fulfil the want
+        // in one `BEGIN IMMEDIATE` transaction, keyed on file_path (NOT
+        // release_id) — for Music, file_path is the want-derived album
+        // DIRECTORY, identical across every release of the same album, so
+        // a second release for an already-fulfilled want (the
+        // quality-upgrade path) resolves to the SAME file_path the first
+        // release's have already owns. file_path is therefore the natural
+        // collision key against `idx_haves_file_path` (unconditional
+        // UNIQUE). Any prior have at this file_path — a same-release retry
+        // or a genuine cross-release upgrade — is deleted inside the same
+        // transaction, and its id becomes the new have's
+        // `upgraded_from_id` (exactly what that column is for).
+        let file_path = if mapped_media_type == MediaType::Music {
+            first
+                .final_path
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| first.final_path.clone())
+        } else {
+            first.final_path.clone()
+        };
+        let file_size_bytes = total_size(results.iter().map(|r| r.final_path.as_path())).await?;
+        let file_path_str = file_path.to_string_lossy().into_owned();
+
+        let mut tx = begin_immediate(&self.write_pool)
+            .await
+            .context(DatabaseSnafu)?;
+
+        let stale = want::get_have_by_file_path(&mut *tx, &file_path_str)
+            .await
+            .context(DatabaseSnafu)?;
+        let upgraded_from_id = if let Some(stale) = stale {
+            want::delete_have(&mut *tx, &stale.id)
+                .await
+                .context(DatabaseSnafu)?;
+            Some(stale.id)
+        } else {
+            None
+        };
+
+        let have = Have {
+            id: uuid::Uuid::now_v7().as_bytes().to_vec(),
+            want_id: want_id_bytes.clone(),
+            release_id: Some(release_id_bytes.clone()),
+            media_type: want.media_type.clone(),
+            media_type_id: first.media_id.as_bytes().to_vec(),
+            quality_score: release.quality_score,
+            file_path: file_path_str,
+            file_size_bytes,
+            status: "complete".to_string(),
+            imported_at: now.clone(),
+            upgraded_from_id,
+        };
+        want::insert_have(&mut *tx, &have)
+            .await
+            .context(DatabaseSnafu)?;
+        want::update_want_status(&mut *tx, &want_id_bytes, "fulfilled", Some(&now))
+            .await
+            .context(DatabaseSnafu)?;
+
+        commit_tx(tx).await.context(DatabaseSnafu)?;
+
+        Ok(())
+    }
+}
+
+impl ImportService for ImportAdapter {
+    fn import(
+        &self,
+        completed: CompletedDownload,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>> {
+        Box::pin(async move {
+            self.import_inner(completed)
+                .await
+                .map_err(|e| e.to_string())
+        })
+    }
+}
+
+/// True if `path` is a directory holding at least one importable media file
+/// for `media_type`.
+///
+/// FIX 4 (re-review): checking mere non-emptiness let a debris-only directory
+/// (an album whose audio was removed by a cleanup, leaving only `.nfo` /
+/// thumbnail / `.DS_Store` sidecars) read as a complete have — the want would
+/// be marked fulfilled with no real content and never re-acquired. A missing,
+/// unreadable, empty, or media-free directory is `false` so the short-circuit
+/// falls through to re-import.
+async fn directory_contains_media(path: &str, media_type: MediaType) -> bool {
+    let path = PathBuf::from(path);
+    tokio::task::spawn_blocking(move || {
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            return false;
+        };
+        entries.flatten().any(|entry| {
+            let p = entry.path();
+            p.is_file() && is_supported_extension(&p, media_type)
+        })
+    })
+    .await
+    .unwrap_or(false)
+}
+
+/// Resolves `download_path` INTO the list of importable source files:
+/// the containing directory's supported members for a multi-file download,
+/// or the file itself for a single-file one (see `CompletedDownload::download_path`).
+async fn enumerate_files(
+    download_path: &Path,
+    media_type: MediaType,
+) -> Result<Vec<PathBuf>, ImportAdapterError> {
+    let metadata = tokio::fs::metadata(download_path)
+        .await
+        .context(StatSnafu {
+            path: download_path.to_path_buf(),
+        })?;
+
+    if metadata.is_dir() {
+        // WHY: one walk per import call — a fresh permit-1 semaphore is
+        // sufficient (this is not the scanner's cross-library concurrency
+        // limiter; `walk_library` merely requires a `&Semaphore` handle).
+        let semaphore = Semaphore::new(1);
+        let (results, _stats) = walk_library(download_path, media_type, &semaphore)
+            .await
+            .context(WalkSnafu {
+                path: download_path.to_path_buf(),
+            })?;
+        if results.is_empty() {
+            return NoFilesSnafu {
+                path: download_path.to_path_buf(),
+            }
+            .fail();
+        }
+        let files: Vec<PathBuf> = results.into_iter().map(|r| r.path).collect();
+        // FIX 3: Music imports every track (distinct file_path per file —
+        // correct). Movie/Book have no per-file disambiguation token in
+        // their naming template (see kathodos::import::template::
+        // valid_tokens), so every enumerated file would resolve to the
+        // SAME target path — import only the single largest candidate
+        // (the feature/main file); companions (samples, extras, subtitle
+        // sidecars) are skipped and info-logged.
+        if media_type == MediaType::Music {
+            Ok(files)
+        } else {
+            select_largest_file(files)
+                .await
+                .context(NoFilesSnafu {
+                    path: download_path.to_path_buf(),
+                })
+                .map(|p| vec![p])
+        }
+    } else {
+        if !is_supported_extension(download_path, media_type) {
+            return UnsupportedFileSnafu {
+                path: download_path.to_path_buf(),
+                media_type,
+            }
+            .fail();
+        }
+        Ok(vec![download_path.to_path_buf()])
+    }
+}
+
+/// Picks the single largest file (the feature/main file) from a multi-file
+/// candidate set, info-logging the rest as skipped companions. `None` only
+/// for an empty input (callers guarantee non-empty via a prior
+/// `results.is_empty()` check upstream in `enumerate_files`).
+async fn select_largest_file(files: Vec<PathBuf>) -> Option<PathBuf> {
+    let mut sized: Vec<(PathBuf, u64)> = tokio::task::spawn_blocking(move || {
+        files
+            .into_iter()
+            .map(|p| {
+                let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
+                (p, size)
+            })
+            .collect()
+    })
+    .await
+    .unwrap_or_default(); // WHY: a spawn_blocking join failure (task panic) falls back to no candidates, not a fabricated file — `largest` below then legitimately becomes `None`
+
+    sized.sort_by(|a, b| b.1.cmp(&a.1));
+    let mut candidates = sized.into_iter();
+    let largest = candidates.next().map(|(p, _)| p);
+    for (skipped, _) in candidates {
+        info!(path = %skipped.display(), "skipping companion file  -  single largest file wins for this media type");
+    }
+    largest
+}
+
+async fn total_size<'a>(paths: impl Iterator<Item = &'a Path>) -> Result<i64, ImportAdapterError> {
+    let owned: Vec<PathBuf> = paths.map(Path::to_path_buf).collect();
+    let sum = tokio::task::spawn_blocking(move || {
+        owned
+            .iter()
+            .filter_map(|p| std::fs::metadata(p).ok())
+            .map(|m| m.len())
+            .sum::<u64>()
+    })
+    .await
+    .unwrap_or(0);
+    Ok(i64::try_from(sum).unwrap_or(i64::MAX))
+}
+
+/// Best-effort 4-digit year extraction FROM free text (e.g. a release
+/// title like "Album Name (2019) [FLAC]"). Splits on maximal digit runs so a
+/// longer run (catalog numbers, bitrates) never false-matches on its first 4
+/// digits; `None` if no run of exactly 4 digits falls in a plausible
+/// release-year range.
+fn best_effort_year(text: &str) -> Option<u32> {
+    text.split(|c: char| !c.is_ascii_digit())
+        .filter(|run| run.chars().count() == 4)
+        .find_map(|run| {
+            run.parse::<u32>()
+                .ok()
+                .filter(|year| (1900..=2099).contains(year))
+        })
+}
+
+/// Per-import `MetadataResolver`: builds template tokens from a fixed
+/// priority ladder — embedded tags first, then DB hints (want/release/
+/// registry), then a filename-parse fallback. Deliberately does not touch
+/// epignosis's provider/network lookups: imports stay deterministic; richer
+/// identification is a later enrichment pass over the same library.
+struct DownloadResolver {
+    want_title: String,
+    artist_or_author: Option<String>,
+    release_title: String,
+    quality_score: u32,
+}
+
+impl DownloadResolver {
+    fn new(want: &Want, release: &Release, registry_display_name: Option<String>) -> Self {
+        Self {
+            want_title: want.title.clone(),
+            artist_or_author: registry_display_name,
+            release_title: release.title.clone(),
+            quality_score: u32::try_from(release.quality_score.max(0)).unwrap_or(u32::MAX),
+        }
+    }
+}
+
+impl MetadataResolver for DownloadResolver {
+    async fn resolve_identity(
+        &self,
+        path: &Path,
+        media_type: MediaType,
+    ) -> Result<kathodos::ResolvedMetadata, EpignosisError> {
+        let tags = match read_tags(path).await {
+            Ok(tags) => tags,
+            Err(e) => {
+                // WHY: a per-file tag-read failure is not fatal — the
+                // resolver falls back to DB hints / filename parsing.
+                warn!(path = %path.display(), error = %e, "tag read failed  -  falling back to DB/filename hints");
+                FileTags::default()
+            }
+        };
+        if tags.is_empty() {
+            // WHY: distinct FROM the read-error branch above — a successful
+            // read that simply found no populated fields (untagged file, or
+            // a container lofty parses but doesn't map any items for). Same
+            // fallback path, worth a lower-noise log line for diagnosing a
+            // library that resolves mostly FROM filenames.
+            tracing::debug!(path = %path.display(), "no embedded tags  -  resolving FROM DB/filename hints only");
+        }
+        let parsed = epignosis::parse_filename(path);
+        let year = tags.year.or_else(|| best_effort_year(&self.release_title));
+        let extension = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_string();
+
+        let mut tokens = std::collections::HashMap::new();
+        tokens.insert("Extension".to_string(), extension);
+
+        match media_type {
+            MediaType::Music => {
+                let artist = tags
+                    .artist
+                    .clone()
+                    .or_else(|| tags.album_artist.clone())
+                    .or_else(|| self.artist_or_author.clone())
+                    .or_else(|| parsed.artist.clone());
+                if let Some(v) = artist {
+                    tokens.insert("Artist Name".to_string(), v);
+                }
+                tokens.insert("Album Title".to_string(), self.want_title.clone());
+                if let Some(y) = year {
+                    tokens.insert("Year".to_string(), y.to_string());
+                }
+                if let Some(t) = tags.track_number.or(parsed.track_number) {
+                    tokens.insert("Track Number".to_string(), t.to_string());
+                }
+                if let Some(d) = tags.disc_number {
+                    tokens.insert("Disc Number".to_string(), d.to_string());
+                }
+                let title = tags
+                    .title
+                    .clone()
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| Some(parsed.title.clone()).filter(|s| !s.is_empty()));
+                if let Some(t) = title {
+                    tokens.insert("Track Title".to_string(), t);
+                }
+            }
+            MediaType::Movie => {
+                tokens.insert("Movie Title".to_string(), self.want_title.clone());
+                if let Some(y) = year {
+                    tokens.insert("Year".to_string(), y.to_string());
+                }
+            }
+            MediaType::Book => {
+                if let Some(v) = self.artist_or_author.clone() {
+                    tokens.insert("Author Name".to_string(), v);
+                }
+                tokens.insert("Title".to_string(), self.want_title.clone());
+                if let Some(y) = year {
+                    tokens.insert("Year".to_string(), y.to_string());
+                }
+            }
+            // INVARIANT: import_inner gates media_type to
+            // SUPPORTED_WANT_MEDIA_TYPES before a DownloadResolver is ever
+            // built — reached only if that gate is bypassed.
+            _ => {}
+        }
+
+        Ok(kathodos::ResolvedMetadata {
+            media_type,
+            tokens,
+            quality_score: self.quality_score,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use apotheke::migrate::MIGRATOR;
+    use horismos::{LibraryConfig, MediaType as LibMediaType, WatcherMode};
+    use themelion::create_event_bus;
+
+    use super::*;
+
+    async fn migrated_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn seed_profile(pool: &SqlitePool) -> i64 {
+        sqlx::query_scalar("SELECT id FROM quality_profiles WHERE media_type = 'music' LIMIT 1")
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    fn adapter(pool: SqlitePool, libraries: HashMap<String, LibraryConfig>) -> ImportAdapter {
+        let (event_tx, _rx) = create_event_bus(16);
+        ImportAdapter::new(
+            pool.clone(),
+            pool,
+            Section::fixed(TaxisConfig {
+                libraries,
+                ..TaxisConfig::default()
+            }),
+            event_tx,
+        )
+    }
+
+    fn music_library(path: &str) -> LibraryConfig {
+        LibraryConfig {
+            path: PathBuf::from(path),
+            media_type: LibMediaType::Music,
+            watcher_mode: WatcherMode::Auto,
+            poll_interval_seconds: 300,
+            scan_interval_hours: 24,
+        }
+    }
+
+    fn make_completed(
+        want_id: WantId,
+        release_id: ReleaseId,
+        download_path: PathBuf,
+    ) -> CompletedDownload {
+        CompletedDownload {
+            download_id: themelion::DownloadId::new(),
+            download_path,
+            source_path: PathBuf::from("/unused"),
+            want_id,
+            release_id,
+            protocol: syntaxis::DownloadProtocol::Torrent,
+            requires_copy: false,
+        }
+    }
+
+    async fn seed_want_release(pool: &SqlitePool, media_type: &str) -> (WantId, ReleaseId) {
+        let profile_id = seed_profile(pool).await;
+        let want_id = WantId::new();
+        want::insert_want(
+            pool,
+            &Want {
+                id: want_id.as_bytes().to_vec(),
+                media_type: media_type.to_string(),
+                title: "Test Album".to_string(),
+                registry_id: None,
+                quality_profile_id: profile_id,
+                status: "searching".to_string(),
+                source: None,
+                source_ref: None,
+                added_at: "2026-01-01T00:00:00Z".to_string(),
+                fulfilled_at: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let release_id = ReleaseId::new();
+        want::insert_release(
+            pool,
+            &Release {
+                id: release_id.as_bytes().to_vec(),
+                want_id: want_id.as_bytes().to_vec(),
+                indexer_id: 1,
+                title: "Test Album FLAC".to_string(),
+                size_bytes: 1000,
+                quality_score: 90,
+                custom_format_score: 0,
+                download_url: "https://example.com/release.torrent".to_string(),
+                protocol: "torrent".to_string(),
+                info_hash: None,
+                found_at: "2026-01-01T00:00:00Z".to_string(),
+                grabbed_at: None,
+                rejected_reason: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        (want_id, release_id)
+    }
+
+    #[tokio::test]
+    async fn no_matching_library_is_an_error() {
+        let pool = migrated_pool().await;
+        let (want_id, release_id) = seed_want_release(&pool, "music_album").await;
+        let dir = tempfile::TempDir::new().unwrap();
+        let download_path = dir.path().join("album");
+        std::fs::create_dir_all(&download_path).unwrap();
+        std::fs::write(download_path.join("track.flac"), b"data").unwrap();
+
+        let svc = adapter(pool, HashMap::new());
+        let result = svc
+            .import_inner(make_completed(want_id, release_id, download_path))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ImportAdapterError::NoMatchingLibrary { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn two_music_libraries_picks_lexicographically_first() {
+        let pool = migrated_pool().await;
+        let (want_id, release_id) = seed_want_release(&pool, "music_album").await;
+        let dir = tempfile::TempDir::new().unwrap();
+        let download_path = dir.path().join("album");
+        std::fs::create_dir_all(&download_path).unwrap();
+        std::fs::write(download_path.join("track.flac"), b"data").unwrap();
+
+        let lib_root_a = dir.path().join("lib-a");
+        let lib_root_b = dir.path().join("lib-b");
+        std::fs::create_dir_all(&lib_root_a).unwrap();
+        std::fs::create_dir_all(&lib_root_b).unwrap();
+
+        let mut libraries = HashMap::new();
+        libraries.insert(
+            "zzz-library".to_string(),
+            music_library(lib_root_b.to_str().unwrap()),
+        );
+        libraries.insert(
+            "aaa-library".to_string(),
+            music_library(lib_root_a.to_str().unwrap()),
+        );
+
+        let svc = adapter(pool, libraries);
+        svc.import_inner(make_completed(want_id, release_id, download_path))
+            .await
+            .unwrap();
+
+        // "aaa-library" sorts first lexicographically — its root must have
+        // received the import, "zzz-library" must not.
+        let a_has_files = std::fs::read_dir(&lib_root_a).unwrap().next().is_some();
+        assert!(a_has_files, "lexicographically-first library must be used");
+        let b_has_files = std::fs::read_dir(&lib_root_b).unwrap().next().is_some();
+        assert!(
+            !b_has_files,
+            "non-selected library must not receive the import"
+        );
+    }
+
+    // WHY: Music `have.file_path` is the album DIRECTORY (see FIX 4) — the
+    // short-circuit fixture must reflect that, not a bare file, or the
+    // directory-emptiness check would (correctly) refuse to short-circuit.
+    fn complete_music_have(
+        want_id: WantId,
+        release_id: ReleaseId,
+        file_path: &std::path::Path,
+    ) -> Have {
+        Have {
+            id: uuid::Uuid::now_v7().as_bytes().to_vec(),
+            want_id: want_id.as_bytes().to_vec(),
+            release_id: Some(release_id.as_bytes().to_vec()),
+            media_type: "music_album".to_string(),
+            media_type_id: uuid::Uuid::now_v7().as_bytes().to_vec(),
+            quality_score: 90,
+            file_path: file_path.to_string_lossy().into_owned(),
+            file_size_bytes: 4,
+            status: "complete".to_string(),
+            imported_at: "2026-01-01T00:00:00Z".to_string(),
+            upgraded_from_id: None,
+        }
+    }
+
+    // ── FIX 1b / crash-replay: short-circuit must fulfil the want ──────────
+
+    #[tokio::test]
+    async fn haves_short_circuit_skips_reimport_when_directory_still_present() {
+        let pool = migrated_pool().await;
+        let (want_id, release_id) = seed_want_release(&pool, "music_album").await;
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let existing_album_dir = dir.path().join("already-here-album");
+        std::fs::create_dir_all(&existing_album_dir).unwrap();
+        std::fs::write(existing_album_dir.join("track.flac"), b"data").unwrap();
+
+        want::insert_have(
+            &pool,
+            &complete_music_have(want_id, release_id, &existing_album_dir),
+        )
+        .await
+        .unwrap();
+
+        // A download_path that would error if actually touched — proves the
+        // short-circuit returns before any filesystem enumeration.
+        let untouched_download_path = dir.path().join("does-not-exist");
+
+        let mut libraries = HashMap::new();
+        libraries.insert(
+            "music".to_string(),
+            music_library(dir.path().to_str().unwrap()),
+        );
+        let svc = adapter(pool.clone(), libraries);
+
+        let result = svc
+            .import_inner(make_completed(want_id, release_id, untouched_download_path))
+            .await;
+        assert!(result.is_ok(), "expected no-op Ok, got {result:?}");
+
+        // FIX 1b (crash-replay): a complete have with files present must
+        // never return Ok while leaving the want un-fulfilled — this is the
+        // self-heal for a crash between a prior insert_have and
+        // update_want_status (or a recovery::reload_queue replay).
+        // `seed_want_release` leaves the want at "searching"; the
+        // short-circuit alone must be the thing that moves it to
+        // "fulfilled" here, since no full import ran.
+        let want = want::get_want(&pool, want_id.as_bytes().as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(want.status, "fulfilled");
+    }
+
+    // ── FIX 4: empty/partial directory must not short-circuit ──────────────
+
+    #[tokio::test]
+    async fn haves_short_circuit_falls_through_when_album_directory_has_no_media() {
+        let pool = migrated_pool().await;
+        let (want_id, release_id) = seed_want_release(&pool, "music_album").await;
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // An album directory recorded as "complete" whose audio was removed by
+        // a cleanup, leaving only non-media debris (a .nfo sidecar). This is
+        // NON-empty, so a mere entry-count check would wrongly short-circuit;
+        // the media-aware check must still fall through and re-import.
+        let empty_album_dir = dir.path().join("debris-album");
+        std::fs::create_dir_all(&empty_album_dir).unwrap();
+        std::fs::write(empty_album_dir.join("album.nfo"), b"leftover metadata").unwrap();
+
+        want::insert_have(
+            &pool,
+            &complete_music_have(want_id, release_id, &empty_album_dir),
+        )
+        .await
+        .unwrap();
+
+        let download_path = dir.path().join("download");
+        std::fs::create_dir_all(&download_path).unwrap();
+        std::fs::write(download_path.join("track.flac"), b"data").unwrap();
+
+        let lib_root = dir.path().join("library");
+        std::fs::create_dir_all(&lib_root).unwrap();
+        let mut libraries = HashMap::new();
+        libraries.insert(
+            "music".to_string(),
+            music_library(lib_root.to_str().unwrap()),
+        );
+        let svc = adapter(pool.clone(), libraries);
+
+        svc.import_inner(make_completed(want_id, release_id, download_path))
+            .await
+            .unwrap();
+
+        let haves = want::list_haves_for_want(&pool, want_id.as_bytes().as_ref())
+            .await
+            .unwrap();
+        let reimported = haves
+            .iter()
+            .any(|h| h.file_path.starts_with(lib_root.to_str().unwrap()));
+        assert!(
+            reimported,
+            "an empty recorded directory must fall through and actually re-import, \
+             not short-circuit as complete: {haves:?}"
+        );
+
+        let want = want::get_want(&pool, want_id.as_bytes().as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(want.status, "fulfilled");
+    }
+
+    // ── FIX 1a/1c: upgrade path — file_path-keyed, atomic finalize ─────────
+
+    #[tokio::test]
+    async fn second_release_for_same_want_upgrades_have_without_unique_violation() {
+        let pool = migrated_pool().await;
+        let (want_id, release_a) = seed_want_release(&pool, "music_album").await;
+
+        // A second release for the SAME want — the quality-upgrade path.
+        // Both releases resolve to the SAME album directory (same want
+        // title, same filename — see DownloadResolver::resolve_identity),
+        // which is exactly the file_path collision FIX 1a addresses.
+        let release_b = ReleaseId::new();
+        want::insert_release(
+            &pool,
+            &Release {
+                id: release_b.as_bytes().to_vec(),
+                want_id: want_id.as_bytes().to_vec(),
+                indexer_id: 1,
+                title: "Test Album FLAC Upgrade".to_string(),
+                size_bytes: 2000,
+                quality_score: 95,
+                custom_format_score: 0,
+                download_url: "https://example.com/release-b.torrent".to_string(),
+                protocol: "torrent".to_string(),
+                info_hash: None,
+                found_at: "2026-01-01T00:00:00Z".to_string(),
+                grabbed_at: None,
+                rejected_reason: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let lib_root = dir.path().join("library");
+        std::fs::create_dir_all(&lib_root).unwrap();
+        let mut libraries = HashMap::new();
+        libraries.insert(
+            "music".to_string(),
+            music_library(lib_root.to_str().unwrap()),
+        );
+        let svc = adapter(pool.clone(), libraries);
+
+        let download_a = dir.path().join("download-a");
+        std::fs::create_dir_all(&download_a).unwrap();
+        std::fs::write(download_a.join("track.flac"), b"release a data").unwrap();
+        svc.import_inner(make_completed(want_id, release_a, download_a))
+            .await
+            .unwrap();
+
+        let haves_after_a = want::list_haves_for_want(&pool, want_id.as_bytes().as_ref())
+            .await
+            .unwrap();
+        assert_eq!(haves_after_a.len(), 1);
+        let first_have_id = haves_after_a[0].id.clone();
+
+        let download_b = dir.path().join("download-b");
+        std::fs::create_dir_all(&download_b).unwrap();
+        std::fs::write(download_b.join("track.flac"), b"release b data upgraded").unwrap();
+
+        // Must NOT be a UNIQUE-constraint (idx_haves_file_path) violation.
+        svc.import_inner(make_completed(want_id, release_b, download_b))
+            .await
+            .unwrap();
+
+        let haves_after_b = want::list_haves_for_want(&pool, want_id.as_bytes().as_ref())
+            .await
+            .unwrap();
+        assert_eq!(
+            haves_after_b.len(),
+            1,
+            "upgrade must replace, not duplicate, the have row: {haves_after_b:?}"
+        );
+        let have = &haves_after_b[0];
+        assert_eq!(
+            have.release_id.as_deref(),
+            Some(release_b.as_bytes().as_slice())
+        );
+        assert_eq!(
+            have.upgraded_from_id.as_deref(),
+            Some(first_have_id.as_slice()),
+            "upgraded_from_id must point at the prior have it replaced"
+        );
+
+        let want = want::get_want(&pool, want_id.as_bytes().as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(want.status, "fulfilled");
+    }
+
+    // ── FIX 3: Movie/Book multi-file collision — largest file wins ─────────
+
+    #[tokio::test]
+    async fn movie_multi_file_download_imports_only_the_largest_file() {
+        let pool = migrated_pool().await;
+        let (want_id, release_id) = seed_want_release(&pool, "movie").await;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let download_path = dir.path().join("movie-download");
+        std::fs::create_dir_all(&download_path).unwrap();
+        std::fs::write(download_path.join("movie.mkv"), vec![0u8; 5000]).unwrap();
+        std::fs::write(download_path.join("sample.mkv"), vec![0u8; 100]).unwrap();
+
+        let lib_root = dir.path().join("library");
+        std::fs::create_dir_all(&lib_root).unwrap();
+        let mut libraries = HashMap::new();
+        libraries.insert(
+            "movies".to_string(),
+            LibraryConfig {
+                path: lib_root.clone(),
+                media_type: LibMediaType::Video,
+                watcher_mode: WatcherMode::Auto,
+                poll_interval_seconds: 300,
+                scan_interval_hours: 24,
+            },
+        );
+        let svc = adapter(pool.clone(), libraries);
+
+        svc.import_inner(make_completed(want_id, release_id, download_path))
+            .await
+            .unwrap();
+
+        let haves = want::list_haves_for_want(&pool, want_id.as_bytes().as_ref())
+            .await
+            .unwrap();
+        assert_eq!(
+            haves.len(),
+            1,
+            "only the single largest file should have been imported: {haves:?}"
+        );
+        assert_eq!(haves[0].file_size_bytes, 5000);
+    }
+
+    #[test]
+    fn best_effort_year_finds_a_plausible_four_digit_run() {
+        assert_eq!(best_effort_year("Album Name (2019) [FLAC]"), Some(2019));
+        assert_eq!(best_effort_year("no year here"), None);
+        // A 5-digit run must not false-match on its first 4 digits.
+        assert_eq!(best_effort_year("catalog-12345"), None);
+        assert_eq!(best_effort_year(""), None);
+    }
+}

--- a/crates/archon/src/lib.rs
+++ b/crates/archon/src/lib.rs
@@ -1,0 +1,3 @@
+//! Library surface for the `archon` binary — exists so `tests/` integration crates can reach internals (e.g. `import::ImportAdapter`) that a bin-only crate cannot expose.
+
+pub mod import;

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -23,7 +23,7 @@ use prostheke::providers::Provider;
 use prostheke::{SubtitleManager, SubtitleService};
 use snafu::ResultExt;
 use syndesmos::{ScrobbleClient, ScrobbleClientBuilder};
-use syntaxis::{CompletedDownload, DownloadQueue, QueueManager};
+use syntaxis::{DownloadQueue, QueueManager};
 use themelion::{MediaId, MediaType, create_event_bus};
 use tokio::signal::unix::SignalKind;
 use tokio::sync::broadcast::error::RecvError;
@@ -600,18 +600,24 @@ impl MonitorService for RequestMonitor {
     }
 }
 
+// WHY: the want-type half delegates to `themelion::MediaType::as_want_str`
+// (the schema-CHECK single source of truth); `quality_media_type` is a
+// distinct dimension (the quality-rank-table key — see
+// `apotheke::repo::quality::rank_table_for`, where "movie" and "tv" both
+// resolve to "video_quality_ranks") with no canonical helper of its own.
 fn request_media_types(media_type: themelion::MediaType) -> Option<(&'static str, &'static str)> {
-    match media_type {
-        themelion::MediaType::Music => Some(("music_album", "music")),
-        themelion::MediaType::Audiobook => Some(("audiobook", "audiobook")),
-        themelion::MediaType::Book => Some(("book", "book")),
-        themelion::MediaType::Comic => Some(("comic", "comic")),
-        themelion::MediaType::Podcast => Some(("podcast", "podcast")),
-        themelion::MediaType::Movie => Some(("movie", "movie")),
-        themelion::MediaType::Tv => Some(("tv_series", "tv")),
-        themelion::MediaType::News => None,
-        _ => None,
-    }
+    let want_str = media_type.as_want_str()?;
+    let quality_str = match media_type {
+        themelion::MediaType::Music => "music",
+        themelion::MediaType::Audiobook => "audiobook",
+        themelion::MediaType::Book => "book",
+        themelion::MediaType::Comic => "comic",
+        themelion::MediaType::Podcast => "podcast",
+        themelion::MediaType::Movie => "movie",
+        themelion::MediaType::Tv => "tv",
+        _ => return None,
+    };
+    Some((want_str, quality_str))
 }
 
 /// Swappable behind a std `RwLock` (never held across an .await) so the
@@ -873,26 +879,6 @@ impl ergasia::DownloadEngine for SessionEngine {
     }
 }
 
-// ── ImportService stub ──────────────────────────────────────────────────────
-
-// TODO[deliberate-prudent] #300: replace with real ImportService that calls kathodos // kanon:ignore RUST/todo-no-issue -- richer quadrant rule covers this // kanon:ignore META/rule-todo-without-issue -- richer quadrant rule covers this
-struct StubImportService;
-
-impl syntaxis::ImportService for StubImportService {
-    fn import(
-        &self,
-        completed: CompletedDownload,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>> {
-        Box::pin(async move {
-            tracing::info!(
-                download_id = %completed.download_id,
-                "import stub: download completed, import pipeline not yet wired"
-            );
-            Err("import pipeline not wired".to_string())
-        })
-    }
-}
-
 // ── Serve entry point ───────────────────────────────────────────────────────
 
 pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), HostError> {
@@ -1129,11 +1115,21 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         session: Arc::clone(&ergasia_session),
         extraction_config: config_handle.section(|c| &c.ergasia),
     });
+    // WHY: #602 keystone — the production ImportService. A `Section` (not
+    // the frozen boot_config) so a `taxis.libraries` edit is picked up on
+    // the next completed download without a restart (`Section::get()` is a
+    // per-call snapshot; see `import::ImportAdapter`).
+    let import_adapter = Arc::new(archon::import::ImportAdapter::new(
+        db.read.clone(),
+        db.write.clone(),
+        config_handle.section(|c| &c.taxis),
+        event_tx.clone(),
+    ));
     let syntaxis_svc = Arc::new(
         DownloadQueue::new(
             db.write.clone(),
             engine_adapter,
-            Arc::new(StubImportService),
+            import_adapter,
             boot_config.syntaxis.clone(),
         )
         .await
@@ -2456,7 +2452,7 @@ mod service_adapter_tests {
     use apotheke::migrate::MIGRATOR;
     use paroche::state::{DynCurationService, DynMetadataResolver, DynQueueManager, ServiceError};
     use sqlx::SqlitePool;
-    use syntaxis::QueueManager;
+    use syntaxis::{CompletedDownload, QueueManager};
     use themelion::create_event_bus;
     use themelion::ids::{DownloadId, ReleaseId, WantId};
 
@@ -2468,6 +2464,20 @@ mod service_adapter_tests {
             .expect("in-memory sqlite opens");
         MIGRATOR.run(&pool).await.expect("migrations run");
         pool
+    }
+
+    // WHY: these tests exercise DownloadQueue wiring, not import behavior —
+    // a no-op stands in for the real `archon::import::ImportAdapter`, which
+    // has its own dedicated unit + integration tests.
+    struct NoopImportService;
+
+    impl syntaxis::ImportService for NoopImportService {
+        fn import(
+            &self,
+            _completed: CompletedDownload,
+        ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>> {
+            Box::pin(async { Ok(()) })
+        }
     }
 
     // ── #470: CurationAdapter delegates to the live kritike service ────────
@@ -2625,7 +2635,7 @@ mod service_adapter_tests {
             DownloadQueue::new(
                 pool,
                 Arc::clone(&engine),
-                Arc::new(StubImportService),
+                Arc::new(NoopImportService),
                 horismos::SyntaxisConfig {
                     max_concurrent_downloads: 2,
                     max_per_tracker: 3,
@@ -2688,7 +2698,7 @@ mod service_adapter_tests {
             DownloadQueue::new(
                 pool,
                 engine,
-                Arc::new(StubImportService),
+                Arc::new(NoopImportService),
                 horismos::SyntaxisConfig {
                     max_concurrent_downloads: 2,
                     max_per_tracker: 3,
@@ -2734,7 +2744,7 @@ mod service_adapter_tests {
             DownloadQueue::new(
                 pool.clone(),
                 Arc::clone(&engine),
-                Arc::new(StubImportService),
+                Arc::new(NoopImportService),
                 horismos::SyntaxisConfig {
                     max_concurrent_downloads: 2,
                     max_per_tracker: 3,
@@ -2787,7 +2797,7 @@ mod service_adapter_tests {
             DownloadQueue::new(
                 pool.clone(),
                 Arc::clone(&engine),
-                Arc::new(StubImportService),
+                Arc::new(NoopImportService),
                 horismos::SyntaxisConfig {
                     max_concurrent_downloads: 2,
                     max_per_tracker: 3,
@@ -3096,8 +3106,6 @@ mod tests {
     use apotheke::migrate::MIGRATOR;
     use paroche::state::{DynSubtitleService, ServiceError};
     use sqlx::SqlitePool;
-    use syntaxis::ImportService;
-    use themelion::ids::{DownloadId, ReleaseId, WantId};
 
     use super::*;
 
@@ -3337,23 +3345,6 @@ mod tests {
         // The function should accept a Vec<u8> writer and fail on missing config.
         let result = run_serve(args, &mut out).await;
         assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn stub_import_service_fails_until_import_pipeline_is_wired() {
-        let completed = CompletedDownload {
-            download_id: DownloadId::new(),
-            download_path: PathBuf::from("/data/downloads/album"),
-            source_path: PathBuf::from("/data/downloads/album"),
-            want_id: WantId::new(),
-            release_id: ReleaseId::new(),
-            protocol: syntaxis::DownloadProtocol::Torrent,
-            requires_copy: false,
-        };
-
-        let result = StubImportService.import(completed).await;
-
-        assert_eq!(result, Err("import pipeline not wired".to_string()));
     }
 
     // ── Cloudflare-bypass proxy wiring ──────────────────────────────────────

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -1156,6 +1156,8 @@ async fn member_on_admin_routes_returns_403() -> Result<(), TestError> {
     Ok(())
 }
 
+#[path = "acquisition_integration/import_tests.rs"]
+mod import_tests;
 #[path = "acquisition_integration/pipeline_tests.rs"]
 mod pipeline_tests;
 #[path = "acquisition_integration/recovery_tests.rs"]

--- a/crates/archon/tests/acquisition_integration/import_tests.rs
+++ b/crates/archon/tests/acquisition_integration/import_tests.rs
@@ -1,0 +1,364 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use archon::import::ImportAdapter;
+use ergasia::{DownloadProgress, DownloadState, ErgasiaError, ExtractionResult};
+use horismos::{
+    LibraryConfig, MediaType as HorismosMediaType, Section, SyntaxisConfig, TaxisConfig,
+    WatcherMode,
+};
+use std::sync::Arc;
+use syntaxis::{DownloadQueue, ImportService, QueueItem, QueueManager};
+use themelion::ids::{DownloadId, ReleaseId, WantId};
+use themelion::{HarmoniaEvent, create_event_bus};
+use tokio::sync::mpsc;
+
+use super::{TestError, test_db};
+
+// ── real-file fixture: a minimal, hand-built lofty-readable tagged FLAC ────
+
+fn vorbis_comment_block(tags: &[(&str, &str)]) -> Vec<u8> {
+    let vendor = b"kathodos-integration-test";
+    let mut data = Vec::new();
+    data.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    data.extend_from_slice(vendor);
+    data.extend_from_slice(&(tags.len() as u32).to_le_bytes());
+    for (k, v) in tags {
+        let comment = format!("{k}={v}");
+        data.extend_from_slice(&(comment.len() as u32).to_le_bytes());
+        data.extend_from_slice(comment.as_bytes());
+    }
+    data
+}
+
+/// Big-endian bit packer FOR the FLAC STREAMINFO block's odd-width fields
+/// (20-bit sample rate, 3-bit channel count, 5-bit bit depth, 36-bit sample
+/// total) — hand-computing those byte boundaries is error-prone, so this
+/// packs them programmatically instead.
+struct BitWriter {
+    buf: Vec<u8>,
+    acc: u64,
+    nbits: u32,
+}
+
+impl BitWriter {
+    fn new() -> Self {
+        Self {
+            buf: Vec::new(),
+            acc: 0,
+            nbits: 0,
+        }
+    }
+
+    fn write_bits(&mut self, value: u64, bits: u32) {
+        self.acc = (self.acc << bits) | (value & ((1u64 << bits) - 1));
+        self.nbits += bits;
+        while self.nbits >= 8 {
+            self.nbits -= 8;
+            self.buf.push(((self.acc >> self.nbits) & 0xFF) as u8);
+        }
+    }
+
+    fn finish(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+fn streaminfo_block() -> Vec<u8> {
+    let mut bw = BitWriter::new();
+    bw.write_bits(4096, 16); // min block size
+    bw.write_bits(4096, 16); // max block size
+    bw.write_bits(0, 24); // min frame size (unknown)
+    bw.write_bits(0, 24); // max frame size (unknown)
+    bw.write_bits(44100, 20); // sample rate
+    bw.write_bits(1, 3); // channels - 1 (2 channels)
+    bw.write_bits(15, 5); // bits per sample - 1 (16 bits)
+    bw.write_bits(0, 36); // total samples (unknown — no audio frames follow)
+    let mut block = bw.finish();
+    block.extend_from_slice(&[0u8; 16]); // MD5 signature (all-zero = unknown, valid per spec)
+    debug_assert_eq!(block.len(), 34);
+    block
+}
+
+/// Builds a minimal valid FLAC file (STREAMINFO + VORBIS_COMMENT, zero audio
+/// frames — lofty's properties reader tolerates an all-zero STREAMINFO and
+/// no trailing audio data, see `flac::properties::read_properties`) with the
+/// given tags, so `kathodos::import::tags::read_tags` exercises real lofty
+/// parsing rather than a mock resolver.
+fn make_tagged_flac(title: &str, artist: &str, track: &str, year: &str) -> Vec<u8> {
+    let streaminfo = streaminfo_block();
+    let vorbis = vorbis_comment_block(&[
+        ("TITLE", title),
+        ("ARTIST", artist),
+        ("TRACKNUMBER", track),
+        ("DATE", year),
+    ]);
+
+    let mut out = Vec::new();
+    out.extend_from_slice(b"fLaC");
+
+    out.push(0x00); // block type 0 (STREAMINFO), not last
+    let len = streaminfo.len() as u32;
+    out.extend_from_slice(&len.to_be_bytes()[1..4]);
+    out.extend_from_slice(&streaminfo);
+
+    out.push(0x84); // last-block flag (0x80) | block type 4 (VORBIS_COMMENT)
+    let len2 = vorbis.len() as u32;
+    out.extend_from_slice(&len2.to_be_bytes()[1..4]);
+    out.extend_from_slice(&vorbis);
+
+    out
+}
+
+// ── local download engine (configurable content_path, unlike the shared MockEngine) ─
+
+struct ImportTestEngine {
+    started_tx: mpsc::UnboundedSender<DownloadId>,
+    content_dir: PathBuf,
+}
+
+impl ergasia::DownloadEngine for ImportTestEngine {
+    async fn start_download(
+        &self,
+        request: ergasia::DownloadRequest,
+    ) -> Result<DownloadId, ErgasiaError> {
+        let _ = self.started_tx.send(request.download_id);
+        Ok(request.download_id)
+    }
+
+    async fn cancel_download(&self, _download_id: DownloadId) -> Result<(), ErgasiaError> {
+        Ok(())
+    }
+
+    async fn get_progress(
+        &self,
+        download_id: DownloadId,
+    ) -> Result<DownloadProgress, ErgasiaError> {
+        Ok(DownloadProgress {
+            download_id,
+            state: DownloadState::Downloading,
+            percent_complete: 50,
+            download_speed_bps: 0,
+            upload_speed_bps: 0,
+            peers_connected: 0,
+            seeders: 0,
+            eta_seconds: None,
+            error: None,
+        })
+    }
+
+    async fn content_path(&self, _download_id: DownloadId) -> Result<PathBuf, ErgasiaError> {
+        Ok(self.content_dir.clone())
+    }
+
+    async fn extract(
+        &self,
+        _download_path: &std::path::Path,
+        _output_dir: &std::path::Path,
+    ) -> Result<Option<ExtractionResult>, ErgasiaError> {
+        Ok(None)
+    }
+}
+
+fn test_syntaxis_config() -> SyntaxisConfig {
+    SyntaxisConfig {
+        max_concurrent_downloads: 5,
+        max_per_tracker: 3,
+        retry_count: 2,
+        retry_backoff_base_seconds: 0,
+        stalled_download_timeout_hours: 24,
+    }
+}
+
+async fn seed_profile_id(pool: &sqlx::SqlitePool) -> i64 {
+    sqlx::query_scalar("SELECT id FROM quality_profiles WHERE media_type = 'music' LIMIT 1")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+// ── the completion→import regression (#602 keystone) ────────────────────────
+
+#[tokio::test]
+async fn download_completion_imports_into_library() -> Result<(), TestError> {
+    let pool = test_db().await?;
+    let profile_id = seed_profile_id(&pool).await;
+
+    let want_id = WantId::new();
+    apotheke::repo::want::insert_want(
+        &pool,
+        &apotheke::repo::want::Want {
+            id: want_id.as_bytes().to_vec(),
+            media_type: "music_album".to_string(),
+            title: "Test Album".to_string(),
+            registry_id: None,
+            quality_profile_id: profile_id,
+            status: "searching".to_string(),
+            source: None,
+            source_ref: None,
+            added_at: "2026-01-01T00:00:00Z".to_string(),
+            fulfilled_at: None,
+        },
+    )
+    .await?;
+
+    let release_id = ReleaseId::new();
+    apotheke::repo::want::insert_release(
+        &pool,
+        &apotheke::repo::want::Release {
+            id: release_id.as_bytes().to_vec(),
+            want_id: want_id.as_bytes().to_vec(),
+            indexer_id: 1,
+            title: "Test Album FLAC".to_string(),
+            size_bytes: 1_000_000,
+            quality_score: 90,
+            custom_format_score: 0,
+            download_url: "magnet:?xt=urn:btih:import-test".to_string(),
+            protocol: "torrent".to_string(),
+            info_hash: None,
+            found_at: "2026-01-01T00:00:00Z".to_string(),
+            grabbed_at: None,
+            rejected_reason: None,
+        },
+    )
+    .await?;
+
+    // A tempdir download directory: one lofty-tagged .flac + one junk .nfo,
+    // proving walk_library's extension filter runs.
+    let download_dir = tempfile::TempDir::new()?;
+    std::fs::write(
+        download_dir.path().join("01 - Track.flac"),
+        make_tagged_flac("Test Track", "Test Artist", "1", "2024"),
+    )?;
+    std::fs::write(download_dir.path().join("release.nfo"), b"not a media file")?;
+
+    // A tempdir library root, wired as the sole Music library.
+    let library_root = tempfile::TempDir::new()?;
+    let mut libraries = HashMap::new();
+    libraries.insert(
+        "music".to_string(),
+        LibraryConfig {
+            path: library_root.path().to_path_buf(),
+            media_type: HorismosMediaType::Music,
+            watcher_mode: WatcherMode::Auto,
+            poll_interval_seconds: 300,
+            scan_interval_hours: 24,
+        },
+    );
+    let taxis = Section::fixed(TaxisConfig {
+        libraries,
+        ..TaxisConfig::default()
+    });
+
+    let (event_tx, _) = create_event_bus(64);
+    let import_adapter: Arc<dyn ImportService> = Arc::new(ImportAdapter::new(
+        pool.clone(),
+        pool.clone(),
+        taxis,
+        event_tx.clone(),
+    ));
+
+    let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+    let engine = Arc::new(ImportTestEngine {
+        started_tx,
+        content_dir: download_dir.path().to_path_buf(),
+    });
+
+    let svc = Arc::new(
+        DownloadQueue::new(pool.clone(), engine, import_adapter, test_syntaxis_config()).await?,
+    );
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut assert_rx = event_tx.subscribe();
+    let _listener = svc.start(event_tx.subscribe(), shutdown.clone());
+
+    let queue_id = uuid::Uuid::now_v7();
+    svc.enqueue(QueueItem {
+        id: queue_id,
+        want_id,
+        release_id,
+        download_url: "magnet:?xt=urn:btih:import-test".to_string(),
+        protocol: syntaxis::DownloadProtocol::Torrent,
+        priority: 4,
+        tracker_id: None,
+        info_hash: None,
+        retry_count: 0,
+    })
+    .await?;
+
+    let dl_id = tokio::time::timeout(Duration::from_secs(5), started_rx.recv())
+        .await?
+        .expect("engine should have received start_download");
+
+    event_tx.send(HarmoniaEvent::DownloadCompleted {
+        download_id: dl_id,
+        path: download_dir.path().to_path_buf(),
+    })?;
+
+    // Poll for terminal queue state — the pipeline runs on a spawned task.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut status = String::new();
+    while tokio::time::Instant::now() < deadline {
+        status = sqlx::query_scalar("SELECT status FROM download_queue WHERE id = ?")
+            .bind(queue_id.as_bytes().as_slice())
+            .fetch_one(&pool)
+            .await?;
+        if status == "completed" || status == "failed" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        status, "completed",
+        "the pipeline must reach a terminal 'completed' state"
+    );
+
+    // The imported file landed at its canonical templated path.
+    let expected_path = library_root
+        .path()
+        .join("Test Artist")
+        .join("Test Album (2024)")
+        .join("01 - Test Track.flac");
+    assert!(
+        expected_path.exists(),
+        "expected imported file at {expected_path:?}; library_root contains: {:?}",
+        walk_dir_names(library_root.path())
+    );
+
+    // haves row is complete, want is fulfilled.
+    let have_status: String = sqlx::query_scalar("SELECT status FROM haves WHERE want_id = ?")
+        .bind(want_id.as_bytes().as_slice())
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(have_status, "complete");
+
+    let want_status: String = sqlx::query_scalar("SELECT status FROM wants WHERE id = ?")
+        .bind(want_id.as_bytes().as_slice())
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(want_status, "fulfilled");
+
+    // ImportCompleted was published on the bus.
+    let mut saw_import_completed = false;
+    while let Ok(event) = tokio::time::timeout(Duration::from_millis(200), assert_rx.recv()).await {
+        if matches!(event?, HarmoniaEvent::ImportCompleted { .. }) {
+            saw_import_completed = true;
+            break;
+        }
+    }
+    assert!(
+        saw_import_completed,
+        "expected an ImportCompleted event on the bus"
+    );
+
+    shutdown.cancel();
+    Ok(())
+}
+
+fn walk_dir_names(root: &std::path::Path) -> Vec<PathBuf> {
+    walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path().to_path_buf())
+        .collect()
+}

--- a/crates/kathodos/src/import/fileops.rs
+++ b/crates/kathodos/src/import/fileops.rs
@@ -133,6 +133,115 @@ fn is_cross_device(e: &std::io::Error) -> bool {
     e.kind() == std::io::ErrorKind::CrossesDevices || e.raw_os_error() == Some(18) // EXDEV on Linux
 }
 
+/// Checks whether `target` already holds the same content as `source`.
+///
+/// Two tiers: (1) exact same `(dev, ino)` — `target` is a hardlink of
+/// `source` (the common same-filesystem `ImportOrigin::Download` case);
+/// (2) for distinct inodes (an EXDEV cross-device copy), equal size AND a
+/// byte-for-byte content comparison. A missing `target` is `Ok(false)`, not
+/// an error — the common case (no prior import).
+///
+/// WHY the byte compare rather than the old same-size heuristic: size alone
+/// returned `true` for any distinct file that merely matched the target's
+/// length, silently dropping a genuinely different (e.g. higher-quality)
+/// file as "already present" (data loss). Size alone also cannot recognize a
+/// legitimate EXDEV-copy re-import, so it would suffix a duplicate on every
+/// crash-replay. A content compare is correct on both axes; it runs only on
+/// an equal-size collision (rare), and the archon haves short-circuit (keyed
+/// on `file_path`) remains the durable idempotency layer.
+pub async fn same_file(source: &Path, target: &Path) -> Result<bool, TaxisError> {
+    let source = source.to_path_buf();
+    let target = target.to_path_buf();
+
+    tokio::task::spawn_blocking(move || same_file_blocking(&source, &target))
+        .await
+        .map_err(|e| TaxisError::BlockingTaskFailed {
+            message: e.to_string(),
+            location: snafu::location!(),
+        })
+        .and_then(|r| r)
+}
+
+fn same_file_blocking(source: &Path, target: &Path) -> Result<bool, TaxisError> {
+    use std::os::unix::fs::MetadataExt;
+
+    if !target.exists() {
+        return Ok(false);
+    }
+
+    let source_meta = std::fs::metadata(source).map_err(|e| TaxisError::FileOperation {
+        operation: "stat".into(),
+        source_path: source.to_path_buf(),
+        target_path: target.to_path_buf(),
+        source: e,
+        location: snafu::location!(),
+    })?;
+    let target_meta = std::fs::metadata(target).map_err(|e| TaxisError::FileOperation {
+        operation: "stat".into(),
+        source_path: source.to_path_buf(),
+        target_path: target.to_path_buf(),
+        source: e,
+        location: snafu::location!(),
+    })?;
+
+    // Exact hardlink: the import already landed as a second link to the
+    // source inode (same-filesystem `hardlink_or_copy`).
+    if source_meta.dev() == target_meta.dev() && source_meta.ino() == target_meta.ino() {
+        return Ok(true);
+    }
+
+    // WHY: a cross-device import copies (EXDEV fallback) to a FRESH inode, so
+    // a crash-replay re-import cannot match by inode and would otherwise
+    // suffix a duplicate every retry. Fall back to a content comparison —
+    // gated on equal size (cheap), then a byte compare. A byte compare (NOT
+    // size alone) is required: a genuinely different file of equal length
+    // must not be treated as already-present (that would silently drop it).
+    if source_meta.len() != target_meta.len() {
+        return Ok(false);
+    }
+    files_have_identical_content(source, target)
+}
+
+/// Byte-for-byte comparison of two files, chunked so large media never loads
+/// wholesale. Callers gate this on equal size (it assumes both files have the
+/// same length).
+fn files_have_identical_content(source: &Path, target: &Path) -> Result<bool, TaxisError> {
+    use std::io::BufRead;
+
+    let op_err = |operation: &str, e: std::io::Error| TaxisError::FileOperation {
+        operation: operation.into(),
+        source_path: source.to_path_buf(),
+        target_path: target.to_path_buf(),
+        source: e,
+        location: snafu::location!(),
+    };
+
+    let mut sf =
+        std::io::BufReader::new(std::fs::File::open(source).map_err(|e| op_err("open", e))?);
+    let mut tf =
+        std::io::BufReader::new(std::fs::File::open(target).map_err(|e| op_err("open", e))?);
+    loop {
+        // fill_buf + consume avoids fixed-buffer index slicing; the compared
+        // prefix goes through `.get()`, never direct indexing.
+        let consumed = {
+            let sbuf = sf.fill_buf().map_err(|e| op_err("read", e))?;
+            let tbuf = tf.fill_buf().map_err(|e| op_err("read", e))?;
+            match (sbuf.is_empty(), tbuf.is_empty()) {
+                (true, true) => return Ok(true),
+                (true, false) | (false, true) => return Ok(false),
+                (false, false) => {}
+            }
+            let len = sbuf.len().min(tbuf.len());
+            if sbuf.get(..len) != tbuf.get(..len) {
+                return Ok(false);
+            }
+            len
+        };
+        sf.consume(consumed);
+        tf.consume(consumed);
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FileOpResult {
@@ -198,5 +307,74 @@ mod tests {
         let path = dir.path().join("a/b/c/file.flac");
         ensure_parent_dirs(&path).await.unwrap();
         assert!(dir.path().join("a/b/c").exists());
+    }
+
+    #[tokio::test]
+    async fn same_file_true_for_hardlink() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source.flac");
+        let target = dir.path().join("target.flac");
+        std::fs::write(&source, b"FLAC data").unwrap();
+        hardlink_or_copy(&source, &target).await.unwrap();
+
+        assert!(same_file(&source, &target).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn same_file_false_for_missing_target() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source.flac");
+        let target = dir.path().join("target.flac");
+        std::fs::write(&source, b"FLAC data").unwrap();
+
+        assert!(!same_file(&source, &target).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn same_file_false_for_distinct_content_and_size() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source.flac");
+        let target = dir.path().join("target.flac");
+        std::fs::write(&source, b"short").unwrap();
+        std::fs::write(&target, b"a much longer distinct payload").unwrap();
+
+        assert!(!same_file(&source, &target).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn same_file_false_for_distinct_content_same_size() {
+        // FIX 2: a genuinely different file that merely matches the target's
+        // byte length must NOT be treated as identical — the removed
+        // size-only heuristic silently dropped such files as "already
+        // present" (data loss). Both are 16 bytes, distinct content.
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source.flac");
+        let target = dir.path().join("target.flac");
+        std::fs::write(&source, b"aaaaaaaaaaaaaaaa").unwrap();
+        std::fs::write(&target, b"bbbbbbbbbbbbbbbb").unwrap();
+
+        assert!(!same_file(&source, &target).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn same_file_true_for_identical_cross_device_copy() {
+        // FIX 2 (re-review): a cross-device import copies to a FRESH inode, so
+        // a crash-replay re-import must still be recognized as already-present
+        // by content — otherwise every retry suffixes a duplicate. Distinct
+        // inodes, identical bytes ⇒ true.
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source.flac");
+        let target = dir.path().join("target.flac");
+        std::fs::write(&source, b"identical bytes across a copy").unwrap();
+        copy_file(&source, &target).await.unwrap();
+
+        // Distinct inodes (a copy, not a hardlink)...
+        use std::os::unix::fs::MetadataExt;
+        assert_ne!(
+            std::fs::metadata(&source).unwrap().ino(),
+            std::fs::metadata(&target).unwrap().ino()
+        );
+        // ...but identical content ⇒ same file for idempotency.
+        assert!(same_file(&source, &target).await.unwrap());
     }
 }

--- a/crates/kathodos/src/import/mod.rs
+++ b/crates/kathodos/src/import/mod.rs
@@ -1,6 +1,7 @@
 pub mod conflict;
 pub mod fileops;
 pub mod identify;
+pub mod tags;
 pub mod template;
 
 use std::collections::HashMap;
@@ -11,7 +12,7 @@ use tracing::instrument;
 
 use crate::error::{EpignosisError, TaxisError};
 use crate::import::conflict::{ConflictOutcome, DEFAULT_MAX_SUFFIX, resolve_conflict};
-use crate::import::fileops::{hardlink_or_copy, rename_file};
+use crate::import::fileops::{hardlink_or_copy, rename_file, same_file};
 use crate::import::template::TemplateEngine;
 
 // WHY: pure data — source descriptor for a media import.
@@ -55,6 +56,13 @@ pub enum ImportOperation {
     Added,
     Upgraded,
     Skipped,
+    /// The target already holds this exact source (same `(dev, ino)` —
+    /// a hardlink of `source`) — a re-run against a prior successful
+    /// import on the same filesystem. No file operation was performed and
+    /// no `ImportCompleted` event was emitted. See `fileops::same_file`:
+    /// this is an exact-inode fast-path only; the durable idempotency
+    /// layer is the archon haves short-circuit keyed on `file_path`.
+    AlreadyPresent,
 }
 
 // WHY: pure data — import job awaiting processing.
@@ -143,6 +151,26 @@ impl<R: MetadataResolver> ImportPipeline<R> {
         let engine = TemplateEngine::parse(template_str, media_type)?;
         let relative_path = engine.resolve(&metadata.tokens)?;
         let target_path = source.library_root.join(&relative_path);
+
+        // Idempotency short-circuit: a restart mid-pipeline re-runs the whole
+        // import for the same source, so a target that already holds this
+        // exact source must not be re-hardlinked (which would fall through
+        // to a `_2`-suffixed duplicate below — see conflict::resolve_conflict,
+        // which never sees the true existing quality and always suffixes on
+        // any collision).
+        if same_file(&source.path, &target_path).await? {
+            tracing::info!(
+                path = %target_path.display(),
+                "import target already holds this source  -  skipping file operation"
+            );
+            return Ok(ImportResult {
+                media_id: MediaId::new(),
+                media_type,
+                final_path: target_path,
+                quality_score: metadata.quality_score,
+                operation: ImportOperation::AlreadyPresent,
+            });
+        }
 
         // Conflict check and file operation
         let outcome = resolve_conflict(
@@ -356,5 +384,62 @@ mod tests {
 
         let event = rx.try_recv().unwrap();
         assert!(matches!(event, HarmoniaEvent::ImportCompleted { .. }));
+    }
+
+    // ── idempotency regression (a restart mid-pipeline re-runs import) ──────
+
+    #[tokio::test]
+    async fn download_reimport_is_idempotent_not_suffixed() {
+        let dir = TempDir::new().unwrap();
+        let source_file = dir.path().join("source.flac");
+        let library_root = dir.path().join("library");
+        std::fs::create_dir_all(&library_root).unwrap();
+        std::fs::write(&source_file, b"FLAC data").unwrap();
+
+        let (tx, mut rx) = create_event_bus(16);
+        let resolver = MockResolver {
+            tokens: music_tokens(),
+            quality: 300,
+        };
+        let pipeline = ImportPipeline::new(resolver, tx);
+
+        let make_source = || ImportSource {
+            path: source_file.clone(),
+            library_name: "music".into(),
+            media_type: MediaType::Music,
+            origin: ImportOrigin::Download {
+                want_id: WantId::new(),
+                release_id: ReleaseId::new(),
+            },
+            naming_template: Some("{Artist Name}/{Track Title}.{Extension}".to_string()),
+            library_root: library_root.clone(),
+        };
+
+        let first = pipeline.process(make_source()).await.unwrap();
+        assert_eq!(first.operation, ImportOperation::Added);
+        assert!(first.final_path.exists());
+
+        let second = pipeline.process(make_source()).await.unwrap();
+        assert_eq!(second.operation, ImportOperation::AlreadyPresent);
+        assert_eq!(second.final_path, first.final_path);
+
+        // No `_2`-suffixed duplicate was created.
+        let entries: Vec<_> = std::fs::read_dir(first.final_path.parent().unwrap())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected exactly one file, got {entries:?}"
+        );
+
+        // Exactly one ImportCompleted — the second run emits none.
+        let event = rx.try_recv().unwrap();
+        assert!(matches!(event, HarmoniaEvent::ImportCompleted { .. }));
+        assert!(
+            rx.try_recv().is_err(),
+            "AlreadyPresent must not emit a second ImportCompleted"
+        );
     }
 }

--- a/crates/kathodos/src/import/tags.rs
+++ b/crates/kathodos/src/import/tags.rs
@@ -1,0 +1,261 @@
+use std::path::Path;
+
+use lofty::prelude::{Accessor, ItemKey, TaggedFileExt};
+use tracing::instrument;
+
+use crate::error::TaxisError;
+
+// WHY: pure data — embedded tag fields read from a media file via lofty.
+/// Embedded metadata read from a single media file.
+///
+/// A missing field (untagged file, unsupported container, or a genuinely
+/// absent tag item) is `None`, never an error — callers fall back to other
+/// hint sources (DB, filename) per field.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct FileTags {
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub album_artist: Option<String>,
+    pub track_number: Option<u32>,
+    pub disc_number: Option<u32>,
+    pub year: Option<u32>,
+}
+
+impl FileTags {
+    /// True if every field is `None` — either the file carried no primary
+    /// tag at all, or its primary tag existed but populated none of the
+    /// fields this resolver ladder consumes. Distinct FROM a read error
+    /// (`Err`): this is a successful read that simply found nothing,
+    /// signalling callers to weight DB/filename fallbacks more heavily.
+    pub fn is_empty(&self) -> bool {
+        self.title.is_none()
+            && self.artist.is_none()
+            && self.album.is_none()
+            && self.album_artist.is_none()
+            && self.track_number.is_none()
+            && self.disc_number.is_none()
+            && self.year.is_none()
+    }
+}
+
+/// Reads embedded tags FROM `path` using lofty.
+///
+/// Runs on a blocking thread — lofty's reader is synchronous. A malformed or
+/// untagged file is a real error here (the caller decides whether that is
+/// fatal); an absent individual field within a successfully-read tag is not.
+#[instrument]
+pub async fn read_tags(path: &Path) -> Result<FileTags, TaxisError> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || read_tags_blocking(&path))
+        .await
+        .map_err(|e| TaxisError::BlockingTaskFailed {
+            message: e.to_string(),
+            location: snafu::location!(),
+        })
+        .and_then(|r| r)
+}
+
+fn read_tags_blocking(path: &Path) -> Result<FileTags, TaxisError> {
+    let tagged = lofty::read_from_path(path).map_err(|source| TaxisError::TagRead {
+        path: path.to_path_buf(),
+        source,
+        location: snafu::location!(),
+    })?;
+
+    let Some(tag) = tagged.primary_tag() else {
+        return Ok(FileTags::default());
+    };
+
+    let year = tag
+        .date()
+        .map(|ts| u32::from(ts.year))
+        .or_else(|| tag.get_string(ItemKey::Year).and_then(|s| s.parse().ok()));
+
+    Ok(FileTags {
+        title: tag.title().map(|v| v.to_string()),
+        artist: tag.artist().map(|v| v.to_string()),
+        album: tag.album().map(|v| v.to_string()),
+        album_artist: tag.get_string(ItemKey::AlbumArtist).map(|v| v.to_string()),
+        track_number: tag.track(),
+        disc_number: tag.disk(),
+        year,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::{NamedTempFile, TempDir};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn corrupt_file_returns_tag_read_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("corrupt.flac");
+        std::fs::write(&path, b"not a real flac file").unwrap();
+
+        let result = read_tags(&path).await;
+        assert!(matches!(result, Err(TaxisError::TagRead { .. })));
+    }
+
+    #[tokio::test]
+    async fn nonexistent_file_returns_tag_read_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing.flac");
+
+        let result = read_tags(&path).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn file_tags_default_is_all_none() {
+        let tags = FileTags::default();
+        assert!(tags.title.is_none());
+        assert!(tags.artist.is_none());
+        assert!(tags.album.is_none());
+        assert!(tags.album_artist.is_none());
+        assert!(tags.track_number.is_none());
+        assert!(tags.disc_number.is_none());
+        assert!(tags.year.is_none());
+    }
+
+    // ── real-file positive read (hand-built FLAC + VORBIS_COMMENT tag) ──────
+
+    /// Big-endian bit packer FOR the FLAC STREAMINFO block's odd-width
+    /// fields (20-bit sample rate, 3-bit channel count, 5-bit bit depth,
+    /// 36-bit sample total) — hand-computing those byte boundaries is
+    /// error-prone, so this packs them programmatically instead.
+    struct BitWriter {
+        buf: Vec<u8>,
+        acc: u64,
+        nbits: u32,
+    }
+
+    impl BitWriter {
+        fn new() -> Self {
+            Self {
+                buf: Vec::new(),
+                acc: 0,
+                nbits: 0,
+            }
+        }
+
+        fn write_bits(&mut self, value: u64, bits: u32) {
+            self.acc = (self.acc << bits) | (value & ((1u64 << bits) - 1));
+            self.nbits += bits;
+            while self.nbits >= 8 {
+                self.nbits -= 8;
+                self.buf.push(((self.acc >> self.nbits) & 0xFF) as u8);
+            }
+        }
+
+        fn finish(self) -> Vec<u8> {
+            self.buf
+        }
+    }
+
+    fn streaminfo_block() -> Vec<u8> {
+        let mut bw = BitWriter::new();
+        bw.write_bits(4096, 16); // min block size
+        bw.write_bits(4096, 16); // max block size
+        bw.write_bits(0, 24); // min frame size (unknown)
+        bw.write_bits(0, 24); // max frame size (unknown)
+        bw.write_bits(44100, 20); // sample rate
+        bw.write_bits(1, 3); // channels - 1 (2 channels)
+        bw.write_bits(15, 5); // bits per sample - 1 (16 bits)
+        bw.write_bits(0, 36); // total samples (unknown — no audio frames follow)
+        let mut block = bw.finish();
+        block.extend_from_slice(&[0u8; 16]); // MD5 signature (all-zero = unknown, valid per spec)
+        block
+    }
+
+    fn vorbis_comment_block(tags: &[(&str, &str)]) -> Vec<u8> {
+        let vendor = b"kathodos-test";
+        let mut data = Vec::new();
+        data.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+        data.extend_from_slice(vendor);
+        data.extend_from_slice(&(tags.len() as u32).to_le_bytes());
+        for (k, v) in tags {
+            let comment = format!("{k}={v}");
+            data.extend_from_slice(&(comment.len() as u32).to_le_bytes());
+            data.extend_from_slice(comment.as_bytes());
+        }
+        data
+    }
+
+    /// Builds a minimal valid FLAC file (STREAMINFO + VORBIS_COMMENT, zero
+    /// audio frames) with the given tags — the smallest real container
+    /// exercising `read_tags`'s success path against actual lofty parsing
+    /// rather than a mock.
+    fn make_tagged_flac(
+        title: &str,
+        artist: &str,
+        album: &str,
+        track: &str,
+        year: &str,
+    ) -> NamedTempFile {
+        let streaminfo = streaminfo_block();
+        let vorbis = vorbis_comment_block(&[
+            ("TITLE", title),
+            ("ARTIST", artist),
+            ("ALBUM", album),
+            ("TRACKNUMBER", track),
+            ("DATE", year),
+        ]);
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"fLaC");
+
+        out.push(0x00); // block type 0 (STREAMINFO), not last
+        let len = streaminfo.len() as u32;
+        out.extend_from_slice(&len.to_be_bytes()[1..4]);
+        out.extend_from_slice(&streaminfo);
+
+        out.push(0x84); // last-block flag (0x80) | block type 4 (VORBIS_COMMENT)
+        let len2 = vorbis.len() as u32;
+        out.extend_from_slice(&len2.to_be_bytes()[1..4]);
+        out.extend_from_slice(&vorbis);
+
+        let mut f = tempfile::Builder::new().suffix(".flac").tempfile().unwrap();
+        f.write_all(&out).unwrap();
+        f
+    }
+
+    #[tokio::test]
+    async fn reads_embedded_tags_from_real_file() {
+        let flac = make_tagged_flac("Test Track", "Test Artist", "Test Album", "3", "1999");
+
+        let tags = read_tags(flac.path()).await.unwrap();
+
+        assert_eq!(tags.title.as_deref(), Some("Test Track"));
+        assert_eq!(tags.artist.as_deref(), Some("Test Artist"));
+        assert_eq!(tags.album.as_deref(), Some("Test Album"));
+        assert_eq!(tags.track_number, Some(3));
+        assert_eq!(tags.year, Some(1999));
+    }
+
+    #[tokio::test]
+    async fn untagged_valid_file_returns_all_none() {
+        // WHY: a STREAMINFO-only FLAC (no VORBIS_COMMENT block) has no
+        // primary tag at all — distinct FROM `make_tagged_flac` with empty
+        // string values, which would still produce an (empty-string) tag.
+        let streaminfo = streaminfo_block();
+        let mut out = Vec::new();
+        out.extend_from_slice(b"fLaC");
+        out.push(0x80); // block type 0 (STREAMINFO), LAST block
+        let len = streaminfo.len() as u32;
+        out.extend_from_slice(&len.to_be_bytes()[1..4]);
+        out.extend_from_slice(&streaminfo);
+
+        let mut f = tempfile::Builder::new().suffix(".flac").tempfile().unwrap();
+        f.write_all(&out).unwrap();
+
+        let tags = read_tags(f.path()).await.unwrap();
+        assert_eq!(tags.title, None);
+        assert_eq!(tags.artist, None);
+    }
+}

--- a/crates/themelion/src/media.rs
+++ b/crates/themelion/src/media.rs
@@ -32,6 +32,46 @@ impl fmt::Display for MediaType {
     }
 }
 
+impl MediaType {
+    /// Canonical string form of `apotheke`'s `wants.media_type` CHECK
+    /// constraint (`music_album`, `audiobook`, `book`, `comic`, `podcast`,
+    /// `movie`, `tv_series`). Distinct FROM [`Display`](fmt::Display), which
+    /// is human-readable and covers `News` (which has no want
+    /// representation — `None` here).
+    ///
+    /// The single source of truth for this mapping — callers that need it
+    /// (e.g. archon's want/release wiring) should delegate here instead of
+    /// hand-matching the CHECK values, which drifts silently from the schema.
+    pub fn as_want_str(&self) -> Option<&'static str> {
+        match self {
+            Self::Music => Some("music_album"),
+            Self::Audiobook => Some("audiobook"),
+            Self::Book => Some("book"),
+            Self::Comic => Some("comic"),
+            Self::Podcast => Some("podcast"),
+            Self::Movie => Some("movie"),
+            Self::Tv => Some("tv_series"),
+            Self::News => None,
+        }
+    }
+
+    /// Parses a `wants.media_type` CHECK-constraint value back into a
+    /// [`MediaType`]. Inverse of [`MediaType::as_want_str`]; `None` for any
+    /// string outside the 7 CHECK values.
+    pub fn parse_want_str(s: &str) -> Option<Self> {
+        match s {
+            "music_album" => Some(Self::Music),
+            "audiobook" => Some(Self::Audiobook),
+            "book" => Some(Self::Book),
+            "comic" => Some(Self::Comic),
+            "podcast" => Some(Self::Podcast),
+            "movie" => Some(Self::Movie),
+            "tv_series" => Some(Self::Tv),
+            _ => None,
+        }
+    }
+}
+
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -94,6 +134,52 @@ mod tests {
         assert_eq!(MediaType::News.to_string(), "news");
         assert_eq!(MediaType::Movie.to_string(), "movie");
         assert_eq!(MediaType::Tv.to_string(), "tv");
+    }
+
+    #[test]
+    fn want_str_round_trips_all_check_values() {
+        for mt in [
+            MediaType::Music,
+            MediaType::Audiobook,
+            MediaType::Book,
+            MediaType::Comic,
+            MediaType::Podcast,
+            MediaType::Movie,
+            MediaType::Tv,
+        ] {
+            let s = mt
+                .as_want_str()
+                .unwrap_or_else(|| panic!("{mt:?} must have a want string"));
+            assert_eq!(
+                MediaType::parse_want_str(s),
+                Some(mt),
+                "round-trip failed for {mt:?} via {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn as_want_str_matches_schema_check_values() {
+        assert_eq!(MediaType::Music.as_want_str(), Some("music_album"));
+        assert_eq!(MediaType::Audiobook.as_want_str(), Some("audiobook"));
+        assert_eq!(MediaType::Book.as_want_str(), Some("book"));
+        assert_eq!(MediaType::Comic.as_want_str(), Some("comic"));
+        assert_eq!(MediaType::Podcast.as_want_str(), Some("podcast"));
+        assert_eq!(MediaType::Movie.as_want_str(), Some("movie"));
+        assert_eq!(MediaType::Tv.as_want_str(), Some("tv_series"));
+    }
+
+    #[test]
+    fn news_has_no_want_representation() {
+        assert_eq!(MediaType::News.as_want_str(), None);
+    }
+
+    #[test]
+    fn parse_want_str_rejects_unknown_values() {
+        assert_eq!(MediaType::parse_want_str("bogus"), None);
+        assert_eq!(MediaType::parse_want_str(""), None);
+        assert_eq!(MediaType::parse_want_str("Music"), None);
+        assert_eq!(MediaType::parse_want_str("news"), None);
     }
 
     #[test]


### PR DESCRIPTION
**Closes #602** (the keystone — completed downloads now actually import into the library). Honest redo of the falsely-closed #300 (StubImportService was never removed; verified against the tree).

An `ImportAdapter` (crates/archon/src/import.rs) implements `syntaxis::ImportService` by driving `kathodos::ImportPipeline`. A `DownloadResolver` resolves metadata via a tags → DB-hints → filename ladder (no network in the import path — deterministic). The completed download's files land at their canonical template path (`{Artist}/{Album} ({Year})/NN - {Title}.ext` for music), a `haves` row records the import, and the want is fulfilled.

Reviewed adversarially in two rounds (8 findings then 2, all fixed):
- **File_path-keyed transactional finalize** with `upgraded_from_id` — a second release for an already-fulfilled want (quality upgrade) no longer collides on the `haves.file_path` UNIQUE index; the have-write + want-fulfill are one transaction (no crash-split stranding). Migration 014 makes `upgraded_from_id` unenforced lineage metadata (a live FK made delete-then-insert-referencing-deleted impossible).
- **Strict-then-content `same_file`** — exact inode match, else equal-size + byte-compare: a different same-size file is never silently dropped, and an EXDEV cross-device copy is still idempotent on crash-replay.
- **Largest-file-only for Movie/Book** (no multi-file target collision); **media-aware short-circuit** (a debris-only album dir re-imports rather than marking a want fulfilled with no content).

Scope: music/movie/book wants import; audiobook/comic/podcast/tv deferred to #612 (needs a horismos::MediaType extension — never silently misfiled). Gate green (full workspace).