### PR TITLE
fix(deps): bump event-listener to 5.4.2 for RUSTSEC-2026-0221

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,15 +1037,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,11 +1714,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Finding

`event-listener` 5.4.1 allows `!Send` tags to cross thread boundaries via `StackSlot` — **RUSTSEC-2026-0221**. It reaches this repo as a transitive dependency, and the advisory is fixed upstream in 5.4.2.

## Why this blocks everything

`cargo audit` and `osv-scanner` are both **required** checks here, and both fail on this single lockfile entry. That means *every* open PR in this repo is red regardless of its own content — the failure has nothing to do with the branch under test. `osv-scanner` itself reports the fix is available:

```
| https://osv.dev/RUSTSEC-2026-0221 | crates.io | event-listener | 5.4.1 | 5.4.2 | Cargo.lock |
1 vulnerability can be fixed.
```

Every other advisory in that scan is already triaged and filtered with a documented review-by date; this is the only unfiltered one.

## Change

Lockfile-only, minimal and precise:

```
cargo update -p event-listener --precise 5.4.2
```

No other package version changed. In harmonia, `concurrent-queue` also drops out because 5.4.2 no longer depends on it; in theatron only the version and checksum lines move.

## Verification

CI is the verifier — `cargo audit` and `osv-scanner` on this PR are the direct test of the fix, since they are the checks that currently fail.
