### PR TITLE
fix(desktop): stop the standalone lockfile drifting behind releases

### DIFF
--- a/crates/theatron/desktop/Cargo.lock
+++ b/crates/theatron/desktop/Cargo.lock
@@ -3690,7 +3690,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skene"
-version = "0.1.14"
+version = "0.2.1"
 dependencies = [
  "reqwest",
  "serde",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,11 @@
           "type": "toml",
           "path": "Cargo.lock",
           "jsonpath": "$.package[?(!@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/theatron/desktop/Cargo.lock",
+          "jsonpath": "$.package[?(@.name == 'skene')].version"
         }
       ]
     }


### PR DESCRIPTION
`crates/theatron/desktop` is excluded from the root workspace and carries its own `Cargo.lock`, which was absent from `release-please-config.json`'s `extra-files`. `release-please` patches the root `Cargo.toml` and root `Cargo.lock` on release, but nothing patched the desktop one, so it drifted behind every release: main recorded `skene` at 0.1.14 in the desktop lock while the root workspace was at 0.2.1, and `cargo metadata --locked` in the desktop workspace exited 101 — it could not be resolved reproducibly.

Adds an `extra-files` entry that patches `crates/theatron/desktop/Cargo.lock` by selecting the `skene` package by name, rather than reusing the root lock's `$.package[?(!@.source)].version` jsonpath: the desktop lock has two unsourced packages, and the other one is `periskopio` (the desktop crate itself), versioned independently at 0.1.14. The broader jsonpath would have rewritten `periskopio` to the root's version and left the lock disagreeing with its own manifest.

The lock edit in this PR is surgical (bumps only the `skene` version field) rather than a regenerate, so no transitive dependency is resolved to a different version by this change.

Verified: CI only — the commit carries no gate-passed trailer, so local verification cannot be confirmed from the branch itself. Reviewers should confirm `cargo metadata --locked --manifest-path crates/theatron/desktop/Cargo.toml` succeeds before merge.
