### PR TITLE
fix(periskopio): restore standalone compilation (#620)

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,53 @@
+# WHY: periskopio is workspace-excluded, so workspace CI does not compile it.
+name: Desktop
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/theatron/**"
+      - ".github/workflows/desktop.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/theatron/**"
+      - ".github/workflows/desktop.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  desktop-check:
+    name: Desktop check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+      - name: Install desktop system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            libayatana-appindicator3-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            pkg-config
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: periskopio-${{ hashFiles('crates/theatron/desktop/Cargo.toml') }}
+          workspaces: "crates/theatron/desktop"
+      - name: Check desktop
+        run: cargo check --manifest-path crates/theatron/desktop/Cargo.toml

--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -223,8 +223,9 @@ STANDARDS/aggregate-status-without-detail:crates/paroche/src/routes/**
 # the doc comment would break the Display impl's message.
 STANDARDS/tautological-doc:crates/**
 
-# WHY: theatron/desktop is the only crate with an independent version since
-# it tracks the UI release cadence separate from the server workspace.
+# WHY: theatron/desktop is excluded from the root workspace and cannot inherit
+# root package metadata. It also tracks the UI release cadence separately.
+MANIFEST/package-workspace-inheritance:crates/theatron/desktop/Cargo.toml
 RELEASES/independent-crate-version:crates/theatron/desktop/Cargo.toml
 
 # WHY: feature-gate-check fires where dsp stages have cfg-gated feature

--- a/crates/theatron/desktop/Cargo.lock
+++ b/crates/theatron/desktop/Cargo.lock
@@ -2705,6 +2705,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "periskopio"
+version = "0.1.14"
+dependencies = [
+ "dioxus",
+ "dirs",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "skene",
+ "snafu",
+ "tokio",
+ "toml 1.1.0+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3689,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "skene"
+version = "0.1.14"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tracing",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3978,33 +4005,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "theatron-core"
-version = "0.1.1"
-dependencies = [
- "reqwest",
- "serde",
- "serde_json",
- "snafu",
- "tracing",
-]
-
-[[package]]
-name = "theatron-desktop"
-version = "0.1.1"
-dependencies = [
- "dioxus",
- "dirs",
- "reqwest",
- "serde",
- "serde_json",
- "snafu",
- "theatron-core",
- "tokio",
- "toml 1.1.0+spec-1.1.0",
- "tracing",
 ]
 
 [[package]]

--- a/crates/theatron/desktop/Cargo.toml
+++ b/crates/theatron/desktop/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "periskopio"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
+version = "0.1.14"
+edition = "2024"
+license = "AGPL-3.0-or-later"
 description = "Dioxus desktop UI for the Harmonia media platform"
 publish = false
 
@@ -35,7 +35,7 @@ snafu = { version = "0.8", features = ["rust_1_65"] }
 dirs = "6"
 toml = "1.0"
 
-# theatron-desktop uses inline lints because Cargo does not allow combining
+# periskopio uses inline lints because Cargo does not allow combining
 # workspace lint inheritance with package-level overrides.
 [lints.rust]
 future_incompatible = { level = "warn", priority = -1 }

--- a/crates/theatron/desktop/src/main.rs
+++ b/crates/theatron/desktop/src/main.rs
@@ -1,5 +1,5 @@
 //! Entry point for the Harmonia desktop application.
 
 fn main() {
-    theatron_desktop::run();
+    periskopio::run();
 }

--- a/crates/theatron/desktop/src/state.rs
+++ b/crates/theatron/desktop/src/state.rs
@@ -1,6 +1,6 @@
 //! Global application state managed via Dioxus signals.
 
-use theatron_core::types::ConnectionStatus;
+use skene::types::ConnectionStatus;
 
 // WHY: default dev URL; overridden at runtime via HARMONIA_SERVER_URL env var
 // kanon:ignore SECURITY/hardcoded-loopback-url

--- a/crates/theatron/desktop/src/views/settings.rs
+++ b/crates/theatron/desktop/src/views/settings.rs
@@ -118,7 +118,7 @@ pub(crate) fn Settings() -> Element {
                     style: "{ABOUT_STYLE}",
                     p { "Harmonia Desktop" }
                     p { "Self-hosted media platform" }
-                    p { "Built with Dioxus + theatron-core" }
+                    p { "Built with Dioxus + skene" }
                 }
             }
         }

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -42,10 +42,10 @@ gh pr list --state merged --limit 200
 Completed phases:
 - **Phase 1-2:** foundation (themelion, apotheke, horismos, exousia, paroche,
   kathodos, epignosis, kritike, komide, eksetasis, archon)
-- **Phase 3:** acquisition + requests (ergasia, syntaxis, aitesis, syndesmos);
-  desktop UI (theatron) reached feature parity for music + audiobook playback
+- **Phase 3:** acquisition + requests (ergasia, syntaxis, aitesis, syndesmos)
 - **Phase 3.5+ (in progress):** QUIC streaming (syndesis), subtitles (prostheke),
-  consolidated theatron workspace
+  consolidated theatron workspace; the `periskopio` desktop client is pre-alpha,
+  with stub views and no playback wiring
 
 ## Why monorepo
 

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -1,8 +1,11 @@
 # Desktop architecture
 
-The desktop client is a Dioxus (Rust) application named **proskenion**, living in
-`crates/theatron/desktop/`. It shares types and an API client with future TUI
-and web frontends via `crates/theatron/core/` (`theatron-core`).
+The desktop client is a pre-alpha Dioxus (Rust) application named
+**periskopio**, living in `crates/theatron/desktop/`. Shared types and an API
+client live in `crates/theatron/core/` (`skene`) for reuse by future frontends.
+
+The routed views are stubs. Playback is not wired, and the `skene` API client is
+not connected to the UI.
 
 This crate is **excluded from the workspace** in root `Cargo.toml` to decouple
 its build from backend CI. Build standalone:
@@ -15,10 +18,9 @@ cargo build --release --manifest-path crates/theatron/desktop/Cargo.toml
 ## Current state
 
 - Framework: Dioxus 0.7 (`desktop`, `router` features)
-- Shared client: `theatron-core` (reqwest + serde + snafu)
-- Config persistence: `dirs` + `toml` for local settings (server URL, token)
-- Auth: Bearer JWT issued by `exousia`; stored locally, refreshed on the
-  server via `paroche`
+- Shared client: `skene` (reqwest + serde + snafu), not yet wired to the UI
+- App state: development server URL, in-memory auth placeholder, and theme
+- Playback: not implemented
 
 ## Prior Tauri/React design (removed)
 
@@ -26,9 +28,10 @@ The initial design used Tauri 2 with a React + Zustand + TanStack Query frontend
 That approach was retired in favor of Dioxus to keep the entire stack in Rust and
 share types with the backend without a code-generation layer. History is in git.
 
-## Communication
+## Planned communication
 
-The desktop talks to a `harmonia serve` instance over HTTP (REST + WebSocket)
-and, for audio, over QUIC via `syndesis`. See
+The planned client communicates with a `harmonia serve` instance over HTTP
+(REST + WebSocket) and uses `syndesis` for audio over QUIC. Neither transport is
+wired into the current desktop UI. See
 [`../architecture/binary-modes.md`](../architecture/binary-modes.md) for the
 current `archon` subcommands and the standalone desktop package boundary.


### PR DESCRIPTION
Lane fix for #620; hosted CI (gate / full-gate-build) is the compile+test proof.

Refs #620