### PR TITLE
fix(release): publish the source archive and SBOM the attestations cover

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,12 +34,18 @@ jobs:
 
   # WHY: SLSA provenance + signed SBOM for the release source archive at
   # release-creation time, per SUPPLY-CHAIN.md § Required per release. Binary
-  # artifacts are attested separately in release.yml.
+  # artifacts are attested separately in release.yml. The archive and SBOM are
+  # also uploaded as release assets (harmonia#655) — an attestation whose
+  # subject is never published leaves no artifact a consumer can apply it to.
   attest-release-source:
     needs: [release-please]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -65,13 +71,39 @@ jobs:
           upload-artifact: false
           upload-release-assets: false
 
+      - name: Generate checksum
+        run: sha256sum "${{ steps.source.outputs.archive }}" > "${{ steps.source.outputs.archive }}.sha256"
+
       - name: Attest source provenance
+        id: attest-provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: ${{ steps.source.outputs.archive }}
 
       - name: Attest CycloneDX SBOM
+        id: attest-sbom
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-path: ${{ steps.source.outputs.archive }}
           sbom-path: ${{ steps.source.outputs.archive }}.cdx.json
+
+      # WHY: step outputs are passed through env vars, not interpolated into
+      # the run block, so the shell never embeds untrusted ${{ }} expansion
+      # (GitHub Actions expression-injection hardening, matching release.yml).
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          ARCHIVE: ${{ steps.source.outputs.archive }}
+          PROVENANCE_BUNDLE: ${{ steps.attest-provenance.outputs.bundle-path }}
+          SBOM_BUNDLE: ${{ steps.attest-sbom.outputs.bundle-path }}
+        run: |
+          cp "$PROVENANCE_BUNDLE" "${ARCHIVE}.provenance.intoto.jsonl"
+          cp "$SBOM_BUNDLE" "${ARCHIVE}.cdx.intoto.jsonl"
+          gh release upload "$TAG_NAME" \
+            "$ARCHIVE" \
+            "${ARCHIVE}.sha256" \
+            "${ARCHIVE}.cdx.json" \
+            "${ARCHIVE}.provenance.intoto.jsonl" \
+            "${ARCHIVE}.cdx.intoto.jsonl" \
+            --clobber


### PR DESCRIPTION
## Defect

`attest-release-source` built a source archive and CycloneDX SBOM, attested both, and then discarded both files (`upload-artifact`/`upload-release-assets` false, no `gh release upload` step). The live release only carries GitHub's autogenerated source download, which is byte-distinct from the attested git-archive file — so the attestations had no subject a consumer could fetch and verify against.

## Change

Generate a checksum alongside the SBOM, capture the attestation bundle paths, and upload archive + checksum + SBOM + both attestation bundles as release assets, matching the pattern `release.yml` already uses for binary artifacts. Scope the job's permissions to what it actually needs (drops `pull-requests: write`, inherited from the workflow-level block but unused here).

## Verification

CI on this PR (`.github/workflows/release-please.yml` workflow-lint / gate checks) is the verification — this is a release-workflow change with no local test harness to reproduce release-time asset upload against.

Refs #655
