### PR TITLE
feat(archon): MCP acquisition tools (search/enqueue/list/cancel) over a serve-hosted socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "walkdir",
  "zetesis",
@@ -5257,9 +5258,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/_llm/apis.toml
+++ b/_llm/apis.toml
@@ -1,5 +1,39 @@
-# WHY: archon exposes an MCP command surface but no standalone MCP server; empty array satisfies schema
-mcp_tools = []
+# WHY: `harmonia mcp` is a stdio JSON-RPC MCP server (protocol 2025-06-18).
+# The 4 offline tools run in-process (no server needed); the 4 acquisition
+# tools forward to a running `harmonia serve` over its local Unix-domain
+# bridge socket (#609). download_url is credential-redacted on every
+# acquisition-tool output.
+[[mcp_tools]]
+name = "harmonia_db_migrate"
+description = "Apply embedded SQLite migrations from a harmonia.toml config path (offline; no server required)."
+
+[[mcp_tools]]
+name = "harmonia_migrate_library"
+description = "Run the canonical storage migrator for music/books/audiobooks/podcasts (offline)."
+
+[[mcp_tools]]
+name = "harmonia_play_file"
+description = "Play a local audio file through the Akouo engine; blocks until playback stops (offline)."
+
+[[mcp_tools]]
+name = "harmonia_render"
+description = "Run the headless renderer loop; blocks while active (offline)."
+
+[[mcp_tools]]
+name = "harmonia_search_releases"
+description = "Search configured indexers across media types; each result carries a release_id for enqueue-by-reference. Redacted URLs. Requires a running harmonia serve."
+
+[[mcp_tools]]
+name = "harmonia_enqueue_download"
+description = "Enqueue exactly one of a cached release_id (resolved server-side) or a magnet URI into the live download queue. Requires a running harmonia serve."
+
+[[mcp_tools]]
+name = "harmonia_list_downloads"
+description = "List download_queue rows, optionally filtered by status or id; the completion-observability surface. Redacted URLs. Requires a running harmonia serve."
+
+[[mcp_tools]]
+name = "harmonia_cancel_download"
+description = "Cancel a queued or active download by its queue row id, stopping a live torrent session. Requires a running harmonia serve."
 
 [meta]
 name = "harmonia"
@@ -33,6 +67,10 @@ purpose = "Renderer mode."
 [[cli_commands]]
 name = "harmonia migrate"
 purpose = "Migrate library state and canonical filesystem layout."
+
+[[cli_commands]]
+name = "harmonia mcp"
+purpose = "Run the stdio JSON-RPC MCP server (8 tools). The 4 offline tools run in-process; the 4 acquisition tools forward to a running 'harmonia serve' over its local Unix-domain bridge socket. Takes --config to resolve the bridge socket path and call timeout."
 
 [[http_routes]]
 method = "various"

--- a/crates/archon/Cargo.toml
+++ b/crates/archon/Cargo.toml
@@ -53,6 +53,7 @@ reqwest.workspace = true
 sqlx.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
+url.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 rand.workspace = true

--- a/crates/archon/src/cli.rs
+++ b/crates/archon/src/cli.rs
@@ -22,8 +22,18 @@ pub(crate) enum Command {
     Render(RenderArgs),
     /// Migrate a legacy media library to canonical storage layout
     Migrate(MigrateArgs),
-    /// Run a local MCP stdio server for agent-driven maintenance operations
-    Mcp,
+    /// Run a local MCP stdio server for agent-driven maintenance and
+    /// acquisition operations (the acquisition tools require a running
+    /// `harmonia serve` reachable over its MCP bridge socket)
+    Mcp(McpArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct McpArgs {
+    /// Path to harmonia.toml — resolves the acquisition bridge socket path
+    /// and call timeout; the 4 offline tools work without it too.
+    #[arg(short, long, default_value = "harmonia.toml")]
+    pub(crate) config: PathBuf,
 }
 
 #[derive(Args)]
@@ -286,6 +296,18 @@ mod tests {
     #[test]
     fn mcp_parses() {
         let cli = Cli::parse_from(["harmonia", "mcp"]);
-        assert!(matches!(cli.command, Command::Mcp));
+        let Command::Mcp(args) = cli.command else {
+            panic!("expected Mcp command");
+        };
+        assert_eq!(args.config, PathBuf::from("harmonia.toml"));
+    }
+
+    #[test]
+    fn mcp_config_override_parses() {
+        let cli = Cli::parse_from(["harmonia", "mcp", "--config", "/etc/harmonia.toml"]);
+        let Command::Mcp(args) = cli.command else {
+            panic!("expected Mcp command");
+        };
+        assert_eq!(args.config, PathBuf::from("/etc/harmonia.toml"));
     }
 }

--- a/crates/archon/src/error.rs
+++ b/crates/archon/src/error.rs
@@ -150,6 +150,14 @@ pub enum HostError {
         location: snafu::Location,
     },
 
+    #[snafu(display("MCP acquisition bridge socket error at '{}': {source}", path.display()))]
+    McpBridgeBind {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("migrate: source directory does not exist: {}", path.display()))]
     MigrateSourceMissing {
         path: std::path::PathBuf,

--- a/crates/archon/src/lib.rs
+++ b/crates/archon/src/lib.rs
@@ -1,3 +1,4 @@
 //! Library surface for the `archon` binary — exists so `tests/` integration crates can reach internals (e.g. `import::ImportAdapter`) that a bin-only crate cannot expose.
 
 pub mod import;
+pub mod mcp_bridge;

--- a/crates/archon/src/main.rs
+++ b/crates/archon/src/main.rs
@@ -45,7 +45,7 @@ async fn main() {
             .await
         }
         Command::Migrate(args) => migrate::run_migrate(args, &mut stdout).await,
-        Command::Mcp => mcp::run_stdio().await,
+        Command::Mcp(args) => mcp::run_stdio(args.config).await,
     };
 
     if let Err(e) = result {

--- a/crates/archon/src/mcp.rs
+++ b/crates/archon/src/mcp.rs
@@ -1,27 +1,68 @@
 use std::io::{BufRead, Write};
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use serde_json::{Value, json};
 use snafu::ResultExt;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
 use crate::cli::{CliMediaType, DbMigrateArgs, MigrateArgs, PlayArgs};
-use crate::error::{HostError, OutputSnafu};
+use crate::error::{ConfigSnafu, HostError, OutputSnafu};
 
 const SERVER_NAME: &str = "harmonia";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PROTOCOL_VERSION: &str = "2025-06-18";
 
-pub(crate) async fn run_stdio() -> Result<(), HostError> {
+/// Resolved once at process start — the acquisition bridge socket path and
+/// per-call deadline. The 4 offline tools never touch this; the 4
+/// acquisition tools forward through it on every call (no pooling).
+#[derive(Clone)]
+pub(crate) struct McpContext {
+    pub(crate) socket_path: PathBuf,
+    pub(crate) call_timeout: Duration,
+}
+
+impl McpContext {
+    fn from_config(config: &horismos::Config) -> Self {
+        Self {
+            socket_path: archon::mcp_bridge::resolve_socket_path(config),
+            call_timeout: Duration::from_secs(config.mcp.call_timeout_secs),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Default for McpContext {
+    fn default() -> Self {
+        Self {
+            socket_path: PathBuf::from("harmonia-mcp.sock"),
+            call_timeout: Duration::from_secs(120),
+        }
+    }
+}
+
+pub(crate) async fn run_stdio(config_path: PathBuf) -> Result<(), HostError> {
+    let (config, warnings) =
+        horismos::load_config(Some(config_path.as_path())).context(ConfigSnafu)?;
+    for w in &warnings {
+        tracing::warn!(field = %w.field, "{}", w.message);
+    }
+    let ctx = McpContext::from_config(&config);
+
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let reader = std::io::BufReader::new(stdin.lock());
     let mut writer = stdout.lock();
 
-    run_stdio_with_io(reader, &mut writer).await
+    run_stdio_with_io(reader, &mut writer, &ctx).await
 }
 
-async fn run_stdio_with_io<R, W>(reader: R, writer: &mut W) -> Result<(), HostError>
+async fn run_stdio_with_io<R, W>(
+    reader: R,
+    writer: &mut W,
+    ctx: &McpContext,
+) -> Result<(), HostError>
 where
     R: BufRead,
     W: Write,
@@ -30,7 +71,7 @@ where
         let line = line.context(OutputSnafu {
             operation: "read MCP request",
         })?;
-        let Some(response) = handle_line(&line).await else {
+        let Some(response) = handle_line(&line, ctx).await else {
             continue;
         };
         let encoded = serde_json::to_string(&response).map_err(|e| HostError::Mcp {
@@ -48,7 +89,7 @@ where
     Ok(())
 }
 
-async fn handle_line(line: &str) -> Option<Value> {
+async fn handle_line(line: &str, ctx: &McpContext) -> Option<Value> {
     let message = match serde_json::from_str::<Value>(line) {
         Ok(message) => message,
         Err(e) => {
@@ -60,10 +101,10 @@ async fn handle_line(line: &str) -> Option<Value> {
         }
     };
 
-    handle_message(message).await
+    handle_message(message, ctx).await
 }
 
-async fn handle_message(message: Value) -> Option<Value> {
+async fn handle_message(message: Value, ctx: &McpContext) -> Option<Value> {
     if message.is_array() {
         return Some(error_response(
             Value::Null,
@@ -82,7 +123,7 @@ async fn handle_message(message: Value) -> Option<Value> {
         (Some(id), Some("ping")) => Some(success_response(id, json!({}))),
         (Some(id), Some("tools/list")) => Some(success_response(id, tools_list_result())),
         (Some(id), Some("tools/call")) => {
-            Some(success_response(id, call_tool_result(&message).await))
+            Some(success_response(id, call_tool_result(&message, ctx).await))
         }
         (Some(id), Some(method)) => Some(error_response(
             id,
@@ -111,7 +152,7 @@ fn initialize_result(message: &Value) -> Value {
             "name": SERVER_NAME,
             "version": SERVER_VERSION
         },
-        "instructions": "Local MCP stdio surface for Harmonia maintenance operations. The HTTP API remains the canonical remote service API."
+        "instructions": "Local MCP stdio surface for Harmonia. The 4 offline tools (db_migrate, migrate_library, play_file, render) run in-process with no server required. The 4 acquisition tools (search_releases, enqueue_download, list_downloads, cancel_download) forward to a running 'harmonia serve' over its local acquisition bridge socket — if the server isn't running, those calls return a tool-level error naming the socket. The HTTP API remains the canonical remote service API."
     })
 }
 
@@ -121,7 +162,11 @@ fn tools_list_result() -> Value {
             db_migrate_tool(),
             migrate_library_tool(),
             play_file_tool(),
-            render_tool()
+            render_tool(),
+            search_releases_tool(),
+            enqueue_download_tool(),
+            list_downloads_tool(),
+            cancel_download_tool()
         ]
     })
 }
@@ -205,10 +250,93 @@ fn render_tool() -> Value {
     })
 }
 
-async fn call_tool_result(message: &Value) -> Value {
+fn search_releases_tool() -> Value {
+    json!({
+        "name": "harmonia_search_releases",
+        "title": "Search acquisition indexers",
+        "description": "Search configured indexers for a release across media types. Each result carries a release_id usable with harmonia_enqueue_download; download URLs are credential-redacted. Requires a running 'harmonia serve'.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query_text": { "type": "string" },
+                "media_type": { "type": "string", "enum": ["any", "tv", "movie", "music", "book"] },
+                "artist": { "type": "string" },
+                "album": { "type": "string" },
+                "author": { "type": "string" },
+                "imdb_id": { "type": "string" },
+                "tvdb_id": { "type": "integer" },
+                "tmdb_id": { "type": "integer" },
+                "season": { "type": "integer" },
+                "episode": { "type": "integer" },
+                "category_ids": { "type": "array", "items": { "type": "integer" } },
+                "limit": { "type": "integer", "default": 100 },
+                "offset": { "type": "integer", "default": 0 }
+            },
+            "additionalProperties": false
+        }
+    })
+}
+
+fn enqueue_download_tool() -> Value {
+    json!({
+        "name": "harmonia_enqueue_download",
+        "title": "Enqueue a download",
+        "description": "Enqueue exactly one of a cached search result (release_id) or a magnet URI. release_id resolves its credentialed download URL server-side — the credential never crosses this tool boundary. Requires a running 'harmonia serve'.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "release_id": { "type": "string", "description": "A release_id from a prior harmonia_search_releases result." },
+                "magnet": { "type": "string", "description": "A magnet: URI. Raw http(s) URLs are rejected — use release_id for credentialed indexer results." },
+                "priority": { "type": "integer", "minimum": 1, "maximum": 4, "default": 4 },
+                "want_id": { "type": "string", "description": "Optional want row UUID to associate; a fresh UUIDv7 is generated when omitted." }
+            },
+            "additionalProperties": false
+        }
+    })
+}
+
+fn list_downloads_tool() -> Value {
+    json!({
+        "name": "harmonia_list_downloads",
+        "title": "List queued and active downloads",
+        "description": "List download_queue rows, optionally filtered by status or id. download_url is credential-redacted. Requires a running 'harmonia serve'.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "status": { "type": "string", "enum": ["queued", "downloading", "post_processing", "importing", "completed", "failed"] },
+                "id": { "type": "string", "description": "Filter to one download_queue row id." },
+                "limit": { "type": "integer", "default": 50 }
+            },
+            "additionalProperties": false
+        }
+    })
+}
+
+fn cancel_download_tool() -> Value {
+    json!({
+        "name": "harmonia_cancel_download",
+        "title": "Cancel a queued or active download",
+        "description": "Cancels the queue item, stopping a live download when one is active. Requires a running 'harmonia serve'.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "The download_queue row id (from harmonia_enqueue_download or harmonia_list_downloads)." }
+            },
+            "required": ["id"],
+            "additionalProperties": false
+        }
+    })
+}
+
+async fn call_tool_result(message: &Value, ctx: &McpContext) -> Value {
     let Some(name) = message.pointer("/params/name").and_then(Value::as_str) else {
         return tool_error("tools/call requires params.name");
     };
+
+    if archon::mcp_bridge::is_acquisition_tool(name) {
+        return call_via_bridge(ctx, message).await;
+    }
+
     let arguments = message
         .pointer("/params/arguments")
         .cloned()
@@ -218,6 +346,78 @@ async fn call_tool_result(message: &Value) -> Value {
         Ok(output) => tool_success(output),
         Err(message) => tool_error(message),
     }
+}
+
+// ── Acquisition-tool forwarding over the serve-hosted bridge socket ────────
+
+enum BridgeCallError {
+    Unavailable,
+    Timeout,
+    Protocol(String),
+}
+
+async fn call_via_bridge(ctx: &McpContext, message: &Value) -> Value {
+    match forward_to_bridge(ctx, message).await {
+        Ok(response) => {
+            if let Some(result) = response.get("result") {
+                result.clone()
+            } else if let Some(error) = response.get("error") {
+                let text = error
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("mcp bridge returned an error");
+                archon::mcp_bridge::tool_error(text.to_string())
+            } else {
+                archon::mcp_bridge::tool_error(
+                    "malformed response from the harmonia server's MCP bridge",
+                )
+            }
+        }
+        Err(BridgeCallError::Unavailable) => archon::mcp_bridge::tool_error(format!(
+            "harmonia server is not running (socket {} unavailable); start 'harmonia serve'",
+            ctx.socket_path.display()
+        )),
+        Err(BridgeCallError::Timeout) => archon::mcp_bridge::tool_error(format!(
+            "harmonia server did not respond within {}s on the MCP bridge; it may be overloaded",
+            ctx.call_timeout.as_secs()
+        )),
+        Err(BridgeCallError::Protocol(detail)) => {
+            archon::mcp_bridge::tool_error(format!("MCP bridge protocol error: {detail}"))
+        }
+    }
+}
+
+/// Connects to the bridge socket per call (no pooling), writes the ORIGINAL
+/// `tools/call` request line unchanged, and awaits exactly one response line
+/// under `ctx.call_timeout`.
+async fn forward_to_bridge(ctx: &McpContext, message: &Value) -> Result<Value, BridgeCallError> {
+    let connect = tokio::net::UnixStream::connect(&ctx.socket_path);
+    let mut stream = tokio::time::timeout(ctx.call_timeout, connect)
+        .await
+        .map_err(|_| BridgeCallError::Timeout)?
+        .map_err(|_| BridgeCallError::Unavailable)?;
+
+    let mut line =
+        serde_json::to_string(message).map_err(|e| BridgeCallError::Protocol(e.to_string()))?;
+    line.push('\n');
+    tokio::time::timeout(ctx.call_timeout, stream.write_all(line.as_bytes()))
+        .await
+        .map_err(|_| BridgeCallError::Timeout)?
+        .map_err(|e| BridgeCallError::Protocol(e.to_string()))?;
+
+    let mut reader = tokio::io::BufReader::new(&mut stream);
+    let mut response_line = String::new();
+    tokio::time::timeout(ctx.call_timeout, reader.read_line(&mut response_line))
+        .await
+        .map_err(|_| BridgeCallError::Timeout)?
+        .map_err(|e| BridgeCallError::Protocol(e.to_string()))?;
+
+    if response_line.trim().is_empty() {
+        return Err(BridgeCallError::Protocol(
+            "empty response from bridge".to_string(),
+        ));
+    }
+    serde_json::from_str(&response_line).map_err(|e| BridgeCallError::Protocol(e.to_string()))
 }
 
 async fn call_tool(name: &str, arguments: &Value) -> Result<String, String> {
@@ -408,15 +608,27 @@ fn error_response(id: Value, code: i64, message: String) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use paroche::state::{
+        DynQueueManager, DynSearchService, EnqueueItem, ResolvedRelease, ServiceError, ServiceFut,
+    };
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
     use super::*;
 
     #[tokio::test]
-    async fn tools_list_includes_offline_command_tools() {
-        let response = handle_message(json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/list"
-        }))
+    async fn tools_list_includes_all_eight_tools() {
+        let response = handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list"
+            }),
+            &McpContext::default(),
+        )
         .await
         .expect("request should produce a response");
 
@@ -429,10 +641,15 @@ mod tests {
             .filter_map(|tool| tool.get("name").and_then(Value::as_str))
             .collect();
 
+        assert_eq!(names.len(), 8, "{names:?}");
         assert!(names.contains(&"harmonia_db_migrate"));
         assert!(names.contains(&"harmonia_migrate_library"));
         assert!(names.contains(&"harmonia_play_file"));
         assert!(names.contains(&"harmonia_render"));
+        assert!(names.contains(&"harmonia_search_releases"));
+        assert!(names.contains(&"harmonia_enqueue_download"));
+        assert!(names.contains(&"harmonia_list_downloads"));
+        assert!(names.contains(&"harmonia_cancel_download"));
     }
 
     #[tokio::test]
@@ -443,20 +660,23 @@ mod tests {
         std::fs::create_dir_all(&album).unwrap();
         std::fs::write(album.join("01 Song.flac"), b"not real audio").unwrap();
 
-        let response = handle_message(json!({
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/call",
-            "params": {
-                "name": "harmonia_migrate_library",
-                "arguments": {
-                    "source": source.path(),
-                    "target": target.path(),
-                    "media_type": "music",
-                    "dry_run": true
+        let response = handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "harmonia_migrate_library",
+                    "arguments": {
+                        "source": source.path(),
+                        "target": target.path(),
+                        "media_type": "music",
+                        "dry_run": true
+                    }
                 }
-            }
-        }))
+            }),
+            &McpContext::default(),
+        )
         .await
         .expect("request should produce a response");
 
