### PR TITLE
fix(llm-corpus): stop restating volatile tracker state in current_state.toml

### DIFF
--- a/_llm/current_state.toml
+++ b/_llm/current_state.toml
@@ -4,28 +4,19 @@ repo = "forkwright/harmonia"
 generated = false
 source_docs = [
   "README.md",
-  "<canonical-state-doc>/STATE.md",
+  "kanon/projects/harmonia/STATE.md",
 ]
 
+# WHY: this file used to embed phase percentages, dated recent-work entries, and
+# a restated open-issue list. All three drift out from under a hand-maintained
+# snapshot within hours of the next merge (harmonia#682) and there is no derivation
+# pipeline that regenerates them from git/tracker authorities yet. Until that
+# derivation exists, this file carries only pointers to the live authorities —
+# never restated tracker or history facts — so it cannot go stale.
 [state]
-summary = "Harmonia is a Rust media-platform workspace with canonical storage and server capabilities largely shipped; Dioxus desktop remains the Phase 3.5 tail."
-current_phase = "Phase 3.5: canonical storage plus Dioxus desktop, nearly complete."
-updated = "2026-05-05"
+summary = "Harmonia is a Rust media-platform workspace: acquisition, canonical storage, and HTTP/OpenSubsonic serving are shipped; remaining work is tracked live, not here."
+authority = "kanon/projects/harmonia/STATE.md is the canonical phase/planning snapshot (cross-repo). Verify current phase and recent work there against GitHub, not by restating it in this file."
 
-[[recent]]
-date = "2026-04-22"
-item = "NOTICE canonicalized and forge sync timer active."
-
-[[recent]]
-date = "2026-04-13"
-item = "Canonical storage, import/rename, path templates, sidecars, migrate subcommand, and legacy cleanup completed."
-
-[[open_threads]]
-name = "Dioxus desktop port"
-issue = 0
-status = "Remaining Phase 3.5 scope; mines patterns from aletheia proskenion and theatron."
-
-[[open_threads]]
-name = "calibre retirement research"
-issue = 214
-status = "Research tickets remain under the calibre-retirement epic."
+[open_threads]
+authority = "gh issue list --repo forkwright/harmonia --state open"
+note = "Open-thread numbers and statuses are read live from the tracker. Do not restate an issue list or its status here — every restatement has gone stale before the next merge."

--- a/crates/archon/tests/llm_corpus_check.rs
+++ b/crates/archon/tests/llm_corpus_check.rs
@@ -1,0 +1,72 @@
+//! harmonia#682 — `_llm/current_state.toml` must stay a live pointer, not a
+//! restated snapshot. Guards the two structural failure modes the file
+//! actually shipped with: an unresolved `<...>` placeholder locator, and a
+//! sentinel `issue = 0` standing in for a real tracker reference.
+
+use std::path::Path;
+
+fn current_state_path() -> &'static Path {
+    Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../_llm/current_state.toml"
+    ))
+}
+
+#[test]
+fn current_state_has_no_unresolved_placeholder() {
+    let raw = std::fs::read_to_string(current_state_path()).expect("read _llm/current_state.toml");
+    assert!(
+        !raw.contains('<') || !raw.contains('>'),
+        "_llm/current_state.toml contains an unresolved '<...>' placeholder \
+         (e.g. a locator like <canonical-state-doc>); every source_docs entry \
+         must resolve to a real path"
+    );
+}
+
+#[test]
+fn current_state_has_no_sentinel_issue_id() {
+    let raw = std::fs::read_to_string(current_state_path()).expect("read _llm/current_state.toml");
+    let value: toml::Value =
+        toml::from_str(&raw).expect("_llm/current_state.toml must be valid TOML");
+
+    if let Some(threads) = value.get("open_threads").and_then(|v| v.as_array()) {
+        for thread in threads {
+            if let Some(issue) = thread.get("issue").and_then(toml::Value::as_integer) {
+                assert_ne!(
+                    issue, 0,
+                    "_llm/current_state.toml carries a sentinel `issue = 0` open \
+                     thread; a real thread needs a real issue number, and one \
+                     that has none should not be restated here at all"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn current_state_does_not_restate_volatile_tracker_snapshots() {
+    let raw = std::fs::read_to_string(current_state_path()).expect("read _llm/current_state.toml");
+    let value: toml::Value =
+        toml::from_str(&raw).expect("_llm/current_state.toml must be valid TOML");
+
+    // WHY: `[[recent]]` (dated work log) and per-thread `[[open_threads]]`
+    // entries are exactly the two shapes that went stale in harmonia#682 —
+    // this file must point at git/tracker authorities instead of restating
+    // their contents.
+    assert!(
+        value.get("recent").is_none(),
+        "_llm/current_state.toml must not carry a dated [[recent]] work log; \
+         point at `git log` / CHANGELOG.md instead"
+    );
+
+    let table_threads = value
+        .get("open_threads")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().any(|t| t.get("issue").is_some()))
+        .unwrap_or(false);
+    assert!(
+        !table_threads,
+        "_llm/current_state.toml must not restate per-issue open-thread \
+         entries; point at `gh issue list --repo forkwright/harmonia` instead"
+    );
+}


### PR DESCRIPTION
## Defect

`_llm/current_state.toml` carried a dated phase snapshot, a `[[recent]]` work log, and per-issue open-thread entries (one using sentinel `issue = 0`, the other pointing at an issue closed months ago) alongside an unresolved `<canonical-state-doc>` placeholder in `source_docs`. Agents are pointed at this file as current context, so the stale content actively manufactured wrong planning state.

## Change

Replace the restated snapshot with pointers to the live authorities (`kanon/projects/harmonia/STATE.md` for phase/planning, `gh issue list` for open threads) and add a regression test that fails on either failure mode returning: an unresolved placeholder locator, or a restated per-issue open-thread entry (including the sentinel issue id).

## Verification

New regression test `crates/archon/tests/llm_corpus_check.rs` asserts the corpus no longer carries an unresolved placeholder locator or a restated per-issue open-thread entry; CI on this PR runs it.

Refs #682
