### PR TITLE
feat(horismos,kathodos,archon): media-type coverage for audiobook/comic/podcast/tv (#612)

### DIFF
--- a/crates/archon/src/import.rs
+++ b/crates/archon/src/import.rs
@@ -19,12 +19,19 @@ use themelion::{EventSender, MediaType, ReleaseId, WantId};
 use tokio::sync::Semaphore;
 use tracing::{info, instrument, warn};
 
-/// Want media types with a real library mapping today (`horismos::MediaType`
-/// only distinguishes Music/Video/Book — see `kathodos::import::identify::resolve_media_type`).
-/// The remaining CHECK values (`audiobook`, `comic`, `podcast`, `tv_series`)
-/// have no library type to land in; see `UnsupportedWantMediaType` below.
-const SUPPORTED_WANT_MEDIA_TYPES: [MediaType; 3] =
-    [MediaType::Music, MediaType::Movie, MediaType::Book];
+/// Want media types with a library mapping. Every `wants.media_type` CHECK
+/// value now resolves to a `horismos::MediaType` library type via
+/// `kathodos::import::identify::resolve_media_type`; the gate remains as a
+/// safety net for any future want type added without a library mapping.
+const SUPPORTED_WANT_MEDIA_TYPES: [MediaType; 7] = [
+    MediaType::Music,
+    MediaType::Movie,
+    MediaType::Book,
+    MediaType::Audiobook,
+    MediaType::Comic,
+    MediaType::Podcast,
+    MediaType::Tv,
+];
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
@@ -57,10 +64,7 @@ pub(crate) enum ImportAdapterError {
         location: snafu::Location,
     },
 
-    // TODO[deliberate-prudent] #612: extend horismos::MediaType past Music/Video/Book so audiobook/comic/podcast/tv_series wants can resolve a library // kanon:ignore RUST/todo-no-issue -- richer quadrant rule covers this // kanon:ignore META/rule-todo-without-issue -- richer quadrant rule covers this
-    #[snafu(display(
-        "no library type for '{media_type}'  -  horismos::MediaType only supports Music/Video/Book today (forkwright/harmonia#612)"
-    ))]
+    #[snafu(display("no library type maps to want media_type '{media_type}'"))]
     UnsupportedWantMediaType {
         media_type: String,
         #[snafu(implicit)]
@@ -183,7 +187,7 @@ impl ImportAdapter {
         let mut candidates: Vec<(&String, &LibraryConfig)> = taxis
             .libraries
             .iter()
-            .filter(|(_, lib)| resolve_media_type(&lib.media_type) == mapped_media_type)
+            .filter(|(_, lib)| resolve_media_type(&lib.media_type) == Some(mapped_media_type))
             .collect();
         candidates.sort_by(|a, b| a.0.cmp(b.0));
         let (library_name, library_cfg) = candidates
@@ -597,9 +601,55 @@ impl MetadataResolver for DownloadResolver {
                     tokens.insert("Year".to_string(), y.to_string());
                 }
             }
-            // INVARIANT: import_inner gates media_type to
-            // SUPPORTED_WANT_MEDIA_TYPES before a DownloadResolver is ever
-            // built — reached only if that gate is bypassed.
+            MediaType::Audiobook => {
+                let author = tags
+                    .artist
+                    .clone()
+                    .or_else(|| tags.album_artist.clone())
+                    .or_else(|| self.artist_or_author.clone())
+                    .or_else(|| parsed.artist.clone());
+                if let Some(v) = author {
+                    tokens.insert("Author Name".to_string(), v);
+                }
+                tokens.insert("Title".to_string(), self.want_title.clone());
+                if let Some(y) = year {
+                    tokens.insert("Year".to_string(), y.to_string());
+                }
+            }
+            MediaType::Comic => {
+                tokens.insert("Series Name".to_string(), self.want_title.clone());
+                if let Some(y) = year {
+                    tokens.insert("Year".to_string(), y.to_string());
+                }
+            }
+            MediaType::Podcast => {
+                tokens.insert("Podcast Title".to_string(), self.want_title.clone());
+                let episode = tags
+                    .title
+                    .clone()
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| Some(parsed.title.clone()).filter(|s| !s.is_empty()));
+                if let Some(t) = episode {
+                    tokens.insert("Episode Title".to_string(), t);
+                }
+            }
+            MediaType::Tv => {
+                tokens.insert("Series Title".to_string(), self.want_title.clone());
+                let episode_title = tags
+                    .title
+                    .clone()
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| Some(parsed.title.clone()).filter(|s| !s.is_empty()));
+                if let Some(t) = episode_title {
+                    tokens.insert("Episode Title".to_string(), t);
+                }
+            }
+            // WHY: `News` has no want representation (parse_want_str -> None), so
+            // no want ever maps to it, and the gate admits the other 7. This arm
+            // is the non_exhaustive fallback for a future themelion variant.
+            // NOTE: season/episode/issue/series tokens need metadata enrichment,
+            // not available in this filename/DB-hint resolver — the template
+            // skips the missing tokens, keeping the primary identifying tokens.
             _ => {}
         }
 
