### PR TITLE
chore(standards): drop stale standards/ pointer stub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,8 @@ technology choices.
 
 ## Standards
 
-Kanon-synced standards are summarized in [standards/](standards/). Canonical files
-live under `~/dev/kanon/crates/basanos/standards/`: STANDARDS.md, RUST.md,
-SQL.md, SHELL.md, WRITING.md, and AGENT-DOCS.md.
+Canonical standards live under `~/dev/kanon/crates/basanos/standards/`:
+STANDARDS.md, RUST.md, SQL.md, SHELL.md, WRITING.md, and AGENT-DOCS.md.
 
 ## Build and test
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 ## Documentation
 
-- [standards/](standards/): pointer to canonical fleet standards (kanon `crates/basanos/standards/`)
-- [CLAUDE.md](CLAUDE.md): repo conventions and standards links
+- [CLAUDE.md](CLAUDE.md): repo conventions and standards links (canonical standards live in kanon `crates/basanos/standards/`)
 - [docs/lexicon.md](docs/lexicon.md): Project name registry
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Agents: for a compressed crate map and technology index, load
 - [PROJECT.md](PROJECT.md): Project overview and phase status
 - [LESSONS.md](LESSONS.md): Operational rules from real failures
 - [WORKING-AGREEMENT.md](WORKING-AGREEMENT.md): Syn + Cody collaboration protocol
-- [../standards/README.md](../standards/README.md): Code standards (kanon-synced)
+- Code standards: `~/dev/kanon/crates/basanos/standards/` (kanon-synced)
 
 ## Architecture
 

--- a/docs/architecture/errors.md
+++ b/docs/architecture/errors.md
@@ -2,7 +2,7 @@
 
 > How Harmonia crates define, propagate, and log errors across subsystem boundaries.
 > Error enums listed here map 1:1 to the crate inventory in [cargo.md](cargo.md).
-> Patterns mandated by [standards/README.md](../../standards/README.md) and the GreptimeDB reference architecture.
+> Patterns mandated by `~/dev/kanon/crates/basanos/standards/RUST.md` and the GreptimeDB reference architecture.
 
 ## Purpose
 

--- a/standards/README.md
+++ b/standards/README.md
@@ -1,3 +1,0 @@
-# Standards
-
-Canonical fleet standards live in the internal standards corpus. This pointer file replaces the per-repo standards copy that was drifting.


### PR DESCRIPTION
## Summary
- standards/README.md was a pointer stub; CLAUDE.md claimed it "summarized" kanon standards but it contained none
- Removed standards/ and repointed CLAUDE.md, README.md, docs/README.md, docs/architecture/errors.md directly at kanon crates/basanos/standards/
- Kanon is the only standards home

## Test plan
- [x] Verified no other markdown links to standards/ remain (prose mentions of `standards/RUST.md` as a convention name, not links, left as-is)