### PR TITLE
fix(zetesis,paroche,archon): credentialed enqueue-by-reference with a results cache

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -180,11 +180,16 @@ impl DynSearchService for SearchAdapter {
         let service = Arc::clone(&self.0);
         Box::pin(async move {
             let query = search_query_from_json(query)?;
-            let results = service
+            let outcome = service
                 .search(query, CancellationToken::new())
                 .await
                 .map_err(search_error)?;
-            serde_json::to_value(serde_json::json!({ "results": results }))
+            // WHY: serializes SearchOutcome as-is — adds `query_id` and a
+            // per-result `release_id` on top of the prior `{"results": [...]}`
+            // shape (#608). Purely additive JSON; every existing field stays.
+            // The route layer redacts every `download_url` before this
+            // reaches an HTTP response.
+            serde_json::to_value(&outcome)
                 .map_err(|error| ServiceError::Internal(error.to_string()))
         })
     }
@@ -210,13 +215,49 @@ impl DynSearchService for SearchAdapter {
             serde_json::to_value(caps).map_err(|error| ServiceError::Internal(error.to_string()))
         })
     }
+
+    fn cached_results(&self, query_id: uuid::Uuid) -> ServiceFut<serde_json::Value> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            let outcome = service
+                .cached_results(themelion::QueryId::from_uuid(query_id))
+                .ok_or(ServiceError::NotFound)?;
+            serde_json::to_value(&outcome)
+                .map_err(|error| ServiceError::Internal(error.to_string()))
+        })
+    }
+
+    fn resolve_release(
+        &self,
+        release_id: uuid::Uuid,
+    ) -> ServiceFut<paroche::state::ResolvedRelease> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            let resolved = service
+                .resolve_release(release_id)
+                .ok_or(ServiceError::NotFound)?;
+            Ok(paroche::state::ResolvedRelease {
+                download_url: resolved.download_url,
+                protocol: release_protocol_wire_string(resolved.protocol),
+                info_hash: resolved.info_hash,
+            })
+        })
+    }
+}
+
+fn release_protocol_wire_string(protocol: zetesis::ReleaseProtocol) -> String {
+    match protocol {
+        zetesis::ReleaseProtocol::Torrent => "torrent".to_string(),
+        zetesis::ReleaseProtocol::Nzb => "nzb".to_string(),
+        // WHY: ReleaseProtocol is #[non_exhaustive] — a future variant maps
+        // to a sentinel that `DownloadProtocol::parse` rejects downstream
+        // (`ServiceError::InvalidInput`), rather than silently mis-tagging
+        // the enqueue as an existing protocol.
+        _ => "unknown".to_string(),
+    }
 }
 
 fn search_query_from_json(value: serde_json::Value) -> Result<zetesis::SearchQuery, ServiceError> {
-    if value.get("query_id").is_some() {
-        return Err(ServiceError::NotFound);
-    }
-
     let media_type = value
         .get("media_type")
         .and_then(serde_json::Value::as_str)
@@ -3053,13 +3094,6 @@ mod search_adapter_tests {
         assert_eq!(query.artist.as_deref(), Some("Miles Davis"));
         assert_eq!(query.limit, 25);
         assert_eq!(query.offset, 5);
-    }
-
-    #[test]
-    fn search_query_from_json_rejects_cached_result_lookup() {
-        let error = search_query_from_json(json!({ "query_id": "q-1" }))
-            .expect_err("cached result lookup is not backed by zetesis search fan-out");
-        assert!(matches!(error, ServiceError::NotFound));
     }
 
     #[test]

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -54,6 +54,12 @@ impl DynSearchService for MockSearchService {
     fn refresh_caps(&self, _indexer_id: i64) -> ServiceFut<Value> {
         Box::pin(async { Ok(json!({"caps": []})) })
     }
+    fn cached_results(&self, _query_id: Uuid) -> ServiceFut<Value> {
+        Box::pin(async { Err(paroche::state::ServiceError::NotAvailable) })
+    }
+    fn resolve_release(&self, _release_id: Uuid) -> ServiceFut<paroche::state::ResolvedRelease> {
+        Box::pin(async { Err(paroche::state::ServiceError::NotAvailable) })
+    }
 }
 
 // ── Mock download engine ─────────────────────────────────────────────────────

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -99,6 +99,10 @@ pub const LIVE: &[&str] = &[
     // #575: ByparrProxy's per-host cookie reuse window — a change rebuilds
     // the proxy (same swap as cf_proxy_url; cookie cache resets, logged).
     "zetesis.cf_cookie_refresh_minutes",
+    // #608: the in-memory results cache reads TTL/cap live from the Section
+    // on every insert/lookup — no rebuild needed.
+    "zetesis.result_cache_ttl_seconds",
+    "zetesis.result_cache_max_queries",
     // ergasia — step 7 (SessionEngine rebuilds ExtractionLimits per call)
     "ergasia.max_extraction_depth",
     "ergasia.max_decompression_ratio",

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -331,6 +331,23 @@ pub struct SearchSubsystemConfig {
     pub cf_proxy_url: Option<String>,
     pub cf_proxy_timeout_seconds: u64,
     pub cf_cookie_refresh_minutes: u64,
+    /// TTL (seconds) a completed search's results stay resolvable via `GET
+    /// /api/v1/search/{query_id}/results` and enqueue-by-`release_id`.
+    #[serde(default = "default_result_cache_ttl_seconds")]
+    pub result_cache_ttl_seconds: u64,
+    /// Maximum completed searches held in the in-memory results cache at
+    /// once; the oldest is evicted (with its releases) once a new search
+    /// would exceed this.
+    #[serde(default = "default_result_cache_max_queries")]
+    pub result_cache_max_queries: usize,
+}
+
+fn default_result_cache_ttl_seconds() -> u64 {
+    1800
+}
+
+fn default_result_cache_max_queries() -> usize {
+    32
 }
 
 impl Default for SearchSubsystemConfig {
@@ -349,6 +366,8 @@ impl Default for SearchSubsystemConfig {
             cf_proxy_url: None,
             cf_proxy_timeout_seconds: 60,
             cf_cookie_refresh_minutes: 30,
+            result_cache_ttl_seconds: default_result_cache_ttl_seconds(),
+            result_cache_max_queries: default_result_cache_max_queries(),
         }
     }
 }

--- a/crates/paroche/src/routes/download.rs
+++ b/crates/paroche/src/routes/download.rs
@@ -106,7 +106,11 @@ pub struct QueueSnapshotResponse {
 pub struct EnqueueRequest {
     pub want_id: String,
     pub release_id: String,
-    pub download_url: String,
+    /// Absent (or omitted) resolves the RELEASE server-side via
+    /// `release_id` — the enqueue-by-reference path for a credentialed
+    /// Torznab/Newznab search hit (#608). A magnet URI or a manual raw URL
+    /// still goes here directly.
+    pub download_url: Option<String>,
     #[serde(default = "default_protocol")]
     pub protocol: String,
     #[serde(default = "default_interactive_priority")]
@@ -181,17 +185,43 @@ pub async fn enqueue_download(
     _admin: RequireAdmin,
     Json(body): Json<EnqueueRequest>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
-    if body.download_url.trim().is_empty() {
+    let want_id = Uuid::parse_str(&body.want_id).map_err(|_| ParocheError::InvalidId)?;
+    let release_id = Uuid::parse_str(&body.release_id).map_err(|_| ParocheError::InvalidId)?;
+
+    // WHY: a present-but-empty/whitespace download_url stays a 422 (today's
+    // behavior, unchanged); an ABSENT download_url resolves the release
+    // server-side (#608) — the client never sees the indexer's credentialed
+    // URL. The resolved protocol wins over the body's default; info_hash
+    // falls back to the body's only when the resolved release carries none.
+    let (download_url, protocol, info_hash) = if let Some(url) = body
+        .download_url
+        .as_deref()
+        .filter(|url| !url.trim().is_empty())
+    {
+        (
+            url.to_string(),
+            body.protocol.clone(),
+            body.info_hash.clone(),
+        )
+    } else if body.download_url.is_some() {
         return Err(ParocheError::Validation {
             message: "download_url is required".to_string(),
         });
-    }
+    } else {
+        let resolved = state.search.resolve_release(release_id).await?;
+        (
+            resolved.download_url,
+            resolved.protocol,
+            resolved.info_hash.or_else(|| body.info_hash.clone()),
+        )
+    };
 
-    crate::net_validate::validate_download_url(&body.download_url).await?;
+    // SAFETY: the by-reference path must not become an SSRF bypass — the
+    // RESOLVED url is validated the same as a client-supplied one, never
+    // trusted just because it came from the server-side cache.
+    crate::net_validate::validate_download_url(&download_url).await?;
 
     let queue_id = Uuid::now_v7();
-    let want_id = Uuid::parse_str(&body.want_id).map_err(|_| ParocheError::InvalidId)?;
-    let release_id = Uuid::parse_str(&body.release_id).map_err(|_| ParocheError::InvalidId)?;
 
     state
         .queue
@@ -199,10 +229,10 @@ pub async fn enqueue_download(
             queue_id,
             want_id,
             release_id,
-            download_url: body.download_url,
-            protocol: body.protocol,
+            download_url,
+            protocol,
             priority: body.priority.clamp(1, 4),
-            info_hash: body.info_hash,
+            info_hash,
         })
         .await?;
 
@@ -281,6 +311,7 @@ mod tests {
         reason = "kanon: test-missing-use-super; parent items accessed via explicit super:: prefix in test bodies"
     )]
     use super::*;
+    use crate::state::{DynSearchService, ResolvedRelease, ServiceError, ServiceFut};
     use crate::test_helpers::test_state;
 
     async fn token_for(
@@ -520,6 +551,209 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn enqueue_download_rejects_whitespace_only_download_url() {
+        let (state, auth) = test_state().await;
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let app = crate::build_router(state);
+        let resp = post_enqueue(&app, &token, "   ").await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // ── #608: enqueue-by-reference — resolve_release server-side join ───────
+
+    /// Search stub whose `resolve_release` answers with a fixed outcome — a
+    /// stand-in for zetesis's results cache.
+    enum ResolveStub {
+        Found {
+            download_url: String,
+            protocol: String,
+            info_hash: Option<String>,
+        },
+        Miss,
+    }
+
+    struct StubResolveSearch(ResolveStub);
+
+    impl DynSearchService for StubResolveSearch {
+        fn search(&self, _query: serde_json::Value) -> ServiceFut<serde_json::Value> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+        fn test_indexer(&self, _indexer_id: i64) -> ServiceFut<serde_json::Value> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+        fn refresh_caps(&self, _indexer_id: i64) -> ServiceFut<serde_json::Value> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+        fn cached_results(&self, _query_id: uuid::Uuid) -> ServiceFut<serde_json::Value> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+        fn resolve_release(&self, _release_id: uuid::Uuid) -> ServiceFut<ResolvedRelease> {
+            match &self.0 {
+                ResolveStub::Found {
+                    download_url,
+                    protocol,
+                    info_hash,
+                } => {
+                    let download_url = download_url.clone();
+                    let protocol = protocol.clone();
+                    let info_hash = info_hash.clone();
+                    Box::pin(async move {
+                        Ok(ResolvedRelease {
+                            download_url,
+                            protocol,
+                            info_hash,
+                        })
+                    })
+                }
+                ResolveStub::Miss => Box::pin(async { Err(ServiceError::NotFound) }),
+            }
+        }
+    }
+
+    fn resolve_body(protocol: Option<&str>) -> String {
+        let mut body = serde_json::json!({
+            "want_id": uuid::Uuid::now_v7().to_string(),
+            "release_id": uuid::Uuid::now_v7().to_string(),
+        });
+        if let Some(protocol) = protocol {
+            body["protocol"] = serde_json::Value::String(protocol.to_string());
+        }
+        body.to_string()
+    }
+
+    async fn post_enqueue_body(
+        app: &axum::Router,
+        token: &str,
+        body: String,
+    ) -> axum::response::Response {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/downloads")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn enqueue_download_resolves_release_when_download_url_absent() {
+        let (mut state, auth) = test_state().await;
+        let queue = persisting_queue(&app_pool(&auth));
+        state.queue = queue.clone();
+        state.search = std::sync::Arc::new(StubResolveSearch(ResolveStub::Found {
+            download_url: "http://203.0.113.10/dl/42?apikey=SECRET".to_string(),
+            protocol: "torrent".to_string(),
+            info_hash: None,
+        }));
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let app = crate::build_router(state);
+
+        let resp = post_enqueue_body(&app, &token, resolve_body(None)).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let enqueued = queue.enqueued.lock().unwrap().clone();
+        assert_eq!(
+            enqueued.len(),
+            1,
+            "the resolved release must reach the queue manager"
+        );
+        assert_eq!(
+            enqueued[0].download_url, "http://203.0.113.10/dl/42?apikey=SECRET",
+            "the queue must receive the UNREDACTED resolved URL"
+        );
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            body["data"]["download_url"], "http://203.0.113.10/dl/42?apikey=REDACTED",
+            "the HTTP response must carry the REDACTED URL"
+        );
+        assert!(
+            !String::from_utf8_lossy(&bytes).contains("SECRET"),
+            "the raw indexer credential must never reach the response body"
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_download_resolve_miss_enqueues_nothing_and_returns_404() {
+        let (mut state, auth) = test_state().await;
+        let queue = persisting_queue(&app_pool(&auth));
+        state.queue = queue.clone();
+        state.search = std::sync::Arc::new(StubResolveSearch(ResolveStub::Miss));
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let pool = app_pool(&auth);
+        let app = crate::build_router(state);
+
+        let resp = post_enqueue_body(&app, &token, resolve_body(None)).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(queue.enqueued.lock().unwrap().is_empty());
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM download_queue")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "an unresolved release must not reach the queue");
+    }
+
+    #[tokio::test]
+    async fn enqueue_download_rejects_resolved_url_to_private_space() {
+        let (mut state, auth) = test_state().await;
+        let queue = persisting_queue(&app_pool(&auth));
+        state.queue = queue.clone();
+        state.search = std::sync::Arc::new(StubResolveSearch(ResolveStub::Found {
+            download_url: "http://127.0.0.1/dl/42?apikey=SECRET".to_string(),
+            protocol: "torrent".to_string(),
+            info_hash: None,
+        }));
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let pool = app_pool(&auth);
+        let app = crate::build_router(state);
+
+        let resp = post_enqueue_body(&app, &token, resolve_body(None)).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "SSRF validation must run on the RESOLVED url too — by-reference \
+             must not become the SSRF bypass"
+        );
+        assert!(queue.enqueued.lock().unwrap().is_empty());
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM download_queue")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn enqueue_download_resolved_protocol_wins_over_body_default() {
+        let (mut state, auth) = test_state().await;
+        let queue = persisting_queue(&app_pool(&auth));
+        state.queue = queue.clone();
+        state.search = std::sync::Arc::new(StubResolveSearch(ResolveStub::Found {
+            download_url: "http://203.0.113.10/dl/42.nzb?apikey=SECRET".to_string(),
+            protocol: "nzb".to_string(),
+            info_hash: None,
+        }));
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let app = crate::build_router(state);
+
+        // Body carries the interactive default ("torrent"); the resolved
+        // release is nzb and must win.
+        let resp = post_enqueue_body(&app, &token, resolve_body(Some("torrent"))).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let enqueued = queue.enqueued.lock().unwrap().clone();
+        assert_eq!(enqueued.len(), 1);
+        assert_eq!(enqueued[0].protocol, "nzb");
     }
 
     // ── #469/#499: enqueue/cancel/reprioritize reach the live queue manager ─

--- a/crates/paroche/src/routes/search.rs
+++ b/crates/paroche/src/routes/search.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use exousia::AuthenticatedUser;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::error::ParocheError;
 use crate::response::ApiResponse;
@@ -64,11 +65,12 @@ pub async fn get_search_results(
     Path(query_id): Path<String>,
 ) -> Result<impl axum::response::IntoResponse, ParocheError> {
     // Retrieve cached results for a prior search. The query_id is produced by
-    // the search service and stored server-side; when the search service is not
+    // the search service and held server-side in an in-memory TTL cache; an
+    // unknown or expired id is a 404, and when the search service is not
     // wired this returns 503.
-    let query = serde_json::json!({ "query_id": query_id });
+    let query_id = Uuid::parse_str(&query_id).map_err(|_| ParocheError::InvalidId)?;
 
-    let mut results = state.search.search(query).await?;
+    let mut results = state.search.cached_results(query_id).await?;
     // WHY: same credential exposure as `search` — cached results carry the
     // same raw download_urls.
     crate::redact::redact_download_urls_in_json(&mut results);
@@ -105,18 +107,34 @@ mod tests {
     use crate::state::{DynSearchService, ServiceError, ServiceFut};
     use crate::test_helpers::test_state;
 
-    /// Search stub returning a fixed result payload, standing in for zetesis.
-    struct FixedSearch(serde_json::Value);
+    /// Search stub standing in for zetesis. `Some(value)` answers `search`
+    /// and `cached_results` with a fixed payload (a "hit"); `None` answers
+    /// `cached_results` with `NotFound` (an unknown/expired query id).
+    struct FixedSearch(Option<serde_json::Value>);
 
     impl DynSearchService for FixedSearch {
         fn search(&self, _query: serde_json::Value) -> ServiceFut<serde_json::Value> {
-            let results = self.0.clone();
-            Box::pin(async move { Ok(results) })
+            match self.0.clone() {
+                Some(results) => Box::pin(async move { Ok(results) }),
+                None => Box::pin(async { Err(ServiceError::NotAvailable) }),
+            }
         }
         fn test_indexer(&self, _indexer_id: i64) -> ServiceFut<serde_json::Value> {
             Box::pin(async { Err(ServiceError::NotAvailable) })
         }
         fn refresh_caps(&self, _indexer_id: i64) -> ServiceFut<serde_json::Value> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+        fn cached_results(&self, _query_id: uuid::Uuid) -> ServiceFut<serde_json::Value> {
+            match self.0.clone() {
+                Some(results) => Box::pin(async move { Ok(results) }),
+                None => Box::pin(async { Err(ServiceError::NotFound) }),
+            }
+        }
+        fn resolve_release(
+            &self,
+            _release_id: uuid::Uuid,
+        ) -> ServiceFut<crate::state::ResolvedRelease> {
             Box::pin(async { Err(ServiceError::NotAvailable) })
         }
     }
@@ -139,13 +157,13 @@ mod tests {
     #[tokio::test]
     async fn search_redacts_indexer_credentials_in_results() {
         let (mut state, auth) = test_state().await;
-        state.search = Arc::new(FixedSearch(serde_json::json!({
+        state.search = Arc::new(FixedSearch(Some(serde_json::json!({
             "results": [{
                 "title": "Kind of Blue",
                 "download_url":
                     "https://indexer.example/dl/42?apikey=SECRET&file=x.torrent",
             }]
-        })));
+        }))));
         let token = member_token(&auth).await;
 
         let app = crate::build_router(state);
@@ -178,19 +196,21 @@ mod tests {
     #[tokio::test]
     async fn cached_search_results_redact_indexer_credentials() {
         let (mut state, auth) = test_state().await;
-        state.search = Arc::new(FixedSearch(serde_json::json!({
+        state.search = Arc::new(FixedSearch(Some(serde_json::json!({
+            "query_id": uuid::Uuid::now_v7().to_string(),
             "results": [{
+                "release_id": uuid::Uuid::now_v7().to_string(),
                 "title": "Kind of Blue",
                 "download_url": "https://indexer.example/dl/42?passkey=SECRET",
             }]
-        })));
+        }))));
         let token = member_token(&auth).await;
 
         let app = crate::build_router(state);
         let resp = app
             .oneshot(
                 Request::builder()
-                    .uri("/api/v1/search/q-123/results")
+                    .uri(format!("/api/v1/search/{}/results", uuid::Uuid::now_v7()))
                     .header("Authorization", format!("Bearer {token}"))
                     .body(Body::empty())
                     .unwrap(),
@@ -206,5 +226,44 @@ mod tests {
             "https://indexer.example/dl/42?passkey=REDACTED"
         );
         assert!(!String::from_utf8_lossy(&bytes).contains("SECRET"));
+    }
+
+    #[tokio::test]
+    async fn cached_search_results_unknown_query_id_returns_404() {
+        let (mut state, auth) = test_state().await;
+        state.search = Arc::new(FixedSearch(None));
+        let token = member_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/search/{}/results", uuid::Uuid::now_v7()))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cached_search_results_rejects_garbage_query_id() {
+        let (state, auth) = test_state().await;
+        let token = member_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/search/not-a-uuid/results")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -99,11 +99,46 @@ impl From<aitesis::AitesisError> for RequestServiceError {
     }
 }
 
+/// Server-side-only resolution of a cached search result's REAL,
+/// credentialed download URL — the enqueue-by-reference join
+/// `enqueue_download` uses so a Torznab/Newznab indexer credential never
+/// crosses the HTTP boundary to a client (#608). Local mirror of
+/// `zetesis::ResolvedRelease`, decoupled the same way `EnqueueItem` and
+/// `DynQueueManager` stay decoupled from syntaxis types.
+pub struct ResolvedRelease {
+    pub download_url: String,
+    /// Wire-form protocol (`"torrent"` / `"nzb"`) — the SAME form
+    /// `EnqueueItem::protocol` expects.
+    pub protocol: String,
+    pub info_hash: Option<String>,
+}
+
+impl std::fmt::Debug for ResolvedRelease {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedRelease")
+            .field(
+                "download_url",
+                &crate::redact::redact_download_url(&self.download_url),
+            )
+            .field("protocol", &self.protocol)
+            .field("info_hash", &self.info_hash)
+            .finish()
+    }
+}
+
 /// Search across indexers via zetesis.
 pub trait DynSearchService: Send + Sync {
     fn search(&self, query: serde_json::Value) -> ServiceFut<serde_json::Value>;
     fn test_indexer(&self, indexer_id: i64) -> ServiceFut<serde_json::Value>;
     fn refresh_caps(&self, indexer_id: i64) -> ServiceFut<serde_json::Value>;
+    /// Retrieves a prior search's cached, redaction-pending results by
+    /// `query_id` — backs `GET /api/v1/search/{query_id}/results`. The
+    /// caller MUST redact `download_url` before this reaches an HTTP
+    /// response; `NotFound` on an unknown or expired query id.
+    fn cached_results(&self, query_id: uuid::Uuid) -> ServiceFut<serde_json::Value>;
+    /// Resolves a cached release's UNREDACTED download URL for
+    /// enqueue-by-reference. `NotFound` on an unknown or expired release id.
+    fn resolve_release(&self, release_id: uuid::Uuid) -> ServiceFut<ResolvedRelease>;
 }
 
 /// Feed subscription lifecycle via komide's `FeedSchedulerService`
@@ -328,6 +363,12 @@ impl DynSearchService for NullSearch {
         Box::pin(async { Err(ServiceError::NotAvailable) })
     }
     fn refresh_caps(&self, _indexer_id: i64) -> ServiceFut<serde_json::Value> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+    fn cached_results(&self, _query_id: uuid::Uuid) -> ServiceFut<serde_json::Value> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+    fn resolve_release(&self, _release_id: uuid::Uuid) -> ServiceFut<ResolvedRelease> {
         Box::pin(async { Err(ServiceError::NotAvailable) })
     }
 }

--- a/crates/zetesis/src/lib.rs
+++ b/crates/zetesis/src/lib.rs
@@ -3,6 +3,7 @@ pub mod client;
 pub mod error;
 pub mod rate_limit;
 pub mod repo;
+pub mod results_cache;
 pub mod search;
 pub(crate) mod test_support;
 pub mod types;
@@ -13,6 +14,6 @@ pub use client::cardigann::{CardigannClient, CardigannRegistry};
 pub use error::SearchIndexerError;
 pub use search::SearchIndexerService;
 pub use types::{
-    DownloadResponse, IndexerCaps, IndexerStatus, ReleaseProtocol, SearchMediaType, SearchQuery,
-    SearchResult,
+    CataloguedResult, DownloadResponse, IndexerCaps, IndexerStatus, ReleaseProtocol,
+    ResolvedRelease, SearchMediaType, SearchOutcome, SearchQuery, SearchResult,
 };

--- a/crates/zetesis/src/results_cache.rs
+++ b/crates/zetesis/src/results_cache.rs
@@ -1,0 +1,289 @@
+//! In-memory TTL cache mapping a completed search's `QueryId` to its
+//! deduped results, and each result's minted `ReleaseId` back to the
+//! ORIGINAL, credentialed `SearchResult` — the server-side join that lets
+//! `POST /api/v1/downloads` enqueue-by-reference without ever handing the
+//! indexer credential to a client (#608).
+//!
+//! WHY: hand-rolled `std::sync::Mutex`, never held across an `.await` —
+//! matches this crate's lock discipline (`SearchIndexerService`'s
+//! `cf_proxy`/`cardigann` swap fields in `search.rs`). Every method here is a
+//! synchronous critical section; nothing awaits while the lock is held.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+use themelion::{QueryId, ReleaseId};
+use uuid::Uuid;
+
+use crate::types::{CataloguedResult, ResolvedRelease, SearchOutcome, SearchResult};
+
+struct CachedQuery {
+    created: Instant,
+    results: Vec<CataloguedResult>,
+}
+
+#[derive(Default)]
+struct CacheInner {
+    /// Insertion order, oldest first — also age order, since `QueryId` is
+    /// minted immediately before insert and entries are appended in call
+    /// order.
+    order: VecDeque<QueryId>,
+    by_query: HashMap<QueryId, CachedQuery>,
+    by_release: HashMap<Uuid, (QueryId, usize)>,
+}
+
+impl CacheInner {
+    fn is_stale(created: Instant, ttl: Duration, now: Instant) -> bool {
+        now.duration_since(created) >= ttl
+    }
+
+    /// Drops every cached query whose age has passed `ttl`, oldest-first.
+    /// `order` is age-ordered, so this stops at the first still-fresh entry
+    /// — a single `ttl` value used within one call keeps staleness monotonic
+    /// front-to-back.
+    fn purge_expired(&mut self, ttl: Duration) {
+        let now = Instant::now();
+        while let Some(&query_id) = self.order.front() {
+            let Some(cached) = self.by_query.get(&query_id) else {
+                // INVARIANT: order and by_query stay in lockstep; a missing
+                // entry here means a prior evict already dropped it.
+                self.order.pop_front();
+                continue;
+            };
+            if !Self::is_stale(cached.created, ttl, now) {
+                break;
+            }
+            self.evict_front();
+        }
+    }
+
+    /// Evicts the single oldest cached query: pops `order`, `by_query`, and
+    /// every `by_release` entry it owns.
+    fn evict_front(&mut self) {
+        let Some(query_id) = self.order.pop_front() else {
+            return;
+        };
+        if let Some(cached) = self.by_query.remove(&query_id) {
+            for item in &cached.results {
+                self.by_release.remove(item.release_id.as_uuid());
+            }
+        }
+    }
+
+    fn evict_to_cap(&mut self, max_queries: usize) {
+        while self.order.len() > max_queries {
+            self.evict_front();
+        }
+    }
+}
+
+/// Hand-rolled synchronous results cache — see module docs.
+#[derive(Default)]
+pub struct ResultsCache(std::sync::Mutex<CacheInner>);
+
+impl ResultsCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stores a completed search's deduped results under `query_id`, minting
+    /// one fresh `ReleaseId` per result. Purges expired queries and evicts
+    /// down to `max_queries` (oldest-first) AFTER the insert — with
+    /// `ttl == Duration::ZERO` the entry just inserted is immediately
+    /// purged, so the cache retains nothing (an immediate miss on every
+    /// subsequent lookup), which is the correct behavior for a
+    /// zero-configured TTL.
+    pub fn insert(
+        &self,
+        query_id: QueryId,
+        results: Vec<SearchResult>,
+        ttl: Duration,
+        max_queries: usize,
+    ) -> SearchOutcome {
+        let catalogued: Vec<CataloguedResult> = results
+            .into_iter()
+            .map(|result| CataloguedResult {
+                release_id: ReleaseId::new(),
+                result,
+            })
+            .collect();
+
+        let mut inner = self.0.lock().unwrap_or_else(|e| e.into_inner());
+
+        for (idx, item) in catalogued.iter().enumerate() {
+            inner
+                .by_release
+                .insert(*item.release_id.as_uuid(), (query_id, idx));
+        }
+        inner.by_query.insert(
+            query_id,
+            CachedQuery {
+                created: Instant::now(),
+                results: catalogued.clone(),
+            },
+        );
+        inner.order.push_back(query_id);
+
+        inner.purge_expired(ttl);
+        inner.evict_to_cap(max_queries);
+
+        SearchOutcome {
+            query_id,
+            results: catalogued,
+        }
+    }
+
+    /// Looks up a prior search's cached results. Lazy TTL expiry: a stale
+    /// entry reads as absent WITHOUT being physically purged here (the next
+    /// `insert` sweeps it) — idempotent, side-effect-free.
+    pub fn cached_results(&self, query_id: QueryId, ttl: Duration) -> Option<SearchOutcome> {
+        let inner = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        let cached = inner.by_query.get(&query_id)?;
+        if CacheInner::is_stale(cached.created, ttl, Instant::now()) {
+            return None;
+        }
+        Some(SearchOutcome {
+            query_id,
+            results: cached.results.clone(),
+        })
+    }
+
+    /// Resolves a single release's UNREDACTED download URL. Idempotent and
+    /// non-consuming — a retry after a failed enqueue must still resolve
+    /// (see `paroche::routes::download::enqueue_download`).
+    pub fn resolve_release(&self, release_id: Uuid, ttl: Duration) -> Option<ResolvedRelease> {
+        let inner = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        let &(query_id, idx) = inner.by_release.get(&release_id)?;
+        let cached = inner.by_query.get(&query_id)?;
+        if CacheInner::is_stale(cached.created, ttl, Instant::now()) {
+            return None;
+        }
+        let item = cached.results.get(idx)?;
+        Some(ResolvedRelease {
+            download_url: item.result.download_url.clone(),
+            protocol: item.result.protocol,
+            info_hash: item.result.info_hash.clone(),
+            indexer_id: item.result.indexer_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap as StdHashMap;
+
+    use super::*;
+    use crate::types::ReleaseProtocol;
+
+    fn result(title: &str, indexer_id: i64) -> SearchResult {
+        SearchResult {
+            title: title.to_string(),
+            guid: None,
+            download_url: format!("https://indexer.example/dl/{title}?apikey=SECRET"),
+            size_bytes: Some(1_000_000),
+            seeders: Some(5),
+            leechers: Some(1),
+            info_hash: Some(format!("hash-{title}")),
+            category_id: Some(2000),
+            publication_date: None,
+            indexer_id,
+            protocol: ReleaseProtocol::Torrent,
+            download_volume_factor: 1.0,
+            upload_volume_factor: 1.0,
+            custom_attrs: StdHashMap::new(),
+        }
+    }
+
+    #[test]
+    fn insert_then_resolve_returns_the_exact_credentialed_url() {
+        let cache = ResultsCache::new();
+        let query_id = QueryId::new();
+        let outcome = cache.insert(
+            query_id,
+            vec![result("Release.One", 1)],
+            Duration::from_secs(60),
+            32,
+        );
+        let release_id = *outcome.results[0].release_id.as_uuid();
+
+        let resolved = cache
+            .resolve_release(release_id, Duration::from_secs(60))
+            .expect("just-inserted release must resolve");
+        assert_eq!(
+            resolved.download_url,
+            "https://indexer.example/dl/Release.One?apikey=SECRET"
+        );
+        assert_eq!(resolved.indexer_id, 1);
+    }
+
+    #[test]
+    fn cached_results_returns_the_same_outcome() {
+        let cache = ResultsCache::new();
+        let query_id = QueryId::new();
+        cache.insert(
+            query_id,
+            vec![result("Release.One", 1)],
+            Duration::from_secs(60),
+            32,
+        );
+
+        let fetched = cache
+            .cached_results(query_id, Duration::from_secs(60))
+            .expect("cached query must be retrievable");
+        assert_eq!(fetched.results.len(), 1);
+        assert_eq!(fetched.results[0].result.title, "Release.One");
+    }
+
+    #[test]
+    fn ttl_zero_is_an_immediate_miss() {
+        let cache = ResultsCache::new();
+        let query_id = QueryId::new();
+        let outcome = cache.insert(query_id, vec![result("Release.One", 1)], Duration::ZERO, 32);
+        let release_id = *outcome.results[0].release_id.as_uuid();
+
+        assert!(cache.cached_results(query_id, Duration::ZERO).is_none());
+        assert!(cache.resolve_release(release_id, Duration::ZERO).is_none());
+    }
+
+    #[test]
+    fn unknown_query_and_release_miss_cleanly() {
+        let cache = ResultsCache::new();
+        assert!(
+            cache
+                .cached_results(QueryId::new(), Duration::from_secs(60))
+                .is_none()
+        );
+        assert!(
+            cache
+                .resolve_release(Uuid::now_v7(), Duration::from_secs(60))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn cap_eviction_drops_the_oldest_query_and_its_releases() {
+        let cache = ResultsCache::new();
+        let q1 = QueryId::new();
+        let o1 = cache.insert(q1, vec![result("Q1", 1)], Duration::from_secs(60), 2);
+        let r1 = *o1.results[0].release_id.as_uuid();
+
+        let q2 = QueryId::new();
+        cache.insert(q2, vec![result("Q2", 1)], Duration::from_secs(60), 2);
+
+        // Third search — over the cap of 2 — must evict q1 (oldest), taking
+        // its by_release entry with it.
+        let q3 = QueryId::new();
+        cache.insert(q3, vec![result("Q3", 1)], Duration::from_secs(60), 2);
+
+        assert!(
+            cache.cached_results(q1, Duration::from_secs(60)).is_none(),
+            "the oldest query must be evicted once the cap is exceeded"
+        );
+        assert!(
+            cache.resolve_release(r1, Duration::from_secs(60)).is_none(),
+            "evicting a query must drop its by_release entries too"
+        );
+        assert!(cache.cached_results(q2, Duration::from_secs(60)).is_some());
+        assert!(cache.cached_results(q3, Duration::from_secs(60)).is_some());
+    }
+}

--- a/crates/zetesis/src/search.rs
+++ b/crates/zetesis/src/search.rs
@@ -19,7 +19,11 @@ use crate::client::{DynIndexerClient, IndexerConfig, SsrfGuardResolver};
 use crate::error::{self, SearchIndexerError};
 use crate::rate_limit::RateLimiter;
 use crate::repo::{self, IndexerRow};
-use crate::types::{IndexerCaps, IndexerStatus, SearchMediaType, SearchQuery, SearchResult};
+use crate::results_cache::ResultsCache;
+use crate::types::{
+    IndexerCaps, IndexerStatus, ResolvedRelease, SearchMediaType, SearchOutcome, SearchQuery,
+    SearchResult,
+};
 
 /// Fallback back-off when a 429 carries no Retry-After header.
 const DEFAULT_RETRY_AFTER_SECS: u64 = 60;
@@ -64,6 +68,10 @@ pub struct SearchIndexerService {
     // client that created it. In-memory only: a restart re-logs-in,
     // matching the CF-bypass cookie posture.
     cardigann_sessions: Arc<SessionStore>,
+    // WHY: hand-rolled std Mutex, never held across an .await — see
+    // `results_cache` module docs. TTL/cap are read live from `config` at
+    // every insert/lookup call site, not cached on the service.
+    results_cache: ResultsCache,
     event_tx: EventSender,
 }
 
@@ -98,6 +106,7 @@ impl SearchIndexerService {
             config,
             cardigann: std::sync::RwLock::new(Arc::new(cardigann)),
             cardigann_sessions: Arc::new(SessionStore::new()),
+            results_cache: ResultsCache::new(),
             event_tx,
         }
     }
@@ -159,7 +168,7 @@ impl SearchIndexerService {
         &self,
         query: SearchQuery,
         ct: CancellationToken,
-    ) -> Result<Vec<SearchResult>, SearchIndexerError> {
+    ) -> Result<SearchOutcome, SearchIndexerError> {
         let query_id = QueryId::new();
         // WHY: one snapshot for the whole operation — a mid-search reload
         // cannot mix an old bound from before the change with a new one FROM
@@ -287,7 +296,38 @@ impl SearchIndexerService {
             "search completed"
         );
 
-        Ok(deduped)
+        // WHY: catalogs the whole deduped set under query_id, minting one
+        // ReleaseId per result — the server-side join enqueue-by-reference
+        // resolves at enqueue time (#608). TTL/cap are read from the same
+        // `cfg` snapshot this call already took, so a mid-search reload
+        // cannot mix an old bound with a new one.
+        let outcome = self.results_cache.insert(
+            query_id,
+            deduped,
+            Duration::from_secs(cfg.result_cache_ttl_seconds),
+            cfg.result_cache_max_queries,
+        );
+
+        Ok(outcome)
+    }
+
+    /// Retrieves a prior search's cached results by `query_id`. Idempotent —
+    /// a repeat call before the TTL elapses returns the same outcome.
+    /// `None` on an unknown or expired query id.
+    pub fn cached_results(&self, query_id: QueryId) -> Option<SearchOutcome> {
+        let ttl = Duration::from_secs(self.config.get().result_cache_ttl_seconds);
+        self.results_cache.cached_results(query_id, ttl)
+    }
+
+    /// Resolves a cached release's REAL, unredacted download URL — the
+    /// server-side join `paroche::routes::download::enqueue_download` uses
+    /// so a credentialed indexer URL never crosses the HTTP boundary to a
+    /// client. Idempotent and non-consuming: a retry after a failed enqueue
+    /// still resolves. `None` when the release id is unknown or its parent
+    /// query has expired.
+    pub fn resolve_release(&self, release_id: uuid::Uuid) -> Option<ResolvedRelease> {
+        let ttl = Duration::from_secs(self.config.get().result_cache_ttl_seconds);
+        self.results_cache.resolve_release(release_id, ttl)
     }
 
     pub async fn test_indexer(

--- a/crates/zetesis/src/search/tests.rs
+++ b/crates/zetesis/src/search/tests.rs
@@ -553,6 +553,75 @@ async fn cardigann_search_end_to_end_through_dispatch() {
     );
 }
 
+// ── #608: enqueue-by-reference — results cache end-to-end through a live
+// credentialed Torznab search ──────────────────────────────────────────
+
+const CREDENTIALED_FEED_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <title>Private Tracker</title>
+    <item>
+      <title>Credentialed.Release.2024</title>
+      <guid>cred-guid-1</guid>
+      <size>734003200</size>
+      <link>https://private-tracker.example/dl/42?apikey=SECRET</link>
+      <torznab:attr name="seeders" value="10"/>
+      <torznab:attr name="infohash" value="deadbeefcred"/>
+    </item>
+  </channel>
+</rss>"#;
+
+#[tokio::test]
+async fn resolve_release_returns_the_exact_credentialed_url_after_search() {
+    let (service, pool) = make_service().await;
+    let (mock_url, _server) = spawn_one_shot_http(200, "OK", &[], CREDENTIALED_FEED_XML).await;
+    seed_indexer(&pool, &mock_url).await;
+
+    let outcome = service
+        .search(SearchQuery::new(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome.results.len(), 1);
+    let release_id = *outcome.results[0].release_id.as_uuid();
+
+    let resolved = service
+        .resolve_release(release_id)
+        .expect("a release from a just-completed search must resolve");
+    assert_eq!(
+        resolved.download_url,
+        "https://private-tracker.example/dl/42?apikey=SECRET"
+    );
+
+    let cached = service
+        .cached_results(outcome.query_id)
+        .expect("cached_results must return the same completed search");
+    assert_eq!(cached.results.len(), 1);
+    assert_eq!(
+        cached.results[0].release_id.as_uuid(),
+        outcome.results[0].release_id.as_uuid()
+    );
+}
+
+#[tokio::test]
+async fn zero_ttl_config_makes_resolve_release_an_immediate_miss() {
+    let (service, pool) = make_service_with(SearchSubsystemConfig {
+        result_cache_ttl_seconds: 0,
+        ..SearchSubsystemConfig::default()
+    })
+    .await;
+    let (mock_url, _server) = spawn_one_shot_http(200, "OK", &[], CREDENTIALED_FEED_XML).await;
+    seed_indexer(&pool, &mock_url).await;
+
+    let outcome = service
+        .search(SearchQuery::new(), CancellationToken::new())
+        .await
+        .unwrap();
+    let release_id = *outcome.results[0].release_id.as_uuid();
+
+    assert!(service.cached_results(outcome.query_id).is_none());
+    assert!(service.resolve_release(release_id).is_none());
+}
+
 #[tokio::test]
 async fn cardigann_row_without_definition_marks_failed() {
     let (service, pool) = make_service().await;

--- a/crates/zetesis/src/types.rs
+++ b/crates/zetesis/src/types.rs
@@ -87,6 +87,75 @@ pub enum ReleaseProtocol {
     Nzb,
 }
 
+/// A search result joined with its server-side release identity — the
+/// catalog entry the results cache hands back. `release_id` is the stable
+/// key `POST /api/v1/downloads` resolves server-side at enqueue time; the
+/// paroche HTTP boundary redacts `download_url` on every RESPONSE path
+/// (this type carries the raw value — redaction happens at the route layer,
+/// not here).
+#[derive(Debug, Clone, Serialize)]
+pub struct CataloguedResult {
+    pub release_id: themelion::ReleaseId,
+    #[serde(flatten)]
+    pub result: SearchResult,
+}
+
+// WHY: ergonomic field/method access to the wrapped SearchResult
+// (`catalogued.title`, `catalogued.download_url`) without repeating
+// `.result` at every call site — the release_id is the only genuinely new
+// field this type adds.
+impl std::ops::Deref for CataloguedResult {
+    type Target = SearchResult;
+    fn deref(&self) -> &SearchResult {
+        &self.result
+    }
+}
+
+/// A completed search: its `QueryId` (the key `GET
+/// /api/v1/search/{query_id}/results` looks up) and every catalogued
+/// result — what the results cache stores and `SearchIndexerService::search`
+/// returns.
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchOutcome {
+    pub query_id: themelion::QueryId,
+    pub results: Vec<CataloguedResult>,
+}
+
+// WHY: ergonomic Vec-like access (`outcome.len()`, `outcome.is_empty()`,
+// `outcome[0]`) — SearchOutcome's results ARE the search's payload; query_id
+// is a genuine field, accessed directly, not through this deref.
+impl std::ops::Deref for SearchOutcome {
+    type Target = Vec<CataloguedResult>;
+    fn deref(&self) -> &Vec<CataloguedResult> {
+        &self.results
+    }
+}
+
+/// Server-side-only resolution of a cached release's REAL download URL —
+/// the credentialed value a Torznab/Newznab indexer embeds. Deliberately NOT
+/// `Serialize`: a compile error is the guard against ever placing this on an
+/// HTTP response path. The only legitimate consumer is
+/// `SearchIndexerService::resolve_release`'s caller inside
+/// `paroche::routes::download::enqueue_download`.
+#[derive(Clone)]
+pub struct ResolvedRelease {
+    pub download_url: String,
+    pub protocol: ReleaseProtocol,
+    pub info_hash: Option<String>,
+    pub indexer_id: i64,
+}
+
+impl std::fmt::Debug for ResolvedRelease {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedRelease")
+            .field("download_url", &"[redacted]")
+            .field("protocol", &self.protocol)
+            .field("info_hash", &self.info_hash)
+            .field("indexer_id", &self.indexer_id)
+            .finish()
+    }
+}
+
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum DownloadResponse {
@@ -149,4 +218,25 @@ pub fn supports_function(caps: &IndexerCaps, function_type: &str) -> bool {
     caps.search_functions
         .iter()
         .any(|f| f.function_type == function_type && f.available)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolved_release_debug_never_prints_the_credentialed_url() {
+        let resolved = ResolvedRelease {
+            download_url: "https://indexer.example/dl/42?apikey=SECRET".to_string(),
+            protocol: ReleaseProtocol::Torrent,
+            info_hash: Some("abc123".to_string()),
+            indexer_id: 7,
+        };
+        let debug = format!("{resolved:?}");
+        assert!(
+            !debug.contains("SECRET"),
+            "ResolvedRelease Debug must never print the credentialed URL: {debug}"
+        );
+        assert!(!debug.contains("indexer.example"));
+    }
 }

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -130,6 +130,7 @@ from the new section on change (`SectionWatcher::changed()`).
 | `per_indexer_rate_limit_requests` / `per_indexer_rate_limit_window_seconds` | LIVE | `RateLimiter::reconfigure` — preserves in-flight embargoes |
 | `caps_refresh_hours` | LIVE | zetesis supervisor caps-refresh tick (15 min) judges each indexer's `last_tested` staleness against the live value on every tick |
 | `cardigann_definitions_dir` | LIVE | registry reload + swap |
+| `result_cache_ttl_seconds` / `result_cache_max_queries` | LIVE | #608 — the in-memory results cache (query_id → results, release_id → resolved release) reads the TTL/cap from the live `Section` on every insert and lookup |
 
 ### ergasia — session shape RESTART; the rest LIVE
 

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -88,6 +88,8 @@ search_timeout_seconds = 30
 # error otherwise); cardigann_definitions_dir is optional
 cf_proxy_timeout_seconds = 60
 cf_cookie_refresh_minutes = 30
+result_cache_ttl_seconds = 1800      # how long a search's results stay enqueueable by release_id
+result_cache_max_queries = 32        # oldest search evicted once exceeded
 
 [ergasia]
 # Torrent download execution (librqbit) — see download/torrent.md


### PR DESCRIPTION
**Closes #608.** A private-tracker search hit whose `download_url` embeds credentials can now be enqueued through the API without the client ever seeing the credential.

Search results were ephemeral (dropped on response), so a redacted `download_url` had no server-side path back to the real URL. This adds an in-memory TTL results cache in zetesis (bounded, no new deps, credentials never on disk): each result gets a server-minted `release_id`; `POST /api/v1/downloads` accepts `release_id` with no `download_url` and resolves the unredacted URL server-side (SSRF-validated on the resolved URL too — by-reference is not an SSRF bypass). Raw `download_url` input still works for magnets/manual URLs. The previously-dead `GET /api/v1/search/{query_id}/results` route is wired (redacted).

Security invariant (compile-enforced + tested): the unredacted URL crosses the HTTP boundary only in requests — `ResolvedRelease` has no `Serialize` derive (a leak is a compile error), every response path stays redacted, and route tests assert the credential never appears in a response body. Gate green (full workspace); 3-lens adversarial security review clean (0 findings).