### PR TITLE
ci(gate): adopt hybrid-gate.yml, drop duplicate concurrency + inline ai-attribution (kanon#2522)

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -1,3 +1,24 @@
+# WHY(kanon#2522): replaces the trailer-only gate-attestation.yml with the
+# fleet hybrid gate (aletheia#6426 generalized in forkwright/.github). A
+# trailer-stamped PR takes the fast path; a trailer-less (off-slot) PR falls
+# through to a real CI build of fmt/check/clippy/nextest[/doctest] on
+# GH-hosted ubuntu-latest. All gate logic lives in the reusable workflow —
+# this file only supplies harmonia's own commands and flags.
+#
+# WHY hosted in forkwright/.github, not forkwright/kanon: GitHub cannot
+# resolve a workflow_call reference into a private repo owned by a personal
+# account for other-repo callers — proven empirically across the first four
+# adoption PRs (aletheia#6438, koinon#15, heurema#9, sphragis#13), each
+# originally pointed at forkwright/kanon and failing to even schedule the
+# workflow, before being repointed at the public forkwright/.github host
+# (already serving the org-default trailer-only reusable to 8 repos
+# successfully).
+#
+# WHY no ai-attribution job here: the extended hybrid-gate.yml (declaring
+# both ai_attribution_check and docs_only_exemption workflow_call inputs) is
+# now live at forkwright/.github — the centralized `ai_attribution_check:
+# true` input below runs that check, replacing the standalone inline job
+# this file used to carry.
 name: Gate Attestation
 
 on:
@@ -7,126 +28,23 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# WHY no concurrency: block here: hybrid-gate.yml itself already declares
+# `concurrency: group: ${{ github.workflow }}-${{ github.ref }}` and its own
+# comment states callers must NOT also set a concurrency group with that
+# same key, or the shared group self-cancels.
 
 jobs:
-  gate-attestation:
-    name: gate-attestation
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Verify Gate-Passed trailer
-        env:
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          # WHY author-gated, not actor-gated: github.actor changes to whoever
-          # re-runs the workflow, which silently re-arms the trailer check on
-          # bot PRs. The PR author is the stable identity worth waiving.
-          # WHY branch-shaped for release-please: its PRs are authored as
-          # github-actions[bot] under GITHUB_TOKEN, so an author match on
-          # release-please[bot] never fires — the branch pattern is stable.
-          # Release-PR content is generated version bumps; its verification is
-          # the live deny/audit/osv checks + the --locked release build.
-          case "$PR_HEAD_REF" in
-            release-please--branches--*)
-              echo "Release-please branch ($PR_HEAD_REF): gate attestation exempt."
-              exit 0
-              ;;
-          esac
-          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
-            echo "Trusted bot PR author: $PR_AUTHOR"
-            echo "Gate attestation auto-passed for trusted bot PR."
-            exit 0
-          fi
-
-          # WHY: Harmonia runs its full cargo and kanon gates locally before push.
-          # GitHub Actions provides the app-pinned check-run required by branch protection.
-          commits=$(git log --format="%H" "origin/${{ github.base_ref }}..HEAD")
-          if [ -z "$commits" ]; then
-            echo "ERROR: No commits found in PR"
-            exit 1
-          fi
-
-          found=false
-          for sha in $commits; do
-            body=$(git log -1 --format="%b" "$sha")
-            if echo "$body" | grep -q "^Gate-Passed:"; then
-              version=$(echo "$body" | grep "^Gate-Passed:" | head -1)
-              echo "Found gate attestation: $version"
-              found=true
-              break
-            fi
-          done
-
-          if [ "$found" = false ]; then
-            echo "ERROR: No Gate-Passed trailer found in any PR commit."
-            echo "Run the local gate and commit with the trailer."
-            exit 1
-          fi
-
-      - name: Verify no AI attribution
-        env:
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          # WHY: the basanos WORKFLOW/no-ai-attribution gate is local-only; a
-          # GitHub squash-merge folds the PR body into main's history without
-          # running it. This step closes that CI-side hole.
-          # WHY branch-shaped for release-please: same rationale as the trailer
-          # check above — the author varies, the branch pattern does not.
-          case "$PR_HEAD_REF" in
-            release-please--branches--*)
-              echo "Release-please branch ($PR_HEAD_REF): AI attribution check exempt."
-              exit 0
-              ;;
-          esac
-          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
-            echo "Trusted bot PR author: $PR_AUTHOR"
-            echo "AI attribution check auto-passed for trusted bot PR."
-            exit 0
-          fi
-
-          # WHY line-anchored: PR bodies may legitimately discuss the policy in
-          # prose (e.g. quoting "Co-authored-by: Claude …"). Only trailer-shaped
-          # lines and explicit generated-with/robot markers are enforcement targets.
-          pattern='^(co-authored-by:.*(claude|gpt|codex|kimi|gemini|anthropic)|🤖|generated with)'
-          violation=0
-
-          title_hits=$(printf '%s\n' "$PR_TITLE" | grep -inE "$pattern" || true)
-          if [ -n "$title_hits" ]; then
-            echo "ERROR: AI attribution marker found in PR title."
-            printf '%s\n' "$title_hits" | sed 's/^/  title: /'
-            violation=1
-          fi
-
-          # Guard null/empty PR body so the step does not crash; grep on an empty
-          # string simply returns no matches, but the explicit || true makes the
-          # intent obvious and protects against unexpected GitHub env quirks.
-          body_hits=$(printf '%s\n' "$PR_BODY" | grep -inE "$pattern" || true)
-          if [ -n "$body_hits" ]; then
-            echo "ERROR: AI attribution marker found in PR body."
-            printf '%s\n' "$body_hits" | sed 's/^/  body: /'
-            violation=1
-          fi
-
-          commit_hits=$(git log --format="%s%n%b" "origin/${{ github.base_ref }}..HEAD" | grep -inE "$pattern" || true)
-          if [ -n "$commit_hits" ]; then
-            echo "ERROR: AI attribution marker found in PR-range commits."
-            printf '%s\n' "$commit_hits" | sed 's/^/  commit: /'
-            violation=1
-          fi
-
-          if [ "$violation" -ne 0 ]; then
-            echo "Remove AI attribution markers (Co-authored-by AI, 🤖, 'generated with') from the PR title, body, and commits."
-            exit 1
-          fi
+  gate:
+    uses: forkwright/.github/.github/workflows/hybrid-gate.yml@main
+    with:
+      fmt_cmd: "cargo fmt --all -- --check"
+      check_cmd: "cargo check --workspace --all-targets"
+      clippy_cmd: "cargo clippy --workspace --all-targets -- -D warnings"
+      nextest_cmd: "cargo nextest run --workspace"
+      doctest_cmd: "cargo test --workspace --doc"
+      system_packages: "libasound2-dev pkg-config"
+      needs_fleet_repo_token: false
+      rust_cache_key: "gate-attestation"
+      ai_attribution_check: true
+      docs_only_exemption: true
+    secrets: inherit