@@ -475,12 +695,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn offline_tool_never_touches_the_bridge() {
+        // WHY: a socket_path that cannot exist proves the offline tool path
+        // never dials it — any bridge involvement would surface as a
+        // "harmonia server is not running" / "MCP bridge" message instead of
+        // db_migrate's own (unrelated) config-load failure.
+        let ctx = McpContext {
+            socket_path: PathBuf::from("/nonexistent/harmonia-mcp-test.sock"),
+            call_timeout: Duration::from_secs(2),
+        };
+        let response = handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/call",
+                "params": {
+                    "name": "harmonia_db_migrate",
+                    "arguments": { "config": "/nonexistent/harmonia.toml" }
+                }
+            }),
+            &ctx,
+        )
+        .await
+        .expect("request should produce a response");
+
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .expect("tool response should include text");
+        assert!(!text.contains("MCP bridge"), "{text}");
+        assert!(!text.contains("harmonia server is not running"), "{text}");
+    }
+
+    #[tokio::test]
     async fn stdio_runner_writes_one_response_per_request_line() {
         let input = br#"{"jsonrpc":"2.0","id":"a","method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}
 "#;
         let mut output = Vec::new();
 
-        run_stdio_with_io(&input[..], &mut output).await.unwrap();
+        run_stdio_with_io(&input[..], &mut output, &McpContext::default())
+            .await
+            .unwrap();
 
         let line = String::from_utf8(output).unwrap();
         let response: Value = serde_json::from_str(line.trim()).unwrap();
@@ -488,5 +743,161 @@ mod tests {
             response.pointer("/result/serverInfo/name"),
             Some(&json!("harmonia"))
         );
+    }
+
+    // ── Acquisition-tool bridge forwarding (stdio side) ─────────────────────
+
+    #[tokio::test]
+    async fn acquisition_tool_call_reports_actionable_error_when_socket_absent() {
+        let ctx = McpContext {
+            socket_path: PathBuf::from("/nonexistent/harmonia-mcp-test.sock"),
+            call_timeout: Duration::from_secs(2),
+        };
+        let response = handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": { "name": "harmonia_search_releases", "arguments": {} }
+            }),
+            &ctx,
+        )
+        .await
+        .expect("request should produce a response");
+
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(true))
+        );
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(text.contains("harmonia server is not running"), "{text}");
+        assert!(text.contains("harmonia serve"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn acquisition_tool_call_times_out_when_bridge_hangs() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("hang.sock");
+        let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
+        tokio::spawn(async move {
+            // WHY: accept and hold the connection without ever writing a
+            // response line — the client's call_timeout must fire on read.
+            if let Ok((_stream, _addr)) = listener.accept().await {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+            }
+        });
+
+        let ctx = McpContext {
+            socket_path,
+            call_timeout: Duration::from_millis(100),
+        };
+        let response = handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": { "name": "harmonia_list_downloads", "arguments": {} }
+            }),
+            &ctx,
+        )
+        .await
+        .expect("request should produce a response");
+
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(true))
+        );
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(text.contains("did not respond"), "{text}");
+    }
+
+    // ── Full round trip: stdio surface -> real bridge over a real socket ───
+
+    struct EmptySearch;
+    impl DynSearchService for EmptySearch {
+        fn search(&self, _query: Value) -> ServiceFut<Value> {
+            Box::pin(async { Ok(json!({ "results": [] })) })
+        }
+        fn test_indexer(&self, _indexer_id: i64) -> ServiceFut<Value> {
+            Box::pin(async { Ok(json!({})) })
+        }
+        fn refresh_caps(&self, _indexer_id: i64) -> ServiceFut<Value> {
+            Box::pin(async { Ok(json!({})) })
+        }
+        fn cached_results(&self, _query_id: Uuid) -> ServiceFut<Value> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+        fn resolve_release(&self, _release_id: Uuid) -> ServiceFut<ResolvedRelease> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+    }
+
+    struct NoopQueue;
+    impl DynQueueManager for NoopQueue {
+        fn enqueue(&self, _item: EnqueueItem) -> ServiceFut<()> {
+            Box::pin(async { Ok(()) })
+        }
+        fn cancel(&self, _queue_id: Uuid) -> ServiceFut<()> {
+            Box::pin(async { Err(ServiceError::NotFound) })
+        }
+        fn reprioritize(&self, _queue_id: Uuid, _priority: u8) -> ServiceFut<()> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn acquisition_tool_call_round_trips_through_a_real_bridge() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        apotheke::migrate::MIGRATOR.run(&pool).await.unwrap();
+        let db = Arc::new(apotheke::DbPools {
+            read: pool.clone(),
+            write: pool,
+        });
+        let bridge_ctx = archon::mcp_bridge::BridgeContext {
+            search: Arc::new(EmptySearch),
+            queue: Arc::new(NoopQueue),
+            db,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("mcp.sock");
+        let shutdown = CancellationToken::new();
+        let handle = archon::mcp_bridge::spawn(socket_path.clone(), bridge_ctx, shutdown.clone())
+            .await
+            .expect("bridge binds");
+
+        let ctx = McpContext {
+            socket_path,
+            call_timeout: Duration::from_secs(5),
+        };
+        let response = handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": { "name": "harmonia_list_downloads", "arguments": {} }
+            }),
+            &ctx,
+        )
+        .await
+        .expect("request should produce a response");
+
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(false)),
+            "{response:?}"
+        );
+        assert_eq!(
+            response.pointer("/result/structuredContent/downloads"),
+            Some(&json!([]))
+        );
+
+        shutdown.cancel();
+        handle.await.unwrap();
     }
 }

