### PR TITLE
feat(zetesis): Cardigann POST search paths

### DIFF
--- a/crates/zetesis/src/client/cardigann/definition.rs
+++ b/crates/zetesis/src/client/cardigann/definition.rs
@@ -472,9 +472,16 @@ fn validate(def: &CardigannDefinition) -> Result<(), SearchIndexerError> {
     };
 
     for path in &def.search.paths {
-        match path.method.as_deref() {
-            None | Some("get") => {}
+        let is_post = match path.method.as_deref() {
+            None | Some("get") => false,
+            Some("post") => true,
             Some(other) => return Err(unsupported(format!("search path method {other:?}"))),
+        };
+        if is_post && (def.search.inputs.contains_key("$raw") || path.inputs.contains_key("$raw")) {
+            // WHY: $raw splices verbatim into a query string; a POST search
+            // sends its inputs as a form body, where that splice has no
+            // meaning. Reject rather than silently drop it (fail-loud).
+            return Err(unsupported("$raw input with POST search".to_string()));
         }
         if let Some(response) = &path.response
             && response.response_type.as_deref() != Some("html")

--- a/crates/zetesis/src/client/cardigann/definition/tests.rs
+++ b/crates/zetesis/src/client/cardigann/definition/tests.rs
@@ -260,17 +260,30 @@ fn unsupported_filter_rejected_at_load() {
 }
 
 #[test]
-fn post_search_path_rejected_at_load() {
+fn post_search_path_accepted_at_load() {
     let yaml = minimal_with(
         r#"  paths:
     - path: /a
       method: post"#,
+    );
+    parse_definition(&yaml, "test").expect("POST search paths are supported");
+}
+
+#[test]
+fn raw_input_with_post_search_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a
+      method: post
+  inputs:
+    $raw: "q={{ .Keywords }}""#,
     );
     let err = parse_definition(&yaml, "test").unwrap_err();
     assert!(
         matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
         "got {err:?}"
     );
+    assert!(err.to_string().contains("$raw"), "got {err}");
 }
 
 #[test]

--- a/crates/zetesis/src/client/cardigann/mod.rs
+++ b/crates/zetesis/src/client/cardigann/mod.rs
@@ -230,6 +230,22 @@ impl CardigannClient {
                 location: snafu::Location::new(file!(), line!(), column!()),
             });
         }
