### PR TITLE
fix(lint): mark the RFC 6598 range citation as a reviewed reference

### DIFF
--- a/crates/eksetasis/src/client/mod.rs
+++ b/crates/eksetasis/src/client/mod.rs
@@ -325,7 +325,8 @@ fn ip_is_disallowed(ip: IpAddr) -> bool {
                 || v4.is_link_local()
                 || v4.is_unspecified()
                 || v4.is_broadcast()
-                // NOTE: shared address space (CGNAT), RFC 6598: 100.64.0.0/10
+                // NOTE: rejects RFC 6598 shared address space (CGNAT).
+                // pii-allow: 100.64.0.0/10 is the range base and prefix RFC 6598 defines, not a fleet host.
                 || (u32::from(v4) & 0xFFC0_0000) == 0x6440_0000
         }
         IpAddr::V6(v6) => {

--- a/crates/paroche/src/net_validate.rs
+++ b/crates/paroche/src/net_validate.rs
@@ -133,7 +133,8 @@ fn ip_is_disallowed(ip: IpAddr) -> bool {
                 || v4.is_link_local()
                 || v4.is_unspecified()
                 || v4.is_broadcast()
-                // NOTE: shared address space (CGNAT), RFC 6598: 100.64.0.0/10
+                // NOTE: rejects RFC 6598 shared address space (CGNAT).
+                // pii-allow: 100.64.0.0/10 is the range base and prefix RFC 6598 defines, not a fleet host.
                 || (u32::from(v4) & 0xFFC0_0000) == 0x6440_0000
         }
         IpAddr::V6(v6) => {


### PR DESCRIPTION
## Defect

`ip_is_disallowed` in `crates/eksetasis/src/client/mod.rs` and `crates/paroche/src/net_validate.rs` carries the same comment documenting why CGNAT space is rejected, and cites the range literal `100.64.0.0/10`. The OIKOS/private-content lint matches that literal as a possible fleet host address and flags it, with no way to satisfy the rule by redacting the citation — the literal is the RFC 6598 range's own base address and prefix length, not a host. Both sites fired on `main`; since `gate-attestation` here is a standalone trailer check with no full-build fallback, no branch in this repo could earn a `Gate-Passed` trailer while the lint stage stayed red.

## Change

Adds a `pii-allow` annotation to both comments marking the citation as a reviewed, deliberate reference, matching the escape hatch the rule itself documents. No code logic changes — the `ip_is_disallowed` rejection behavior is identical before and after.

## Verification

Comment-only change with no behavior difference; verification is that the OIKOS/private-content lint stage stops flagging these two sites (CI/lint-only, no runtime test applicable).