--- a/crates/archon/src/mcp_bridge.rs
+++ b/crates/archon/src/mcp_bridge.rs
@@ -1,0 +1,1416 @@
+//! Serve-hosted MCP acquisition bridge (#609).
+//!
+//! `harmonia mcp` is a bare stdio process with no config, DB, or services —
+//! the live `DynSearchService`/`DynQueueManager` only exist inside a running
+//! `harmonia serve`. Enqueue/cancel MUST reach the RUNNING syntaxis service
+//! or the row is invisible until restart (the #499/#469 defect class), so
+//! the stdio surface cannot be a thin in-process adapter for these tools —
+//! it reaches this Unix-domain-socket bridge instead, spawned by `serve`
+//! right after `AppState` construction and holding Arc clones of the SAME
+//! services `AppState` got.
+//!
+//! Wire protocol: newline-delimited JSON-RPC 2.0 — one `tools/call` request
+//! line in, one response line out per connection request (mirrors the
+//! stdio surface's own framing so both sides share one mental model).
+//!
+//! Auth: filesystem, not HTTP. The socket is 0600, owned by the process
+//! that ran `harmonia serve`; anyone who can connect can already read
+//! `harmonia.toml` and the database file. `structuredContent`/`text`
+//! payloads still run every `download_url` through `paroche::redact` — the
+//! MCP client is an LLM whose transcripts leave the box, so a raw indexer
+//! passkey must never reach it even though the local-operator trust model
+//! doesn't otherwise gate this surface.
+//!
+//! The socket lives in a DEDICATED `harmonia-mcp/` runtime subdirectory
+//! (chmod'd 0700) beside `database.db_path` — never in `db_path`'s own
+//! directory, which may be shared with other users/processes we must not
+//! chmod (#609 adversarial review finding).
+
+// NOTE: `Permissions`/`PermissionsExt` live at module scope — `from_mode` is
+// a pure value builder (not I/O), and keeping the `std::fs::` path out of the
+// async `spawn` body avoids a false-positive blocking-io-in-async lint on the
+// mode constructor there; the actual filesystem writes all go through
+// `tokio::fs`.
+#[cfg(unix)]
+use std::fs::Permissions;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use apotheke::DbPools;
+use paroche::state::{DynQueueManager, DynSearchService, EnqueueItem, ServiceError};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tracing::Instrument;
+use url::Url;
+use uuid::Uuid;
+
+const ACQUISITION_TOOLS: [&str; 4] = [
+    "harmonia_search_releases",
+    "harmonia_enqueue_download",
+    "harmonia_list_downloads",
+    "harmonia_cancel_download",
+];
+
+/// True for the 4 tool names the bridge serves — the stdio surface uses
+/// this to decide "forward to the bridge" vs. "run in-process."
+pub fn is_acquisition_tool(name: &str) -> bool {
+    ACQUISITION_TOOLS.contains(&name)
+}
+
+/// Narrow context handed to the bridge listener — Arc clones of exactly
+/// what `AppState` got for `search`/`queue`/`db`. No locks, nothing held
+/// across an `.await`.
+#[derive(Clone)]
+pub struct BridgeContext {
+    pub search: Arc<dyn DynSearchService>,
+    pub queue: Arc<dyn DynQueueManager>,
+    pub db: Arc<DbPools>,
+}
+
+impl BridgeContext {
+    /// Assembles the bridge context from the live acquisition services.
+    pub fn new(
+        search: Arc<dyn DynSearchService>,
+        queue: Arc<dyn DynQueueManager>,
+        db: Arc<DbPools>,
+    ) -> Self {
+        Self { search, queue, db }
+    }
+
+    /// Dispatches one tool call to its handler. Exposed directly (not only
+    /// via the socket) so dispatch-level tests can drive it without a real
+    /// UDS connection. Pure — no I/O beyond the service calls themselves.
+    pub async fn dispatch(&self, name: &str, arguments: &Value) -> Value {
+        match name {
+            "harmonia_search_releases" => handle_search(arguments, self).await,
+            "harmonia_enqueue_download" => handle_enqueue(arguments, self).await,
+            "harmonia_list_downloads" => handle_list(arguments, self).await,
+            "harmonia_cancel_download" => handle_cancel(arguments, self).await,
+            other => tool_error(format!("unknown acquisition tool: {other}")),
+        }
+    }
+}
+
+/// Derives the bridge socket path FROM config — the SAME derivation both
+/// `harmonia serve` (binds) and `harmonia mcp` (connects) run
+/// independently, so the two processes agree without operator wiring.
+/// `mcp.socket_path` overrides; otherwise a DEDICATED `harmonia-mcp/`
+/// runtime subdirectory beside `database.db_path`, holding
+/// `harmonia-mcp.sock`.
+///
+/// WHY a dedicated subdir, not a sibling file: `spawn` chmods the socket's
+/// parent directory `0700` so only the operator can enter it. `db_path`'s
+/// own directory may be shared (other files, other users) — chmodding it
+/// would be wrong (and its failure would be a false-fatal serve-startup
+/// error). A subdirectory we alone create is ours to chmod.
+pub fn resolve_socket_path(config: &horismos::Config) -> PathBuf {
+    config.mcp.socket_path.clone().unwrap_or_else(|| {
+        let parent = config
+            .database
+            .db_path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        parent.join("harmonia-mcp").join("harmonia-mcp.sock")
+    })
+}
+
+// ── JSON-RPC / MCP tool-result envelope helpers ─────────────────────────────
+//
+// Shared by this module's own per-connection protocol AND the stdio surface
+// (`archon::mcp_bridge::{...}`, called from the bin crate's mcp.rs) — one
+// definition of what a JSON-RPC response / MCP tool result looks like.
+
+pub fn success_response(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+pub fn error_response(id: Value, code: i64, message: String) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+/// A tool-level failure (`isError: true`) — a normal JSON-RPC SUCCESS
+/// response whose result reports the tool itself failed. Distinct from a
+/// JSON-RPC protocol error: a bad release_id is the caller's input, not a
+/// broken wire.
+pub fn tool_error(message: impl Into<String>) -> Value {
+    let message = message.into();
+    json!({
+        "content": [{ "type": "text", "text": message }],
+        "structuredContent": { "ok": false },
+        "isError": true
+    })
+}
+
+/// A tool success carrying a structured JSON payload — `structuredContent`
+/// holds it verbatim; `text` is its compact serialization for clients that
+/// only render the text block.
+pub fn tool_success_json(payload: Value) -> Value {
+    let text = serde_json::to_string(&payload).unwrap_or_else(|_| payload.to_string());
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "structuredContent": payload,
+        "isError": false
+    })
+}
+
+fn service_error_to_tool_error(error: ServiceError) -> Value {
+    match error {
+        ServiceError::NotFound => tool_error("not found"),
+        ServiceError::NotAvailable => {
+            tool_error("the backing acquisition service is not available")
+        }
+        ServiceError::InvalidInput(message) => tool_error(message),
+        ServiceError::Internal(message) => {
+            // WHY: the tool result carries no detail for an internal fault —
+            // mirrors paroche::error's ParocheError::Internal mapping: the
+            // detail lands in the log or it is lost entirely.
+            tracing::error!(%message, "mcp acquisition bridge: service call failed");
+            tool_error("internal service error — see server logs")
+        }
+        // WHY: ServiceError is #[non_exhaustive] — a future variant degrades
+        // to a generic internal error rather than failing to build.
+        other => {
+            tracing::error!(?other, "mcp acquisition bridge: unclassified service error");
+            tool_error("internal service error — see server logs")
+        }
+    }
+}
+
+// ── Tool handlers (pure — no I/O beyond the service calls themselves) ──────
+
+async fn handle_search(arguments: &Value, ctx: &BridgeContext) -> Value {
+    let request: paroche::routes::search::SearchRequest =
+        match serde_json::from_value(arguments.clone()) {
+            Ok(r) => r,
+            Err(e) => return tool_error(format!("invalid search arguments: {e}")),
+        };
+    // WHY: builds the SAME query JSON the HTTP route builds
+    // (paroche::routes::search::search) — the search service reads generic
+    // JSON keys, not the SearchRequest type, so round-tripping through the
+    // route's own DTO keeps the two surfaces from drifting apart.
+    let query = match serde_json::to_value(&request) {
+        Ok(v) => v,
+        Err(e) => return tool_error(format!("failed to encode search query: {e}")),
+    };
+    match ctx.search.search(query).await {
+        Ok(mut results) => {
+            // WHY: redaction stays ON for MCP output — the client transcript
+            // leaves the box (an LLM), so a raw indexer apikey/passkey must
+            // never reach it, exactly like the HTTP /api/v1/search route.
+            paroche::redact::redact_download_urls_in_json(&mut results);
+            tool_success_json(results)
+        }
+        Err(error) => service_error_to_tool_error(error),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct EnqueueArguments {
+    release_id: Option<String>,
+    magnet: Option<String>,
+    #[serde(default = "default_enqueue_priority")]
+    priority: u8,
+    want_id: Option<String>,
+}
+
+fn default_enqueue_priority() -> u8 {
+    4
+}
+
+async fn handle_enqueue(arguments: &Value, ctx: &BridgeContext) -> Value {
+    let args: EnqueueArguments = match serde_json::from_value(arguments.clone()) {
+        Ok(a) => a,
+        Err(e) => return tool_error(format!("invalid enqueue arguments: {e}")),
+    };
+
+    let (release_id, download_url, protocol, info_hash) =
+        match (args.release_id.as_deref(), args.magnet.as_deref()) {
+            (Some(_), Some(_)) => {
+                return tool_error("exactly one of release_id or magnet is required, not both");
+            }
+            (None, None) => return tool_error("exactly one of release_id or magnet is required"),
+            (Some(raw_release_id), None) => {
+                let release_id = match Uuid::parse_str(raw_release_id) {
+                    Ok(id) => id,
+                    Err(_) => return tool_error("release_id must be a valid UUID"),
+                };
+                // WHY: the #608 seam — resolves the credentialed download
+                // URL server-side so the indexer credential never crosses
+                // this tool boundary.
+                match ctx.search.resolve_release(release_id).await {
+                    Ok(resolved) => (
+                        release_id,
+                        resolved.download_url,
+                        resolved.protocol,
+                        resolved.info_hash,
+                    ),
+                    Err(ServiceError::NotFound) => {
+                        return tool_error(format!(
+                            "release {release_id} not found or its search result cache entry \
+                             expired — search again"
+                        ));
+                    }
+                    Err(error) => return service_error_to_tool_error(error),
+                }
+            }
+            (None, Some(magnet)) => {
+                let parsed = match Url::parse(magnet) {
+                    Ok(u) => u,
+                    Err(_) => return tool_error("magnet is not a valid URI"),
+                };
+                if parsed.scheme() != "magnet" {
+                    return tool_error(
+                        "magnet must be a magnet: URI — raw http(s) URLs are rejected; use \
+                         release_id for credentialed indexer results",
+                    );
+                }
+                (
+                    Uuid::now_v7(),
+                    magnet.to_string(),
+                    "torrent".to_string(),
+                    None,
+                )
+            }
+        };
+
+    // SAFETY: the by-reference path must not become an SSRF bypass — the
+    // RESOLVED url is validated the same as a client-supplied one, never
+    // trusted just because it came from the server-side cache (mirrors
+    // paroche::routes::download::enqueue_download).
+    if let Err(error) = paroche::net_validate::validate_download_url(&download_url).await {
+        return tool_error(error.to_string());
+    }
+
+    let want_id = match args.want_id.as_deref().map(Uuid::parse_str).transpose() {
+        Ok(id) => id.unwrap_or_else(Uuid::now_v7),
+        Err(_) => return tool_error("want_id must be a valid UUID"),
+    };
+    let queue_id = Uuid::now_v7();
+    let priority = args.priority.clamp(1, 4);
+
+    if let Err(error) = ctx
+        .queue
+        .enqueue(EnqueueItem {
+            queue_id,
+            want_id,
+            release_id,
+            download_url,
+            protocol,
+            priority,
+            info_hash,
+        })
+        .await
+    {
+        return service_error_to_tool_error(error);
+    }
+
+    match paroche::routes::download::fetch_download(&ctx.db.read, queue_id).await {
+        Ok(Some(row)) => match serde_json::to_value(row) {
+            Ok(payload) => tool_success_json(payload),
+            Err(e) => tool_error(format!("failed to encode the persisted queue row: {e}")),
+        },
+        Ok(None) => tool_error("queue row vanished immediately after insert"),
+        Err(e) => tool_error(format!("failed to read back the persisted queue row: {e}")),
+    }
+}
+
+const KNOWN_DOWNLOAD_STATUSES: [&str; 6] = [
+    "queued",
+    "downloading",
+    "post_processing",
+    "importing",
+    "completed",
+    "failed",
+];
+
+// WHY: bounds an unbounded client-supplied limit from reaching the DB —
+// `get_queue_snapshot` has no cap at all; the MCP surface is a new attack
+// surface (an LLM-driven caller), so it gets a defensive ceiling.
+const MAX_LIST_LIMIT: u32 = 500;
+
+#[derive(serde::Deserialize)]
+struct ListArguments {
+    status: Option<String>,
+    id: Option<String>,
+    #[serde(default = "default_list_limit")]
+    limit: u32,
+}
+
+fn default_list_limit() -> u32 {
+    50
+}
+
+async fn handle_list(arguments: &Value, ctx: &BridgeContext) -> Value {
+    let args: ListArguments = match serde_json::from_value(arguments.clone()) {
+        Ok(a) => a,
+        Err(e) => return tool_error(format!("invalid list arguments: {e}")),
+    };
+    if let Some(status) = args.status.as_deref()
+        && !KNOWN_DOWNLOAD_STATUSES.contains(&status)
+    {
+        return tool_error(format!(
+            "status must be one of {KNOWN_DOWNLOAD_STATUSES:?}; got {status}"
+        ));
+    }
+    let id = match args.id.as_deref().map(Uuid::parse_str).transpose() {
+        Ok(id) => id,
+        Err(_) => return tool_error("id must be a valid UUID"),
+    };
+    let limit = args.limit.clamp(1, MAX_LIST_LIMIT);
+
+    match paroche::routes::download::list_downloads(&ctx.db.read, args.status.as_deref(), id, limit)
+        .await
+    {
+        Ok(rows) => tool_success_json(json!({ "downloads": rows })),
+        Err(e) => tool_error(format!("failed to list downloads: {e}")),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct CancelArguments {
+    id: String,
+}
+
+async fn handle_cancel(arguments: &Value, ctx: &BridgeContext) -> Value {
+    let args: CancelArguments = match serde_json::from_value(arguments.clone()) {
+        Ok(a) => a,
+        Err(e) => return tool_error(format!("invalid cancel arguments: {e}")),
+    };
+    let id = match Uuid::parse_str(&args.id) {
+        Ok(id) => id,
+        Err(_) => return tool_error("id must be a valid UUID"),
+    };
+    match ctx.queue.cancel(id).await {
+        Ok(()) => tool_success_json(json!({ "ok": true, "id": id.to_string() })),
+        Err(ServiceError::NotFound) => tool_error(format!("download {id} not found")),
+        Err(error) => service_error_to_tool_error(error),
+    }
+}
+
+// ── Wire protocol (one request line -> one response line) ──────────────────
+
+/// Handles one raw JSON-RPC request line, returning the encoded response
+/// line (no trailing newline).
+pub async fn handle_request_line(line: &str, ctx: &BridgeContext) -> String {
+    let message: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(e) => {
+            return encode(&error_response(
+                Value::Null,
+                -32700,
+                format!("parse error: {e}"),
+            ));
+        }
+    };
+    let id = message.get("id").cloned().unwrap_or(Value::Null);
+    if message.get("method").and_then(Value::as_str) != Some("tools/call") {
+        return encode(&error_response(
+            id,
+            -32601,
+            "the mcp acquisition bridge only serves tools/call".to_string(),
+        ));
+    }
+    let Some(name) = message.pointer("/params/name").and_then(Value::as_str) else {
+        return encode(&success_response(
+            id,
+            tool_error("tools/call requires params.name"),
+        ));
+    };
+    let arguments = message
+        .pointer("/params/arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let result = ctx.dispatch(name, &arguments).await;
+    encode(&success_response(id, result))
+}
+
+fn encode(value: &Value) -> String {
+    // WHY: infallible for these envelope shapes in practice; a stray
+    // serialize failure still degrades to a valid, if generic, line rather
+    // than panicking a connection handler.
+    serde_json::to_string(value).unwrap_or_else(|_| {
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"internal encode error"}}"#
+            .to_string()
+    })
+}
+
+// ── UDS listener (server side) ──────────────────────────────────────────────
+
+// WHY: a `tools/call` request line is tiny (a UUID + a handful of scalar
+// fields) — this is the wire-frame CEILING, not an expected size, sibling
+// to `MAX_LIST_LIMIT`'s defensive-cap discipline above. Without it, a
+// connection that streams bytes with no newline grows the request buffer
+// unbounded until it OOMs the whole `serve` process (HTTP API, downloads,
+// everything) — one malicious/broken MCP client should only be able to
+// cost itself a closed connection, never the process.
+#[cfg(unix)]
+const MAX_REQUEST_BYTES: usize = 256 * 1024;
+
+#[cfg(unix)]
+async fn handle_connection(
+    stream: tokio::net::UnixStream,
+    ctx: BridgeContext,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    let (reader, mut writer) = stream.into_split();
+    let mut reader = BufReader::new(reader);
+    let mut buf: Vec<u8> = Vec::new();
+    loop {
+        buf.clear();
+        // WHY: the shutdown race sits AT the read point (a request
+        // boundary) only — once `handle_request_line` below is polled, this
+        // loop no longer selects against `shutdown`, so an in-flight
+        // enqueue/cancel always finishes its dispatch and writes its
+        // response before the connection can be torn down.
+        //
+        // `.take(..)` is re-created every iteration so the byte budget is
+        // per-REQUEST, not per-connection — a long-lived connection may
+        // send many small requests without ever tripping the ceiling.
+        let mut limited = (&mut reader).take(MAX_REQUEST_BYTES as u64);
+        let read = tokio::select! {
+            () = shutdown.cancelled() => return,
+            read = limited.read_until(b'\n', &mut buf) => read,
+        };
+        let n = match read {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(error = %e, "mcp bridge connection read error");
+                return;
+            }
+        };
+        if n == 0 {
+            return; // EOF
+        }
+        if buf.last() != Some(&b'\n') {
+            // WHY: no newline within MAX_REQUEST_BYTES means either the
+            // wire-frame ceiling was hit or the peer vanished mid-frame — a
+            // conforming client (this bridge's own `mcp.rs` forwarder
+            // included) always terminates a request with `\n`, so either
+            // way the frame is unusable. Reject and close now rather than
+            // keep reading further (the whole point of the cap).
+            let response = encode(&error_response(
+                Value::Null,
+                -32600,
+                format!("request exceeds the {MAX_REQUEST_BYTES}-byte wire-frame limit"),
+            ));
+            // WHY: best-effort notify then close — a write failure here
+            // changes nothing (we return regardless), so it is logged at
+            // debug, never propagated.
+            let notify = async {
+                writer.write_all(response.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+                writer.flush().await
+            };
+            if let Err(e) = notify.await {
+                tracing::debug!(error = %e, "mcp bridge: could not send oversized-frame error to peer");
+            }
+            tracing::warn!(
+                limit = MAX_REQUEST_BYTES,
+                "mcp bridge closed a connection whose request exceeded the wire-frame ceiling"
+            );
+            return;
+        }
+        let line = match std::str::from_utf8(&buf) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "mcp bridge connection received a non-utf8 line");
+                return;
+            }
+        };
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let response = handle_request_line(trimmed, &ctx).await;
+        if writer.write_all(response.as_bytes()).await.is_err()
+            || writer.write_all(b"\n").await.is_err()
+            || writer.flush().await.is_err()
+        {
+            tracing::warn!("mcp bridge connection write error");
+            return;
+        }
+    }
+}
+
+// WHY: bounded shutdown grace — long enough for a real tool call (indexer
+// fan-out, a DB write) to finish, short enough that a wedged connection
+// cannot hang process shutdown forever. Best-effort past this point: we log
+// and unlink anyway rather than block shutdown indefinitely.
+#[cfg(unix)]
+const SHUTDOWN_DRAIN_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[cfg(unix)]
+async fn run_accept_loop(
+    listener: tokio::net::UnixListener,
+    ctx: BridgeContext,
+    shutdown: tokio_util::sync::CancellationToken,
+    socket_path: PathBuf,
+) {
+    // WHY: shutdown used to join only THIS accept loop — spawned
+    // per-connection tasks were dropped mid-call, silently losing an
+    // in-flight enqueue/cancel (#609 adversarial review finding). Tracking
+    // every connection task here lets shutdown DRAIN them before the socket
+    // is unlinked.
+    let tracker = tokio_util::task::TaskTracker::new();
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => break,
+            accepted = listener.accept() => {
+                match accepted {
+                    Ok((stream, _addr)) => {
+                        let conn_ctx = ctx.clone();
+                        let conn_shutdown = shutdown.clone();
+                        tracker.spawn(
+                            handle_connection(stream, conn_ctx, conn_shutdown)
+                                .instrument(tracing::info_span!("mcp_bridge_conn")),
+                        );
+                    }
+                    Err(e) => tracing::warn!(error = %e, "mcp bridge accept error"),
+                }
+            }
+        }
+    }
+
+    tracker.close();
+    if tokio::time::timeout(SHUTDOWN_DRAIN_GRACE, tracker.wait())
+        .await
+        .is_err()
+    {
+        tracing::warn!(
+            grace_secs = SHUTDOWN_DRAIN_GRACE.as_secs(),
+            "mcp bridge: connections still in flight after the shutdown grace period; \
+             unlinking the socket anyway"
+        );
+    }
+
+    // WHY: best-effort — a failed remove leaves a stale file that the NEXT
+    // startup's stale-socket unlink (in `spawn`) cleans up; not worth a
+    // panic on shutdown.
+    tokio::fs::remove_file(&socket_path).await.ok();
+    tracing::info!(socket = %socket_path.display(), "mcp acquisition bridge stopped");
+}
+
+/// Binds the acquisition bridge's Unix domain socket and spawns its accept
+/// loop. Bind is FATAL — mirrors the HTTP listener's startup posture: a
+/// server that cannot bind its configured surface must not come up
+/// half-alive. The socket's parent directory is a dedicated runtime dir
+/// this process owns (see `resolve_socket_path`) — created and `chmod`'d
+/// `0700`; a failure here is a legitimate fatal (it means another user owns
+/// what should be our runtime dir). The socket file itself is `chmod`'d
+/// `0600` after bind, belt-and-suspenders on top of the directory
+/// permission. If a socket already exists at the target path, it is
+/// LIVENESS-CHECKED, not blindly unlinked: a successful connect means
+/// another `harmonia serve` instance is already bound there (fatal — its
+/// live socket is left untouched); a refused connect means the inode is
+/// stale and is removed before rebinding.
+#[cfg(unix)]
+pub async fn spawn(
+    socket_path: PathBuf,
+    ctx: BridgeContext,
+    shutdown: tokio_util::sync::CancellationToken,
+) -> Result<tokio::task::JoinHandle<()>, std::io::Error> {
+    if let Some(parent) = socket_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        tokio::fs::create_dir_all(parent).await?;
+        tokio::fs::set_permissions(parent, Permissions::from_mode(0o700)).await?;
+    }
+    if tokio::fs::try_exists(&socket_path).await.unwrap_or(false) {
+        // WHY: a SECOND `harmonia serve` started against the same config
+        // must not silently sever a FIRST, still-live instance's MCP
+        // surface by unlinking its socket out from under it. Attempting a
+        // connect is the standard stale-socket protocol: `Ok` proves a
+        // peer is actually listening (not just that a stale inode exists),
+        // `Err` (connection refused / no such process) proves it is dead.
+        match tokio::net::UnixStream::connect(&socket_path).await {
+            Ok(_live) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AddrInUse,
+                    format!(
+                        "another harmonia serve instance is already bound to {}",
+                        socket_path.display()
+                    ),
+                ));
+            }
+            Err(_) => {
+                tokio::fs::remove_file(&socket_path).await?;
+            }
+        }
+    }
+    let listener = tokio::net::UnixListener::bind(&socket_path)?;
+    tokio::fs::set_permissions(&socket_path, Permissions::from_mode(0o600)).await?;
+
+    tracing::info!(socket = %socket_path.display(), "mcp acquisition bridge listening");
+
+    Ok(tokio::spawn(
+        run_accept_loop(listener, ctx, shutdown, socket_path)
+            .instrument(tracing::info_span!("mcp_bridge")),
+    ))
+}
+
+#[cfg(not(unix))]
+pub async fn spawn(
+    _socket_path: PathBuf,
+    _ctx: BridgeContext,
+    _shutdown: tokio_util::sync::CancellationToken,
+) -> Result<tokio::task::JoinHandle<()>, std::io::Error> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "the MCP acquisition bridge requires a Unix domain socket; unsupported on this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use apotheke::migrate::MIGRATOR;
+    use paroche::state::{ResolvedRelease, ServiceFut};
+    use sqlx::SqlitePool;
+
+    use super::*;
+
+    // ── Stub search / queue services ─────────────────────────────────────
+
+    struct StubSearch {
+        results: Value,
+        resolve: HashMap<Uuid, (String, String, Option<String>)>,
+    }
+
+    impl DynSearchService for StubSearch {
+        fn search(&self, _query: Value) -> ServiceFut<Value> {
+            let results = self.results.clone();
+            Box::pin(async move { Ok(results) })
+        }
+        fn test_indexer(&self, _indexer_id: i64) -> ServiceFut<Value> {
+            Box::pin(async { Ok(json!({})) })
+        }
+        fn refresh_caps(&self, _indexer_id: i64) -> ServiceFut<Value> {
+            Box::pin(async { Ok(json!({})) })
+        }
+        fn cached_results(&self, _query_id: Uuid) -> ServiceFut<Value> {
+            Box::pin(async { Err(ServiceError::NotAvailable) })
+        }
+        fn resolve_release(&self, release_id: Uuid) -> ServiceFut<ResolvedRelease> {
+            let found =
+                self.resolve
+                    .get(&release_id)
+                    .map(|(url, protocol, hash)| ResolvedRelease {
+                        download_url: url.clone(),
+                        protocol: protocol.clone(),
+                        info_hash: hash.clone(),
+                    });
+            Box::pin(async move { found.ok_or(ServiceError::NotFound) })
+        }
+    }
+
+    /// Records every enqueue/cancel and, when given a pool, PERSISTS the
+    /// enqueued row exactly as the real syntaxis service does — so
+    /// `handle_enqueue`'s "re-read the persisted row, redacted" step has a
+    /// row to read (the WHY the response can be checked for redaction).
+    #[derive(Default)]
+    struct StubQueue {
+        enqueued: Mutex<Vec<EnqueueItem>>,
+        cancelled: Mutex<Vec<Uuid>>,
+        known: Mutex<std::collections::HashSet<Uuid>>,
+        persist: Option<SqlitePool>,
+    }
+
+    impl StubQueue {
+        fn with_pool(pool: SqlitePool) -> Self {
+            Self {
+                persist: Some(pool),
+                ..Self::default()
+            }
+        }
+    }
+
+    impl DynQueueManager for StubQueue {
+        fn enqueue(&self, item: EnqueueItem) -> ServiceFut<()> {
+            self.known.lock().unwrap().insert(item.queue_id);
+            let pool = self.persist.clone();
+            self.enqueued.lock().unwrap().push(item.clone());
+            Box::pin(async move {
+                if let Some(pool) = pool {
+                    sqlx::query(
+                        "INSERT INTO download_queue (id, want_id, release_id, download_url, \
+                         protocol, priority, info_hash, status) \
+                         VALUES (?, ?, ?, ?, ?, ?, ?, 'queued')",
+                    )
+                    .bind(item.queue_id.as_bytes().as_slice())
+                    .bind(item.want_id.as_bytes().as_slice())
+                    .bind(item.release_id.as_bytes().as_slice())
+                    .bind(item.download_url.as_str())
+                    .bind(item.protocol.as_str())
+                    .bind(i64::from(item.priority))
+                    .bind(item.info_hash.as_deref())
+                    .execute(&pool)
+                    .await
+                    .map_err(|e| ServiceError::Internal(e.to_string()))?;
+                }
+                Ok(())
+            })
+        }
+        fn cancel(&self, queue_id: Uuid) -> ServiceFut<()> {
+            let found = self.known.lock().unwrap().contains(&queue_id);
+            if found {
+                self.cancelled.lock().unwrap().push(queue_id);
+            }
+            Box::pin(async move {
+                if found {
+                    Ok(())
+                } else {
+                    Err(ServiceError::NotFound)
+                }
+            })
+        }
+        fn reprioritize(&self, _queue_id: Uuid, _priority: u8) -> ServiceFut<()> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    async fn test_db() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite opens");
+        MIGRATOR.run(&pool).await.expect("migrations run");
+        pool
+    }
+
+    async fn test_ctx(search: StubSearch, queue: StubQueue) -> BridgeContext {
+        let pool = test_db().await;
+        ctx_with_pool(pool, search, Arc::new(queue))
+    }
+
+    /// Builds a context whose `db` is the SAME pool a persisting StubQueue
+    /// writes to — so an enqueue's row is visible to the read-back. Keeps
+    /// the concrete `Arc<StubQueue>` type at the call site for inspection.
+    fn ctx_with_pool(pool: SqlitePool, search: StubSearch, queue: Arc<StubQueue>) -> BridgeContext {
+        BridgeContext {
+            search: Arc::new(search),
+            queue,
+            db: Arc::new(DbPools {
+                read: pool.clone(),
+                write: pool,
+            }),
+        }
+    }
+
+    fn empty_search() -> StubSearch {
+        StubSearch {
+            results: json!({ "results": [] }),
+            resolve: HashMap::new(),
+        }
+    }
+
+    // ── tools/list membership ────────────────────────────────────────────
+
+    #[test]
+    fn is_acquisition_tool_covers_exactly_the_four_names() {
+        assert!(is_acquisition_tool("harmonia_search_releases"));
+        assert!(is_acquisition_tool("harmonia_enqueue_download"));
+        assert!(is_acquisition_tool("harmonia_list_downloads"));
+        assert!(is_acquisition_tool("harmonia_cancel_download"));
+        assert!(!is_acquisition_tool("harmonia_db_migrate"));
+        assert!(!is_acquisition_tool("unknown_tool"));
+    }
+
+    // ── search ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn search_redacts_credentialed_download_urls() {
+        let search = StubSearch {
+            results: json!({
+                "results": [{
+                    "release_id": Uuid::now_v7().to_string(),
+                    "download_url": "https://indexer.example/dl?apikey=SECRETVALUE",
+                    "title": "Some Album"
+                }]
+            }),
+            resolve: HashMap::new(),
+        };
+        let ctx = test_ctx(search, StubQueue::default()).await;
+
+        let result = ctx
+            .dispatch(
+                "harmonia_search_releases",
+                &json!({ "query_text": "test", "media_type": "music" }),
+            )
+            .await;
+
+        assert_eq!(result["isError"], false);
+        let rendered = serde_json::to_string(&result).unwrap();
+        assert!(
+            !rendered.contains("SECRETVALUE"),
+            "no unredacted credential may appear anywhere in the tool result: {rendered}"
+        );
+        assert!(rendered.contains("REDACTED"));
+    }
+
+    #[tokio::test]
+    async fn search_rejects_structurally_invalid_arguments() {
+        // WHY: media_type VALUE validation is the search service's job
+        // (serve.rs parse_search_media_type) — the bridge's own guarantee is
+        // rejecting a structurally-invalid argument (a wrong-typed field)
+        // before it ever reaches the service.
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let result = ctx
+            .dispatch(
+                "harmonia_search_releases",
+                &json!({ "limit": "not-a-number" }),
+            )
+            .await;
+        assert_eq!(result["isError"], true);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("invalid search arguments")
+        );
+    }
+
+    // ── enqueue ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn enqueue_rejects_neither_release_id_nor_magnet() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let result = ctx.dispatch("harmonia_enqueue_download", &json!({})).await;
+        assert_eq!(result["isError"], true);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("exactly one")
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_rejects_both_release_id_and_magnet() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let result = ctx
+            .dispatch(
+                "harmonia_enqueue_download",
+                &json!({
+                    "release_id": Uuid::now_v7().to_string(),
+                    "magnet": "magnet:?xt=urn:btih:abc"
+                }),
+            )
+            .await;
+        assert_eq!(result["isError"], true);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("not both")
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_rejects_http_url_in_magnet_arm() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let result = ctx
+            .dispatch(
+                "harmonia_enqueue_download",
+                &json!({ "magnet": "https://example.com/credentialed?apikey=SECRET" }),
+            )
+            .await;
+        assert_eq!(result["isError"], true);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("magnet:")
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_rejects_private_tracker_magnet() {
+        // WHY: validate_download_url rejects a magnet whose tr= trackers all
+        // resolve to non-public address space — this exercises the SSRF
+        // guard staying wired on the magnet arm.
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let result = ctx
+            .dispatch(
+                "harmonia_enqueue_download",
+                &json!({ "magnet": "magnet:?xt=urn:btih:abc&tr=http://127.0.0.1:6969/announce" }),
+            )
+            .await;
+        assert_eq!(result["isError"], true);
+    }
+
+    #[tokio::test]
+    async fn enqueue_release_id_not_found_reports_not_found() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let result = ctx
+            .dispatch(
+                "harmonia_enqueue_download",
+                &json!({ "release_id": Uuid::now_v7().to_string() }),
+            )
+            .await;
+        assert_eq!(result["isError"], true);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("not found")
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_release_id_resolves_persists_and_redacts_response() {
+        // WHY: a magnet-form resolved URL validates without DNS (no tr=
+        // trackers), keeping the test network-free while still carrying a
+        // credential-shaped `apikey=` param that redaction must strip.
+        let release_id = Uuid::now_v7();
+        let credentialed =
+            "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd&apikey=SECRETVALUE";
+        let mut resolve = HashMap::new();
+        resolve.insert(
+            release_id,
+            (credentialed.to_string(), "torrent".to_string(), None),
+        );
+        let search = StubSearch {
+            results: json!({}),
+            resolve,
+        };
+        let pool = test_db().await;
+        let queue = Arc::new(StubQueue::with_pool(pool.clone()));
+        let ctx = ctx_with_pool(pool, search, Arc::clone(&queue));
+
+        let result = ctx
+            .dispatch(
+                "harmonia_enqueue_download",
+                &json!({ "release_id": release_id.to_string(), "priority": 3 }),
+            )
+            .await;
+
+        assert_eq!(result["isError"], false, "{result:?}");
+        // The QUEUE received the UNREDACTED, credentialed URL.
+        let enqueued = queue.enqueued.lock().unwrap();
+        assert_eq!(enqueued.len(), 1);
+        assert_eq!(enqueued[0].download_url, credentialed);
+        assert_eq!(enqueued[0].priority, 3);
+        drop(enqueued);
+        // The RESPONSE is redacted — no credential anywhere in it.
+        let rendered = serde_json::to_string(&result).unwrap();
+        assert!(
+            !rendered.contains("SECRETVALUE"),
+            "the enqueue response must never carry the unredacted credential: {rendered}"
+        );
+        assert!(rendered.contains("REDACTED"));
+        assert_eq!(result["structuredContent"]["priority"], 3);
+        assert!(
+            !result["structuredContent"]["id"]
+                .as_str()
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    // ── list ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_rejects_unknown_status() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let result = ctx
+            .dispatch(
+                "harmonia_list_downloads",
+                &json!({ "status": "not-a-status" }),
+            )
+            .await;
+        assert_eq!(result["isError"], true);
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_status_and_redacts() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let queued_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO download_queue (id, want_id, release_id, download_url, protocol, \
+             priority, status) VALUES (?, ?, ?, ?, 'torrent', 4, 'queued')",
+        )
+        .bind(queued_id.as_bytes().as_slice())
+        .bind(Uuid::now_v7().as_bytes().as_slice())
+        .bind(Uuid::now_v7().as_bytes().as_slice())
+        .bind("magnet:?xt=urn:btih:abc&apikey=SECRETVALUE")
+        .execute(&ctx.db.read)
+        .await
+        .unwrap();
+        let completed_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO download_queue (id, want_id, release_id, download_url, protocol, \
+             priority, status) VALUES (?, ?, ?, ?, 'torrent', 4, 'completed')",
+        )
+        .bind(completed_id.as_bytes().as_slice())
+        .bind(Uuid::now_v7().as_bytes().as_slice())
+        .bind(Uuid::now_v7().as_bytes().as_slice())
+        .bind("magnet:?xt=urn:btih:def")
+        .execute(&ctx.db.read)
+        .await
+        .unwrap();
+
+        let result = ctx
+            .dispatch("harmonia_list_downloads", &json!({ "status": "queued" }))
+            .await;
+
+        assert_eq!(result["isError"], false);
+        let downloads = result["structuredContent"]["downloads"].as_array().unwrap();
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(downloads[0]["id"], queued_id.to_string());
+        let rendered = serde_json::to_string(&result).unwrap();
+        assert!(!rendered.contains("SECRETVALUE"));
+    }
+
+    // ── cancel ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn cancel_rejects_invalid_uuid() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let result = ctx
+            .dispatch("harmonia_cancel_download", &json!({ "id": "not-a-uuid" }))
+            .await;
+        assert_eq!(result["isError"], true);
+    }
+
+    #[tokio::test]
+    async fn cancel_unknown_id_reports_not_found() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let result = ctx
+            .dispatch(
+                "harmonia_cancel_download",
+                &json!({ "id": Uuid::now_v7().to_string() }),
+            )
+            .await;
+        assert_eq!(result["isError"], true);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("not found")
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_known_id_succeeds() {
+        let queue = StubQueue::default();
+        let queue_id = Uuid::now_v7();
+        queue.known.lock().unwrap().insert(queue_id);
+        let ctx = test_ctx(empty_search(), queue).await;
+
+        let result = ctx
+            .dispatch(
+                "harmonia_cancel_download",
+                &json!({ "id": queue_id.to_string() }),
+            )
+            .await;
+
+        assert_eq!(result["isError"], false);
+        assert_eq!(result["structuredContent"]["ok"], true);
+        assert_eq!(result["structuredContent"]["id"], queue_id.to_string());
+    }
+
+    // ── wire protocol round trip over a real UDS socket ──────────────────
+
+    #[tokio::test]
+    async fn real_socket_round_trip_serves_a_tool_call() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("bridge.sock");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = spawn(socket_path.clone(), ctx, shutdown.clone())
+            .await
+            .expect("bridge binds");
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path)
+            .await
+            .expect("connects to the real socket");
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "harmonia_list_downloads", "arguments": {} }
+        });
+        let mut line = serde_json::to_string(&request).unwrap();
+        line.push('\n');
+        stream.write_all(line.as_bytes()).await.unwrap();
+
+        let mut reader = BufReader::new(stream);
+        let mut response_line = String::new();
+        reader.read_line(&mut response_line).await.unwrap();
+        let response: Value = serde_json::from_str(&response_line).unwrap();
+        assert_eq!(response["result"]["isError"], false);
+
+        shutdown.cancel();
+        handle.await.unwrap();
+        assert!(
+            !socket_path.exists(),
+            "the socket must be unlinked on shutdown"
+        );
+    }
+
+    // ── FIX 1: bounded request read ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn oversized_request_is_rejected_and_the_bridge_survives() {
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("bridge.sock");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = spawn(socket_path.clone(), ctx, shutdown.clone())
+            .await
+            .expect("bridge binds");
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path)
+            .await
+            .expect("connects to the real socket");
+        // WHY: bytes with NO trailing newline, bigger than MAX_REQUEST_BYTES
+        // — exercises the read cap without needing a syntactically valid
+        // (but merely oversized) JSON body.
+        let oversized = vec![b'a'; MAX_REQUEST_BYTES + 1024];
+        stream.write_all(&oversized).await.unwrap();
+
+        let mut reader = BufReader::new(&mut stream);
+        let mut response_line = String::new();
+        tokio::time::timeout(Duration::from_secs(2), reader.read_line(&mut response_line))
+            .await
+            .expect("bridge must respond before the timeout")
+            .unwrap();
+        let response: Value = serde_json::from_str(&response_line).unwrap();
+        assert_eq!(response["error"]["code"], -32600);
+        assert!(
+            response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("exceeds"),
+            "{response:?}"
+        );
+
+        // the bridge then closes the connection — a further read is EOF.
+        let mut trailing = String::new();
+        let eof = reader.read_line(&mut trailing).await.unwrap();
+        assert_eq!(
+            eof, 0,
+            "the bridge must close the connection after an oversized request"
+        );
+
+        // the bridge process itself must still be alive — a FRESH
+        // connection on the same socket must still be served normally.
+        let mut stream2 = tokio::net::UnixStream::connect(&socket_path)
+            .await
+            .expect("the bridge must still be listening after one bad connection");
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "harmonia_list_downloads", "arguments": {} }
+        });
+        let mut line = serde_json::to_string(&request).unwrap();
+        line.push('\n');
+        stream2.write_all(line.as_bytes()).await.unwrap();
+        let mut reader2 = BufReader::new(stream2);
+        let mut response_line2 = String::new();
+        reader2.read_line(&mut response_line2).await.unwrap();
+        let response2: Value = serde_json::from_str(&response_line2).unwrap();
+        assert_eq!(response2["result"]["isError"], false, "{response2:?}");
+
+        shutdown.cancel();
+        handle.await.unwrap();
+    }
+
+    // ── FIX 3: liveness check before unlinking a socket ──────────────────
+
+    #[tokio::test]
+    async fn spawn_refuses_a_second_instance_on_the_same_socket() {
+        let ctx1 = test_ctx(empty_search(), StubQueue::default()).await;
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("bridge.sock");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = spawn(socket_path.clone(), ctx1, shutdown.clone())
+            .await
+            .expect("first instance binds");
+
+        let ctx2 = test_ctx(empty_search(), StubQueue::default()).await;
+        let second_shutdown = tokio_util::sync::CancellationToken::new();
+        let result = spawn(socket_path.clone(), ctx2, second_shutdown).await;
+        assert!(
+            result.is_err(),
+            "a second instance must refuse to bind over a LIVE socket"
+        );
+
+        // the FIRST instance's socket must still be reachable — a failed
+        // second-instance bind attempt must not have unlinked it.
+        let mut stream = tokio::net::UnixStream::connect(&socket_path)
+            .await
+            .expect("the first instance's socket must remain live and untouched");
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "harmonia_list_downloads", "arguments": {} }
+        });
+        let mut line = serde_json::to_string(&request).unwrap();
+        line.push('\n');
+        stream.write_all(line.as_bytes()).await.unwrap();
+        let mut reader = BufReader::new(stream);
+        let mut response_line = String::new();
+        reader.read_line(&mut response_line).await.unwrap();
+        let response: Value = serde_json::from_str(&response_line).unwrap();
+        assert_eq!(response["result"]["isError"], false, "{response:?}");
+
+        shutdown.cancel();
+        handle.await.unwrap();
+    }
+
+    // ── FIX 4: shutdown drains in-flight connections ─────────────────────
+
+    /// A queue whose `cancel` sleeps before resolving — simulates a tool
+    /// call genuinely in flight when shutdown fires mid-dispatch.
+    struct SlowCancelQueue {
+        known: HashSet<Uuid>,
+        delay: Duration,
+    }
+
+    impl DynQueueManager for SlowCancelQueue {
+        fn enqueue(&self, _item: EnqueueItem) -> ServiceFut<()> {
+            Box::pin(async { Ok(()) })
+        }
+        fn cancel(&self, queue_id: Uuid) -> ServiceFut<()> {
+            let found = self.known.contains(&queue_id);
+            let delay = self.delay;
+            Box::pin(async move {
+                tokio::time::sleep(delay).await;
+                if found {
+                    Ok(())
+                } else {
+                    Err(ServiceError::NotFound)
+                }
+            })
+        }
+        fn reprioritize(&self, _queue_id: Uuid, _priority: u8) -> ServiceFut<()> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_an_inflight_call_before_unlinking() {
+        let queue_id = Uuid::now_v7();
+        let mut known = HashSet::new();
+        known.insert(queue_id);
+        let queue = SlowCancelQueue {
+            known,
+            delay: Duration::from_millis(300),
+        };
+        let pool = test_db().await;
+        let ctx = BridgeContext {
+            search: Arc::new(empty_search()),
+            queue: Arc::new(queue),
+            db: Arc::new(DbPools {
+                read: pool.clone(),
+                write: pool,
+            }),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("bridge.sock");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = spawn(socket_path.clone(), ctx, shutdown.clone())
+            .await
+            .expect("bridge binds");
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path)
+            .await
+            .expect("connects to the real socket");
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "harmonia_cancel_download", "arguments": { "id": queue_id.to_string() } }
+        });
+        let mut line = serde_json::to_string(&request).unwrap();
+        line.push('\n');
+        stream.write_all(line.as_bytes()).await.unwrap();
+
+        // WHY: give the accept loop time to actually dispatch the request
+        // (start the slow `cancel()` future) before triggering shutdown —
+        // the race must genuinely exercise "in flight," not "not yet
+        // started."
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        shutdown.cancel();
+
+        let mut reader = BufReader::new(&mut stream);
+        let mut response_line = String::new();
+        tokio::time::timeout(Duration::from_secs(2), reader.read_line(&mut response_line))
+            .await
+            .expect(
+                "the in-flight call's response must still arrive — shutdown must not abort \
+                 mid-dispatch",
+            )
+            .unwrap();
+        let response: Value = serde_json::from_str(&response_line).unwrap();
+        assert_eq!(response["result"]["isError"], false, "{response:?}");
+        assert_eq!(response["result"]["structuredContent"]["ok"], true);
+
+        // the bridge must still have completed its full shutdown (accept
+        // loop stopped, socket unlinked) within the grace period.
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("shutdown must complete within the drain grace period")
+            .unwrap();
+        assert!(!socket_path.exists());
+    }
+
+    // ── FIX 2: dedicated socket subdirectory ──────────────────────────────
+
+    #[tokio::test]
+    async fn socket_lives_in_a_dedicated_0700_subdir_with_a_0600_socket_and_both_sides_agree() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = horismos::Config {
+            database: horismos::DatabaseConfig {
+                db_path: dir.path().join("harmonia.sqlite"),
+                ..horismos::DatabaseConfig::default()
+            },
+            ..horismos::Config::default()
+        };
+
+        // WHY: `resolve_socket_path` is the ONE shared derivation both
+        // `harmonia serve` (this call, standing in for the serve side) and
+        // `harmonia mcp` (this second call, standing in for the stdio
+        // client) run independently — calling it twice from the same
+        // config proves they land on the identical path.
+        let serve_side = resolve_socket_path(&config);
+        let mcp_side = resolve_socket_path(&config);
+        assert_eq!(
+            serve_side, mcp_side,
+            "serve and mcp must derive the identical socket path from the same config"
+        );
+        assert_eq!(
+            serve_side,
+            dir.path().join("harmonia-mcp").join("harmonia-mcp.sock")
+        );
+        assert_ne!(
+            serve_side.parent(),
+            Some(dir.path()),
+            "the socket's parent must be a DEDICATED subdirectory, never db_path's own directory"
+        );
+
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = spawn(serve_side.clone(), ctx, shutdown.clone())
+            .await
+            .expect("bridge binds");
+
+        let subdir_meta = tokio::fs::metadata(serve_side.parent().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(subdir_meta.permissions().mode() & 0o777, 0o700);
+        let socket_meta = tokio::fs::metadata(&serve_side).await.unwrap();
+        assert_eq!(socket_meta.permissions().mode() & 0o777, 0o600);
+
+        shutdown.cancel();
+        handle.await.unwrap();
+    }
+}

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -39,7 +39,8 @@ use zetesis::cf_bypass::noop::NoProxy;
 use crate::cli::ServeArgs;
 use crate::error::{
     ConfigSnafu, DatabaseSnafu, DownloadEngineSnafu, DownloadQueueSnafu, FeedSchedulerSnafu,
-    HostError, ListenAddrSnafu, ReloadTaskPanickedSnafu, ScannerSnafu, ServerSnafu,
+    HostError, ListenAddrSnafu, McpBridgeBindSnafu, ReloadTaskPanickedSnafu, ScannerSnafu,
+    ServerSnafu,
 };
 use crate::shutdown::shutdown_signal;
 use crate::startup::{ensure_admin_user, init_tracing};
