### PR TITLE
fix(archon,paroche): persist want and release rows before enqueue, on both surfaces

### DIFF
--- a/crates/archon/src/mcp.rs
+++ b/crates/archon/src/mcp.rs
@@ -281,15 +281,16 @@ fn enqueue_download_tool() -> Value {
     json!({
         "name": "harmonia_enqueue_download",
         "title": "Enqueue a download",
-        "description": "Enqueue exactly one of a cached search result (release_id) or a magnet URI. release_id resolves its credentialed download URL server-side — the credential never crosses this tool boundary. Requires a running 'harmonia serve'.",
+        "description": "Enqueue exactly one of a cached search result (release_id) or a magnet URI, against an existing want. release_id resolves its credentialed download URL server-side — the credential never crosses this tool boundary. Requires a running 'harmonia serve'.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "release_id": { "type": "string", "description": "A release_id from a prior harmonia_search_releases result." },
                 "magnet": { "type": "string", "description": "A magnet: URI. Raw http(s) URLs are rejected — use release_id for credentialed indexer results." },
                 "priority": { "type": "integer", "minimum": 1, "maximum": 4, "default": 4 },
-                "want_id": { "type": "string", "description": "Optional want row UUID to associate; a fresh UUIDv7 is generated when omitted." }
+                "want_id": { "type": "string", "description": "An existing want row UUID to associate this download with — must already exist; the tool never invents one." }
             },
+            "required": ["want_id"],
             "additionalProperties": false
         }
     })

--- a/crates/archon/src/mcp_bridge.rs
+++ b/crates/archon/src/mcp_bridge.rs
@@ -825,16 +825,18 @@ mod tests {
             Box::pin(async { Err(ServiceError::NotAvailable) })
         }
         fn resolve_release(&self, release_id: Uuid) -> ServiceFut<ResolvedRelease> {
-            let found = self.resolve.get(&release_id).cloned().map(|entry| {
-                ResolvedRelease {
+            let found = self
+                .resolve
+                .get(&release_id)
+                .cloned()
+                .map(|entry| ResolvedRelease {
                     download_url: entry.download_url,
                     protocol: entry.protocol,
                     info_hash: entry.info_hash,
                     indexer_id: entry.indexer_id,
                     title: entry.title,
                     size_bytes: entry.size_bytes,
-                }
-            });
+                });
             Box::pin(async move { found.ok_or(ServiceError::NotFound) })
         }
     }
