### PR TITLE
chore(syndesmos): mark planned Plex surfaces held (#632)

### DIFF
--- a/crates/syndesmos/src/plex/collections.rs
+++ b/crates/syndesmos/src/plex/collections.rs
@@ -11,7 +11,7 @@ use crate::error::SyndesmodError;
 /// maps Harmonia tags → Plex collection create/update calls.
 #[expect(
     dead_code,
-    reason = "placeholder trait surface defined by spec; implementation deferred to post-v1, tracked in #642"
+    reason = "held: placeholder trait surface defined by spec; implementation deferred to post-v1, tracked in #642"
 )]
 pub(crate) trait CollectionManager: Send + Sync {
     /// Synchronises a named collection, creating or updating it in Plex.

--- a/crates/syndesmos/src/plex/notify.rs
+++ b/crates/syndesmos/src/plex/notify.rs
@@ -16,7 +16,7 @@ use crate::retry::{CircuitBreaker, with_retry};
     not(test),
     expect(
         dead_code,
-        reason = "primary entry point once PlexNotifyRequired carries MediaType, tracked in #644"
+        reason = "held: primary entry point once PlexNotifyRequired carries MediaType, tracked in #644"
     )
 )]
 #[instrument(skip(client, api, circuit))]

--- a/crates/syndesmos/src/plex/stats.rs
+++ b/crates/syndesmos/src/plex/stats.rs
@@ -11,7 +11,7 @@ use crate::error::SyndesmodError;
 /// queries `/status/sessions/history/all` and maps to Harmonia records.
 #[expect(
     dead_code,
-    reason = "placeholder trait surface defined by spec; implementation deferred to post-v1, tracked in #643"
+    reason = "held: placeholder trait surface defined by spec; implementation deferred to post-v1, tracked in #643"
 )]
 pub(crate) trait StatsProvider: Send + Sync {
     /// Returns raw watch history entries for the given Plex user.


### PR DESCRIPTION
Lane fix for #632; hosted CI (gate / full-gate-build) is the compile+test proof.

Refs #632