@@ -1301,17 +1302,19 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     });
 
     // 13. Build HTTP router
+    let search_adapter: Arc<dyn DynSearchService> = Arc::new(SearchAdapter(zetesis));
+    let queue_adapter: Arc<dyn DynQueueManager> = Arc::new(QueueAdapter(Arc::clone(&syntaxis_svc)));
     let state = AppState {
-        db,
+        db: Arc::clone(&db),
         config: config_handle.clone(),
         event_tx,
         auth,
         import,
         metadata: metadata_adapter,
         curation: Arc::new(CurationAdapter(curation_service)),
-        search: Arc::new(SearchAdapter(zetesis)),
+        search: Arc::clone(&search_adapter),
         download_engine: Arc::new(EngineAdapter(ergasia_session)),
-        queue: Arc::new(QueueAdapter(Arc::clone(&syntaxis_svc))),
+        queue: Arc::clone(&queue_adapter),
         requests: Arc::new(RequestAdapter(request_service)),
         external: external_adapter,
         subtitles,
@@ -1319,6 +1322,24 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         feeds: feeds_adapter,
     };
     let router = paroche::build_router(state);
+
+    // 13b. #609: spawn the MCP acquisition bridge over a Unix domain socket.
+    // WHY: `harmonia mcp` is a bare stdio process with no services; its 4
+    // acquisition tools reach the LIVE search/queue services (the same Arc
+    // clones AppState got) only through this socket. Bind is FATAL, mirroring
+    // the HTTP listener's startup posture below — the bridge is part of the
+    // configured surface; a bind failure must not leave the server half-alive
+    // (a mounted `harmonia mcp` would silently report "server not running").
+    let mcp_socket_path = archon::mcp_bridge::resolve_socket_path(&boot_config);
+    let mcp_bridge_handle = archon::mcp_bridge::spawn(
+        mcp_socket_path.clone(),
+        archon::mcp_bridge::BridgeContext::new(search_adapter, queue_adapter, db),
+        shutdown_token.child_token(),
+    )
+    .await
+    .context(McpBridgeBindSnafu {
+        path: mcp_socket_path,
+    })?;
 
     // 14. Bind + serve — the #529 step-5 supervisor rebinds the listener
     // live on a (paroche.listen_addr, paroche.port) change. The STARTUP bind