### PR DESCRIPTION
## What

Adopts the fleet hybrid gate (kanon#2522) in place of the trailer-only
`gate-attestation.yml` passthrough. A `Gate-Passed`-trailer PR still
fast-paths; a trailer-less PR now falls through to a real
fmt/check/clippy/nextest/doctest build on GH-hosted `ubuntu-latest`
instead of hard-sticking on a missing trailer with no way to ever pass.

## Fixes applied to the drafted caller

- Repointed `uses:` from `forkwright/kanon/.github/workflows/hybrid-gate.yml@main`
  to `forkwright/.github/.github/workflows/hybrid-gate.yml@main`. GitHub
  cannot resolve a `workflow_call` reference into a private repo owned by
  a personal account for other-repo callers — the first four adoption PRs
  (aletheia#6438, koinon#15, heurema#9, sphragis#13) each proved this
  empirically before being repointed at the public `.github` host, which
  already serves 8 repos successfully.
- Dropped the caller's own `concurrency:` block. `hybrid-gate.yml`
  already declares that exact group on the reusable side and its own
  comment states callers must not duplicate it — a caller that does
  self-cancels the shared group.
- Dropped the inline `ai-attribution` job. It duplicated what
  `hybrid-gate.yml`'s `ai_attribution_check: true` input now runs
  centrally; also added `docs_only_exemption: true` (both inputs are
  live on `forkwright/.github`'s `hybrid-gate.yml`, verified before
  this PR).

## Verification

- Confirmed harmonia has a root `Cargo.toml` (Rust workspace) and
  `rust-toolchain.toml`.
- Confirmed `forkwright/.github/.github/workflows/hybrid-gate.yml@main`
  declares `ai_attribution_check` and `docs_only_exemption` inputs.
- `system_packages`/`fmt_cmd`/`check_cmd`/`clippy_cmd`/`nextest_cmd`/
  `doctest_cmd` mirror harmonia's existing `ci.yml` exactly.
