### PR TITLE
fix(deps): bump serde_with 3.20.0 -> 3.21.0 (GHSA-7gcf-g7xr-8hxj)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5039,9 +5039,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -5059,9 +5059,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
**main's security scan is currently red** — this fixes it.

A newly-published advisory ([GHSA-7gcf-g7xr-8hxj](https://osv.dev/GHSA-7gcf-g7xr-8hxj), CVSS 5.1 medium) against `serde_with` 3.20.0 turned osv-scanner red on main **with no code change**; every open PR inherits the failure. osv reports it as fixable:

```
Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 1 Medium, 0 Low)
| https://osv.dev/GHSA-7gcf-g7xr-8hxj | 5.1 | crates.io | serde_with | 3.20.0 | FIXED: 3.21.0 |
```

`serde_with` is a transitive dependency, so this is lockfile-only (`cargo update -p serde_with`, which also carries `serde_with_macros` 3.20.0 → 3.21.0). No manifest change.

Full `kanon gate --full` green (fmt/check/clippy/nextest/deny/lint).