@@ -1343,8 +1364,16 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // 16. Cleanup  -  reverse startup ORDER
     info!("shutting down subsystems");
 
-    // Cancel all acquisition background tasks (syndesmos event handler, syntaxis listener)
+    // Cancel all acquisition background tasks (syndesmos event handler,
+    // syntaxis listener, #609 MCP bridge)
     shutdown_token.cancel();
+
+    // #609: the bridge accept loop observes the same shutdown token and
+    // unlinks its socket on exit; join it so the socket is gone before the
+    // process returns.
+    if let Err(e) = mcp_bridge_handle.await {
+        tracing::warn!(error = %e, "mcp acquisition bridge panicked during shutdown");
+    }
 
     // #529 step 8: the syndesmos supervisor now owns the event handler's
     // full lifecycle (its own cancel + await is internal to it); joining the

--- a/crates/archon/tests/mcp_acquisition_acceptance.rs
+++ b/crates/archon/tests/mcp_acquisition_acceptance.rs
@@ -1,0 +1,345 @@
+//! #609 acceptance: drive search -> enqueue -> observe completion ENTIRELY
+//! through the MCP acquisition surface — the real serve-hosted Unix-domain
+//! socket bridge over a real `syntaxis::DownloadQueue`, no HTTP router, no
+//! exousia auth, no startup banner.
+//!
+//! The "MCP surface" here is the bridge socket's newline-delimited JSON-RPC
+//! wire — exactly what `harmonia mcp`'s stdio process forwards. A raw
+//! `UnixStream` client speaking that wire is the honest end-to-end driver.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use apotheke::DbPools;
+use apotheke::migrate::MIGRATOR;
+use archon::mcp_bridge::{BridgeContext, spawn};
+use ergasia::{DownloadProgress, DownloadState, ErgasiaError, ExtractionResult};
+use paroche::state::{
+    DynQueueManager, DynSearchService, EnqueueItem, ResolvedRelease, ServiceError, ServiceFut,
+};
+use serde_json::{Value, json};
+use sqlx::SqlitePool;
+use syntaxis::{CompletedDownload, DownloadQueue, ImportService, QueueManager};
+use themelion::ids::DownloadId;
+use themelion::{HarmoniaEvent, create_event_bus};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+type TestError = Box<dyn std::error::Error + Send + Sync>; // kanon:ignore RUST/box-dyn-error -- integration test helper
+
+// ── A stub indexer that both searches and resolves a release by reference ──
+
+struct AcceptanceSearch {
+    magnet: String,
+    release_id: Uuid,
+}
+
+impl DynSearchService for AcceptanceSearch {
+    fn search(&self, _query: Value) -> ServiceFut<Value> {
+        let magnet = self.magnet.clone();
+        let release_id = self.release_id;
+        Box::pin(async move {
+            Ok(json!({
+                "results": [{
+                    "release_id": release_id.to_string(),
+                    "title": "Kind of Blue - FLAC",
+                    "download_url": magnet,
+                    "protocol": "torrent"
+                }]
+            }))
+        })
+    }
+    fn test_indexer(&self, _indexer_id: i64) -> ServiceFut<Value> {
+        Box::pin(async { Ok(json!({})) })
+    }
+    fn refresh_caps(&self, _indexer_id: i64) -> ServiceFut<Value> {
+        Box::pin(async { Ok(json!({})) })
+    }
+    fn cached_results(&self, _query_id: Uuid) -> ServiceFut<Value> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+    fn resolve_release(&self, release_id: Uuid) -> ServiceFut<ResolvedRelease> {
+        let magnet = self.magnet.clone();
+        let known = self.release_id;
+        Box::pin(async move {
+            if release_id == known {
+                Ok(ResolvedRelease {
+                    download_url: magnet,
+                    protocol: "torrent".to_string(),
+                    info_hash: None,
+                })
+            } else {
+                Err(ServiceError::NotFound)
+            }
+        })
+    }
+}
+
+// ── The live queue-manager adapter over a real DownloadQueue<MockEngine> ───
+
+struct QueueAdapter(Arc<DownloadQueue<MockEngine>>);
+
+impl DynQueueManager for QueueAdapter {
+    fn enqueue(&self, item: EnqueueItem) -> ServiceFut<()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            let protocol = syntaxis::DownloadProtocol::parse(&item.protocol)
+                .ok_or_else(|| ServiceError::InvalidInput("unsupported protocol".to_string()))?;
+            service
+                .enqueue(syntaxis::QueueItem {
+                    id: item.queue_id,
+                    want_id: themelion::WantId::from_uuid(item.want_id),
+                    release_id: themelion::ReleaseId::from_uuid(item.release_id),
+                    download_url: item.download_url,
+                    protocol,
+                    priority: item.priority,
+                    tracker_id: None,
+                    info_hash: item.info_hash,
+                    retry_count: 0,
+                })
+                .await
+                .map(|_| ())
+                .map_err(|e| ServiceError::Internal(e.to_string()))
+        })
+    }
+    fn cancel(&self, queue_id: Uuid) -> ServiceFut<()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .cancel_by_queue_id(queue_id)
+                .await
+                .map_err(|e| match e {
+                    syntaxis::SyntaxisError::ItemNotFound { .. } => ServiceError::NotFound,
+                    other => ServiceError::Internal(other.to_string()),
+                })
+        })
+    }
+    fn reprioritize(&self, queue_id: Uuid, priority: u8) -> ServiceFut<()> {
+        let service = Arc::clone(&self.0);
+        Box::pin(async move {
+            service
+                .reprioritize_by_queue_id(queue_id, priority)
+                .await
+                .map_err(|e| ServiceError::Internal(e.to_string()))
+        })
+    }
+}
+
+// ── A MockEngine that dispatches and reports its started ids ───────────────
+
+struct MockEngine {
+    started_tx: mpsc::UnboundedSender<DownloadId>,
+}
+
+impl ergasia::DownloadEngine for MockEngine {
+    async fn start_download(
+        &self,
+        request: ergasia::DownloadRequest,
+    ) -> Result<DownloadId, ErgasiaError> {
+        let _ = self.started_tx.send(request.download_id);
+        Ok(request.download_id)
+    }
+    async fn cancel_download(&self, _download_id: DownloadId) -> Result<(), ErgasiaError> {
+        Ok(())
+    }
+    async fn get_progress(
+        &self,
+        download_id: DownloadId,
+    ) -> Result<DownloadProgress, ErgasiaError> {
+        Ok(DownloadProgress {
+            download_id,
+            state: DownloadState::Downloading,
+            percent_complete: 100,
+            download_speed_bps: 0,
+            upload_speed_bps: 0,
+            peers_connected: 1,
+            seeders: 1,
+            eta_seconds: Some(0),
+            error: None,
+        })
+    }
+    async fn content_path(
+        &self,
+        _download_id: DownloadId,
+    ) -> Result<std::path::PathBuf, ErgasiaError> {
+        Ok(std::path::PathBuf::from("/data/downloads/kind-of-blue"))
+    }
+    async fn extract(
+        &self,
+        _download_path: &std::path::Path,
+        _output_dir: &std::path::Path,
+    ) -> Result<Option<ExtractionResult>, ErgasiaError> {
+        Ok(None)
+    }
+}
+
+struct MockImportService;
+
+impl ImportService for MockImportService {
+    fn import(
+        &self,
+        _completed: CompletedDownload,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+async fn test_db() -> Result<SqlitePool, TestError> {
+    let pool = SqlitePool::connect("sqlite::memory:").await?;
+    MIGRATOR.run(&pool).await?;
+    Ok(pool)
+}
+
+// ── MCP wire client ─────────────────────────────────────────────────────────
+
+/// Speaks the bridge's newline-delimited JSON-RPC over one reused socket
+/// connection — the same wire `harmonia mcp` forwards. Returns the tool
+/// `result` object.
+async fn call_tool(
+    reader: &mut BufReader<UnixStream>,
+    id: i64,
+    name: &str,
+    arguments: Value,
+) -> Result<Value, TestError> {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": { "name": name, "arguments": arguments }
+    });
+    let mut line = serde_json::to_string(&request)?;
+    line.push('\n');
+    reader.get_mut().write_all(line.as_bytes()).await?;
+    reader.get_mut().flush().await?;
+
+    let mut response_line = String::new();
+    reader.read_line(&mut response_line).await?;
+    let response: Value = serde_json::from_str(&response_line)?;
+    Ok(response["result"].clone())
+}
+
+#[tokio::test]
+async fn search_enqueue_and_observe_completion_over_the_mcp_surface() -> Result<(), TestError> {
+    let pool = test_db().await?;
+    let db = Arc::new(DbPools {
+        read: pool.clone(),
+        write: pool.clone(),
+    });
+    let (event_tx, _) = create_event_bus(64);
+
+    // Real syntaxis DownloadQueue + a MockEngine, listener wired to the bus.
+    let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+    let queue_svc = Arc::new(
+        DownloadQueue::new(
+            pool.clone(),
+            Arc::new(MockEngine { started_tx }),
+            Arc::new(MockImportService) as Arc<dyn ImportService>,
+            horismos::SyntaxisConfig {
+                max_concurrent_downloads: 5,
+                max_per_tracker: 3,
+                retry_count: 1,
+                retry_backoff_base_seconds: 0,
+                stalled_download_timeout_hours: 24,
+            },
+        )
+        .await?,
+    );
+    let queue_shutdown = CancellationToken::new();
+    let _listener = queue_svc.start(event_tx.subscribe(), queue_shutdown.clone());
+
+    let release_id = Uuid::now_v7();
+    let bridge_ctx = BridgeContext {
+        search: Arc::new(AcceptanceSearch {
+            magnet: "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd".to_string(),
+            release_id,
+        }),
+        queue: Arc::new(QueueAdapter(Arc::clone(&queue_svc))),
+        db,
+    };
+
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("harmonia-mcp.sock");
+    let bridge_shutdown = CancellationToken::new();
+    let bridge_handle = spawn(socket_path.clone(), bridge_ctx, bridge_shutdown.clone()).await?;
+
+    // Once the engine reports a dispatch, complete it on the event bus — a
+    // MockEngine that "completes" driving the row through the pipeline.
+    let completion_bus = event_tx.clone();
+    tokio::spawn(async move {
+        if let Some(download_id) = started_rx.recv().await {
+            let _ = completion_bus.send(HarmoniaEvent::DownloadCompleted {
+                download_id,
+                path: std::path::PathBuf::from("/data/downloads/kind-of-blue"),
+            });
+        }
+    });
+
+    let stream = UnixStream::connect(&socket_path).await?;
+    let mut reader = BufReader::new(stream);
+
+    // 1. SEARCH — a release_id comes back, no raw credential leaks.
+    let search_result = call_tool(
+        &mut reader,
+        1,
+        "harmonia_search_releases",
+        json!({ "query_text": "Kind of Blue", "media_type": "music" }),
+    )
+    .await?;
+    assert_eq!(search_result["isError"], false, "{search_result:?}");
+    let results = search_result["structuredContent"]["results"]
+        .as_array()
+        .expect("results array");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["release_id"], release_id.to_string());
+
+    // 2. ENQUEUE by release_id — the credentialed url is resolved + validated
+    //    server-side; the persisted row id comes back for observation.
+    let enqueue_result = call_tool(
+        &mut reader,
+        2,
+        "harmonia_enqueue_download",
+        json!({ "release_id": release_id.to_string(), "priority": 4 }),
+    )
+    .await?;
+    assert_eq!(enqueue_result["isError"], false, "{enqueue_result:?}");
+    let download_id = enqueue_result["structuredContent"]["id"]
+        .as_str()
+        .expect("enqueue returns the queue row id")
+        .to_string();
+
+    // 3. POLL LIST until the row settles as completed — the completion
+    //    observability surface, entirely over MCP.
+    let mut final_status = String::new();
+    for _ in 0..100 {
+        let list_result = call_tool(
+            &mut reader,
+            3,
+            "harmonia_list_downloads",
+            json!({ "id": download_id }),
+        )
+        .await?;
+        assert_eq!(list_result["isError"], false, "{list_result:?}");
+        let downloads = list_result["structuredContent"]["downloads"]
+            .as_array()
+            .expect("downloads array");
+        if let Some(row) = downloads.first() {
+            final_status = row["status"].as_str().unwrap_or("").to_string();
+            if final_status == "completed" {
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        final_status, "completed",
+        "the enqueued download must settle as completed, observed only through the MCP surface"
+    );
+
+    bridge_shutdown.cancel();
+    bridge_handle.await?;
+    queue_shutdown.cancel();
+    Ok(())
+}

--- a/crates/horismos/src/config.rs
+++ b/crates/horismos/src/config.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
-    KomideConfig, KritikeConfig, ParocheConfig, ProsthekeConfig, SearchSubsystemConfig,
+    KomideConfig, KritikeConfig, McpConfig, ParocheConfig, ProsthekeConfig, SearchSubsystemConfig,
     SyndesmosConfig, SyntaxisConfig, TaxisConfig,
 };
 
