### PR TITLE
fix(zetesis): redact all credential query params in logged URLs, not just apikey (#623)

### DIFF
--- a/crates/zetesis/src/cf_bypass/byparr.rs
+++ b/crates/zetesis/src/cf_bypass/byparr.rs
@@ -115,7 +115,7 @@ impl ByparrProxy {
     ) -> Result<ProxyResponse, SearchIndexerError> {
         // WHY: errors embed the redacted form so the API key never reaches a
         // log line; the request itself still carries the real URL.
-        let redacted = crate::client::redact_api_key(url);
+        let redacted = crate::client::redact_secrets(url);
         let host = reqwest::Url::parse(url)
             .ok()
             .and_then(|u| u.host_str().map(str::to_string));

--- a/crates/zetesis/src/cf_bypass/noop.rs
+++ b/crates/zetesis/src/cf_bypass/noop.rs
@@ -15,7 +15,7 @@ impl CloudflareProxy for NoProxy {
         _ct: CancellationToken,
     ) -> Pin<Box<dyn Future<Output = Result<ProxyResponse, SearchIndexerError>> + Send + '_>> {
         // WHY: redact at construction so the API key never reaches a log line.
-        let url = crate::client::redact_api_key(url);
+        let url = crate::client::redact_secrets(url);
         Box::pin(async move {
             Err(SearchIndexerError::NoCfBypass {
                 url,

--- a/crates/zetesis/src/client/cardigann/mod.rs
+++ b/crates/zetesis/src/client/cardigann/mod.rs
@@ -29,7 +29,7 @@ use url::Url;
 
 use crate::cf_bypass::CloudflareProxy;
 use crate::client::{
-    IndexerClient, IndexerConfig, read_body_bounded, read_body_bytes_bounded, redact_api_key,
+    IndexerClient, IndexerConfig, read_body_bounded, read_body_bytes_bounded, redact_secrets,
     validate_fetch_url,
 };
 use crate::error::{self, SearchIndexerError};
@@ -475,9 +475,9 @@ impl CardigannClient {
         }
         let fut = request.send();
         tokio::select! {
-            result = fut => result.context(error::HttpRequestSnafu { url: redact_api_key(url) }),
+            result = fut => result.context(error::HttpRequestSnafu { url: redact_secrets(url) }),
             () = ct.cancelled() => Err(SearchIndexerError::Cancelled {
-                url: redact_api_key(url),
+                url: redact_secrets(url),
                 location: snafu::Location::new(file!(), line!(), column!()),
             }),
         }
@@ -748,7 +748,7 @@ impl IndexerClient for CardigannClient {
                 extract::extract_rows(&text, &self.definition, &ctx, &now)
             };
             let rows = extracted.map_err(|e| SearchIndexerError::ParseResponse {
-                url: redact_api_key(url.as_str()),
+                url: redact_secrets(url.as_str()),
                 error: e,
                 location: snafu::Location::new(file!(), line!(), column!()),
             })?;
@@ -820,7 +820,7 @@ impl IndexerClient for CardigannClient {
                         .error_for_status()
                         .map(|_| ())
                         .context(error::HttpRequestSnafu {
-                            url: redact_api_key(url.as_str()),
+                            url: redact_secrets(url.as_str()),
                         })
                 }
             }

--- a/crates/zetesis/src/client/cardigann/session.rs
+++ b/crates/zetesis/src/client/cardigann/session.rs
@@ -560,8 +560,10 @@ fn format_cookie_header(cookies: &BTreeMap<String, String>) -> String {
 
 /// URL rendered for logs/errors with its query stripped.
 ///
-/// WHY: get-method login URLs carry credentials in the query; even the
-/// apikey-focused `redact_api_key` would leak them.
+/// WHY: get-method login URLs carry credentials (username/password and
+/// non-standard fields) in the query; stripping the whole query is safer here
+/// than the param-name-based `redact_secrets`, which would still leak a
+/// credential carried in an unrecognized parameter (e.g. a bare `username`).
 fn redact_query(url: &Url) -> String {
     let mut clean = url.clone();
     clean.set_query(None);

--- a/crates/zetesis/src/client/mod.rs
+++ b/crates/zetesis/src/client/mod.rs
@@ -157,27 +157,51 @@ pub(crate) fn build_caps_url(config: &IndexerConfig) -> String {
     url
 }
 
-/// Replaces every `apikey=` query value in `url` with `[REDACTED]`.
+/// Redacts the value of every secret-bearing query parameter in `url` (api key,
+/// tracker passkey, rss key, torrent pass, auth token, session/cookie), leaving
+/// the path and non-secret params intact for diagnostics.
 ///
-/// WHY: indexer URLs built by [`build_search_url`]/[`build_caps_url`] embed
-/// the API key as a query parameter; redacting at error-construction time
-/// keeps the key out of every downstream Display/log path.
-pub(crate) fn redact_api_key(url: &str) -> String {
-    let mut out = String::with_capacity(url.len());
-    let mut rest = url;
-    while let Some((before, after)) = rest.split_once("apikey=") {
-        out.push_str(before);
-        out.push_str("apikey=[REDACTED]");
-        match after.split_once('&') {
-            Some((_value, tail)) => {
-                out.push('&');
-                rest = tail;
-            }
-            None => rest = "",
-        }
-    }
-    out.push_str(rest);
-    out
+/// WHY: indexer URLs — both the native Torznab/Newznab `apikey` and arbitrary
+/// Cardigann-defined credentials like `passkey`/`rss_key`/`torrent_pass` — carry
+/// credentials as query parameters; redacting at error-construction time keeps
+/// them out of every downstream Display/log path. A single-parameter redactor
+/// would leak any credential not literally named `apikey`.
+pub(crate) fn redact_secrets(url: &str) -> String {
+    let Some((base, query)) = url.split_once('?') else {
+        return url.to_string();
+    };
+    let redacted = query
+        .split('&')
+        .map(|pair| match pair.split_once('=') {
+            Some((key, _)) if is_secret_param(key) => format!("{key}=[REDACTED]"),
+            _ => pair.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{base}?{redacted}")
+}
+
+/// True when a query-parameter key names a credential. Substring-matched (case
+/// insensitive) so variants like `torrent_passkey` or `rss_key` are covered.
+fn is_secret_param(key: &str) -> bool {
+    const SECRET_MARKERS: &[&str] = &[
+        "apikey",
+        "api_key",
+        "passkey",
+        "pass_key",
+        "password",
+        "rss_key",
+        "rsskey",
+        "torrent_pass",
+        "authkey",
+        "auth_key",
+        "secret",
+        "token",
+        "session",
+        "cookie",
+    ];
+    let key = key.to_ascii_lowercase();
+    SECRET_MARKERS.iter().any(|marker| key.contains(marker))
 }
 
 /// Reads a response body into a UTF-8 string, enforcing `max_bytes`.
@@ -188,7 +212,7 @@ pub(crate) async fn read_body_bounded(
 ) -> Result<String, SearchIndexerError> {
     let body = read_body_bytes_bounded(response, url, max_bytes).await?;
     String::from_utf8(body).map_err(|e| SearchIndexerError::ParseResponse {
-        url: redact_api_key(url),
+        url: redact_secrets(url),
         error: e.to_string(),
         location: snafu::Location::new(file!(), line!(), column!()),
     })
@@ -210,7 +234,7 @@ pub(crate) async fn read_body_bytes_bounded(
         && declared > max_bytes
     {
         return Err(SearchIndexerError::ResponseTooLarge {
-            url: redact_api_key(url),
+            url: redact_secrets(url),
             size: declared,
             limit: max_bytes,
             location: snafu::Location::new(file!(), line!(), column!()),
@@ -221,12 +245,12 @@ pub(crate) async fn read_body_bytes_bounded(
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.context(error::HttpRequestSnafu {
-            url: redact_api_key(url),
+            url: redact_secrets(url),
         })?;
         let received = body.len() as u64 + chunk.len() as u64;
         if received > max_bytes {
             return Err(SearchIndexerError::ResponseTooLarge {
-                url: redact_api_key(url),
+                url: redact_secrets(url),
                 size: received,
                 limit: max_bytes,
                 location: snafu::Location::new(file!(), line!(), column!()),
@@ -249,7 +273,7 @@ pub(crate) async fn read_body_bytes_bounded(
 /// resolved address is checked; resolution failure rejects (fail-closed).
 pub(crate) async fn validate_fetch_url(url: &str) -> Result<(), SearchIndexerError> {
     let reject = |reason: &str| SearchIndexerError::UnsafeUrl {
-        url: redact_api_key(url),
+        url: redact_secrets(url),
         reason: reason.to_string(),
         location: snafu::Location::new(file!(), line!(), column!()),
     };
@@ -463,25 +487,25 @@ mod tests {
         assert_eq!(urlencoding("normal"), "normal");
     }
 
-    // ── redact_api_key ────────────────────────────────────────────────────────
+    // ── redact_secrets ────────────────────────────────────────────────────────
 
     #[test]
-    fn redact_api_key_strips_value() {
-        let redacted = redact_api_key("https://x/api?t=caps&apikey=secret123");
+    fn redact_secrets_strips_value() {
+        let redacted = redact_secrets("https://x/api?t=caps&apikey=secret123");
         assert!(!redacted.contains("secret123"), "leaked: {redacted}");
         assert_eq!(redacted, "https://x/api?t=caps&apikey=[REDACTED]");
     }
 
     #[test]
-    fn redact_api_key_preserves_trailing_params() {
-        let redacted = redact_api_key("https://x/api?apikey=secret123&t=search&q=abc");
+    fn redact_secrets_preserves_trailing_params() {
+        let redacted = redact_secrets("https://x/api?apikey=secret123&t=search&q=abc");
         assert!(!redacted.contains("secret123"), "leaked: {redacted}");
         assert_eq!(redacted, "https://x/api?apikey=[REDACTED]&t=search&q=abc");
     }
 
     #[test]
-    fn redact_api_key_handles_multiple_occurrences() {
-        let redacted = redact_api_key("https://x/?apikey=one&t=search&apikey=two");
+    fn redact_secrets_handles_multiple_occurrences() {
+        let redacted = redact_secrets("https://x/?apikey=one&t=search&apikey=two");
         assert!(!redacted.contains("one"), "leaked: {redacted}");
         assert!(!redacted.contains("two"), "leaked: {redacted}");
         assert_eq!(
@@ -491,19 +515,40 @@ mod tests {
     }
 
     #[test]
-    fn redact_api_key_no_key_present_noop() {
+    fn redact_secrets_no_key_present_noop() {
         assert_eq!(
-            redact_api_key("https://x/api?t=caps"),
+            redact_secrets("https://x/api?t=caps"),
             "https://x/api?t=caps"
         );
-        assert_eq!(redact_api_key(""), "");
+        assert_eq!(redact_secrets(""), "");
     }
 
     #[test]
-    fn redact_api_key_value_at_end_without_ampersand() {
-        let redacted = redact_api_key("https://x/api?apikey=secret123");
+    fn redact_secrets_value_at_end_without_ampersand() {
+        let redacted = redact_secrets("https://x/api?apikey=secret123");
         assert!(!redacted.contains("secret123"), "leaked: {redacted}");
         assert_eq!(redacted, "https://x/api?apikey=[REDACTED]");
+    }
+
+    #[test]
+    fn redact_secrets_covers_non_apikey_credentials() {
+        for (url, secret) in [
+            ("https://t/dl?passkey=abc123def", "abc123def"),
+            ("https://t/rss?rss_key=zzz999", "zzz999"),
+            ("https://t/get?torrent_pass=pw77", "pw77"),
+            ("https://t/api?authkey=ak55&t=search", "ak55"),
+        ] {
+            let redacted = redact_secrets(url);
+            assert!(!redacted.contains(secret), "leaked in {redacted}");
+            assert!(redacted.contains("[REDACTED]"), "not redacted: {redacted}");
+        }
+        // WHY: non-secret params survive for diagnostics; only the credential
+        // value is scrubbed.
+        let redacted = redact_secrets("https://t/api?passkey=SECRET&t=search&cat=2000");
+        assert_eq!(
+            redacted,
+            "https://t/api?passkey=[REDACTED]&t=search&cat=2000"
+        );
     }
 
     // ── validate_fetch_url ────────────────────────────────────────────────────

--- a/crates/zetesis/src/client/newznab.rs
+++ b/crates/zetesis/src/client/newznab.rs
@@ -11,7 +11,7 @@ use crate::cf_bypass::CloudflareProxy;
 use crate::client::xml::{get_attr_f64, get_attr_u32, parse_caps_xml, parse_feed_xml};
 use crate::client::{
     IndexerClient, IndexerConfig, build_caps_url, build_search_url, read_body_bounded,
-    redact_api_key, validate_fetch_url,
+    redact_secrets, validate_fetch_url,
 };
 use crate::error::{self, SearchIndexerError};
 use crate::types::{
@@ -55,10 +55,10 @@ impl NewznabClient {
 
         let fut = self.http.get(url).timeout(self.timeout).send();
         let response = tokio::select! {
-            result = fut => result.context(error::HttpRequestSnafu { url: redact_api_key(url) })?,
+            result = fut => result.context(error::HttpRequestSnafu { url: redact_secrets(url) })?,
             () = ct.cancelled() => {
                 return Err(SearchIndexerError::Cancelled {
-                    url: redact_api_key(url),
+                    url: redact_secrets(url),
                     location: snafu::Location::new(file!(), line!(), column!()),
                 });
             }
@@ -98,7 +98,7 @@ impl IndexerClient for NewznabClient {
         let url = build_search_url(&self.config, query);
         let xml = self.fetch_xml(&url, ct).await?;
         let feed = parse_feed_xml(&xml).map_err(|e| SearchIndexerError::ParseResponse {
-            url: redact_api_key(&url),
+            url: redact_secrets(&url),
             error: e.to_string(),
             location: snafu::Location::new(file!(), line!(), column!()),
         })?;
@@ -162,7 +162,7 @@ impl IndexerClient for NewznabClient {
         let url = build_caps_url(&self.config);
         let xml = self.fetch_xml(&url, ct).await?;
         parse_caps_xml(&xml).map_err(|e| SearchIndexerError::ParseResponse {
-            url: redact_api_key(&url),
+            url: redact_secrets(&url),
             error: e.to_string(),
             location: snafu::Location::new(file!(), line!(), column!()),
         })

--- a/crates/zetesis/src/client/torznab.rs
+++ b/crates/zetesis/src/client/torznab.rs
@@ -11,7 +11,7 @@ use crate::cf_bypass::CloudflareProxy;
 use crate::client::xml::{get_attr, get_attr_f64, get_attr_u32, parse_caps_xml, parse_feed_xml};
 use crate::client::{
     IndexerClient, IndexerConfig, build_caps_url, build_search_url, read_body_bounded,
-    redact_api_key, validate_fetch_url,
+    redact_secrets, validate_fetch_url,
 };
 use crate::error::{self, SearchIndexerError};
 use crate::types::{
@@ -55,10 +55,10 @@ impl TorznabClient {
 
         let fut = self.http.get(url).timeout(self.timeout).send();
         let response = tokio::select! {
-            result = fut => result.context(error::HttpRequestSnafu { url: redact_api_key(url) })?,
+            result = fut => result.context(error::HttpRequestSnafu { url: redact_secrets(url) })?,
             () = ct.cancelled() => {
                 return Err(SearchIndexerError::Cancelled {
-                    url: redact_api_key(url),
+                    url: redact_secrets(url),
                     location: snafu::Location::new(file!(), line!(), column!()),
                 });
             }
@@ -98,7 +98,7 @@ impl IndexerClient for TorznabClient {
         let url = build_search_url(&self.config, query);
         let xml = self.fetch_xml(&url, ct).await?;
         let feed = parse_feed_xml(&xml).map_err(|e| SearchIndexerError::ParseResponse {
-            url: redact_api_key(&url),
+            url: redact_secrets(&url),
             error: e.to_string(),
             location: snafu::Location::new(file!(), line!(), column!()),
         })?;
@@ -171,7 +171,7 @@ impl IndexerClient for TorznabClient {
         let url = build_caps_url(&self.config);
         let xml = self.fetch_xml(&url, ct).await?;
         parse_caps_xml(&xml).map_err(|e| SearchIndexerError::ParseResponse {
-            url: redact_api_key(&url),
+            url: redact_secrets(&url),
             error: e.to_string(),
             location: snafu::Location::new(file!(), line!(), column!()),
         })


### PR DESCRIPTION
Closes #623.

`redact_api_key` scrubbed only a literal `apikey=` value, so a private-tracker `passkey` / `rss_key` / `torrent_pass` / auth token embedded in a Cardigann indexer URL survived into any logged or `Display`'d error URL — a credential leak into logs (a passkey grants full tracker access under the operator's account).

Renamed to **`redact_secrets`**: it scrubs the value of every query parameter whose key names a credential (substring, case-insensitive: apikey/api_key/passkey/pass_key/password/rss_key/torrent_pass/authkey/secret/token/session/cookie) and leaves non-secret params (`t`, `q`, `cat`) intact for diagnostics. All indexer clients (torznab/newznab/cardigann + the cf_bypass proxies) route their error-URL redaction through it.

Scope note: path-embedded secrets and truly novel param names remain out of scope (the old apikey-only redactor had the same gaps); the get-method login path already strips the *whole* query (`session::redact_query`) since login URLs also carry `username`.

Security review at T0 (per the standing rule that exploit-surface review stays with the orchestrator). Tests: the new passkey/rss_key/torrent_pass/authkey credentials are scrubbed, non-secret params survive, existing apikey cases unchanged. Full `kanon gate --full` green (2253 tests).