### PR TITLE
feat(zetesis): Cardigann JSON search responses (flat arrays)

### DIFF
--- a/crates/zetesis/src/client/cardigann/definition.rs
+++ b/crates/zetesis/src/client/cardigann/definition.rs
@@ -176,6 +176,13 @@ pub struct RowsBlock {
     pub remove: Option<String>,
     #[serde(default)]
     pub dateheaders: Option<FieldBlock>,
+    /// JSON nested-row drill-down (a path into each row). Detected and rejected
+    /// at load — nested JSON rows are deferred.
+    #[serde(default)]
+    pub attribute: Option<ScalarString>,
+    /// JSON nested-row expansion flag. Detected and rejected at load.
+    #[serde(default)]
+    pub multiple: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -470,6 +477,47 @@ fn validate(def: &CardigannDefinition) -> Result<(), SearchIndexerError> {
     let check_filters = |what: &str, specs: &[FilterSpec]| {
         filters::validate(specs).map_err(|e| invalid(format!("{what}: {e}")))
     };
+    let check_json_selector = |what: &str, sel: &str| -> Result<(), SearchIndexerError> {
+        let trimmed = sel.trim();
+        // WHY: strip an optional `$` root exactly as parse_path_segments does
+        // before the leading-`..` check, so `$..name` (JSONPath recursive
+        // descent / the parent-switch idiom) cannot evade the reject and then
+        // silently resolve against the wrong object.
+        let after_root = trimmed.strip_prefix('$').unwrap_or(trimmed);
+        if after_root.starts_with("..") {
+            return Err(unsupported(format!(
+                "{what}: leading '..' parent selectors are not yet supported for json responses"
+            )));
+        }
+        if trimmed.contains(':') {
+            return Err(unsupported(format!(
+                "{what}: ':' pseudo-filter selectors are not yet supported for json responses"
+            )));
+        }
+        crate::client::cardigann::json_extract::parse_path_segments(trimmed)
+            .map(|_| ())
+            .map_err(|e| invalid(format!("{what} selector {sel:?}: {e}")))
+    };
+
+    // WHY: response type is declared per path, but rows/fields are shared, so a
+    // definition is coherently single-type. All paths must agree; xml and other
+    // types are deferred.
+    fn path_kind(path: &SearchPath) -> Option<&str> {
+        path.response
+            .as_ref()
+            .and_then(|r| r.response_type.as_deref())
+    }
+    let first_kind = def.search.paths.first().and_then(path_kind);
+    if def.search.paths.iter().any(|p| path_kind(p) != first_kind) {
+        return Err(unsupported(
+            "mixed response types across search paths".to_string(),
+        ));
+    }
+    let is_json = match first_kind {
+        None | Some("html") => false,
+        Some("json") => true,
+        Some(other) => return Err(unsupported(format!("search response type {other:?}"))),
+    };
 
     for path in &def.search.paths {
         let is_post = match path.method.as_deref() {
@@ -483,14 +531,6 @@ fn validate(def: &CardigannDefinition) -> Result<(), SearchIndexerError> {
             // meaning. Reject rather than silently drop it (fail-loud).
             return Err(unsupported("$raw input with POST search".to_string()));
         }
-        if let Some(response) = &path.response
-            && response.response_type.as_deref() != Some("html")
-        {
-            return Err(unsupported(format!(
-                "search response type {:?}",
-                response.response_type
-            )));
-        }
         check_template("search path", &path.path)?;
         for (key, value) in &path.inputs {
             check_template(&format!("search path input {key}"), &value.0)?;
@@ -501,7 +541,25 @@ fn validate(def: &CardigannDefinition) -> Result<(), SearchIndexerError> {
     }
     check_filters("keywordsfilters", &def.search.keywordsfilters)?;
 
-    check_selector("rows", &def.search.rows.selector)?;
+    if is_json {
+        if def.search.rows.attribute.is_some() || def.search.rows.multiple.is_some() {
+            return Err(unsupported(
+                "rows.attribute / rows.multiple (nested json rows) are not yet supported"
+                    .to_string(),
+            ));
+        }
+        if def.search.rows.remove.is_some() {
+            return Err(unsupported(
+                "rows.remove is not supported for json responses".to_string(),
+            ));
+        }
+        check_json_selector("rows", &def.search.rows.selector)?;
+    } else {
+        check_selector("rows", &def.search.rows.selector)?;
+        if let Some(remove) = &def.search.rows.remove {
+            check_selector("rows.remove", remove)?;
+        }
+    }
     if !def.search.rows.filters.is_empty() {
         warn!(
             definition_id = %def.id,
@@ -513,9 +571,6 @@ fn validate(def: &CardigannDefinition) -> Result<(), SearchIndexerError> {
             definition_id = %def.id,
             "rows.after / rows.dateheaders are not supported and are ignored"
         );
-    }
-    if let Some(remove) = &def.search.rows.remove {
-        check_selector("rows.remove", remove)?;
     }
 
     if def.search.fields.is_empty() {
@@ -536,14 +591,35 @@ fn validate(def: &CardigannDefinition) -> Result<(), SearchIndexerError> {
     }
     for (name, field) in &def.search.fields {
         if let Some(sel) = &field.selector {
-            check_selector(&format!("field {name}"), sel)?;
+            if is_json {
+                check_json_selector(&format!("field {name}"), sel)?;
+            } else {
+                check_selector(&format!("field {name}"), sel)?;
+            }
         }
-        if let Some(remove) = &field.remove {
-            check_selector(&format!("field {name} remove"), remove)?;
-        }
-        if let Some(case) = &field.case {
-            for (case_selector, _) in &case.0 {
-                check_selector(&format!("field {name} case"), case_selector)?;
+        if is_json {
+            // WHY: attribute (HTML attr read) and remove (HTML subtree exclude)
+            // have no JSON meaning; silent-ignore would mask a definition
+            // mistake, so reject. JSON `case` keys are literal values, not CSS
+            // selectors, so they are not selector-validated.
+            if field.attribute.is_some() {
+                return Err(unsupported(format!(
+                    "field {name}: attribute is not supported for json responses"
+                )));
+            }
+            if field.remove.is_some() {
+                return Err(unsupported(format!(
+                    "field {name}: remove is not supported for json responses"
+                )));
+            }
+        } else {
+            if let Some(remove) = &field.remove {
+                check_selector(&format!("field {name} remove"), remove)?;
+            }
+            if let Some(case) = &field.case {
+                for (case_selector, _) in &case.0 {
+                    check_selector(&format!("field {name} case"), case_selector)?;
+                }
             }
         }
         if let Some(text) = &field.text {

--- a/crates/zetesis/src/client/cardigann/definition/tests.rs
+++ b/crates/zetesis/src/client/cardigann/definition/tests.rs
@@ -287,7 +287,48 @@ fn raw_input_with_post_search_rejected_at_load() {
 }
 
 #[test]
-fn json_response_rejected_at_load() {
+fn xml_response_rejected_at_load() {
+    let yaml = minimal_with(
+        r#"  paths:
+    - path: /a
+      response:
+        type: xml"#,
+    );
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
+        "got {err:?}"
+    );
+}
+
+const FLAT_JSON_DEF: &str = r#"
+id: j
+name: J
+links: ["https://j.example/"]
+caps:
+  categorymappings: [{id: 1, cat: Movies}]
+  modes: {search: [q]}
+search:
+  paths:
+    - path: /api
+      response:
+        type: json
+  rows:
+    selector: data.results
+  fields:
+    title: {selector: name}
+    download: {selector: download_url}
+"#;
+
+#[test]
+fn json_flat_response_accepted_at_load() {
+    parse_definition(FLAT_JSON_DEF, "test").expect("flat json definition is supported");
+}
+
+#[test]
+fn json_field_attribute_rejected_at_load() {
+    // WHY: minimal fixture's `download` field sets `attribute: href`, which has
+    // no JSON meaning; it must be rejected, not silently ignored.
     let yaml = minimal_with(
         r#"  paths:
     - path: /a
@@ -299,6 +340,53 @@ fn json_response_rejected_at_load() {
         matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
         "got {err:?}"
     );
+    assert!(err.to_string().contains("attribute"), "got {err}");
+}
+
+#[test]
+fn json_nested_rows_rejected_at_load() {
+    let yaml = FLAT_JSON_DEF.replace(
+        "    selector: data.results\n",
+        "    selector: data.movies\n    attribute: torrents\n    multiple: true\n",
+    );
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
+        "got {err:?}"
+    );
+    assert!(err.to_string().contains("nested json rows"), "got {err}");
+}
+
+#[test]
+fn json_pseudo_filter_selector_rejected_at_load() {
+    let yaml = FLAT_JSON_DEF.replace(
+        "    title: {selector: name}",
+        r#"    title: {selector: "name:contains(x)"}"#,
+    );
+    let err = parse_definition(&yaml, "test").unwrap_err();
+    assert!(
+        matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
+        "got {err:?}"
+    );
+    assert!(err.to_string().contains("pseudo-filter"), "got {err}");
+}
+
+#[test]
+fn json_leading_parent_selector_rejected_at_load() {
+    // WHY: both the bare `..name` and the `$..name` JSONPath recursive-descent
+    // form must be rejected — the parser strips a leading `$` before collapsing
+    // dots, so an unstripped `starts_with("..")` check alone would miss `$..`.
+    for sel in ["..name", "$..name"] {
+        let yaml = FLAT_JSON_DEF.replace(
+            "    title: {selector: name}",
+            &format!("    title: {{selector: \"{sel}\"}}"),
+        );
+        let err = parse_definition(&yaml, "test").unwrap_err();
+        assert!(
+            matches!(err, SearchIndexerError::DefinitionUnsupported { .. }),
+            "selector {sel:?} should be rejected, got {err:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/zetesis/src/client/cardigann/extract.rs
+++ b/crates/zetesis/src/client/cardigann/extract.rs
@@ -217,25 +217,34 @@ fn parse_selector(selector: &str) -> Result<Selector, String> {
 /// is what Cardigann-compatible indexers conventionally emit.
 pub fn parse_size(value: &str) -> Option<u64> {
     let cleaned = value.trim().replace(',', "");
-    let unit_start = cleaned.find(|c: char| c.is_ascii_alphabetic())?;
-    let number: f64 = cleaned.get(..unit_start)?.trim().parse().ok()?;
+    // WHY: a unitless numeric size is a raw byte count (the JSON-API
+    // convention) — upstream `ParseUtil.GetBytes` falls through to the value
+    // itself when no unit matches. A human-formatted size carries a unit.
+    let (number_str, exponent): (&str, i32) = match cleaned.find(|c: char| c.is_ascii_alphabetic())
+    {
+        Some(unit_start) => {
+            let exponent = match cleaned
+                .get(unit_start..)?
+                .trim()
+                .to_ascii_uppercase()
+                .as_str()
+            {
+                "B" => 0,
+                "K" | "KB" | "KIB" => 1,
+                "M" | "MB" | "MIB" => 2,
+                "G" | "GB" | "GIB" => 3,
+                "T" | "TB" | "TIB" => 4,
+                "P" | "PB" | "PIB" => 5,
+                _ => return None,
+            };
+            (cleaned.get(..unit_start)?, exponent)
+        }
+        None => (cleaned.as_str(), 0),
+    };
+    let number: f64 = number_str.trim().parse().ok()?;
     if !number.is_finite() || number < 0.0 {
         return None;
     }
-    let exponent: i32 = match cleaned
-        .get(unit_start..)?
-        .trim()
-        .to_ascii_uppercase()
-        .as_str()
-    {
-        "B" => 0,
-        "K" | "KB" | "KIB" => 1,
-        "M" | "MB" | "MIB" => 2,
-        "G" | "GB" | "GIB" => 3,
-        "T" | "TB" | "TIB" => 4,
-        "P" | "PB" | "PIB" => 5,
-        _ => return None,
-    };
     let bytes = number * 1024_f64.powi(exponent);
     // NOTE: 2^63 bounds the round-trip: every finite f64 below it fits u64.
     if bytes >= 9_223_372_036_854_775_808.0 {
@@ -411,6 +420,14 @@ search:
         assert_eq!(parse_size("12 XB"), None);
         assert_eq!(parse_size("-3 GB"), None);
         assert_eq!(parse_size(""), None);
+    }
+
+    #[test]
+    fn parse_size_unitless_is_raw_bytes() {
+        // WHY: JSON APIs report size as a raw byte count with no unit.
+        assert_eq!(parse_size("734003216"), Some(734_003_216));
+        assert_eq!(parse_size("0"), Some(0));
+        assert_eq!(parse_size("1,610,612,736"), Some(1_610_612_736));
     }
 
     #[test]

--- a/crates/zetesis/src/client/cardigann/json_extract.rs
+++ b/crates/zetesis/src/client/cardigann/json_extract.rs
@@ -1,0 +1,396 @@
+//! JSON row/field extraction for Cardigann definitions (`response.type: json`).
+//!
+//! Mirrors the HTML extractor's shape (rows -> per-field values -> filters) but
+//! selects against a parsed `serde_json::Value` using the dotted/bracket path
+//! grammar Jackett/Prowlarr hand to Newtonsoft `SelectToken`. This module covers
+//! the FLAT-array shape: `rows.selector` resolves directly to the row array, and
+//! each field selector is a path relative to a row object.
+//!
+//! Rejected at load (see `definition::validate`) and tracked in #513: nested
+//! rows (`rows.attribute` / `rows.multiple` + the leading-`..` parent switch)
+//! and the `:has()/:not()/:contains()` pseudo-filter suffix.
+
+use std::collections::BTreeMap;
+
+use jiff::Zoned;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::client::cardigann::definition::{CardigannDefinition, FieldBlock, OrderedPairs};
+use crate::client::cardigann::{filters, template::TemplateContext};
+
+/// Extracted field values for the rows in one JSON search-results body, in
+/// definition field order per row.
+pub fn extract_rows_json(
+    body: &str,
+    def: &CardigannDefinition,
+    ctx: &TemplateContext,
+    now: &Zoned,
+) -> Result<Vec<BTreeMap<String, String>>, String> {
+    let root: Value = serde_json::from_str(body).map_err(|e| format!("invalid JSON body: {e}"))?;
+    let rows_value = select_path(&root, &def.search.rows.selector)?.ok_or_else(|| {
+        format!(
+            "rows selector {:?} matched nothing",
+            def.search.rows.selector
+        )
+    })?;
+    let Value::Array(rows) = rows_value else {
+        // WHY: parity with upstream — a rows selector that resolves to a
+        // non-array is a definition/response mismatch, surfaced as an error
+        // rather than silently yielding zero rows.
+        return Err(format!(
+            "rows selector {:?} did not resolve to a JSON array",
+            def.search.rows.selector
+        ));
+    };
+
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let mut values = BTreeMap::new();
+        for (name, field) in &def.search.fields {
+            match extract_field_json(row, field, ctx, now) {
+                Ok(Some(value)) => {
+                    values.insert(name.clone(), value);
+                }
+                Ok(None) => {}
+                Err(reason) => {
+                    // WHY: one broken field must not fail the whole page; the
+                    // row-level required checks (title, download) decide whether
+                    // the row survives.
+                    debug!(
+                        definition_id = %def.id,
+                        field = %name,
+                        reason = %reason,
+                        "json field extraction failed; treating as absent"
+                    );
+                }
+            }
+        }
+        out.push(values);
+    }
+    Ok(out)
+}
+
+fn extract_field_json(
+    row: &Value,
+    field: &FieldBlock,
+    ctx: &TemplateContext,
+    now: &Zoned,
+) -> Result<Option<String>, String> {
+    // WHY: `text` short-circuits selection entirely (incl. `case`), matching
+    // upstream `handleJsonSelector`.
+    if let Some(text) = &field.text {
+        let rendered = ctx.render(&text.0)?;
+        return filters::apply(rendered, &field.filters, now).map(Some);
+    }
+
+    // Resolve the selector to a raw value. A missing path yields None; a path
+    // resolving to JSON `null` coerces to "" (which normalizes to blank below,
+    // the same as missing — matching upstream's net result).
+    let raw: Option<String> = match &field.selector {
+        Some(selector) => select_path(row, selector.trim_start_matches('.'))?.map(coerce_value),
+        None => None,
+    };
+
+    // `case` for JSON is a value-equality switch (NOT HTML's CSS-match): the
+    // first key equal to the resolved value, or `*`, supplies the replacement.
+    let raw = match &field.case {
+        Some(case) => apply_case_json(raw.as_deref(), case),
+        None => raw,
+    };
+
+    // Normalize and drop blank, mirroring the HTML extractor: a blank value
+    // (missing path, JSON null, empty array/string, no case branch) is absent —
+    // an optional field yields None, a required field errors (dropping the row).
+    let value = raw.map(|v| normalize_space(&v)).filter(|v| !v.is_empty());
+    match value {
+        None if field.optional => Ok(None),
+        None => Err("no value extracted".to_string()),
+        Some(value) => filters::apply(value, &field.filters, now).map(Some),
+    }
+}
+
+/// Applies a JSON `case` block: the first key equal to `value` (or `*`) yields
+/// its replacement value. Returns `None` when no branch matches.
+///
+/// WHY: the replacement is used verbatim (not template-rendered), matching the
+/// HTML extractor's `resolve_case`.
+fn apply_case_json(value: Option<&str>, case: &OrderedPairs) -> Option<String> {
+    for (key, replacement) in &case.0 {
+        if key == "*" || value == Some(key.as_str()) {
+            return Some(replacement.0.clone());
+        }
+    }
+    None
+}
+
+/// Coerces a resolved JSON value to its Cardigann string form: `null` -> "",
+/// scalars -> their string form, arrays -> comma-joined element strings.
+fn coerce_value(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => number_to_string(n),
+        // WHY: upstream `String.Join(",", jarray)` stringifies each element.
+        Value::Array(items) => items
+            .iter()
+            .map(scalar_string)
+            .collect::<Vec<_>>()
+            .join(","),
+        // WHY: a field selector landing on an object is unusual; upstream
+        // `.Value<string>()` would throw. Its compact JSON form is the least
+        // surprising fallback (the field's filters/required-check decide fate).
+        Value::Object(_) => value.to_string(),
+    }
+}
+
+fn scalar_string(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(s) => s.clone(),
+        Value::Number(n) => number_to_string(n),
+        other => other.to_string(),
+    }
+}
+
+/// Renders a JSON number in its Cardigann string form, stripping the trailing
+/// `.0` a whole-number float carries (so `12.0` -> "12") to match upstream .NET
+/// `double.ToString()`. Without this a float-serialized `seeders`/`size` value
+/// fails the strict integer parse downstream and is silently lost.
+fn number_to_string(n: &serde_json::Number) -> String {
+    if let Some(i) = n.as_i64() {
+        return i.to_string();
+    }
+    if let Some(u) = n.as_u64() {
+        return u.to_string();
+    }
+    let rendered = n.to_string();
+    rendered
+        .strip_suffix(".0")
+        .map(str::to_owned)
+        .unwrap_or(rendered)
+}
+
+/// Collapses runs of ASCII whitespace to single spaces and trims the ends.
+///
+/// WHY: mirrors the HTML extractor's `normalize_whitespace` so JSON and HTML
+/// fields feed the shared filter pipeline identically.
+fn normalize_space(value: &str) -> String {
+    value
+        .split(|c: char| c.is_ascii_whitespace())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Walks a dotted/bracket path against `root`. `Ok(None)` = path not found;
+/// `Err` = malformed path syntax.
+///
+/// Supports the subset flat Cardigann JSON definitions exercise: dotted keys
+/// (`data.movies`), `[n]` array indices, and `['key']`/`["key"]` bracket keys,
+/// with an optional leading `$`. The pseudo-filter suffix (`:...(...)`) and the
+/// leading-`..` parent switch are rejected at load, so they never reach here.
+fn select_path<'a>(root: &'a Value, path: &str) -> Result<Option<&'a Value>, String> {
+    let mut current = root;
+    for segment in parse_path_segments(path)? {
+        let next = match segment {
+            Segment::Key(key) => current.get(&key),
+            Segment::Index(index) => current.get(index),
+        };
+        match next {
+            Some(value) => current = value,
+            None => return Ok(None),
+        }
+    }
+    Ok(Some(current))
+}
+
+pub(crate) enum Segment {
+    Key(String),
+    Index(usize),
+}
+
+/// Parses a flat JSON selector into path segments. Used both to extract and,
+/// at load, to verify a definition's selectors are well-formed.
+pub(crate) fn parse_path_segments(path: &str) -> Result<Vec<Segment>, String> {
+    let trimmed = path.trim();
+    // WHY: an optional leading `$` roots the path (Newtonsoft convention); a
+    // leading `.` is also tolerated.
+    let mut rest = trimmed.strip_prefix('$').unwrap_or(trimmed);
+    rest = rest.trim_start_matches('.');
+
+    let mut segments = Vec::new();
+    while !rest.is_empty() {
+        if let Some(after) = rest.strip_prefix('[') {
+            let end = after
+                .find(']')
+                .ok_or_else(|| format!("unclosed '[' in path {path:?}"))?;
+            let inner = after.get(..end).unwrap_or_default().trim();
+            rest = after
+                .get(end + 1..)
+                .unwrap_or_default()
+                .trim_start_matches('.');
+            let quoted = (inner.starts_with('\'') && inner.ends_with('\'') && inner.len() >= 2)
+                || (inner.starts_with('"') && inner.ends_with('"') && inner.len() >= 2);
+            if quoted {
+                let unquoted = inner.get(1..inner.len() - 1).unwrap_or_default();
+                segments.push(Segment::Key(unquoted.to_string()));
+            } else {
+                let index = inner
+                    .parse::<usize>()
+                    .map_err(|_| format!("bad array index {inner:?} in path {path:?}"))?;
+                segments.push(Segment::Index(index));
+            }
+        } else {
+            let end = rest.find(['.', '[']).unwrap_or(rest.len());
+            let key = rest.get(..end).unwrap_or_default();
+            if !key.is_empty() {
+                segments.push(Segment::Key(key.to_string()));
+            }
+            rest = rest.get(end..).unwrap_or_default().trim_start_matches('.');
+        }
+    }
+    Ok(segments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::cardigann::definition::parse_definition;
+
+    fn utc_now() -> Zoned {
+        "2026-06-15T12:00:00Z"
+            .parse::<jiff::Timestamp>()
+            .unwrap()
+            .to_zoned(jiff::tz::TimeZone::UTC)
+    }
+
+    const FLAT_DEF: &str = r#"
+id: j
+name: J
+links: ["https://j.example/"]
+caps:
+  categorymappings: [{id: 1, cat: Movies}]
+  modes: {search: [q]}
+search:
+  paths:
+    - path: /api
+      response:
+        type: json
+  rows:
+    selector: data.results
+  fields:
+    title: {selector: name}
+    download: {selector: dl}
+    tags: {selector: tags}
+    note: {selector: note, optional: true}
+    quality:
+      selector: q
+      case: {"hd": "high", "*": "other"}
+"#;
+
+    fn extract(body: &str) -> Vec<BTreeMap<String, String>> {
+        let def = parse_definition(FLAT_DEF, "test").unwrap();
+        extract_rows_json(body, &def, &TemplateContext::default(), &utc_now()).unwrap()
+    }
+
+    #[test]
+    fn flat_rows_fields_arrays_null_and_case() {
+        let body = r#"{"data": {"results": [
+            {"name": "A", "dl": "http://x/a", "tags": ["x264","web"], "note": null, "q": "hd"},
+            {"name": "B", "dl": "http://x/b", "tags": [], "q": "sd"}
+        ]}}"#;
+        let rows = extract(body);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].get("title").map(String::as_str), Some("A"));
+        assert_eq!(
+            rows[0].get("download").map(String::as_str),
+            Some("http://x/a")
+        );
+        // array -> comma-join
+        assert_eq!(rows[0].get("tags").map(String::as_str), Some("x264,web"));
+        // JSON null on an OPTIONAL field -> blank -> omitted (upstream parity)
+        assert!(!rows[0].contains_key("note"));
+        // case value-equality
+        assert_eq!(rows[0].get("quality").map(String::as_str), Some("high"));
+        assert_eq!(rows[1].get("quality").map(String::as_str), Some("other"));
+        // empty array on a REQUIRED field -> blank -> dropped (row-required decides)
+        assert!(!rows[1].contains_key("tags"));
+        // missing optional field -> absent
+        assert!(!rows[1].contains_key("note"));
+    }
+
+    #[test]
+    fn missing_required_field_is_absent_not_error() {
+        // WHY: a required field missing on a row is dropped to absent here; the
+        // row-required decision happens later in rows_to_results, not extraction.
+        let rows = extract(r#"{"data": {"results": [{"name": "A", "tags": [], "q": "hd"}]}}"#);
+        assert_eq!(rows.len(), 1);
+        assert!(!rows[0].contains_key("download"));
+    }
+
+    #[test]
+    fn rows_selector_missing_errors() {
+        let def = parse_definition(FLAT_DEF, "test").unwrap();
+        let err = extract_rows_json(
+            r#"{"data": {}}"#,
+            &def,
+            &TemplateContext::default(),
+            &utc_now(),
+        )
+        .unwrap_err();
+        assert!(err.contains("matched nothing"), "got {err}");
+    }
+
+    #[test]
+    fn rows_selector_non_array_errors() {
+        let def = parse_definition(FLAT_DEF, "test").unwrap();
+        let err = extract_rows_json(
+            r#"{"data": {"results": {"x": 1}}}"#,
+            &def,
+            &TemplateContext::default(),
+            &utc_now(),
+        )
+        .unwrap_err();
+        assert!(err.contains("did not resolve to a JSON array"), "got {err}");
+    }
+
+    #[test]
+    fn invalid_json_body_errors() {
+        let def = parse_definition(FLAT_DEF, "test").unwrap();
+        let err = extract_rows_json("not json", &def, &TemplateContext::default(), &utc_now())
+            .unwrap_err();
+        assert!(err.contains("invalid JSON body"), "got {err}");
+    }
+
+    #[test]
+    fn path_walker_dotted_index_and_bracket() {
+        let v: Value = serde_json::from_str(r#"{"a": [{"b": 1}, {"b": 2}], "c.d": "x"}"#).unwrap();
+        assert_eq!(select_path(&v, "a[1].b").unwrap().unwrap(), &Value::from(2));
+        assert_eq!(select_path(&v, "a[0].b").unwrap().unwrap(), &Value::from(1));
+        assert_eq!(
+            select_path(&v, "['c.d']").unwrap().unwrap(),
+            &Value::from("x")
+        );
+        assert_eq!(
+            select_path(&v, "$.a[0].b").unwrap().unwrap(),
+            &Value::from(1)
+        );
+        assert!(select_path(&v, "a[9].b").unwrap().is_none());
+        assert!(select_path(&v, "missing").unwrap().is_none());
+    }
+
+    #[test]
+    fn coerce_scalars_and_arrays() {
+        assert_eq!(coerce_value(&Value::Null), "");
+        assert_eq!(coerce_value(&Value::from(42)), "42");
+        assert_eq!(coerce_value(&Value::from(true)), "true");
+        assert_eq!(coerce_value(&Value::from("s")), "s");
+        assert_eq!(coerce_value(&serde_json::json!(["a", 1, null])), "a,1,");
+        // whole-number float -> integer form (no ".0"); fractional preserved
+        assert_eq!(coerce_value(&serde_json::json!(12.0)), "12");
+        assert_eq!(coerce_value(&serde_json::json!(12.5)), "12.5");
+        assert_eq!(coerce_value(&serde_json::json!([1.0, 2.0])), "1,2");
+    }
+}

--- a/crates/zetesis/src/client/cardigann/mod.rs
+++ b/crates/zetesis/src/client/cardigann/mod.rs
@@ -11,6 +11,7 @@ pub mod categories;
 pub mod definition;
 mod extract;
 mod filters;
+mod json_extract;
 mod session;
 mod template;
 
@@ -736,12 +737,20 @@ impl IndexerClient for CardigannClient {
             let text = self
                 .fetch_text(url.as_str(), form_body.as_deref(), ct.clone())
                 .await?;
-            let rows = extract::extract_rows(&text, &self.definition, &ctx, &now).map_err(|e| {
-                SearchIndexerError::ParseResponse {
-                    url: redact_api_key(url.as_str()),
-                    error: e,
-                    location: snafu::Location::new(file!(), line!(), column!()),
-                }
+            let is_json = path
+                .response
+                .as_ref()
+                .and_then(|r| r.response_type.as_deref())
+                == Some("json");
+            let extracted = if is_json {
+                json_extract::extract_rows_json(&text, &self.definition, &ctx, &now)
+            } else {
+                extract::extract_rows(&text, &self.definition, &ctx, &now)
+            };
+            let rows = extracted.map_err(|e| SearchIndexerError::ParseResponse {
+                url: redact_api_key(url.as_str()),
+                error: e,
+                location: snafu::Location::new(file!(), line!(), column!()),
             })?;
             results.extend(self.rows_to_results(rows));
         }

--- a/crates/zetesis/src/client/cardigann/tests.rs
+++ b/crates/zetesis/src/client/cardigann/tests.rs
@@ -289,6 +289,101 @@ fn cf_bypass_with_post_search_unsupported_at_construction() {
     );
 }
 
+// ── JSON responses ──────────────────────────────────────────────────────
+
+const JSON_DEF: &str = r#"---
+id: json-tracker
+name: JSON Tracker
+type: public
+links:
+  - https://json-tracker.example/
+caps:
+  categorymappings:
+    - {id: 6, cat: Movies/HD}
+    - {id: 7, cat: Movies/SD}
+  modes:
+    search: [q]
+    movie-search: [q]
+search:
+  paths:
+    - path: /api/search
+      response:
+        type: json
+  inputs:
+    q: "{{ .Keywords }}"
+  rows:
+    selector: data.results
+  fields:
+    title:
+      selector: name
+    download:
+      selector: download
+    details:
+      selector: url
+    size:
+      selector: size
+    seeders:
+      selector: seeders
+    leechers:
+      selector: leechers
+    category:
+      selector: category_id
+    tags:
+      selector: tags
+"#;
+
+// WHY: row 0 uses a raw-byte numeric `size` and a whole-number float `seeders`
+// to exercise the JSON-API conventions (unitless bytes; float-serialized ints).
+const JSON_BODY: &str = r#"{"data": {"results": [
+  {"name": "Example.Movie.1080p", "download": "https://t/1.torrent", "url": "https://t/d/1",
+   "size": 1610612736, "seeders": 42.0, "leechers": 7, "category_id": 6, "tags": ["x264", "web"]},
+  {"name": "Example.Show.720p", "download": "https://t/2.torrent", "url": "https://t/d/2",
+   "size": "700 MB", "seeders": 10, "leechers": 1, "category_id": 7, "tags": []}
+]}}"#;
+
+#[tokio::test]
+async fn json_search_extracts_rows_and_maps_fields() {
+    let (url, server) = spawn_one_shot_http(
+        200,
+        "OK",
+        &[("content-type", "application/json")],
+        JSON_BODY,
+    )
+    .await;
+    let results = client(JSON_DEF, url.clone(), None)
+        .unwrap()
+        .search(&movie_query(), CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 2);
+    let first = &results[0];
+    assert_eq!(first.title, "Example.Movie.1080p");
+    assert_eq!(first.download_url, "https://t/1.torrent");
+    assert_eq!(first.size_bytes, Some(1_610_612_736));
+    assert_eq!(first.seeders, Some(42));
+    assert_eq!(first.leechers, Some(7));
+    // site category 6 -> Movies/HD -> torznab 2040
+    assert_eq!(first.category_id, Some(2040));
+    // JSON array field -> comma-joined, lands in custom_attrs
+    assert_eq!(
+        first.custom_attrs.get("tags").map(String::as_str),
+        Some("x264,web")
+    );
+
+    let request_line = server
+        .await
+        .unwrap()
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        request_line.starts_with("GET /api/search?"),
+        "got: {request_line}"
+    );
+}
+
 // ── settings overrides ──────────────────────────────────────────────────
 
 #[tokio::test]

--- a/docs/download/indexer-protocol.md
+++ b/docs/download/indexer-protocol.md
@@ -408,7 +408,7 @@ Indexer rows select the client with `protocol = 'cardigann'`; the row's `url` co
 | `id`, `name`, `description`, `links` | Yes | Identity fields; templated links rejected |
 | `caps.categorymappings` (+ legacy `caps.categories`) | Yes | Category ID mapping via the standard Torznab table |
 | `caps.modes` | Yes | Supported search functions |
-| `search.paths` (+ legacy `search.path`) | GET + POST | POST sends inputs as an `application/x-www-form-urlencoded` body (`$raw` + POST rejected at load; POST + `cf_bypass` rejected at construction). JSON/XML responses rejected at load |
+| `search.paths` (+ legacy `search.path`) | GET + POST | POST sends inputs as an `application/x-www-form-urlencoded` body (`$raw` + POST rejected at load; POST + `cf_bypass` rejected at construction). `response.type: json` parses flat result arrays — `rows.selector` and field `selector`s are dotted/`[n]`/`['key']` JSON paths, arrays comma-join, JSON `null` → empty; nested rows (`rows.attribute`/`multiple`, leading `..`) and `:has()/:not()/:contains()` pseudo-filter selectors are rejected at load. `xml` rejected at load |
 | `search.inputs` / `keywordsfilters` | Yes | Template subset: `.Keywords`, `.Categories`, `.Config.<key>`, `.Query.<field>`, `join`; `$raw` input supported. `if`/`range` rejected at load |
 | `search.rows` | `selector` + `remove` | `filters` (andmatch), `after`, `dateheaders` warned and ignored |
 | `search.fields` | Yes | `selector`, `attribute`, `text`, `optional`, `case`, `remove`, filters |


### PR DESCRIPTION
Part of #513 (second of the wave, after POST search in #621; nested JSON rows, pseudo-filter selectors, XML, and the filter tail follow — #513 stays open).

Cardigann search paths with `response.type: json` now parse **flat result arrays**. `rows.selector` and field `selector`s are dotted / `[n]` / `['key']` JSON paths (the Newtonsoft `SelectToken` subset Jackett/Prowlarr use) resolved against the parsed body via a new `json_extract` module. Dispatch picks the JSON vs HTML extractor per path.

**Upstream-faithful coercion** (verified against Jackett `handleJsonSelector` + Newtonsoft): arrays comma-join; scalars stringify with whole-number floats dropping the `.0` (so a float-serialized `seeders`/`size` still parses); a raw numeric `size` is treated as a byte count (the JSON-API convention); a blank value (missing path, JSON `null`, empty array) is absent — optional fields omit, required fields drop the row (matching the HTML extractor). `case` is a value-equality switch, not HTML's CSS match.

**Fail-loud rejects at load** keep the deferred surface honest (nothing silently mis-parses): nested rows (`rows.attribute`/`multiple`, leading `..` **including the `$..` JSONPath form**), `:has()/:not()/:contains()` pseudo-filter selectors, `attribute`/`remove` on a JSON field, mixed response types across paths, and `xml`.

**Review:** two adversarial passes (correctness/fidelity + fail-loud completeness) against live Jackett/Prowlarr source caught 4 silent-corruption bugs — the `$..` reject bypass, unitless-byte size loss, the float-`.0` integer-parse break, and optional-blank noise — all fixed with tests here. Full `kanon gate --full` green (fmt/check/clippy/nextest/deny/lint); 127 cardigann tests.