@@ -37,4 +37,6 @@ pub struct Config {
     pub syndesmos: SyndesmosConfig,
     #[serde(default)]
     pub aitesis: AitesisConfig,
+    #[serde(default)]
+    pub mcp: McpConfig,
 }

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -22,6 +22,11 @@ const RESTART_REQUIRED: &[&str] = &[
     "ergasia.session_state_path",
     "ergasia.listen_port_range",
     "ergasia.peer_connect_timeout_seconds",
+    // #609: the acquisition bridge binds its Unix-domain-socket once at
+    // `harmonia serve` startup and `harmonia mcp` resolves the path once at
+    // its own process start — neither side re-derives the socket path or
+    // timeout mid-run, so a live-rebind has no consumer.
+    "mcp.",
 ];
 
 fn requires_restart(path: &str) -> bool {

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -19,9 +19,9 @@ pub use handle::{
 use snafu::ResultExt;
 pub use subsystems::{
     AggeliaConfig, AitesisConfig, DatabaseConfig, EpignosisConfig, ErgasiaConfig, ExousiaConfig,
-    KomideConfig, KritikeConfig, LastfmConfig, LibraryConfig, MediaType, OpenSubtitlesConfig,
-    ParocheConfig, PlexConfig, ProsthekeConfig, SearchSubsystemConfig, SyndesmosConfig,
-    SyntaxisConfig, TaxisConfig, TidalConfig, WatcherMode,
+    KomideConfig, KritikeConfig, LastfmConfig, LibraryConfig, McpConfig, MediaType,
+    OpenSubtitlesConfig, ParocheConfig, PlexConfig, ProsthekeConfig, SearchSubsystemConfig,
+    SyndesmosConfig, SyntaxisConfig, TaxisConfig, TidalConfig, WatcherMode,
 };
 pub use validation::ValidationWarning;
 

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -637,3 +637,38 @@ impl Default for AitesisConfig {
         }
     }
 }
