### PR TITLE
fix(archon): tag EngineAdapter's dead_code suppression with a held marker (#633)

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -328,7 +328,13 @@ fn search_error(error: eksetasis::SearchIndexerError) -> ServiceError {
     }
 }
 
-struct EngineAdapter(#[expect(dead_code)] Arc<TorrentSession>);
+struct EngineAdapter(
+    #[expect(
+        dead_code,
+        reason = "held: keeps the TorrentSession alive for EngineAdapter's Arc<dyn DynDownloadEngine> type-erasure; DynDownloadEngine has no methods to read the field"
+    )]
+    Arc<TorrentSession>,
+);
 impl DynDownloadEngine for EngineAdapter {}
 
 /// Bridges the running `DownloadQueue` to paroche's queue-manager trait so an


### PR DESCRIPTION
## Fix
`EngineAdapter`'s `#[expect(dead_code)]` on its `Arc<TorrentSession>` field carried no `reason` — the last unwired-dead-code-untracked site in the tree without a #NNN ref or benign marker (the other 11 from #633 are already compliant on main). The field is genuinely never read (`DynDownloadEngine` is a zero-method marker trait); the Arc just keeps the session alive for the `Arc<dyn DynDownloadEngine>` type-erasure, so the `held:` marker — already used for structurally-identical fields in `engine.rs` — is the correct classification.

Refs #633