### PR TITLE
fix(deps): repair ulid 3.0 and rubato 4.0 fallout on main

### DIFF
--- a/crates/akouo-core/src/output/resample.rs
+++ b/crates/akouo-core/src/output/resample.rs
@@ -16,7 +16,7 @@ struct InterleavedIn<'a> {
     frames: usize,
 }
 
-unsafe impl<'a> Adapter<'a, f64> for InterleavedIn<'a> {
+unsafe impl<'a> Adapter<f64> for InterleavedIn<'a> {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> f64 {
         // SAFETY: caller guarantees channel < channels and frame < frames
         unsafe { *self.data.get_unchecked(frame * self.channels + channel) }
@@ -35,7 +35,7 @@ struct InterleavedOut<'a> {
     frames: usize,
 }
 
-unsafe impl<'a> Adapter<'a, f64> for InterleavedOut<'a> {
+unsafe impl<'a> Adapter<f64> for InterleavedOut<'a> {
     unsafe fn read_sample_unchecked(&self, channel: usize, frame: usize) -> f64 {
         // SAFETY: caller guarantees channel < channels and frame < frames
         unsafe { *self.data.get_unchecked(frame * self.channels + channel) }
@@ -48,7 +48,7 @@ unsafe impl<'a> Adapter<'a, f64> for InterleavedOut<'a> {
     }
 }
 
-unsafe impl<'a> AdapterMut<'a, f64> for InterleavedOut<'a> {
+unsafe impl<'a> AdapterMut<f64> for InterleavedOut<'a> {
     unsafe fn write_sample_unchecked(&mut self, channel: usize, frame: usize, value: &f64) -> bool {
         // SAFETY: caller guarantees channel < channels and frame < frames
         unsafe { *self.data.get_unchecked_mut(frame * self.channels + channel) = *value };
@@ -87,7 +87,7 @@ impl Resampler {
 
         let params = SincInterpolationParameters {
             sinc_len: 256,
-            f_cutoff: 0.95,
+            f_cutoff: Some(0.95),
             interpolation: SincInterpolationType::Linear,
             oversampling_factor: 256,
             window: WindowFunction::BlackmanHarris2,

--- a/crates/paroche/src/routes/zone.rs
+++ b/crates/paroche/src/routes/zone.rs
@@ -70,7 +70,7 @@ pub async fn create_zone(
         });
     }
 
-    let id = ulid::Ulid::new().to_string();
+    let id = ulid::Ulid::generate().to_string();
     let created = zone::create_zone(&state.db.write, &id, body.name.trim()).await?;
     let with_members = zone::ZoneWithMembers {
         zone: created,


### PR DESCRIPTION
Main has been compile-broken since the ulid (#640) and rubato (#641) majors landed — every open PR shows the identical Check/Clippy/Test/full-gate-build failure fingerprint. Fixes both breaks: `Ulid::new` → `Ulid::generate` in paroche; audioadapter 4.0 trait-lifetime removal + `f_cutoff: Some(_)` in akouo-core.

A separate issue will document why the majors merged red (required-check gap during the hybrid-gate cutover).

Refs #640 #641