+
+// WHY: pure data — the `harmonia mcp` stdio surface and the `harmonia serve`
+// acquisition bridge derive the SAME socket path FROM this config
+// independently (#609): they are separate processes with no other shared
+// state, so agreement has to come from a deterministic function of config,
+// not coordination at runtime.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct McpConfig {
+    /// Unix-domain-socket path the acquisition bridge binds and the stdio
+    /// surface connects to. `None` derives a default: `harmonia-mcp.sock`
+    /// inside a dedicated `harmonia-mcp/` runtime subdirectory beside
+    /// `database.db_path` (never `db_path`'s own directory, which the
+    /// bridge does not own and must not chmod).
+    #[serde(default)]
+    pub socket_path: Option<PathBuf>,
+    /// Deadline (seconds) for one `tools/call` round trip over the bridge
+    /// socket. Should be at least `zetesis.search_timeout_seconds` — a
+    /// shorter MCP deadline would cut off a legitimate full indexer fan-out.
+    #[serde(default = "default_mcp_call_timeout_secs")]
+    pub call_timeout_secs: u64,
+}
+
+fn default_mcp_call_timeout_secs() -> u64 {
+    120
+}
+
+impl Default for McpConfig {
+    fn default() -> Self {
+        Self {
+            socket_path: None,
+            call_timeout_secs: default_mcp_call_timeout_secs(),
+        }
+    }
+}

