### PR TITLE
fix(syndesis): give each TLS identity test its own temp directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5882,6 +5882,7 @@ dependencies = [
  "sha2 0.11.0",
  "snafu",
  "sqlx",
+ "tempfile",
  "themelion",
  "tokio",
  "toml 1.1.3+spec-1.1.0",

--- a/crates/syndesis/Cargo.toml
+++ b/crates/syndesis/Cargo.toml
@@ -32,6 +32,7 @@ uuid.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 sqlx.workspace = true
 apotheke = { workspace = true }

--- a/crates/syndesis/src/tls/mod.rs
+++ b/crates/syndesis/src/tls/mod.rs
@@ -468,48 +468,46 @@ mod tests {
         assert_ne!(c1.fingerprint, c2.fingerprint);
     }
 
+    // WARNING: these tests write TLS private key material, so each one must
+    // own its directory. A fixed `env::temp_dir().join(...)` path is shared
+    // by every account on the box — whichever user creates it first owns it
+    // and every other user's run fails on permissions, and two concurrent
+    // runs delete each other's key files through the trailing cleanup.
     #[test]
     fn save_and_load_identity_round_trip() {
-        let dir = std::env::temp_dir().join("syndesis_tls_test");
-        let cert_path = dir.join("cert.der");
-        let key_path = dir.join("key.der");
+        let dir = tempfile::TempDir::new().unwrap();
+        let cert_path = dir.path().join("cert.der");
+        let key_path = dir.path().join("key.der");
 
         let (certs, key) = generate_self_signed(&["localhost".to_string()]).unwrap();
         save_identity(&cert_path, &key_path, &certs, &key).unwrap();
         let (loaded_certs, _loaded_key) = load_identity(&cert_path, &key_path).unwrap();
 
         assert_eq!(certs[0].as_ref(), loaded_certs[0].as_ref());
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn save_identity_sets_key_file_permissions_0600() {
         use std::os::unix::fs::PermissionsExt;
 
-        let dir = std::env::temp_dir().join("syndesis_tls_perm_test");
-        let cert_path = dir.join("cert.der");
-        let key_path = dir.join("key.der");
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = tempfile::TempDir::new().unwrap();
+        let cert_path = dir.path().join("cert.der");
+        let key_path = dir.path().join("key.der");
 
         let (certs, key) = generate_self_signed(&["localhost".to_string()]).unwrap();
         save_identity(&cert_path, &key_path, &certs, &key).unwrap();
 
         let mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "fresh key file must be 0600, got {mode:o}");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn save_identity_repairs_loose_key_file_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
-        let dir = std::env::temp_dir().join("syndesis_tls_perm_repair_test");
-        let cert_path = dir.join("cert.der");
-        let key_path = dir.join("key.der");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        let cert_path = dir.path().join("cert.der");
+        let key_path = dir.path().join("key.der");
         std::fs::write(&key_path, b"stale").unwrap();
         std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
@@ -518,7 +516,5 @@ mod tests {
 
         let mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "loose key file must be repaired to 0600");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Defect

The three TLS identity save/load tests in `crates/syndesis/src/tls/mod.rs` each derived their working directory from a fixed `env::temp_dir().join(...)` path (`syndesis_tls_test`, `syndesis_tls_perm_test`, `syndesis_tls_perm_repair_test`). Those paths are shared by every account on the machine: whichever account creates the directory first owns it, and every other account fails on the directory permissions rather than on anything the test measures. The trailing `remove_dir_all` compounds it — two runs racing on the same path can delete each other's key material mid-assertion. These tests write TLS private key material, so a shared, predictable location is the wrong default independent of the race. `save_and_load_identity_round_trip` also never created its own directory and relied on a sibling test having created the shared one first — a hidden ordering dependency.

## Change

Routes all three tests through `tempfile::TempDir` so each owns a private, uniquely-named directory that is removed automatically when the guard drops, and removes the manual `remove_dir_all` cleanup that existed only to service the shared path. Adds `tempfile` as a dev-dependency of `crates/syndesis`. No production code changed — `save_identity` / `load_identity` are untouched; only the test harness changed.

## Verification

No production code path changed, only test fixtures. Verification is CI on this PR (`cargo nextest run` for the `syndesis` crate); the originating commit recorded a local run of 107 `syndesis` tests green with `kanon lint` open violations dropping from 12 to 9, which this PR's CI run will reconfirm from a clean checkout.
