### PR TITLE
ci(gate-attestation): build main after squash-merge

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -24,6 +24,14 @@ name: Gate Attestation
 on:
   pull_request:
     branches: [main]
+  # WHY a push trigger and not just pull_request: a squash merge does not
+  # carry the source commits' trailers, so no commit on main has a
+  # Gate-Passed trailer -- check-trailer finds none and routes to
+  # full-gate-build, which is the job that actually compiles the workspace.
+  # Without this nothing ever builds main, and the first PR to inherit a
+  # merged break is what discovers it (forkwright/theatron#235).
+  push:
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Add a `push: branches: [main]` trigger to `gate-attestation.yml` so squash-merged, trailer-less commits get compiled on main. Additive only — the `pull_request` path is unchanged.

Verified: reviewed and cleared to land during op-pause; CI is the verifier.

Refs forkwright/theatron#235