@@ -959,11 +961,12 @@ mod tests {
     /// returns its id — the ONLY way `handle_enqueue` will now accept a
     /// `want_id` (#651: the tool no longer invents one).
     async fn seed_want(pool: &SqlitePool) -> Uuid {
-        let profile_id: i64 =
-            sqlx::query_scalar("SELECT id FROM quality_profiles WHERE media_type = 'music' LIMIT 1")
-                .fetch_one(pool)
-                .await
-                .expect("migrator seeds a default music quality profile");
+        let profile_id: i64 = sqlx::query_scalar(
+            "SELECT id FROM quality_profiles WHERE media_type = 'music' LIMIT 1",
+        )
+        .fetch_one(pool)
+        .await
+        .expect("migrator seeds a default music quality profile");
         let want_id = Uuid::now_v7();
         want::insert_want(
             pool,
@@ -1354,7 +1357,10 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(release_count, 1, "the retry must not duplicate the release row");
+        assert_eq!(
+            release_count, 1,
+            "the retry must not duplicate the release row"
+        );
     }
 
     #[tokio::test]

--- a/crates/archon/src/mcp_bridge.rs
+++ b/crates/archon/src/mcp_bridge.rs
@@ -39,6 +39,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use apotheke::DbPools;
+use apotheke::repo::want::{self, Release};
 use paroche::state::{DynQueueManager, DynSearchService, EnqueueItem, ServiceError};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -52,6 +53,12 @@ const ACQUISITION_TOOLS: [&str; 4] = [
     "harmonia_list_downloads",
     "harmonia_cancel_download",
 ];
+
+// WHY: `releases.indexer_id` is a plain NOT NULL i64, not an FK — a
+// client-supplied magnet URI never came from a cataloged indexer, so it
+// gets this sentinel rather than a fabricated real indexer id. Real
+// `indexers.id` values are SQLite rowids starting at 1, never 0.
+const MANUAL_MAGNET_INDEXER_ID: i64 = 0;
 
 /// True for the 4 tool names the bridge serves — the stdio surface uses
 /// this to decide "forward to the bridge" vs. "run in-process."
@@ -226,7 +233,7 @@ async fn handle_enqueue(arguments: &Value, ctx: &BridgeContext) -> Value {
         Err(e) => return tool_error(format!("invalid enqueue arguments: {e}")),
     };
 
-    let (release_id, download_url, protocol, info_hash) =
+    let (release_id, download_url, protocol, info_hash, title, size_bytes, indexer_id) =
         match (args.release_id.as_deref(), args.magnet.as_deref()) {
             (Some(_), Some(_)) => {
                 return tool_error("exactly one of release_id or magnet is required, not both");
@@ -246,6 +253,9 @@ async fn handle_enqueue(arguments: &Value, ctx: &BridgeContext) -> Value {
                         resolved.download_url,
                         resolved.protocol,
                         resolved.info_hash,
+                        resolved.title,
+                        resolved.size_bytes,
+                        resolved.indexer_id,
                     ),
                     Err(ServiceError::NotFound) => {
                         return tool_error(format!(
@@ -267,11 +277,29 @@ async fn handle_enqueue(arguments: &Value, ctx: &BridgeContext) -> Value {
                          release_id for credentialed indexer results",
                     );
                 }
+                // WHY: `dn` (display name) / `xl` (exact length) are the
+                // magnet URI spec's own metadata query params — reused as
+                // the persisted release's title/size so a self-supplied
+                // magnet gets a real `releases` row too, not just the
+                // cache-backed release_id arm (#651).
+                let mut title = None;
+                let mut size_bytes = None;
+                for (key, value) in parsed.query_pairs() {
+                    match key.as_ref() {
+                        "dn" => title = Some(value.into_owned()),
+                        "xl" => size_bytes = value.parse::<u64>().ok(),
+                        _ => {}
+                    }
+                }
+                let title = title.unwrap_or_else(|| "magnet download".to_string());
                 (
                     Uuid::now_v7(),
                     magnet.to_string(),
                     "torrent".to_string(),
                     None,
+                    title,
+                    size_bytes,
+                    MANUAL_MAGNET_INDEXER_ID,
                 )
             }
         };
@@ -284,10 +312,83 @@ async fn handle_enqueue(arguments: &Value, ctx: &BridgeContext) -> Value {
         return tool_error(error.to_string());
     }
 
-    let want_id = match args.want_id.as_deref().map(Uuid::parse_str).transpose() {
-        Ok(id) => id.unwrap_or_else(Uuid::now_v7),
+    // WHY: the tool no longer mints a want id for a caller that omits one
+    // (#651) — an invented id can never resolve against `wants`, so the
+    // production `ImportAdapter` deterministically fails after the transfer
+    // completes. The caller must reference a want it already created.
+    let Some(raw_want_id) = args.want_id.as_deref() else {
+        return tool_error(
+            "want_id is required and must reference an existing want row — create the want \
+             first; this tool no longer invents an unresolvable id",
+        );
+    };
+    let want_id = match Uuid::parse_str(raw_want_id) {
+        Ok(id) => id,
         Err(_) => return tool_error("want_id must be a valid UUID"),
     };
+
+    match want::get_want(&ctx.db.read, want_id.as_bytes().as_ref()).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return tool_error(format!(
+                "want {want_id} not found — create it before enqueueing"
+            ));
+        }
+        Err(e) => return tool_error(format!("failed to look up want {want_id}: {e}")),
+    }
+
+    // INVARIANT: the `releases` row for `release_id` must exist BEFORE this
+    // handler calls `queue.enqueue()` below — `syntaxis::ImportService`'s
+    // production adapter resolves both `want_id` and `release_id` against
+    // `apotheke::repo::want::{get_want,get_release}` once the transfer
+    // completes (#651). A search result's `release_id` otherwise lives only
+    // in eksetasis's in-memory cache; persisting it here, ahead of enqueue,
+    // is what makes it a durable identifier rather than a process-local key.
+    match want::get_release(&ctx.db.read, release_id.as_bytes().as_ref()).await {
+        Ok(Some(existing)) if existing.want_id == want_id.as_bytes().to_vec() => {
+            // NOTE: idempotent retry — this exact (release, want) pair is
+            // already persisted (e.g. a prior enqueue attempt failed after
+            // this insert but before the queue write) — reuse it.
+        }
+        Ok(Some(_other_want)) => {
+            return tool_error(format!(
+                "release {release_id} is already recorded under a different want"
+            ));
+        }
+        Ok(None) => {
+            let release = Release {
+                id: release_id.as_bytes().to_vec(),
+                want_id: want_id.as_bytes().to_vec(),
+                indexer_id,
+                title,
+                size_bytes: i64::try_from(size_bytes.unwrap_or(0)).unwrap_or(i64::MAX),
+                // WHY: no pre-download quality-assessment pipeline scores a
+                // raw search hit or magnet yet — kritike::assessment scores
+                // already-imported file tags (kathodos::sidecar output), not
+                // release-name text. 0 is a neutral placeholder, not a
+                // measured quality claim; upgrade decisions over this row
+                // are unaffected since they compare against OTHER releases
+                // of the same want, not an absolute threshold.
+                quality_score: 0,
+                custom_format_score: 0,
+                download_url: download_url.clone(),
+                protocol: protocol.clone(),
+                info_hash: info_hash.clone(),
+                found_at: jiff::Timestamp::now().to_string(),
+                grabbed_at: None,
+                rejected_reason: None,
+            };
+            if let Err(e) = want::insert_release(&ctx.db.write, &release).await {
+                return tool_error(format!("failed to persist release {release_id}: {e}"));
+            }
+        }
+        Err(e) => {
+            return tool_error(format!(
+                "failed to check for an existing release record: {e}"
+            ));
+        }
+    }
+
     let queue_id = Uuid::now_v7();
     let priority = args.priority.clamp(1, 4);
 
@@ -670,6 +771,7 @@ mod tests {
     use std::time::Duration;
 
     use apotheke::migrate::MIGRATOR;
+    use apotheke::repo::want::Want;
     use paroche::state::{ResolvedRelease, ServiceFut};
     use sqlx::SqlitePool;
 
@@ -677,9 +779,35 @@ mod tests {
 
     // ── Stub search / queue services ─────────────────────────────────────
 
+    /// A cached search hit's resolvable form — everything the real
+    /// `eksetasis` results cache would carry for a `release_id`, so
+    /// `handle_enqueue`'s release-persistence step has real data to write.
+    #[derive(Clone)]
+    struct ResolveEntry {
+        download_url: String,
+        protocol: String,
+        info_hash: Option<String>,
+        title: String,
+        size_bytes: Option<u64>,
+        indexer_id: i64,
+    }
+
+    impl ResolveEntry {
+        fn new(download_url: impl Into<String>, protocol: impl Into<String>) -> Self {
+            Self {
+                download_url: download_url.into(),
+                protocol: protocol.into(),
+                info_hash: None,
+                title: "Test.Release.Title".to_string(),
+                size_bytes: Some(1_000_000),
+                indexer_id: 1,
+            }
+        }
+    }
+
     struct StubSearch {
         results: Value,
-        resolve: HashMap<Uuid, (String, String, Option<String>)>,
+        resolve: HashMap<Uuid, ResolveEntry>,
     }
 
     impl DynSearchService for StubSearch {
@@ -697,14 +825,16 @@ mod tests {
             Box::pin(async { Err(ServiceError::NotAvailable) })
         }
         fn resolve_release(&self, release_id: Uuid) -> ServiceFut<ResolvedRelease> {
-            let found =
-                self.resolve
-                    .get(&release_id)
-                    .map(|(url, protocol, hash)| ResolvedRelease {
-                        download_url: url.clone(),
-                        protocol: protocol.clone(),
-                        info_hash: hash.clone(),
-                    });
+            let found = self.resolve.get(&release_id).cloned().map(|entry| {
+                ResolvedRelease {
+                    download_url: entry.download_url,
+                    protocol: entry.protocol,
+                    info_hash: entry.info_hash,
+                    indexer_id: entry.indexer_id,
+                    title: entry.title,
+                    size_bytes: entry.size_bytes,
+                }
+            });
             Box::pin(async move { found.ok_or(ServiceError::NotFound) })
         }
     }
@@ -719,6 +849,13 @@ mod tests {
         cancelled: Mutex<Vec<Uuid>>,
         known: Mutex<std::collections::HashSet<Uuid>>,
         persist: Option<SqlitePool>,
+        /// ORDERING PROBE (#651): for each `enqueue()` call, whether a
+        /// `releases` row for that item's `release_id` already existed AT
+        /// THE MOMENT this stub ran. An end-state check alone ("does the
+        /// row exist once dispatch returns") would still pass if
+        /// `handle_enqueue` persisted the release AFTER calling
+        /// `queue.enqueue()` — this catches exactly that reordering.
+        release_existed_at_enqueue: Arc<Mutex<Vec<bool>>>,
     }
 
     impl StubQueue {
@@ -735,8 +872,17 @@ mod tests {
             self.known.lock().unwrap().insert(item.queue_id);
             let pool = self.persist.clone();
             self.enqueued.lock().unwrap().push(item.clone());
+            let release_existed = Arc::clone(&self.release_existed_at_enqueue);
             Box::pin(async move {
                 if let Some(pool) = pool {
+                    let existed: i64 =
+                        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM releases WHERE id = ?)")
+                            .bind(item.release_id.as_bytes().as_slice())
+                            .fetch_one(&pool)
+                            .await
+                            .unwrap_or(0);
+                    release_existed.lock().unwrap().push(existed != 0);
+
                     sqlx::query(
                         "INSERT INTO download_queue (id, want_id, release_id, download_url, \
                          protocol, priority, info_hash, status) \
@@ -806,6 +952,37 @@ mod tests {
             results: json!({ "results": [] }),
             resolve: HashMap::new(),
         }
+    }
+
+    /// Persists a real `wants` row (and, on first call, its
+    /// `quality_profiles` prerequisite via the migrator's seed data) and
+    /// returns its id — the ONLY way `handle_enqueue` will now accept a
+    /// `want_id` (#651: the tool no longer invents one).
+    async fn seed_want(pool: &SqlitePool) -> Uuid {
+        let profile_id: i64 =
+            sqlx::query_scalar("SELECT id FROM quality_profiles WHERE media_type = 'music' LIMIT 1")
+                .fetch_one(pool)
+                .await
+                .expect("migrator seeds a default music quality profile");
+        let want_id = Uuid::now_v7();
+        want::insert_want(
+            pool,
+            &Want {
+                id: want_id.as_bytes().to_vec(),
+                media_type: "music_album".to_string(),
+                title: "Test Want".to_string(),
+                registry_id: None,
+                quality_profile_id: profile_id,
+                status: "searching".to_string(),
+                source: None,
+                source_ref: None,
+                added_at: jiff::Timestamp::now().to_string(),
+                fulfilled_at: None,
+            },
+        )
+        .await
+        .expect("seed want inserts");
+        want_id
     }
 
     // ── tools/list membership ────────────────────────────────────────────
@@ -970,22 +1147,24 @@ mod tests {
         let credentialed =
             "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd&apikey=SECRETVALUE";
         let mut resolve = HashMap::new();
-        resolve.insert(
-            release_id,
-            (credentialed.to_string(), "torrent".to_string(), None),
-        );
+        resolve.insert(release_id, ResolveEntry::new(credentialed, "torrent"));
         let search = StubSearch {
             results: json!({}),
             resolve,
         };
         let pool = test_db().await;
+        let want_id = seed_want(&pool).await;
         let queue = Arc::new(StubQueue::with_pool(pool.clone()));
         let ctx = ctx_with_pool(pool, search, Arc::clone(&queue));
 
         let result = ctx
             .dispatch(
                 "harmonia_enqueue_download",
-                &json!({ "release_id": release_id.to_string(), "priority": 3 }),
+                &json!({
+                    "release_id": release_id.to_string(),
+                    "want_id": want_id.to_string(),
+                    "priority": 3
+                }),
             )
             .await;
 
@@ -1010,6 +1189,205 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn enqueue_rejects_missing_want_id() {
+        // WHY: #651 — omitting want_id must be a hard rejection, never a
+        // silently minted, unresolvable id.
+        let release_id = Uuid::now_v7();
+        let mut resolve = HashMap::new();
+        resolve.insert(
+            release_id,
+            ResolveEntry::new(
+                "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd",
+                "torrent",
+            ),
+        );
+        let search = StubSearch {
+            results: json!({}),
+            resolve,
+        };
+        let ctx = test_ctx(search, StubQueue::default()).await;
+
+        let result = ctx
+            .dispatch(
+                "harmonia_enqueue_download",
+                &json!({ "release_id": release_id.to_string() }),
+            )
+            .await;
+
+        assert_eq!(result["isError"], true);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("want_id is required")
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_rejects_unknown_want_id() {
+        // WHY: #651 — a well-formed but non-existent want_id must be
+        // rejected too, not accepted and later fail import.
+        let release_id = Uuid::now_v7();
+        let mut resolve = HashMap::new();
+        resolve.insert(
+            release_id,
+            ResolveEntry::new(
+                "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd",
+                "torrent",
+            ),
+        );
+        let search = StubSearch {
+            results: json!({}),
+            resolve,
+        };
+        let ctx = test_ctx(search, StubQueue::default()).await;
+
+        let result = ctx
+            .dispatch(
+                "harmonia_enqueue_download",
+                &json!({
+                    "release_id": release_id.to_string(),
+                    "want_id": Uuid::now_v7().to_string()
+                }),
+            )
+            .await;
+
+        assert_eq!(result["isError"], true);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("not found")
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_persists_the_release_row_before_calling_queue_enqueue() {
+        // WHY: #651's core ordering/durability assertion — an end-state
+        // check ("does a releases row exist once dispatch returns") would
+        // still pass if the persist call were moved to AFTER
+        // `queue.enqueue()`. StubQueue::enqueue records whether the row
+        // already existed the INSTANT it ran, so this fails under that
+        // reordering even though the final state would look identical.
+        let release_id = Uuid::now_v7();
+        let mut resolve = HashMap::new();
+        resolve.insert(
+            release_id,
+            ResolveEntry::new(
+                "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd",
+                "torrent",
+            ),
+        );
+        let search = StubSearch {
+            results: json!({}),
+            resolve,
+        };
+        let pool = test_db().await;
+        let want_id = seed_want(&pool).await;
+        let queue = Arc::new(StubQueue::with_pool(pool.clone()));
+        let ctx = ctx_with_pool(pool.clone(), search, Arc::clone(&queue));
+
+        let result = ctx
+            .dispatch(
+                "harmonia_enqueue_download",
+                &json!({
+                    "release_id": release_id.to_string(),
+                    "want_id": want_id.to_string()
+                }),
+            )
+            .await;
+
+        assert_eq!(result["isError"], false, "{result:?}");
+        let ordering_flags = queue.release_existed_at_enqueue.lock().unwrap().clone();
+        assert_eq!(
+            ordering_flags,
+            vec![true],
+            "the releases row must be written before queue.enqueue() is called, not after"
+        );
+
+        let persisted_want_id: Vec<u8> =
+            sqlx::query_scalar("SELECT want_id FROM releases WHERE id = ?")
+                .bind(release_id.as_bytes().as_slice())
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(persisted_want_id, want_id.as_bytes().to_vec());
+    }
+
+    #[tokio::test]
+    async fn enqueue_release_id_retry_reuses_the_persisted_release_row() {
+        // WHY: a retry (e.g. after a transient queue failure) must not
+        // fail on a duplicate-key insert against an already-persisted
+        // release — the second call reuses the row idempotently.
+        let release_id = Uuid::now_v7();
+        let mut resolve = HashMap::new();
+        resolve.insert(
+            release_id,
+            ResolveEntry::new(
+                "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd",
+                "torrent",
+            ),
+        );
+        let search = StubSearch {
+            results: json!({}),
+            resolve,
+        };
+        let pool = test_db().await;
+        let want_id = seed_want(&pool).await;
+        let queue = Arc::new(StubQueue::with_pool(pool.clone()));
+        let ctx = ctx_with_pool(pool.clone(), search, Arc::clone(&queue));
+        let args = json!({
+            "release_id": release_id.to_string(),
+            "want_id": want_id.to_string()
+        });
+
+        let first = ctx.dispatch("harmonia_enqueue_download", &args).await;
+        assert_eq!(first["isError"], false, "{first:?}");
+        let second = ctx.dispatch("harmonia_enqueue_download", &args).await;
+        assert_eq!(second["isError"], false, "{second:?}");
+
+        let release_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM releases WHERE id = ?")
+            .bind(release_id.as_bytes().as_slice())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(release_count, 1, "the retry must not duplicate the release row");
+    }
+
+    #[tokio::test]
+    async fn enqueue_magnet_arm_persists_a_release_row_from_dn_and_xl() {
+        // WHY: #651's release-row gap is identical on the magnet arm — a
+        // self-supplied magnet also needs a durable `releases` row before
+        // enqueue, derived from the magnet URI's own dn/xl metadata params.
+        let search = empty_search();
+        let pool = test_db().await;
+        let want_id = seed_want(&pool).await;
+        let queue = Arc::new(StubQueue::with_pool(pool.clone()));
+        let ctx = ctx_with_pool(pool.clone(), search, Arc::clone(&queue));
+
+        let result = ctx
+            .dispatch(
+                "harmonia_enqueue_download",
+                &json!({
+                    "magnet": "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd&dn=My.Release&xl=123456",
+                    "want_id": want_id.to_string()
+                }),
+            )
+            .await;
+
+        assert_eq!(result["isError"], false, "{result:?}");
+        let row: (String, i64, i64) =
+            sqlx::query_as("SELECT title, size_bytes, indexer_id FROM releases WHERE want_id = ?")
+                .bind(want_id.as_bytes().as_slice())
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, "My.Release");
+        assert_eq!(row.1, 123_456);
+        assert_eq!(row.2, MANUAL_MAGNET_INDEXER_ID);
     }
 
     // ── list ──────────────────────────────────────────────────────────────

--- a/crates/archon/src/mcp_bridge.rs
+++ b/crates/archon/src/mcp_bridge.rs
@@ -39,7 +39,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use apotheke::DbPools;
-use apotheke::repo::want::{self, Release};
 use paroche::state::{DynQueueManager, DynSearchService, EnqueueItem, ServiceError};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -53,12 +52,6 @@ const ACQUISITION_TOOLS: [&str; 4] = [
     "harmonia_list_downloads",
     "harmonia_cancel_download",
 ];
-
-// WHY: `releases.indexer_id` is a plain NOT NULL i64, not an FK — a
-// client-supplied magnet URI never came from a cataloged indexer, so it
-// gets this sentinel rather than a fabricated real indexer id. Real
-// `indexers.id` values are SQLite rowids starting at 1, never 0.
-const MANUAL_MAGNET_INDEXER_ID: i64 = 0;
 
 /// True for the 4 tool names the bridge serves — the stdio surface uses
 /// this to decide "forward to the bridge" vs. "run in-process."
@@ -281,16 +274,10 @@ async fn handle_enqueue(arguments: &Value, ctx: &BridgeContext) -> Value {
                 // magnet URI spec's own metadata query params — reused as
                 // the persisted release's title/size so a self-supplied
                 // magnet gets a real `releases` row too, not just the
-                // cache-backed release_id arm (#651).
-                let mut title = None;
-                let mut size_bytes = None;
-                for (key, value) in parsed.query_pairs() {
-                    match key.as_ref() {
-                        "dn" => title = Some(value.into_owned()),
-                        "xl" => size_bytes = value.parse::<u64>().ok(),
-                        _ => {}
-                    }
-                }
+                // cache-backed release_id arm (#651). Shared with the HTTP
+                // route's own self-supplied-URL arm.
+                let (title, size_bytes) =
+                    paroche::routes::download::magnet_release_metadata(&parsed);
                 let title = title.unwrap_or_else(|| "magnet download".to_string());
                 (
                     Uuid::now_v7(),
@@ -299,7 +286,7 @@ async fn handle_enqueue(arguments: &Value, ctx: &BridgeContext) -> Value {
                     None,
                     title,
                     size_bytes,
-                    MANUAL_MAGNET_INDEXER_ID,
+                    paroche::routes::download::MANUAL_RELEASE_INDEXER_ID,
                 )
             }
         };
@@ -327,66 +314,42 @@ async fn handle_enqueue(arguments: &Value, ctx: &BridgeContext) -> Value {
         Err(_) => return tool_error("want_id must be a valid UUID"),
     };
 
-    match want::get_want(&ctx.db.read, want_id.as_bytes().as_ref()).await {
-        Ok(Some(_)) => {}
-        Ok(None) => {
-            return tool_error(format!(
-                "want {want_id} not found — create it before enqueueing"
-            ));
-        }
-        Err(e) => return tool_error(format!("failed to look up want {want_id}: {e}")),
-    }
-
-    // INVARIANT: the `releases` row for `release_id` must exist BEFORE this
-    // handler calls `queue.enqueue()` below — `syntaxis::ImportService`'s
-    // production adapter resolves both `want_id` and `release_id` against
-    // `apotheke::repo::want::{get_want,get_release}` once the transfer
-    // completes (#651). A search result's `release_id` otherwise lives only
-    // in eksetasis's in-memory cache; persisting it here, ahead of enqueue,
-    // is what makes it a durable identifier rather than a process-local key.
-    match want::get_release(&ctx.db.read, release_id.as_bytes().as_ref()).await {
-        Ok(Some(existing)) if existing.want_id == want_id.as_bytes().to_vec() => {
-            // NOTE: idempotent retry — this exact (release, want) pair is
-            // already persisted (e.g. a prior enqueue attempt failed after
-            // this insert but before the queue write) — reuse it.
-        }
-        Ok(Some(_other_want)) => {
-            return tool_error(format!(
-                "release {release_id} is already recorded under a different want"
-            ));
-        }
-        Ok(None) => {
-            let release = Release {
-                id: release_id.as_bytes().to_vec(),
-                want_id: want_id.as_bytes().to_vec(),
-                indexer_id,
-                title,
-                size_bytes: i64::try_from(size_bytes.unwrap_or(0)).unwrap_or(i64::MAX),
-                // WHY: no pre-download quality-assessment pipeline scores a
-                // raw search hit or magnet yet — kritike::assessment scores
-                // already-imported file tags (kathodos::sidecar output), not
-                // release-name text. 0 is a neutral placeholder, not a
-                // measured quality claim; upgrade decisions over this row
-                // are unaffected since they compare against OTHER releases
-                // of the same want, not an absolute threshold.
-                quality_score: 0,
-                custom_format_score: 0,
-                download_url: download_url.clone(),
-                protocol: protocol.clone(),
-                info_hash: info_hash.clone(),
-                found_at: jiff::Timestamp::now().to_string(),
-                grabbed_at: None,
-                rejected_reason: None,
-            };
-            if let Err(e) = want::insert_release(&ctx.db.write, &release).await {
-                return tool_error(format!("failed to persist release {release_id}: {e}"));
+    // INVARIANT: the `releases` row for `release_id` (and `want_id`'s own
+    // existence) must be persisted BEFORE this handler calls
+    // `queue.enqueue()` below — shared with the HTTP route via
+    // `paroche::routes::download::persist_release_before_enqueue` (#651):
+    // `syntaxis::ImportService`'s production adapter resolves both ids
+    // against `apotheke::repo::want::{get_want,get_release}` once the
+    // transfer completes. A search result's `release_id` otherwise lives
+    // only in eksetasis's in-memory cache; persisting it here, ahead of
+    // enqueue, is what makes it a durable identifier rather than a
+    // process-local key.
+    if let Err(error) = paroche::routes::download::persist_release_before_enqueue(
+        &ctx.db,
+        want_id,
+        release_id,
+        paroche::routes::download::ReleaseMetadata {
+            indexer_id,
+            title,
+            size_bytes,
+            download_url: download_url.clone(),
+            protocol: protocol.clone(),
+            info_hash: info_hash.clone(),
+        },
+    )
+    .await
+    {
+        return tool_error(match error {
+            paroche::routes::download::ReleasePersistError::WantNotFound => {
+                format!("want {want_id} not found — create it before enqueueing")
             }
-        }
-        Err(e) => {
-            return tool_error(format!(
-                "failed to check for an existing release record: {e}"
-            ));
-        }
+            paroche::routes::download::ReleasePersistError::ReleaseWantConflict => {
+                format!("release {release_id} is already recorded under a different want")
+            }
+            paroche::routes::download::ReleasePersistError::Database(e) => {
+                format!("failed to persist release {release_id}: {e}")
+            }
+        });
     }
 
     let queue_id = Uuid::now_v7();
@@ -771,7 +734,7 @@ mod tests {
     use std::time::Duration;
 
     use apotheke::migrate::MIGRATOR;
-    use apotheke::repo::want::Want;
+    use apotheke::repo::want::{self, Want};
     use paroche::state::{ResolvedRelease, ServiceFut};
     use sqlx::SqlitePool;
 
@@ -1393,7 +1356,7 @@ mod tests {
                 .unwrap();
         assert_eq!(row.0, "My.Release");
         assert_eq!(row.1, 123_456);
-        assert_eq!(row.2, MANUAL_MAGNET_INDEXER_ID);
+        assert_eq!(row.2, paroche::routes::download::MANUAL_RELEASE_INDEXER_ID);
     }
 
     // ── list ──────────────────────────────────────────────────────────────

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -241,6 +241,9 @@ impl DynSearchService for SearchAdapter {
                 download_url: resolved.download_url,
                 protocol: release_protocol_wire_string(resolved.protocol),
                 info_hash: resolved.info_hash,
+                indexer_id: resolved.indexer_id,
+                title: resolved.title,
+                size_bytes: resolved.size_bytes,
             })
         })
     }

--- a/crates/archon/tests/acquisition_integration.rs
+++ b/crates/archon/tests/acquisition_integration.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use aitesis::{IdentityValidator, MonitorService, RequestService, UserRoleProvider};
 use apotheke::DbPools;
 use apotheke::migrate::MIGRATOR;
+use apotheke::repo::want::{self, Want};
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use ergasia::{DownloadProgress, DownloadState, ErgasiaError, ExtractionResult};
@@ -485,12 +486,41 @@ fn build_app(state: AppState) -> axum::Router {
     paroche::build_router(state)
 }
 
+/// Persists a real `wants` row (#651: `enqueue_download` now validates
+/// `want_id` before enqueueing) using the migrator's seeded default music
+/// quality profile.
+async fn seed_want(pool: &SqlitePool) -> Result<Uuid, TestError> {
+    let profile_id: i64 =
+        sqlx::query_scalar("SELECT id FROM quality_profiles WHERE media_type = 'music' LIMIT 1")
+            .fetch_one(pool)
+            .await?;
+    let want_id = Uuid::now_v7();
+    want::insert_want(
+        pool,
+        &Want {
+            id: want_id.as_bytes().to_vec(),
+            media_type: "music_album".to_string(),
+            title: "Test Want".to_string(),
+            registry_id: None,
+            quality_profile_id: profile_id,
+            status: "searching".to_string(),
+            source: None,
+            source_ref: None,
+            added_at: jiff::Timestamp::now().to_string(),
+            fulfilled_at: None,
+        },
+    )
+    .await?;
+    Ok(want_id)
+}
+
 async fn enqueue_via_api(
     app: &axum::Router,
     token: &str,
+    pool: &SqlitePool,
     priority: u8,
 ) -> Result<(StatusCode, Value), TestError> {
-    let want_id = Uuid::now_v7().to_string();
+    let want_id = seed_want(pool).await?.to_string();
     let release_id = Uuid::now_v7().to_string();
     let body = json!({
         "want_id": want_id,
@@ -601,11 +631,11 @@ async fn queue_snapshot_empty_initially() -> Result<(), TestError> {
 
 #[tokio::test]
 async fn enqueue_download_returns_created() -> Result<(), TestError> {
-    let (state, auth, _pool) = test_state().await?;
+    let (state, auth, pool) = test_state().await?;
     let token = admin_token(&auth).await?;
     let app = build_app(state);
 
-    let (status, json) = enqueue_via_api(&app, &token, 4).await?;
+    let (status, json) = enqueue_via_api(&app, &token, &pool, 4).await?;
     assert_eq!(status, StatusCode::CREATED);
     assert!(!json["data"]["id"].as_str().unwrap().is_empty());
     assert_eq!(json["data"]["status"], "queued");
@@ -618,11 +648,11 @@ async fn enqueue_download_returns_created() -> Result<(), TestError> {
 // running queue never learned of it, so nothing dispatched until restart.
 #[tokio::test]
 async fn enqueue_download_dispatches_to_live_engine() -> Result<(), TestError> {
-    let (state, auth, _pool, mut started_rx) = test_state_with_queue(5).await?;
+    let (state, auth, pool, mut started_rx) = test_state_with_queue(5).await?;
     let token = admin_token(&auth).await?;
     let app = build_app(state);
 
-    let (status, _json) = enqueue_via_api(&app, &token, 4).await?;
+    let (status, _json) = enqueue_via_api(&app, &token, &pool, 4).await?;
     assert_eq!(status, StatusCode::CREATED);
 
     let dispatched =
@@ -636,11 +666,11 @@ async fn enqueue_download_dispatches_to_live_engine() -> Result<(), TestError> {
 
 #[tokio::test]
 async fn enqueue_download_appears_in_queue_snapshot() -> Result<(), TestError> {
-    let (state, auth, _pool) = test_state().await?;
+    let (state, auth, pool) = test_state().await?;
     let token = admin_token(&auth).await?;
     let app = build_app(state);
 
-    enqueue_via_api(&app, &token, 3).await?;
+    enqueue_via_api(&app, &token, &pool, 3).await?;
 
     let (status, json) = get_queue_snapshot(&app, &token).await?;
     assert_eq!(status, StatusCode::OK);
@@ -651,14 +681,14 @@ async fn enqueue_download_appears_in_queue_snapshot() -> Result<(), TestError> {
 
 #[tokio::test]
 async fn priority_ordering_highest_first_in_snapshot() -> Result<(), TestError> {
-    let (state, auth, _pool) = test_state().await?;
+    let (state, auth, pool) = test_state().await?;
     let token = admin_token(&auth).await?;
     let app = build_app(state);
 
-    enqueue_via_api(&app, &token, 1).await?;
-    enqueue_via_api(&app, &token, 3).await?;
-    enqueue_via_api(&app, &token, 2).await?;
-    enqueue_via_api(&app, &token, 4).await?;
+    enqueue_via_api(&app, &token, &pool, 1).await?;
+    enqueue_via_api(&app, &token, &pool, 3).await?;
+    enqueue_via_api(&app, &token, &pool, 2).await?;
+    enqueue_via_api(&app, &token, &pool, 4).await?;
 
     let (_, json) = get_queue_snapshot(&app, &token).await?;
     let queued = json["data"]["queued"].as_array().unwrap();
@@ -673,11 +703,11 @@ async fn priority_ordering_highest_first_in_snapshot() -> Result<(), TestError> 
 
 #[tokio::test]
 async fn cancel_download_removes_from_snapshot() -> Result<(), TestError> {
-    let (state, auth, _pool) = test_state().await?;
+    let (state, auth, pool) = test_state().await?;
     let token = admin_token(&auth).await?;
     let app = build_app(state);
 
-    let (_, created) = enqueue_via_api(&app, &token, 3).await?;
+    let (_, created) = enqueue_via_api(&app, &token, &pool, 3).await?;
     let dl_id = created["data"]["id"].as_str().unwrap();
 
     let resp = app
@@ -719,11 +749,11 @@ async fn cancel_nonexistent_download_returns_not_found() -> Result<(), TestError
 
 #[tokio::test]
 async fn reprioritize_download_updates_priority() -> Result<(), TestError> {
-    let (state, auth, _pool) = test_state().await?;
+    let (state, auth, pool) = test_state().await?;
     let token = admin_token(&auth).await?;
     let app = build_app(state);
 
-    let (_, created) = enqueue_via_api(&app, &token, 1).await?;
+    let (_, created) = enqueue_via_api(&app, &token, &pool, 1).await?;
     let dl_id = created["data"]["id"].as_str().unwrap();
 
     let body = json!({"priority": 3});

--- a/crates/archon/tests/mcp_acquisition_acceptance.rs
+++ b/crates/archon/tests/mcp_acquisition_acceptance.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use apotheke::DbPools;
 use apotheke::migrate::MIGRATOR;
+use apotheke::repo::want::{self, Want};
 use archon::mcp_bridge::{BridgeContext, spawn};
 use ergasia::{DownloadProgress, DownloadState, ErgasiaError, ExtractionResult};
 use paroche::state::{
@@ -70,6 +71,9 @@ impl DynSearchService for AcceptanceSearch {
                     download_url: magnet,
                     protocol: "torrent".to_string(),
                     info_hash: None,
+                    indexer_id: 1,
+                    title: "Kind of Blue - FLAC".to_string(),
+                    size_bytes: Some(1_000_000),
                 })
             } else {
                 Err(ServiceError::NotFound)
@@ -193,6 +197,35 @@ async fn test_db() -> Result<SqlitePool, TestError> {
     Ok(pool)
 }
 
+/// Persists a real `wants` row (#651: `handle_enqueue` requires an existing
+/// `want_id` — it no longer invents one) using the migrator's seeded default
+/// music quality profile, mirroring `mcp_bridge`'s own `seed_want` test
+/// helper.
+async fn seed_want(pool: &SqlitePool) -> Result<Uuid, TestError> {
+    let profile_id: i64 =
+        sqlx::query_scalar("SELECT id FROM quality_profiles WHERE media_type = 'music' LIMIT 1")
+            .fetch_one(pool)
+            .await?;
+    let want_id = Uuid::now_v7();
+    want::insert_want(
+        pool,
+        &Want {
+            id: want_id.as_bytes().to_vec(),
+            media_type: "music_album".to_string(),
+            title: "Kind of Blue".to_string(),
+            registry_id: None,
+            quality_profile_id: profile_id,
+            status: "searching".to_string(),
+            source: None,
+            source_ref: None,
+            added_at: jiff::Timestamp::now().to_string(),
+            fulfilled_at: None,
+        },
+    )
+    .await?;
+    Ok(want_id)
+}
+
 // ── MCP wire client ─────────────────────────────────────────────────────────
 
 /// Speaks the bridge's newline-delimited JSON-RPC over one reused socket
@@ -250,6 +283,7 @@ async fn search_enqueue_and_observe_completion_over_the_mcp_surface() -> Result<
     let queue_shutdown = CancellationToken::new();
     let _listener = queue_svc.start(event_tx.subscribe(), queue_shutdown.clone());
 
+    let want_id = seed_want(&pool).await?;
     let release_id = Uuid::now_v7();
     let bridge_ctx = BridgeContext {
         search: Arc::new(AcceptanceSearch {
@@ -301,7 +335,11 @@ async fn search_enqueue_and_observe_completion_over_the_mcp_surface() -> Result<
         &mut reader,
         2,
         "harmonia_enqueue_download",
-        json!({ "release_id": release_id.to_string(), "priority": 4 }),
+        json!({
+            "release_id": release_id.to_string(),
+            "want_id": want_id.to_string(),
+            "priority": 4
+        }),
     )
     .await?;
     assert_eq!(enqueue_result["isError"], false, "{enqueue_result:?}");

--- a/crates/eksetasis/src/results_cache.rs
+++ b/crates/eksetasis/src/results_cache.rs
@@ -164,6 +164,8 @@ impl ResultsCache {
             protocol: item.result.protocol,
             info_hash: item.result.info_hash.clone(),
             indexer_id: item.result.indexer_id,
+            title: item.result.title.clone(),
+            size_bytes: item.result.size_bytes,
         })
     }
 }

--- a/crates/eksetasis/src/types.rs
+++ b/crates/eksetasis/src/types.rs
@@ -143,6 +143,11 @@ pub struct ResolvedRelease {
     pub protocol: ReleaseProtocol,
     pub info_hash: Option<String>,
     pub indexer_id: i64,
+    /// The catalogued result's title — carried through so a caller can
+    /// persist a durable `releases` row before enqueueing (#651); this
+    /// struct is otherwise download-URL-resolution-only.
+    pub title: String,
+    pub size_bytes: Option<u64>,
 }
 
 impl std::fmt::Debug for ResolvedRelease {
@@ -152,6 +157,8 @@ impl std::fmt::Debug for ResolvedRelease {
             .field("protocol", &self.protocol)
             .field("info_hash", &self.info_hash)
             .field("indexer_id", &self.indexer_id)
+            .field("title", &self.title)
+            .field("size_bytes", &self.size_bytes)
             .finish()
     }
 }
@@ -231,6 +238,8 @@ mod tests {
             protocol: ReleaseProtocol::Torrent,
             info_hash: Some("abc123".to_string()),
             indexer_id: 7,
+            title: "Some.Release.Title".to_string(),
+            size_bytes: Some(1_000_000),
         };
         let debug = format!("{resolved:?}");
         assert!(

--- a/crates/paroche/src/error.rs
+++ b/crates/paroche/src/error.rs
@@ -94,6 +94,22 @@ impl From<apotheke::DbError> for ParocheError {
     }
 }
 
+impl From<crate::routes::download::ReleasePersistError> for ParocheError {
+    fn from(error: crate::routes::download::ReleasePersistError) -> Self {
+        match error {
+            crate::routes::download::ReleasePersistError::WantNotFound => ParocheError::NotFound,
+            crate::routes::download::ReleasePersistError::ReleaseWantConflict => {
+                ParocheError::Conflict {
+                    message: "the release is already recorded under a different want".to_string(),
+                }
+            }
+            crate::routes::download::ReleasePersistError::Database(source) => {
+                ParocheError::Database { source }
+            }
+        }
+    }
+}
+
 impl From<crate::state::ServiceError> for ParocheError {
     fn from(error: crate::state::ServiceError) -> Self {
         match error {

--- a/crates/paroche/src/routes/download.rs
+++ b/crates/paroche/src/routes/download.rs
@@ -620,6 +620,15 @@ mod tests {
         Miss,
     }
 
+    // WHY: this route's own resolve/enqueue flow under test never reads
+    // title/size_bytes/indexer_id — they exist on ResolvedRelease only for
+    // the acquisition-bridge persistence path (#651), so the stub fills
+    // them with fixed placeholders rather than threading real values
+    // through every `ResolveStub::Found` call site.
+    const STUB_TITLE: &str = "Stub.Release.Title";
+    const STUB_SIZE_BYTES: Option<u64> = Some(1_000_000);
+    const STUB_INDEXER_ID: i64 = 1;
+
     struct StubResolveSearch(ResolveStub);
 
     impl DynSearchService for StubResolveSearch {
@@ -650,6 +659,9 @@ mod tests {
                             download_url,
                             protocol,
                             info_hash,
+                            indexer_id: STUB_INDEXER_ID,
+                            title: STUB_TITLE.to_string(),
+                            size_bytes: STUB_SIZE_BYTES,
                         })
                     })
                 }

--- a/crates/paroche/src/routes/download.rs
+++ b/crates/paroche/src/routes/download.rs
@@ -1,4 +1,6 @@
 /// Download queue endpoints.
+use apotheke::DbPools;
+use apotheke::repo::want;
 use axum::{
     Json,
     extract::{Path, State},
@@ -144,6 +146,129 @@ pub async fn list_downloads(
 }
 
 // ---------------------------------------------------------------------------
+// Release persistence ahead of enqueue (#651: reused by the MCP acquisition
+// bridge — one definition of the persist-before-enqueue invariant so the
+// HTTP route and the bridge cannot drift back apart on this rule).
+// ---------------------------------------------------------------------------
+
+// WHY: `releases.indexer_id` is a plain NOT NULL i64, not an FK — a
+// self-supplied URL (magnet or a direct file link) never came from a
+// cataloged indexer, so it gets this sentinel rather than a fabricated real
+// indexer id. Real `indexers.id` values are SQLite rowids starting at 1,
+// never 0.
+pub const MANUAL_RELEASE_INDEXER_ID: i64 = 0;
+
+/// Extracts a magnet URI's own `dn` (display name) / `xl` (exact length)
+/// query params — the ONLY release metadata available for a self-supplied
+/// magnet that never went through `resolve_release`'s indexer catalog.
+pub fn magnet_release_metadata(magnet: &url::Url) -> (Option<String>, Option<u64>) {
+    let mut title = None;
+    let mut size_bytes = None;
+    for (key, value) in magnet.query_pairs() {
+        match key.as_ref() {
+            "dn" => title = Some(value.into_owned()),
+            "xl" => size_bytes = value.parse::<u64>().ok(),
+            _ => {}
+        }
+    }
+    (title, size_bytes)
+}
+
+/// Everything needed to persist a `releases` row ahead of enqueue — either
+/// resolved server-side (a cataloged indexer hit via `resolve_release`) or
+/// derived from a self-supplied URL with no catalog entry (a magnet's own
+/// `dn`/`xl` params, or a neutral placeholder for a plain file URL).
+pub struct ReleaseMetadata {
+    pub indexer_id: i64,
+    pub title: String,
+    pub size_bytes: Option<u64>,
+    pub download_url: String,
+    pub protocol: String,
+    pub info_hash: Option<String>,
+}
+
+/// Outcomes of `persist_release_before_enqueue` other than success. Kept
+/// distinct from `ParocheError`/the MCP bridge's `tool_error` so this
+/// module stays decoupled from either surface's error-rendering convention
+/// — each caller maps these to its own shape.
+#[derive(Debug)]
+pub enum ReleasePersistError {
+    /// `want_id` has no row in `wants` — the caller must create it first.
+    WantNotFound,
+    /// `release_id` already exists but is recorded under a DIFFERENT want.
+    ReleaseWantConflict,
+    Database(apotheke::DbError),
+}
+
+impl From<apotheke::DbError> for ReleasePersistError {
+    fn from(source: apotheke::DbError) -> Self {
+        Self::Database(source)
+    }
+}
+
+/// Persists the `releases` row (and validates `want_id`) that MUST exist
+/// before `queue.enqueue()` is called — shared by the HTTP route and the
+/// MCP acquisition bridge (#651). `syntaxis::ImportService`'s production
+/// adapter resolves both `want_id` and `release_id` against
+/// `apotheke::repo::want::{get_want,get_release}` once the transfer
+/// completes; a search result's `release_id` otherwise lives only in
+/// eksetasis's in-memory cache, which does not survive a restart.
+///
+/// Idempotent: a retry with the SAME (release_id, want_id) pair reuses the
+/// existing row rather than erroring on a duplicate insert.
+///
+/// INVARIANT: callers must `.await` this call BEFORE `queue.enqueue()`,
+/// never after — that ordering is what makes the row durable ahead of the
+/// transfer rather than racing it.
+pub async fn persist_release_before_enqueue(
+    db: &DbPools,
+    want_id: Uuid,
+    release_id: Uuid,
+    metadata: ReleaseMetadata,
+) -> Result<(), ReleasePersistError> {
+    match want::get_want(&db.read, want_id.as_bytes().as_ref()).await? {
+        Some(_) => {}
+        None => return Err(ReleasePersistError::WantNotFound),
+    }
+
+    match want::get_release(&db.read, release_id.as_bytes().as_ref()).await? {
+        Some(existing) if existing.want_id == want_id.as_bytes().to_vec() => {
+            // NOTE: idempotent retry — this exact (release, want) pair is
+            // already persisted (e.g. a prior enqueue attempt failed after
+            // this insert but before the queue write) — reuse it.
+        }
+        Some(_other_want) => return Err(ReleasePersistError::ReleaseWantConflict),
+        None => {
+            let release = want::Release {
+                id: release_id.as_bytes().to_vec(),
+                want_id: want_id.as_bytes().to_vec(),
+                indexer_id: metadata.indexer_id,
+                title: metadata.title,
+                size_bytes: i64::try_from(metadata.size_bytes.unwrap_or(0)).unwrap_or(i64::MAX),
+                // WHY: no pre-download quality-assessment pipeline scores a
+                // raw search hit or self-supplied URL yet — kritike::assessment
+                // scores already-imported file tags (kathodos::sidecar
+                // output), not release-name text. 0 is a neutral placeholder,
+                // not a measured quality claim; upgrade decisions over this
+                // row are unaffected since they compare against OTHER
+                // releases of the same want, not an absolute threshold.
+                quality_score: 0,
+                custom_format_score: 0,
+                download_url: metadata.download_url,
+                protocol: metadata.protocol,
+                info_hash: metadata.info_hash,
+                found_at: jiff::Timestamp::now().to_string(),
+                grabbed_at: None,
+                rejected_reason: None,
+            };
+            want::insert_release(&db.write, &release).await?;
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Request types
 // ---------------------------------------------------------------------------
 
@@ -238,15 +363,28 @@ pub async fn enqueue_download(
     // server-side (#608) — the client never sees the indexer's credentialed
     // URL. The resolved protocol wins over the body's default; info_hash
     // falls back to the body's only when the resolved release carries none.
-    let (download_url, protocol, info_hash) = if let Some(url) = body
+    // A self-supplied URL (this arm) never came from a cataloged indexer, so
+    // it carries no title/size_bytes from the search cache — a magnet's own
+    // dn/xl query params are the only metadata available; a plain file URL
+    // gets a neutral placeholder (#651, mirrors the MCP bridge's manual-
+    // magnet arm).
+    let (download_url, protocol, info_hash, indexer_id, title, size_bytes) = if let Some(url) = body
         .download_url
         .as_deref()
         .filter(|url| !url.trim().is_empty())
     {
+        let (title, size_bytes) = url::Url::parse(url)
+            .ok()
+            .filter(|parsed| parsed.scheme() == "magnet")
+            .map(|parsed| magnet_release_metadata(&parsed))
+            .unwrap_or((None, None));
         (
             url.to_string(),
             body.protocol.clone(),
             body.info_hash.clone(),
+            MANUAL_RELEASE_INDEXER_ID,
+            title.unwrap_or_else(|| "manual download".to_string()),
+            size_bytes,
         )
     } else if body.download_url.is_some() {
         return Err(ParocheError::Validation {
@@ -258,6 +396,9 @@ pub async fn enqueue_download(
             resolved.download_url,
             resolved.protocol,
             resolved.info_hash.or_else(|| body.info_hash.clone()),
+            resolved.indexer_id,
+            resolved.title,
+            resolved.size_bytes,
         )
     };
 
@@ -265,6 +406,24 @@ pub async fn enqueue_download(
     // RESOLVED url is validated the same as a client-supplied one, never
     // trusted just because it came from the server-side cache.
     crate::net_validate::validate_download_url(&download_url).await?;
+
+    // INVARIANT: the `releases` row (and `want_id`'s existence) must be
+    // persisted BEFORE `queue.enqueue()` below — see
+    // `persist_release_before_enqueue` (#651).
+    persist_release_before_enqueue(
+        &state.db,
+        want_id,
+        release_id,
+        ReleaseMetadata {
+            indexer_id,
+            title,
+            size_bytes,
+            download_url: download_url.clone(),
+            protocol: protocol.clone(),
+            info_hash: info_hash.clone(),
+        },
+    )
+    .await?;
 
     let queue_id = Uuid::now_v7();
 
@@ -345,16 +504,13 @@ pub fn download_routes() -> axum::Router<AppState> {
 
 #[cfg(test)]
 mod tests {
+    use apotheke::repo::want::{self, Want};
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
     use exousia::AuthService;
     use exousia::user::{CreateUserRequest, UserRole};
     use tower::ServiceExt;
 
-    #[expect(
-        unused_imports,
-        reason = "kanon: test-missing-use-super; parent items accessed via explicit super:: prefix in test bodies"
-    )]
     use super::*;
     use crate::state::{DynSearchService, ResolvedRelease, ServiceError, ServiceFut};
     use crate::test_helpers::test_state;
@@ -378,9 +534,9 @@ mod tests {
             .access_token
     }
 
-    fn enqueue_body(download_url: &str) -> String {
+    fn enqueue_body(want_id: &str, download_url: &str) -> String {
         serde_json::json!({
-            "want_id": uuid::Uuid::now_v7().to_string(),
+            "want_id": want_id,
             "release_id": uuid::Uuid::now_v7().to_string(),
             "download_url": download_url,
         })
@@ -390,6 +546,7 @@ mod tests {
     async fn post_enqueue(
         app: &axum::Router,
         token: &str,
+        want_id: &str,
         download_url: &str,
     ) -> axum::response::Response {
         app.clone()
@@ -399,7 +556,7 @@ mod tests {
                     .uri("/api/v1/downloads")
                     .header("Authorization", format!("Bearer {token}"))
                     .header("content-type", "application/json")
-                    .body(Body::from(enqueue_body(download_url)))
+                    .body(Body::from(enqueue_body(want_id, download_url)))
                     .unwrap(),
             )
             .await
@@ -416,7 +573,10 @@ mod tests {
                     .method("POST")
                     .uri("/api/v1/downloads")
                     .header("content-type", "application/json")
-                    .body(Body::from(enqueue_body("http://203.0.113.10/f.torrent")))
+                    .body(Body::from(enqueue_body(
+                        &uuid::Uuid::now_v7().to_string(),
+                        "http://203.0.113.10/f.torrent",
+                    )))
                     .unwrap(),
             )
             .await
@@ -429,7 +589,13 @@ mod tests {
         let (state, auth) = test_state().await;
         let token = token_for(&auth, "member", UserRole::Member).await;
         let app = crate::build_router(state);
-        let resp = post_enqueue(&app, &token, "http://203.0.113.10/f.torrent").await;
+        let resp = post_enqueue(
+            &app,
+            &token,
+            &uuid::Uuid::now_v7().to_string(),
+            "http://203.0.113.10/f.torrent",
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
@@ -446,7 +612,7 @@ mod tests {
             "http://192.168.1.10/f.torrent",
             "http://[::1]/f.torrent",
         ] {
-            let resp = post_enqueue(&app, &token, url).await;
+            let resp = post_enqueue(&app, &token, &uuid::Uuid::now_v7().to_string(), url).await;
             assert_eq!(
                 resp.status(),
                 StatusCode::UNPROCESSABLE_ENTITY,
@@ -465,6 +631,37 @@ mod tests {
         auth.pools().read.clone()
     }
 
+    /// Persists a real `wants` row (#651: `enqueue_download` now validates
+    /// `want_id` before enqueueing) using the migrator's seeded default
+    /// music quality profile.
+    async fn seed_want(pool: &sqlx::SqlitePool) -> Uuid {
+        let profile_id: i64 = sqlx::query_scalar(
+            "SELECT id FROM quality_profiles WHERE media_type = 'music' LIMIT 1",
+        )
+        .fetch_one(pool)
+        .await
+        .expect("migrator seeds a default music quality profile");
+        let want_id = Uuid::now_v7();
+        want::insert_want(
+            pool,
+            &Want {
+                id: want_id.as_bytes().to_vec(),
+                media_type: "music_album".to_string(),
+                title: "Test Want".to_string(),
+                registry_id: None,
+                quality_profile_id: profile_id,
+                status: "searching".to_string(),
+                source: None,
+                source_ref: None,
+                added_at: jiff::Timestamp::now().to_string(),
+                fulfilled_at: None,
+            },
+        )
+        .await
+        .expect("seed want inserts");
+        want_id
+    }
+
     #[tokio::test]
     async fn enqueue_download_rejects_non_http_schemes() {
         let (state, auth) = test_state().await;
@@ -472,7 +669,7 @@ mod tests {
         let app = crate::build_router(state);
 
         for url in ["ftp://203.0.113.10/f.torrent", "file:///etc/passwd"] {
-            let resp = post_enqueue(&app, &token, url).await;
+            let resp = post_enqueue(&app, &token, &uuid::Uuid::now_v7().to_string(), url).await;
             assert_eq!(
                 resp.status(),
                 StatusCode::UNPROCESSABLE_ENTITY,
@@ -493,10 +690,12 @@ mod tests {
     #[tokio::test]
     async fn enqueue_download_accepts_public_url_for_admin() {
         let (mut state, auth) = test_state().await;
-        state.queue = persisting_queue(&app_pool(&auth));
+        let pool = app_pool(&auth);
+        state.queue = persisting_queue(&pool);
+        let want_id = seed_want(&pool).await.to_string();
         let token = token_for(&auth, "admin", UserRole::Admin).await;
         let app = crate::build_router(state);
-        let resp = post_enqueue(&app, &token, "http://203.0.113.10/f.torrent").await;
+        let resp = post_enqueue(&app, &token, &want_id, "http://203.0.113.10/f.torrent").await;
         assert_eq!(resp.status(), StatusCode::CREATED);
         let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
@@ -510,11 +709,110 @@ mod tests {
     #[tokio::test]
     async fn enqueue_download_accepts_magnet_uri_for_admin() {
         let (mut state, auth) = test_state().await;
-        state.queue = persisting_queue(&app_pool(&auth));
+        let pool = app_pool(&auth);
+        state.queue = persisting_queue(&pool);
+        let want_id = seed_want(&pool).await.to_string();
         let token = token_for(&auth, "admin", UserRole::Admin).await;
         let app = crate::build_router(state);
-        let resp = post_enqueue(&app, &token, "magnet:?xt=urn:btih:abc123def456").await;
+        let resp = post_enqueue(&app, &token, &want_id, "magnet:?xt=urn:btih:abc123def456").await;
         assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    // ── #651: releases/wants persisted before enqueue (HTTP surface) ───────
+
+    #[tokio::test]
+    async fn enqueue_download_rejects_unknown_want_id() {
+        // WHY: #651 — a well-formed but non-existent want_id must be
+        // rejected, not accepted and left to fail import later. Mirrors the
+        // MCP bridge's own `enqueue_rejects_unknown_want_id`.
+        let (mut state, auth) = test_state().await;
+        let pool = app_pool(&auth);
+        state.queue = persisting_queue(&pool);
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let app = crate::build_router(state);
+
+        let resp = post_enqueue(
+            &app,
+            &token,
+            &uuid::Uuid::now_v7().to_string(),
+            "magnet:?xt=urn:btih:unknownwant",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM download_queue")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "an unresolvable want must never reach the queue");
+    }
+
+    #[tokio::test]
+    async fn enqueue_download_magnet_arm_persists_release_row_from_dn_and_xl() {
+        // WHY: #651's release-row gap on the HTTP surface's self-supplied-URL
+        // arm — a magnet posted directly (no by-reference resolve) still
+        // needs a durable `releases` row, derived from the magnet URI's own
+        // dn/xl metadata params, mirroring the MCP bridge's magnet arm.
+        let (mut state, auth) = test_state().await;
+        let pool = app_pool(&auth);
+        state.queue = persisting_queue(&pool);
+        let want_id = seed_want(&pool).await.to_string();
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let app = crate::build_router(state);
+
+        let resp = post_enqueue(
+            &app,
+            &token,
+            &want_id,
+            "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd&dn=My.Release&xl=123456",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let row: (String, i64, i64) =
+            sqlx::query_as("SELECT title, size_bytes, indexer_id FROM releases WHERE want_id = ?")
+                .bind(
+                    uuid::Uuid::parse_str(&want_id)
+                        .unwrap()
+                        .as_bytes()
+                        .as_slice(),
+                )
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, "My.Release");
+        assert_eq!(row.1, 123_456);
+        assert_eq!(row.2, MANUAL_RELEASE_INDEXER_ID);
+    }
+
+    #[tokio::test]
+    async fn enqueue_download_plain_url_persists_release_row_with_placeholder_title() {
+        // WHY: #651 — a plain (non-magnet) direct file URL carries no dn/xl
+        // metadata at all; it still gets a durable `releases` row, using the
+        // neutral placeholder title rather than leaving the row unwritten.
+        let (mut state, auth) = test_state().await;
+        let pool = app_pool(&auth);
+        state.queue = persisting_queue(&pool);
+        let want_id = seed_want(&pool).await.to_string();
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+        let app = crate::build_router(state);
+
+        let resp = post_enqueue(&app, &token, &want_id, "http://203.0.113.10/f.torrent").await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let row: (String, i64) =
+            sqlx::query_as("SELECT title, indexer_id FROM releases WHERE want_id = ?")
+                .bind(
+                    uuid::Uuid::parse_str(&want_id)
+                        .unwrap()
+                        .as_bytes()
+                        .as_slice(),
+                )
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, "manual download");
+        assert_eq!(row.1, MANUAL_RELEASE_INDEXER_ID);
     }
 
     // ── #499: enqueue reaches the live queue manager ────────────────────────
@@ -525,10 +823,11 @@ mod tests {
         let pool = app_pool(&auth);
         let queue = persisting_queue(&pool);
         state.queue = queue.clone();
+        let want_id = seed_want(&pool).await.to_string();
         let token = token_for(&auth, "admin", UserRole::Admin).await;
 
         let app = crate::build_router(state);
-        let resp = post_enqueue(&app, &token, "magnet:?xt=urn:btih:live499").await;
+        let resp = post_enqueue(&app, &token, &want_id, "magnet:?xt=urn:btih:live499").await;
         assert_eq!(resp.status(), StatusCode::CREATED);
         let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
@@ -566,13 +865,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn enqueue_download_persists_the_release_row_before_calling_queue_enqueue() {
+        // WHY: #651's core ordering/durability assertion, mirrored from the
+        // MCP bridge's own `enqueue_persists_the_release_row_before_calling_queue_enqueue`
+        // test — an end-state check alone ("does a releases row exist once
+        // the request returns") would still pass if `enqueue_download`
+        // persisted the release AFTER calling `queue.enqueue()`.
+        // `RecordingQueueManager` records whether the row already existed
+        // the INSTANT it ran, so this fails under that reordering even
+        // though the final state would look identical.
+        let (mut state, auth) = test_state().await;
+        let pool = app_pool(&auth);
+        let queue = persisting_queue(&pool);
+        state.queue = queue.clone();
+        let want_id = seed_want(&pool).await.to_string();
+        let token = token_for(&auth, "admin", UserRole::Admin).await;
+
+        let app = crate::build_router(state);
+        let resp = post_enqueue(&app, &token, &want_id, "magnet:?xt=urn:btih:orderingprobe").await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let ordering_flags = queue.release_existed_at_enqueue.lock().unwrap().clone();
+        assert_eq!(
+            ordering_flags,
+            vec![true],
+            "the releases row must be written before queue.enqueue() is called, not after"
+        );
+
+        let release_id = queue.enqueued.lock().unwrap()[0].release_id;
+        let persisted_want_id: Vec<u8> =
+            sqlx::query_scalar("SELECT want_id FROM releases WHERE id = ?")
+                .bind(release_id.as_bytes().as_slice())
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            persisted_want_id,
+            uuid::Uuid::parse_str(&want_id).unwrap().as_bytes().to_vec()
+        );
+    }
+
+    #[tokio::test]
     async fn enqueue_download_unavailable_when_queue_not_wired() {
         let (state, auth) = test_state().await;
         let token = token_for(&auth, "admin", UserRole::Admin).await;
         let pool = app_pool(&auth);
+        let want_id = seed_want(&pool).await.to_string();
 
         let app = crate::build_router(state);
-        let resp = post_enqueue(&app, &token, "magnet:?xt=urn:btih:nowire").await;
+        let resp = post_enqueue(&app, &token, &want_id, "magnet:?xt=urn:btih:nowire").await;
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
 
         // A download the live queue never accepted must not be persisted — a
@@ -592,6 +933,7 @@ mod tests {
         let resp = post_enqueue(
             &app,
             &token,
+            &uuid::Uuid::now_v7().to_string(),
             "magnet:?xt=urn:btih:abc&tr=http%3A%2F%2F127.0.0.1%3A8080%2Fannounce",
         )
         .await;
@@ -603,7 +945,7 @@ mod tests {
         let (state, auth) = test_state().await;
         let token = token_for(&auth, "admin", UserRole::Admin).await;
         let app = crate::build_router(state);
-        let resp = post_enqueue(&app, &token, "   ").await;
+        let resp = post_enqueue(&app, &token, &uuid::Uuid::now_v7().to_string(), "   ").await;
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
@@ -670,9 +1012,9 @@ mod tests {
         }
     }
 
-    fn resolve_body(protocol: Option<&str>) -> String {
+    fn resolve_body(want_id: &str, protocol: Option<&str>) -> String {
         let mut body = serde_json::json!({
-            "want_id": uuid::Uuid::now_v7().to_string(),
+            "want_id": want_id,
             "release_id": uuid::Uuid::now_v7().to_string(),
         });
         if let Some(protocol) = protocol {
@@ -703,17 +1045,19 @@ mod tests {
     #[tokio::test]
     async fn enqueue_download_resolves_release_when_download_url_absent() {
         let (mut state, auth) = test_state().await;
-        let queue = persisting_queue(&app_pool(&auth));
+        let pool = app_pool(&auth);
+        let queue = persisting_queue(&pool);
         state.queue = queue.clone();
         state.search = std::sync::Arc::new(StubResolveSearch(ResolveStub::Found {
             download_url: "http://203.0.113.10/dl/42?apikey=SECRET".to_string(),
             protocol: "torrent".to_string(),
             info_hash: None,
         }));
+        let want_id = seed_want(&pool).await.to_string();
         let token = token_for(&auth, "admin", UserRole::Admin).await;
         let app = crate::build_router(state);
 
-        let resp = post_enqueue_body(&app, &token, resolve_body(None)).await;
+        let resp = post_enqueue_body(&app, &token, resolve_body(&want_id, None)).await;
         assert_eq!(resp.status(), StatusCode::CREATED);
 
         let enqueued = queue.enqueued.lock().unwrap().clone();
@@ -749,7 +1093,12 @@ mod tests {
         let pool = app_pool(&auth);
         let app = crate::build_router(state);
 
-        let resp = post_enqueue_body(&app, &token, resolve_body(None)).await;
+        let resp = post_enqueue_body(
+            &app,
+            &token,
+            resolve_body(&uuid::Uuid::now_v7().to_string(), None),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
         assert!(queue.enqueued.lock().unwrap().is_empty());
 
@@ -774,7 +1123,12 @@ mod tests {
         let pool = app_pool(&auth);
         let app = crate::build_router(state);
 
-        let resp = post_enqueue_body(&app, &token, resolve_body(None)).await;
+        let resp = post_enqueue_body(
+            &app,
+            &token,
+            resolve_body(&uuid::Uuid::now_v7().to_string(), None),
+        )
+        .await;
         assert_eq!(
             resp.status(),
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -793,19 +1147,21 @@ mod tests {
     #[tokio::test]
     async fn enqueue_download_resolved_protocol_wins_over_body_default() {
         let (mut state, auth) = test_state().await;
-        let queue = persisting_queue(&app_pool(&auth));
+        let pool = app_pool(&auth);
+        let queue = persisting_queue(&pool);
         state.queue = queue.clone();
         state.search = std::sync::Arc::new(StubResolveSearch(ResolveStub::Found {
             download_url: "http://203.0.113.10/dl/42.nzb?apikey=SECRET".to_string(),
             protocol: "nzb".to_string(),
             info_hash: None,
         }));
+        let want_id = seed_want(&pool).await.to_string();
         let token = token_for(&auth, "admin", UserRole::Admin).await;
         let app = crate::build_router(state);
 
         // Body carries the interactive default ("torrent"); the resolved
         // release is nzb and must win.
-        let resp = post_enqueue_body(&app, &token, resolve_body(Some("torrent"))).await;
+        let resp = post_enqueue_body(&app, &token, resolve_body(&want_id, Some("torrent"))).await;
         assert_eq!(resp.status(), StatusCode::CREATED);
 
         let enqueued = queue.enqueued.lock().unwrap().clone();
@@ -824,6 +1180,16 @@ mod tests {
         /// When set, `enqueue` persists the row like the real syntaxis service
         /// does, so the handler's response SELECT has a row to read.
         persist_pool: Option<sqlx::SqlitePool>,
+        /// ORDERING PROBE (#651): for each `enqueue()` call, whether a
+        /// `releases` row for that item's `release_id` already existed AT
+        /// THE MOMENT this stub ran. An end-state check alone ("does the row
+        /// exist once the request returns") would still pass if
+        /// `enqueue_download` persisted the release AFTER calling
+        /// `queue.enqueue()` — this catches exactly that reordering, mirroring
+        /// the MCP bridge's own `StubQueue` probe. Arc-wrapped (not a bare
+        /// `Mutex`) because `ServiceFut` requires `'static`, so the future
+        /// below can only capture an owned clone, never `&self`.
+        release_existed_at_enqueue: std::sync::Arc<std::sync::Mutex<Vec<bool>>>,
     }
 
     impl crate::state::DynQueueManager for RecordingQueueManager {
@@ -833,8 +1199,16 @@ mod tests {
             }
             self.enqueued.lock().unwrap().push(item.clone());
             let pool = self.persist_pool.clone();
+            let release_existed = std::sync::Arc::clone(&self.release_existed_at_enqueue);
             Box::pin(async move {
                 if let Some(pool) = pool {
+                    let existed: i64 =
+                        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM releases WHERE id = ?)")
+                            .bind(item.release_id.as_bytes().as_slice())
+                            .fetch_one(&pool)
+                            .await
+                            .unwrap_or(0);
+                    release_existed.lock().unwrap().push(existed != 0);
                     sqlx::query(
                         "INSERT INTO download_queue \
                          (id, want_id, release_id, download_url, protocol, priority, info_hash) \

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -111,6 +111,12 @@ pub struct ResolvedRelease {
     /// `EnqueueItem::protocol` expects.
     pub protocol: String,
     pub info_hash: Option<String>,
+    pub indexer_id: i64,
+    /// The catalogued result's title — a caller persists a `releases` row
+    /// keyed by (want_id, release_id) using these fields BEFORE enqueueing,
+    /// so the row exists once the transfer completes (#651).
+    pub title: String,
+    pub size_bytes: Option<u64>,
 }
 
 impl std::fmt::Debug for ResolvedRelease {
@@ -122,6 +128,9 @@ impl std::fmt::Debug for ResolvedRelease {
             )
             .field("protocol", &self.protocol)
             .field("info_hash", &self.info_hash)
+            .field("indexer_id", &self.indexer_id)
+            .field("title", &self.title)
+            .field("size_bytes", &self.size_bytes)
             .finish()
     }
 }

--- a/crates/syndesmos/src/events.rs
+++ b/crates/syndesmos/src/events.rs
@@ -61,11 +61,15 @@ pub async fn run_event_handler(
 
 async fn handle_event(service: &ScrobbleClient, event: HarmoniaEvent) {
     match event {
-        HarmoniaEvent::PlexNotifyRequired { media_id } => {
-            if let Err(err) = service.notify_plex_import(media_id).await {
+        HarmoniaEvent::PlexNotifyRequired {
+            media_id,
+            media_type,
+        } => {
+            if let Err(err) = service.notify_plex_import(media_id, media_type).await {
                 tracing::warn!(
                     error = %err,
                     media_id = %media_id,
+                    media_type = %media_type,
                     "plex library notify failed"
                 );
             }
@@ -123,8 +127,11 @@ mod tests {
         });
 
         let media_id = MediaId::new();
-        tx.send(HarmoniaEvent::PlexNotifyRequired { media_id })
-            .unwrap();
+        tx.send(HarmoniaEvent::PlexNotifyRequired {
+            media_id,
+            media_type: themelion::MediaType::Music,
+        })
+        .unwrap();
 
         tokio::time::sleep(Duration::from_millis(50)).await;
         ct.cancel();
@@ -214,6 +221,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
         tx.send(HarmoniaEvent::PlexNotifyRequired {
             media_id: MediaId::new(),
+            media_type: themelion::MediaType::Music,
         })
         .unwrap();
 
@@ -256,6 +264,7 @@ mod tests {
 
         tx.send(HarmoniaEvent::PlexNotifyRequired {
             media_id: MediaId::new(),
+            media_type: themelion::MediaType::Music,
         })
         .unwrap();
 
@@ -321,6 +330,7 @@ mod tests {
 
         tx.send(HarmoniaEvent::PlexNotifyRequired {
             media_id: MediaId::new(),
+            media_type: themelion::MediaType::Music,
         })
         .unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -356,6 +366,7 @@ mod tests {
         // (section 2) — the old (cancelled) client must see nothing further.
         tx.send(HarmoniaEvent::PlexNotifyRequired {
             media_id: MediaId::new(),
+            media_type: themelion::MediaType::Music,
         })
         .unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/syndesmos/src/lib.rs
+++ b/crates/syndesmos/src/lib.rs
@@ -42,7 +42,11 @@ const TIDAL_WANT_PROFILE_TYPE: &str = "music";
     reason = "async fn in trait is stable since Rust 1.75; Send bound concern deferred"
 )]
 pub trait ExternalIntegration: Send + Sync {
-    async fn notify_plex_import(&self, media_id: MediaId) -> Result<(), SyndesmodError>;
+    async fn notify_plex_import(
+        &self,
+        media_id: MediaId,
+        media_type: MediaType,
+    ) -> Result<(), SyndesmodError>;
     async fn scrobble(&self, track_id: MediaId, user_id: UserId) -> Result<(), SyndesmodError>;
     async fn sync_tidal_want_list(&self) -> Result<Vec<MediaId>, SyndesmodError>;
     async fn get_artist_data(
@@ -72,29 +76,6 @@ pub struct ScrobbleClient {
 }
 
 impl ScrobbleClient {
-    /// Refreshes all configured Plex library sections.
-    ///
-    /// WHY: `PlexNotifyRequired` carries only a `MediaId`, not a `MediaType`.
-    /// Without a DB lookup, the service cannot determine the exact section.
-    /// Refreshing all configured sections is correct for v1; a future version
-    /// can narrow this once the event includes the media type.
-    async fn refresh_all_plex_sections(&self) -> Result<(), SyndesmodError> {
-        let api = match &self.plex_api {
-            Some(a) => a.clone(),
-            None => return Ok(()),
-        };
-
-        for &section_id in self.plex_sections.values() {
-            plex::notify::notify_library_scan_by_section(
-                api.as_ref(),
-                section_id,
-                &self.plex_circuit,
-            )
-            .await?;
-        }
-        Ok(())
-    }
-
     /// Persists newly synced Tidal favorites as `searching` wants keyed on the
     /// Tidal ID, so the next sync's diff baseline is populated.
     ///
@@ -135,12 +116,23 @@ impl ScrobbleClient {
 }
 
 impl ExternalIntegration for ScrobbleClient {
-    #[instrument(skip(self), fields(media_id = %media_id))]
-    async fn notify_plex_import(&self, media_id: MediaId) -> Result<(), SyndesmodError> {
-        if self.plex_api.is_none() {
-            return Ok(());
-        }
-        self.refresh_all_plex_sections().await
+    #[instrument(skip(self), fields(media_id = %media_id, media_type = %media_type))]
+    async fn notify_plex_import(
+        &self,
+        media_id: MediaId,
+        media_type: MediaType,
+    ) -> Result<(), SyndesmodError> {
+        let api = match &self.plex_api {
+            Some(a) => a.clone(),
+            None => return Ok(()),
+        };
+        plex::notify::notify_library_scan(
+            api.as_ref(),
+            &self.plex_sections,
+            media_type,
+            &self.plex_circuit,
+        )
+        .await
     }
 
     #[instrument(skip(self), fields(track_id = %track_id, user_id = %user_id))]
@@ -364,7 +356,9 @@ mod tests {
     async fn notify_plex_returns_ok_when_unconfigured() {
         let (tx, _rx) = create_event_bus(32);
         let service = build_service(tx).await;
-        let result = service.notify_plex_import(MediaId::new()).await;
+        let result = service
+            .notify_plex_import(MediaId::new(), MediaType::Music)
+            .await;
         assert!(result.is_ok());
     }
 
@@ -407,9 +401,42 @@ mod tests {
             .with_mock_plex(mock, sections)
             .build();
 
-        service.notify_plex_import(MediaId::new()).await.unwrap();
+        service
+            .notify_plex_import(MediaId::new(), MediaType::Music)
+            .await
+            .unwrap();
 
         assert_eq!(*sections_ref.lock().unwrap(), vec![7u32]);
+    }
+
+    #[tokio::test]
+    async fn notify_plex_refreshes_only_the_matching_section() {
+        // WHY: #644's actual defect — the old handler refreshed EVERY
+        // configured section on every import because PlexNotifyRequired
+        // carried no media_type. With media_type threaded through, only
+        // the section for the imported item's type may be touched.
+        let (tx, _rx) = create_event_bus(32);
+        let mock = Arc::new(MockPlexApi::new());
+        let sections_ref = mock.sections_refreshed.clone();
+
+        let mut sections = HashMap::new();
+        sections.insert(MediaType::Music, 1u32);
+        sections.insert(MediaType::Movie, 2u32);
+
+        let service = ScrobbleClientBuilder::new(tx, test_pool().await)
+            .with_mock_plex(mock, sections)
+            .build();
+
+        service
+            .notify_plex_import(MediaId::new(), MediaType::Movie)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *sections_ref.lock().unwrap(),
+            vec![2u32],
+            "only the Movie section may be refreshed — the Music section must stay untouched"
+        );
     }
 
     // ── Last.fm configured ────────────────────────────────────────────────────

--- a/crates/syndesmos/src/plex/mod.rs
+++ b/crates/syndesmos/src/plex/mod.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 
 use horismos::PlexConfig;
 use snafu::ResultExt;
-use themelion::MediaType;
 
 use crate::error::{PlexApiCallSnafu, SyndesmodError};
 
@@ -35,11 +34,6 @@ impl PlexClient {
             .build()
             .unwrap_or_default(); // WHY: reqwest::Client::default() is a valid fallback; build fails only with invalid TLS config
         Self { http, config }
-    }
-
-    /// Resolves the Plex library section ID for the given media type.
-    pub(crate) fn section_id_for(&self, media_type: MediaType) -> Option<u32> {
-        self.config.library_sections.get(&media_type).copied()
     }
 }
 

--- a/crates/syndesmos/src/plex/notify.rs
+++ b/crates/syndesmos/src/plex/notify.rs
@@ -1,32 +1,25 @@
 //! Plex library scan notification — triggers a section refresh on media import.
 
+use std::collections::HashMap;
+
 use themelion::MediaType;
 use tracing::instrument;
 
 use crate::error::SyndesmodError;
-use crate::plex::{PlexApi, PlexClient};
+use crate::plex::PlexApi;
 use crate::retry::{CircuitBreaker, with_retry};
 
 /// Triggers a Plex library scan for the section that corresponds to `media_type`.
 ///
 /// Returns `Ok(())` silently when `media_type` has no configured section ID.
-// WHY: dead in lib builds (PlexNotifyRequired doesn't carry MediaType yet) but used from tests.
-// cfg_attr restricts the expect to non-test builds where the lint fires.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "held: primary entry point once PlexNotifyRequired carries MediaType, tracked in #644"
-    )
-)]
-#[instrument(skip(client, api, circuit))]
+#[instrument(skip(api, sections, circuit))]
 pub(crate) async fn notify_library_scan(
-    client: &PlexClient,
     api: &dyn PlexApi,
+    sections: &HashMap<MediaType, u32>,
     media_type: MediaType,
     circuit: &CircuitBreaker,
 ) -> Result<(), SyndesmodError> {
-    let section_id = match client.section_id_for(media_type) {
+    let section_id = match sections.get(&media_type).copied() {
         Some(id) => id,
         None => {
             tracing::debug!(
@@ -41,8 +34,12 @@ pub(crate) async fn notify_library_scan(
 }
 
 /// Triggers a Plex library scan for a known section ID directly.
+///
+/// Private: `notify_library_scan` is the sole caller now that the event
+/// handler routes through it with a real `media_type` (#644) — this is no
+/// longer reached from outside the module.
 #[instrument(skip(api, circuit), fields(section_id))]
-pub(crate) async fn notify_library_scan_by_section(
+async fn notify_library_scan_by_section(
     api: &dyn PlexApi,
     section_id: u32,
     circuit: &CircuitBreaker,
@@ -54,20 +51,11 @@ pub(crate) async fn notify_library_scan_by_section(
 mod tests {
     use std::collections::HashMap;
 
-    use horismos::PlexConfig;
     use themelion::MediaType;
 
     use super::*;
     use crate::plex::tests::MockPlexApi;
     use crate::retry::CircuitBreaker;
-
-    fn make_client(sections: HashMap<MediaType, u32>) -> PlexClient {
-        PlexClient::new(PlexConfig {
-            url: "http://plex.test:32400".to_string(),
-            token: "test-token".to_string(),
-            library_sections: sections,
-        })
-    }
 
     fn breaker() -> CircuitBreaker {
         CircuitBreaker::new("plex", 5, std::time::Duration::from_secs(300))
@@ -79,11 +67,10 @@ mod tests {
         sections.insert(MediaType::Music, 1u32);
         sections.insert(MediaType::Movie, 2u32);
 
-        let client = make_client(sections);
         let mock = MockPlexApi::new();
         let circuit = breaker();
 
-        notify_library_scan(&client, &mock, MediaType::Music, &circuit)
+        notify_library_scan(&mock, &sections, MediaType::Music, &circuit)
             .await
             .unwrap();
 
@@ -92,11 +79,11 @@ mod tests {
 
     #[tokio::test]
     async fn returns_ok_when_media_type_has_no_configured_section() {
-        let client = make_client(HashMap::new());
+        let sections = HashMap::new();
         let mock = MockPlexApi::new();
         let circuit = breaker();
 
-        let result = notify_library_scan(&client, &mock, MediaType::Music, &circuit).await;
+        let result = notify_library_scan(&mock, &sections, MediaType::Music, &circuit).await;
         assert!(result.is_ok());
         assert!(mock.refreshed_sections().is_empty());
     }
@@ -106,11 +93,10 @@ mod tests {
         let mut sections = HashMap::new();
         sections.insert(MediaType::Movie, 42u32);
 
-        let client = make_client(sections);
         let mock = MockPlexApi::new();
         let circuit = breaker();
 
-        notify_library_scan(&client, &mock, MediaType::Movie, &circuit)
+        notify_library_scan(&mock, &sections, MediaType::Movie, &circuit)
             .await
             .unwrap();
 

--- a/crates/themelion/src/aggelia/events.rs
+++ b/crates/themelion/src/aggelia/events.rs
@@ -66,7 +66,10 @@ pub enum HarmoniaEvent {
     // Integration events
     /// Taxis imported new media — Plex library needs a scan notification.
     /// Subscribers: Syndesmos (call Plex refresh endpoint)
-    PlexNotifyRequired { media_id: MediaId },
+    PlexNotifyRequired {
+        media_id: MediaId,
+        media_type: MediaType,
+    },
 
     /// Paroche detected playback of a track — scrobbling is now warranted.
     /// Subscribers: Syndesmos (submit scrobble to Last.fm)


### PR DESCRIPTION
Two issues, and the more interesting result is that #644's premise did not survive reading the code.

## #651 — releases and wants were never persisted before enqueue

`handle_enqueue` (MCP) resolved `release_id` against eksetasis's in-memory cache and minted a random `want_id` when the caller omitted one, then enqueued — without either row reaching the database. `syntaxis::DownloadQueue::enqueue` only writes `download_queue`. So the happy path downloaded bytes and then deterministically failed at import, where `ImportAdapter` requires both rows to exist.

The HTTP route `paroche::routes::download::enqueue_download` had the identical defect, taking client-supplied ids at face value. An issue that names one surface does not mean only one surface carries the defect, so both are fixed here.

Both now require an existing `want_id`, validated against `apotheke::repo::want`, and idempotently upsert the `releases` row **before** calling `queue.enqueue()`.

The shared rule lives in one place — `paroche::routes::download`, the lower point in the dependency graph, since archon already depends on paroche and not the reverse. What stays separate is only the error rendering: HTTP maps to `ParocheError` (404/409/500), MCP to `tool_error` text. That mapping is genuinely surface-specific; the persistence rule now has exactly one definition.

For the self-supplied-URL path there is no server-side resolve to draw metadata from, so magnet `dn`/`xl` parameters are parsed where present and a placeholder is used otherwise.

## #644 — the issue's literal fix would have left the feature dead

`HarmoniaEvent::PlexNotifyRequired` has **no production sender anywhere in the tree**. Every occurrence outside the enum definition is inside syndesmos's own tests. The real import pipeline (`kathodos`) emits only `ImportCompleted`, and nothing bridges the two. Widening the event and "threading it through the senders", as the issue asks, would have threaded it through test-only senders and changed nothing at runtime.

What was fixed is the part that is real: the event now carries `media_type`, `notify_plex_import` takes it, and the wasteful `refresh_all_plex_sections` — which refreshed *every* configured Plex section on *every* import — is replaced by a targeted `notify_library_scan`. `notify_library_scan` is decoupled from `&PlexClient` in favour of the section map it actually holds, and `notify_library_scan_by_section` drops to private as the issue asked.

Deciding whether `kathodos` should fire `PlexNotifyRequired`, or syndesmos should subscribe to `ImportCompleted`, or a translator should exist, is an architecture call outside this issue's scope. Plex notification remains unreachable end-to-end until that is settled — stated plainly rather than left implied by a green diff.

## Verification

The ordering tests are the load-bearing ones: each records whether the `releases` row existed **at the instant** `enqueue()` ran, so they fail if the persist is ever moved after the enqueue rather than merely checking the end state. That was confirmed by temporarily moving the call and watching them fail.

Also fixed, both pre-existing: `archon/tests/mcp_acquisition_acceptance.rs` did not compile under `--all-targets`, and `acquisition_integration.rs`'s helper minted an unpersisted `want_id` that would now 404 across six tests.

On the build box, CI-exact: fmt clean, clippy `--all-targets -D warnings` clean, **2285/2285 tests passed**, doctests passing.

Refs #651
Refs #644
