### PR TITLE
chore(ci): suppress gate-attestation concurrency false-positive

### DIFF
--- a/.kanon.yml
+++ b/.kanon.yml
@@ -1,0 +1,13 @@
+# WHY(YAML/missing-concurrency on gate-attestation.yml): the rule detects a push/pull_request
+# workflow with no `concurrency:` block and prescribes adding one. That prescription is wrong
+# for this file: gate-attestation.yml is a thin caller that delegates to
+# `forkwright/.github/.github/workflows/hybrid-gate.yml`, and the callee already declares
+# `concurrency: group: ${{ github.workflow }}-${{ github.ref }}` and documents that callers
+# must NOT also set a group with that key, or the shared group self-cancels. The rule's own
+# rationale — stacked runs wasting compute — is therefore already satisfied by the callee.
+# The check has no `uses:` resolution, so it cannot see the delegation and fires on every
+# hybrid-gate caller.
+# WARNING: this entry does NOT by itself make harmonia's main locally stampable. main carries
+# 11 further violations, and `kanon gate` requires ZERO under strict_warnings. It removes the
+# one violation that is not a real defect, so the remaining count is an honest debt figure.
+suppress: [{rule: YAML/missing-concurrency, files: [.github/workflows/gate-attestation.yml]}]


### PR DESCRIPTION
Adds a narrowly-scoped, documented `.kanon.yml` suppression for the YAML/missing-concurrency lint on `gate-attestation.yml`. The workflow delegates to `forkwright/.github`'s `hybrid-gate.yml` reusable workflow, which already declares its own concurrency group — the lint flags a false positive because it cannot see concurrency declared in the callee.

Verified: reviewed and cleared to land during op-pause; CI is the verifier.