@@ -647,14 +697,18 @@ mod tests {
         )
     }
 
-    fn music_library(path: &str) -> LibraryConfig {
+    fn library(path: &str, media_type: LibMediaType) -> LibraryConfig {
         LibraryConfig {
             path: PathBuf::from(path),
-            media_type: LibMediaType::Music,
+            media_type,
             watcher_mode: WatcherMode::Auto,
             poll_interval_seconds: 300,
             scan_interval_hours: 24,
         }
+    }
+
+    fn music_library(path: &str) -> LibraryConfig {
+        library(path, LibMediaType::Music)
     }
 
     fn make_completed(
@@ -737,6 +791,64 @@ mod tests {
             result,
             Err(ImportAdapterError::NoMatchingLibrary { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn each_media_type_imports_into_its_library() {
+        // WHY(#612): a want of each newly-supported type resolves its library
+        // type and imports end-to-end, rather than erroring at the gate.
+        let cases = [
+            ("audiobook", LibMediaType::Audiobook, "book.m4b"),
+            ("comic", LibMediaType::Comic, "issue.cbz"),
+            ("podcast", LibMediaType::Podcast, "episode.mp3"),
+            ("tv_series", LibMediaType::Tv, "episode.mkv"),
+        ];
+        for (want_type, lib_type, filename) in cases {
+            let pool = migrated_pool().await;
+            let (want_id, release_id) = seed_want_release(&pool, want_type).await;
+            let dir = tempfile::TempDir::new().unwrap();
+            let download_path = dir.path().join("download");
+            std::fs::create_dir_all(&download_path).unwrap();
+            std::fs::write(download_path.join(filename), b"data").unwrap();
+            let lib_root = dir.path().join("library");
+            std::fs::create_dir_all(&lib_root).unwrap();
+
+            let mut libraries = HashMap::new();
+            libraries.insert(
+                "lib".to_string(),
+                library(lib_root.to_str().unwrap(), lib_type),
+            );
+            let svc = adapter(pool.clone(), libraries);
+
+            svc.import_inner(make_completed(want_id, release_id, download_path))
+                .await
+                .unwrap_or_else(|e| panic!("{want_type} import failed: {e}"));
+
+            let want = want::get_want(&pool, want_id.as_bytes().as_ref())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                want.status, "fulfilled",
+                "{want_type} want should be fulfilled after import"
+            );
+
+            // WHY: the imported file must land in the library carrying the title
+            // (not an anonymous `.ext`) — proves resolve_identity populates a
+            // naming token for this type, per #612's organizing purpose.
+            let haves = want::list_haves_for_want(&pool, want_id.as_bytes().as_ref())
+                .await
+                .unwrap();
+            let landed = haves
+                .iter()
+                .find(|h| h.file_path.starts_with(lib_root.to_str().unwrap()))
+                .unwrap_or_else(|| panic!("{want_type}: no have landed in library: {haves:?}"));
+            assert!(
+                landed.file_path.contains("Test Album"),
+                "{want_type}: imported file must carry the title, got {:?}",
+                landed.file_path
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -592,6 +592,24 @@ mod tests {
     }
 
     #[test]
+    fn media_type_serde_covers_every_variant() {
+        for (variant, expected) in [
+            (MediaType::Music, "\"music\""),
+            (MediaType::Video, "\"video\""),
+            (MediaType::Book, "\"book\""),
+            (MediaType::Audiobook, "\"audiobook\""),
+            (MediaType::Comic, "\"comic\""),
+            (MediaType::Podcast, "\"podcast\""),
+            (MediaType::Tv, "\"tv\""),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, expected, "unexpected serde form for {variant:?}");
+            let restored: MediaType = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored, variant);
+        }
+    }
+
+    #[test]
     fn database_config_roundtrip() {
         let original = DatabaseConfig::default();
         let json = serde_json::to_string(&original).unwrap();

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -146,6 +146,10 @@ pub enum MediaType {
     Music,
     Video,
     Book,
+    Audiobook,
+    Comic,
+    Podcast,
+    Tv,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/kathodos/src/import/identify.rs
+++ b/crates/kathodos/src/import/identify.rs
@@ -1,20 +1,23 @@
 use horismos::MediaType as LibMediaType;
 use themelion::MediaType;
 
-/// Map horismos library media type to themelion::MediaType.
-pub fn resolve_media_type(lib_type: &LibMediaType) -> MediaType {
-    match lib_type {
+/// Maps a horismos library media type to its `themelion::MediaType`.
+///
+/// Returns `None` for a library media type with no themelion mapping — a future
+/// `horismos::MediaType` variant added without a mapping here. The caller skips
+/// such a library rather than crashing (`horismos::MediaType` is
+/// `#[non_exhaustive]`, so the wildcard cannot be removed).
+pub fn resolve_media_type(lib_type: &LibMediaType) -> Option<MediaType> {
+    Some(match lib_type {
         LibMediaType::Music => MediaType::Music,
         LibMediaType::Video => MediaType::Movie,
         LibMediaType::Book => MediaType::Book,
-        _ => unreachable!(
-            "unhandled horismos::MediaType variant in resolve_media_type — \
-             was a new variant added without updating this matcher? \
-             at {}:{}",
-            file!(),
-            line!()
-        ),
-    }
+        LibMediaType::Audiobook => MediaType::Audiobook,
+        LibMediaType::Comic => MediaType::Comic,
+        LibMediaType::Podcast => MediaType::Podcast,
+        LibMediaType::Tv => MediaType::Tv,
+        _ => return None,
+    })
 }
 
 /// Detect media type from file extension, given the library's expected type.
@@ -137,17 +140,31 @@ mod tests {
     }
 
     #[test]
-    fn resolve_media_type_music() {
-        assert_eq!(resolve_media_type(&LibMediaType::Music), MediaType::Music);
-    }
-
-    #[test]
-    fn resolve_media_type_video_is_movie() {
-        assert_eq!(resolve_media_type(&LibMediaType::Video), MediaType::Movie);
-    }
-
-    #[test]
-    fn resolve_media_type_book() {
-        assert_eq!(resolve_media_type(&LibMediaType::Book), MediaType::Book);
+    fn resolve_media_type_maps_every_variant() {
+        assert_eq!(
+            resolve_media_type(&LibMediaType::Music),
+            Some(MediaType::Music)
+        );
+        assert_eq!(
+            resolve_media_type(&LibMediaType::Video),
+            Some(MediaType::Movie)
+        );
+        assert_eq!(
+            resolve_media_type(&LibMediaType::Book),
+            Some(MediaType::Book)
+        );
+        assert_eq!(
+            resolve_media_type(&LibMediaType::Audiobook),
+            Some(MediaType::Audiobook)
+        );
+        assert_eq!(
+            resolve_media_type(&LibMediaType::Comic),
+            Some(MediaType::Comic)
+        );
+        assert_eq!(
+            resolve_media_type(&LibMediaType::Podcast),
+            Some(MediaType::Podcast)
+        );
+        assert_eq!(resolve_media_type(&LibMediaType::Tv), Some(MediaType::Tv));
     }
 }

--- a/crates/kathodos/src/scanner/mod.rs
+++ b/crates/kathodos/src/scanner/mod.rs
@@ -37,6 +37,16 @@ impl ScannerManager {
         let mut scan_triggers = HashMap::new();
 
         for (name, lib) in &config.libraries {
+            // WHY: a library whose media_type has no themelion mapping (a future
+            // horismos variant) is skipped rather than crashing the scanner.
+            let Some(media_type) = resolve_media_type(&lib.media_type) else {
+                tracing::warn!(
+                    library = %name,
+                    "library media_type has no themelion mapping; skipping"
+                );
+                continue;
+            };
+
             let (event_raw_tx, event_raw_rx) = mpsc::channel(256);
 
             let lib_name = name.clone();
@@ -73,7 +83,6 @@ impl ScannerManager {
 
             let lib_name2 = name.clone();
             let lib_path = lib.path.clone();
-            let media_type = resolve_media_type(&lib.media_type);
             let scan_interval = Duration::from_secs(lib.scan_interval_hours * 3600);
             let event_tx_scan = event_tx.clone();
             let sem_clone = Arc::clone(&semaphore);

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -49,7 +49,7 @@ scan_concurrency = 4
 
 [taxis.libraries.music]
 path = "/data/music"
-media_type = "music"              # "music" | "video" | "book"
+media_type = "music"              # music|video|book|audiobook|comic|podcast|tv
 watcher_mode = "auto"              # "inotify" | "poll" | "auto"
 poll_interval_seconds = 300
 scan_interval_hours = 24

--- a/docs/media/import-rename.md
+++ b/docs/media/import-rename.md
@@ -9,7 +9,7 @@
 
 The only wired entry point is a completed torrent/NNTP download. `ImportAdapter::import_inner`:
 
-1. Loads the want and release rows, maps the want's media type to a library. Only `Music`, `Movie`, and `Book` resolve to a configured library today (`horismos::MediaType` only has `Music`/`Video`/`Book` variants) — `Audiobook`/`Comic`/`Podcast`/`Tv` wants have no library to land in yet ([forkwright/harmonia#612](https://github.com/forkwright/harmonia/issues/612)).
+1. Loads the want and release rows, maps the want's media type to a library. Every `wants.media_type` value (`music_album`, `audiobook`, `book`, `comic`, `podcast`, `movie`, `tv_series`) resolves to a `horismos::MediaType` library type via `kathodos::import::identify::resolve_media_type`; a want whose type has no configured library errors with `NoMatchingLibrary`.
 2. Checks a haves fast-path: if a `complete` have for this exact release is still present on disk, the import is a no-op (the want is (re)marked `fulfilled` and nothing runs).
 3. Enumerates the downloaded file(s) and runs each through `kathodos::import::ImportPipeline::process`.
 4. Finalizes in one `BEGIN IMMEDIATE` transaction: deletes any stale have at the resulting `file_path`, inserts the new have (`haves.status = "complete"`), and sets `wants.status = "fulfilled"`.

--- a/docs/media/scanner.md
+++ b/docs/media/scanner.md
@@ -33,7 +33,7 @@ scan_interval_hours = 6
 
 [taxis.libraries.movies]
 path = "/media/movies"
-media_type = "movie"
+media_type = "video"
 watcher_mode = "auto"
 scan_interval_hours = 6
 

--- a/docs/nix-deployment.md
+++ b/docs/nix-deployment.md
@@ -42,13 +42,11 @@ inputs.harmonia.url = "github:forkwright/harmonia";
     settings = {
       paroche.port = 8096;
 
-      # horismos::MediaType (crates/horismos/src/subsystems.rs) has only
-      # three variants — music | video | book. There is no dedicated
-      # "audiobook" or "movie" value at the library-config level; audiobooks
-      # and books share `media_type = "book"` here (two libraries, same
-      # type, different paths — this is a supported shape). Every field
-      # below is required: LibraryConfig has no per-field defaults, so an
-      # incomplete entry fails config parsing at startup.
+      # horismos::MediaType (crates/horismos/src/subsystems.rs) variants:
+      # music | video | book | audiobook | comic | podcast | tv — each a
+      # distinct library type. Every field below is required: LibraryConfig
+      # has no per-field defaults, so an incomplete entry fails config
+      # parsing at startup.
       taxis.libraries = {
         music = {
           path = "/media/music";
@@ -59,7 +57,7 @@ inputs.harmonia.url = "github:forkwright/harmonia";
         };
         audiobooks = {
           path = "/media/audiobooks";
-          media_type = "book";
+          media_type = "audiobook";
           watcher_mode = "poll";
           poll_interval_seconds = 300;
           scan_interval_hours = 24;


### PR DESCRIPTION
Closes #612.

`horismos::MediaType` gains **Audiobook / Comic / Podcast / Tv** variants (each a distinct library type). `kathodos::import::identify::resolve_media_type` maps all 7 horismos variants 1:1 into `themelion::MediaType` and now returns `Option` — a future unmapped variant makes the scanner **skip** that library with a warning instead of panicking (the enum is `#[non_exhaustive]`, so the wildcard arm can't be removed; the previous `unreachable!()` was a boot-crash risk). archon's import gate (`SUPPORTED_WANT_MEDIA_TYPES`) admits all 7 want types.

The whole downstream stack (scan extensions, naming templates, quality ranks, DB CHECK, enrichment providers) was already built for these types at the themelion layer — this wires the horismos library-config layer to it.

**Adversarial review caught a real HIGH bug** (fixed here): expanding the gate without updating `DownloadResolver::resolve_identity` would have imported the new types as **anonymous files** (its `match` only had Music/Movie/Book arms + a now-reachable empty wildcard). Added naming-token arms for all 4 (Author/Title, Series Name, Podcast/Episode Title, Series/Episode Title); season/episode/issue/series need metadata enrichment (not in this filename/DB-hint resolver) and degrade gracefully via the template's skip-missing-token behavior.

**Tests:** `resolve_media_type` covers all 7 variants; a per-type end-to-end import test asserts each of the 4 imports into a **named** library path (carries the title, not `.ext`); a horismos serde roundtrip covers every variant. Full `kanon gate --full` green.

Doc fixes bundled: `configuration.md`/`nix-deployment.md`/`import-rename.md` updated; `scanner.md` had a pre-existing invalid `media_type = "movie"` (the library value is `"video"`) — corrected.