+        if indexer.cf_bypass
+            && definition
+                .search
+                .paths
+                .iter()
+                .any(|path| path.method.as_deref() == Some("post"))
+        {
+            // WHY: the bypass proxy is GET-only, so a POST search body cannot
+            // be delivered through it — fail loudly rather than silently
+            // issuing a bodyless GET.
+            return Err(SearchIndexerError::DefinitionUnsupported {
+                definition_id: definition.id.clone(),
+                feature: "cf_bypass combined with POST search".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
         let login_url = if matches!(login, LoginMethod::Interactive { .. }) {
             Some(resolve_login_url(&indexer, &definition, &base_url)?)
         } else {
@@ -327,11 +343,14 @@ impl CardigannClient {
         })
     }
 
-    fn build_search_url(
+    /// Builds the search request for a path: the target URL and, for a POST
+    /// path, the `application/x-www-form-urlencoded` body. GET paths fold their
+    /// inputs into the query string and carry no body.
+    fn build_search_request(
         &self,
         path: &SearchPath,
         ctx: &TemplateContext,
-    ) -> Result<Url, SearchIndexerError> {
+    ) -> Result<(Url, Option<String>), SearchIndexerError> {
         let rendered = ctx
             .render_url(&path.path)
             .map_err(|e| self.invalid(format!("search path: {e}")))?;
@@ -355,6 +374,8 @@ impl CardigannClient {
             inputs.insert(key, &value.0);
         }
 
+        let is_post = path.method.as_deref() == Some("post");
+
         let mut raw_parts: Vec<String> = Vec::new();
         let mut pairs: Vec<(&str, String)> = Vec::new();
         for (key, value) in inputs {
@@ -365,19 +386,32 @@ impl CardigannClient {
                 // via render_url — a keyword like "a&b=c" must not inject an
                 // extra parameter. Only the .Keywords/.Query.* expansions
                 // encode; the definition-author's literal $raw "&"/"=" survive.
+                // $raw is rejected at load for POST paths, so this is GET-only.
                 let rendered = ctx
                     .render_url(value)
                     .map_err(|e| self.invalid(format!("search input {key}: {e}")))?;
                 raw_parts.push(rendered);
             } else {
-                // WHY: non-$raw values pass through append_pair below, which
-                // percent-encodes the whole value — render unencoded here.
+                // WHY: non-$raw values pass through append_pair / form encoding
+                // below, both of which percent-encode the whole value — render
+                // unencoded here.
                 let rendered = ctx
                     .render(value)
                     .map_err(|e| self.invalid(format!("search input {key}: {e}")))?;
                 pairs.push((key, rendered));
             }
         }
+
+        if is_post {
+            // WHY: a POST search delivers its inputs as a form body (mirroring
+            // the login POST), leaving the endpoint URL query-free. raw_parts
+            // is empty here — $raw with POST is rejected at load.
+            let body = url::form_urlencoded::Serializer::new(String::new())
+                .extend_pairs(pairs.iter().map(|(k, v)| (*k, v.as_str())))
+                .finish();
+            return Ok((url, Some(body)));
+        }
+
         // WHY: query_pairs_mut leaves a spurious bare "?" behind even when
         // nothing is appended — only touch the query when pairs exist.
         if !pairs.is_empty() {
@@ -395,7 +429,7 @@ impl CardigannClient {
             };
             url.set_query(Some(&combined));
         }
-        Ok(url)
+        Ok((url, None))
     }
 
     /// Fires one request with the current cookie (static or session),
@@ -403,9 +437,10 @@ impl CardigannClient {
     async fn send_once(
         &self,
         url: &str,
+        body: Option<&str>,
         ct: &CancellationToken,
     ) -> Result<reqwest::Response, SearchIndexerError> {
-        self.send_once_with_cookie(url, self.request_cookie_header(), ct)
+        self.send_once_with_cookie(url, body, self.request_cookie_header(), ct)
             .await
     }
 
@@ -416,10 +451,24 @@ impl CardigannClient {
     async fn send_once_with_cookie(
         &self,
         url: &str,
+        body: Option<&str>,
         cookie: Option<String>,
         ct: &CancellationToken,
     ) -> Result<reqwest::Response, SearchIndexerError> {
-        let mut request = self.http_client.get(url).timeout(self.timeout);
+        // WHY: a form body switches the verb to POST (application/
+        // x-www-form-urlencoded), mirroring the login submit; None stays GET.
+        let mut request = match body {
+            Some(form) => self
+                .http_client
+                .post(url)
+                .header(
+                    reqwest::header::CONTENT_TYPE,
+                    "application/x-www-form-urlencoded",
+                )
+                .body(form.to_owned())
+                .timeout(self.timeout),
+            None => self.http_client.get(url).timeout(self.timeout),
+        };
         if let Some(cookie) = cookie {
             request = request.header(reqwest::header::COOKIE, cookie);
         }
@@ -472,9 +521,10 @@ impl CardigannClient {
     async fn send(
         &self,
         url: &str,
+        body: Option<&str>,
         ct: CancellationToken,
     ) -> Result<reqwest::Response, SearchIndexerError> {
-        let response = self.send_once(url, &ct).await?;
+        let response = self.send_once(url, body, &ct).await?;
         if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
             return Err(self.rate_limited(&response));
         }
@@ -489,7 +539,9 @@ impl CardigannClient {
                 // login's store() and a fresh read, which would send the
                 // retry cookieless and fail a healthy indexer.
                 let established = self.login(*verb, ct.clone()).await?;
-                let retry = self.send_once_with_cookie(url, established, &ct).await?;
+                let retry = self
+                    .send_once_with_cookie(url, body, established, &ct)
+                    .await?;
                 if retry.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
                     return Err(self.rate_limited(&retry));
                 }
@@ -512,13 +564,19 @@ impl CardigannClient {
     async fn fetch_text(
         &self,
         url: &str,
+        body: Option<&str>,
         ct: CancellationToken,
     ) -> Result<String, SearchIndexerError> {
         if self.indexer.cf_bypass {
+            if body.is_some() {
+                // WHY: defensive — POST + cf_bypass is rejected at construction;
+                // the bypass proxy is GET-only and cannot carry a form body.
+                return Err(self.invalid("POST search is unsupported with cf_bypass".to_string()));
+            }
             let response = self.cf_proxy.get(url, ct).await?;
             return Ok(response.body);
         }
-        let response = self.send(url, ct).await?;
+        let response = self.send(url, body, ct).await?;
         read_body_bounded(response, url, self.config.max_response_body_bytes).await
     }
 
@@ -531,7 +589,7 @@ impl CardigannClient {
             let response = self.cf_proxy.get(url, ct).await?;
             return Ok(Bytes::from(response.body));
         }
-        let response = self.send(url, ct).await?;
+        let response = self.send(url, None, ct).await?;
         read_body_bytes_bounded(response, url, self.config.max_response_body_bytes)
             .await
             .map(Bytes::from)
@@ -674,9 +732,11 @@ impl IndexerClient for CardigannClient {
             if !path_applies(path, &site_categories, unconstrained) {
                 continue;
             }
-            let url = self.build_search_url(path, &ctx)?;
-            let body = self.fetch_text(url.as_str(), ct.clone()).await?;
-            let rows = extract::extract_rows(&body, &self.definition, &ctx, &now).map_err(|e| {
+            let (url, form_body) = self.build_search_request(path, &ctx)?;
+            let text = self
+                .fetch_text(url.as_str(), form_body.as_deref(), ct.clone())
+                .await?;
+            let rows = extract::extract_rows(&text, &self.definition, &ctx, &now).map_err(|e| {
                 SearchIndexerError::ParseResponse {
                     url: redact_api_key(url.as_str()),
                     error: e,
@@ -728,7 +788,7 @@ impl IndexerClient for CardigannClient {
             // NOT a healthy session); otherwise it stays a reachability probe.
             match &test_selector {
                 Some(selector) => {
-                    let response = self.send(url.as_str(), ct).await?;
+                    let response = self.send(url.as_str(), None, ct).await?;
                     let body = read_body_bounded(
                         response,
                         url.as_str(),
@@ -746,7 +806,7 @@ impl IndexerClient for CardigannClient {
                     }
                 }
                 None => {
-                    let response = self.send(url.as_str(), ct).await?;
+                    let response = self.send(url.as_str(), None, ct).await?;
                     response
                         .error_for_status()
                         .map(|_| ())
@@ -792,7 +852,7 @@ impl IndexerClient for CardigannClient {
 
         let final_url = match &self.definition.download {
             Some(block) if block.selector.is_some() => {
-                let page = self.fetch_text(url, ct.clone()).await?;
+                let page = self.fetch_text(url, None, ct.clone()).await?;
                 let link = extract::extract_download_link(
                     &page,
                     block.selector.as_deref().unwrap_or_default(),

--- a/crates/zetesis/src/client/cardigann/tests.rs
+++ b/crates/zetesis/src/client/cardigann/tests.rs
@@ -215,6 +215,80 @@ async fn search_extracts_rows_fields_and_maps_categories() {
     assert!(request_line.contains("sort=created"), "got: {request_line}");
 }
 
+// ── POST search ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn post_search_sends_form_body_and_parses_rows() {
+    // WHY: a `method: post` search path sends its inputs as an
+    // application/x-www-form-urlencoded body; the endpoint URL carries no
+    // input query. spawn_sequence_http captures the request body (spawn_raw
+    // stops at the header terminator).
+    let (url, server) = spawn_sequence_http(vec![(200, vec![], SAMPLE_HTML.to_string())]).await;
+    let post_def = SAMPLE_DEF.replace(
+        "    - path: /browse\n",
+        "    - path: /browse\n      method: post\n",
+    );
+    let results = client(&post_def, url.clone(), None)
+        .unwrap()
+        .search(&movie_query(), CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+
+    let heads = server.await.unwrap();
+    let request = &heads[0];
+    let request_line = request.lines().next().unwrap_or_default();
+    assert!(
+        request_line.starts_with("POST /browse "),
+        "got: {request_line}"
+    );
+    assert!(
+        !request_line.contains('?'),
+        "POST endpoint must carry no input query: {request_line}"
+    );
+    assert!(
+        request
+            .to_lowercase()
+            .contains("content-type: application/x-www-form-urlencoded"),
+        "missing form content-type: {request}"
+    );
+    let body = request.split("\r\n\r\n").nth(1).unwrap_or_default();
+    assert!(body.contains("q=test.query"), "form body: {body}");
+    assert!(body.contains("cats=6%2C7"), "form body: {body}");
+    assert!(body.contains("sort=created"), "form body: {body}");
+}
+
+#[test]
+fn cf_bypass_with_post_search_unsupported_at_construction() {
+    // WHY: the bypass proxy is GET-only; a POST search body cannot be
+    // delivered through it, so construction must fail loudly.
+    let post_def = SAMPLE_DEF.replace(
+        "    - path: /browse\n",
+        "    - path: /browse\n      method: post\n",
+    );
+    let err = CardigannClient::new(
+        Arc::new(SearchSubsystemConfig::default()),
+        reqwest::Client::new(),
+        Arc::new(NoProxy),
+        Duration::from_secs(5),
+        IndexerConfig {
+            id: 1,
+            name: "Test".to_string(),
+            url: "https://sample-tracker.example/".to_string(),
+            api_key: None,
+            cf_bypass: true,
+            settings: BTreeMap::new(),
+        },
+        definition(&post_def),
+        Arc::new(SessionStore::new()),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionUnsupported { ref feature, .. } if feature.contains("POST")),
+        "got {err:?}"
+    );
+}
+
 // ── settings overrides ──────────────────────────────────────────────────
 
 #[tokio::test]

--- a/docs/download/indexer-protocol.md
+++ b/docs/download/indexer-protocol.md
@@ -408,7 +408,7 @@ Indexer rows select the client with `protocol = 'cardigann'`; the row's `url` co
 | `id`, `name`, `description`, `links` | Yes | Identity fields; templated links rejected |
 | `caps.categorymappings` (+ legacy `caps.categories`) | Yes | Category ID mapping via the standard Torznab table |
 | `caps.modes` | Yes | Supported search functions |
-| `search.paths` (+ legacy `search.path`) | GET only | POST paths and JSON responses rejected at load |
+| `search.paths` (+ legacy `search.path`) | GET + POST | POST sends inputs as an `application/x-www-form-urlencoded` body (`$raw` + POST rejected at load; POST + `cf_bypass` rejected at construction). JSON/XML responses rejected at load |
 | `search.inputs` / `keywordsfilters` | Yes | Template subset: `.Keywords`, `.Categories`, `.Config.<key>`, `.Query.<field>`, `join`; `$raw` input supported. `if`/`range` rejected at load |
 | `search.rows` | `selector` + `remove` | `filters` (andmatch), `after`, `dateheaders` warned and ignored |
 | `search.fields` | Yes | `selector`, `attribute`, `text`, `optional`, `case`, `remove`, filters |


### PR DESCRIPTION
Part of #513 (Cardigann coverage extension — first of the wave; JSON/XML responses + filter tail follow as separate PRs, so #513 stays open).

Cardigann search paths with `method: post` now send their inputs as an `application/x-www-form-urlencoded` body (mirroring the proven login POST at session.rs); GET paths are unchanged. An optional request body threads through the whole send chain (`fetch_text` → `send` → `send_once_with_cookie`), and the auth-loss re-login retry re-POSTs the same body.

Two fail-loud guards preserve the deferred-features-rejected invariant:
- `$raw` input + POST → rejected at load (`$raw` is a query-string splice; a form body has no splice semantics).
- POST + `cf_bypass` → rejected at construction (the bypass proxy is GET-only and cannot carry a body).

Docs: the `indexer-protocol.md` support table now records GET + POST.

Tests: POST integration (form body asserted via the body-capturing mock server; endpoint carries no input query), POST accepted at load, `$raw`+POST rejected, cf_bypass+POST rejected. Full `kanon gate --full` green (2238 tests, cargo deny/clippy/lint all pass).