--- a/crates/horismos/src/validation.rs
+++ b/crates/horismos/src/validation.rs
@@ -245,6 +245,22 @@ fn validate_timeouts(config: &Config) -> Result<(), HorismosError> {
         }
         .fail();
     }
+    if config.mcp.call_timeout_secs == 0 {
+        return ValidationSnafu {
+            message: "mcp.call_timeout_secs must be greater than 0".to_string(),
+        }
+        .fail();
+    }
+    if config.mcp.call_timeout_secs < config.zetesis.search_timeout_seconds {
+        return ValidationSnafu {
+            message: format!(
+                "mcp.call_timeout_secs ({}) must be at least zetesis.search_timeout_seconds ({}) \
+                 — a shorter MCP deadline would cut off a legitimate full indexer fan-out",
+                config.mcp.call_timeout_secs, config.zetesis.search_timeout_seconds
+            ),
+        }
+        .fail();
+    }
     let score = config.prostheke.min_match_score;
     if !(0.0..=1.0).contains(&score) {
         return ValidationSnafu {

--- a/crates/paroche/src/routes/download.rs
+++ b/crates/paroche/src/routes/download.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use exousia::{AuthenticatedUser, RequireAdmin};
 use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
 use tracing;
 use uuid::Uuid;
 
@@ -96,6 +97,50 @@ pub struct QueueSnapshotResponse {
     pub queued: Vec<DownloadResponse>,
     pub completed_count: i64,
     pub failed_count: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Shared row queries (#609: reused by the MCP acquisition bridge — a
+// single query path avoids `download_queue` SQL drifting between the HTTP
+// surface and the bridge).
+// ---------------------------------------------------------------------------
+
+/// Fetches one persisted download row by its `download_queue` id, redacted
+/// exactly like every other outbound download row.
+pub async fn fetch_download(
+    pool: &SqlitePool,
+    id: Uuid,
+) -> Result<Option<DownloadResponse>, sqlx::Error> {
+    let q = format!("{SELECT_DOWNLOAD} WHERE id = ?");
+    let row = sqlx::query_as::<_, DownloadRow>(&q)
+        .bind(id.as_bytes().as_slice())
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.map(Into::into))
+}
+
+/// Lists persisted download rows, optionally filtered by `status` and/or
+/// `id`, highest priority first. Backs the MCP `harmonia_list_downloads`
+/// tool's flat filtered view (the HTTP `GET /api/v1/downloads` snapshot
+/// keeps its own active/queued split — a different shape, not a filter).
+pub async fn list_downloads(
+    pool: &SqlitePool,
+    status: Option<&str>,
+    id: Option<Uuid>,
+    limit: u32,
+) -> Result<Vec<DownloadResponse>, sqlx::Error> {
+    let id_bytes = id.map(|u| u.as_bytes().to_vec());
+    let q = format!(
+        "{SELECT_DOWNLOAD} WHERE (?1 IS NULL OR status = ?1) AND (?2 IS NULL OR id = ?2) \
+         ORDER BY priority DESC, added_at DESC LIMIT ?3"
+    );
+    let rows = sqlx::query_as::<_, DownloadRow>(&q)
+        .bind(status)
+        .bind(id_bytes)
+        .bind(i64::from(limit))
+        .fetch_all(pool)
+        .await?;
+    Ok(rows.into_iter().map(Into::into).collect())
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -197,6 +197,19 @@ post-subscription events).
 |---|---|
 | `db_path` / `read_pool_size` / `write_pool_max` | sqlx pool sizing is fixed at connect (no resize API); every service holds a frozen `SqlitePool` clone |
 
+### mcp — RESTART (both fields, #609)
+
+| Field | Why |
+|---|---|
+| `socket_path` | the acquisition bridge binds this Unix domain socket once at `harmonia serve` startup and `harmonia mcp` resolves it once at its own process start — a live-rebind has no consumer (both sides would have to re-derive the path together) |
+| `call_timeout_secs` | the stdio `harmonia mcp` process reads it once at start to size its per-call deadline; `harmonia serve` never reads it |
+
+The socket path defaults to a sibling of `database.db_path` named
+`harmonia-mcp.sock` — the SAME derivation both processes run independently, so
+they agree without operator wiring. Validation rejects a `call_timeout_secs`
+below `zetesis.search_timeout_seconds` (a shorter MCP deadline would cut off a
+legitimate full indexer fan-out).
+
 ---
 
 ## Special semantics


### PR DESCRIPTION
**Closes #609.** An agent can now drive acquisition natively — search → enqueue → observe → cancel — over the `harmonia mcp` surface, no hand-rolled HTTP loop or banner-scraped credentials.

`harmonia serve` hosts a Unix-domain-socket listener holding the live search/queue services; `harmonia mcp` forwards 4 acquisition tools over it (the 4 offline maintenance tools keep running in-process). Both processes derive the same socket path deterministically from `database.db_path`. Redaction stays ON for all tool output (LLM transcripts leave the box); `enqueue_download` takes a `release_id` (resolved via #608) or a magnet (http rejected), SSRF-guarded on both arms.

Hardened per a 3-lens adversarial review (4 findings, all fixed): the wire read is capped (no unbounded-line OOM); the socket lives in a dedicated `harmonia-mcp/` 0700 subdir at 0600 (no chmod of a shared parent, and the pre-chmod perms window is closed); a second instance is refused via a liveness check rather than clobbering a live socket; and shutdown drains in-flight tool calls (TaskTracker + grace) instead of dropping them. Gate green (full workspace, incl. the MCP-only acceptance test driving search→enqueue→observe over the bridge).