### PR TITLE
fix(archon,horismos): constrain MCP socket_path overrides to the owned runtime directory

### DIFF
--- a/crates/archon/src/error.rs
+++ b/crates/archon/src/error.rs
@@ -158,6 +158,13 @@ pub enum HostError {
         location: snafu::Location,
     },
 
+    #[snafu(display("invalid MCP bridge socket configuration: {source}"))]
+    McpSocketPath {
+        source: archon::mcp_bridge::SocketPathError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
     #[snafu(display("migrate: source directory does not exist: {}", path.display()))]
     MigrateSourceMissing {
         path: std::path::PathBuf,

--- a/crates/archon/src/mcp.rs
+++ b/crates/archon/src/mcp.rs
@@ -8,7 +8,7 @@ use snafu::ResultExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
 use crate::cli::{CliMediaType, DbMigrateArgs, MigrateArgs, PlayArgs};
-use crate::error::{ConfigSnafu, HostError, OutputSnafu};
+use crate::error::{ConfigSnafu, HostError, McpSocketPathSnafu, OutputSnafu};
 
 const SERVER_NAME: &str = "harmonia";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -24,11 +24,12 @@ pub(crate) struct McpContext {
 }
 
 impl McpContext {
-    fn from_config(config: &horismos::Config) -> Self {
-        Self {
-            socket_path: archon::mcp_bridge::resolve_socket_path(config),
+    fn from_config(config: &horismos::Config) -> Result<Self, HostError> {
+        Ok(Self {
+            socket_path: archon::mcp_bridge::resolve_socket_path(config)
+                .context(McpSocketPathSnafu)?,
             call_timeout: Duration::from_secs(config.mcp.call_timeout_secs),
-        }
+        })
     }
 }
 
@@ -48,7 +49,7 @@ pub(crate) async fn run_stdio(config_path: PathBuf) -> Result<(), HostError> {
     for w in &warnings {
         tracing::warn!(field = %w.field, "{}", w.message);
     }
-    let ctx = McpContext::from_config(&config);
+    let ctx = McpContext::from_config(&config)?;
 
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();

--- a/crates/archon/src/mcp_bridge.rs
+++ b/crates/archon/src/mcp_bridge.rs
@@ -24,7 +24,11 @@
 //! The socket lives in a DEDICATED `harmonia-mcp/` runtime subdirectory
 //! (chmod'd 0700) beside `database.db_path` — never in `db_path`'s own
 //! directory, which may be shared with other users/processes we must not
-//! chmod (#609 adversarial review finding).
+//! chmod (#609 adversarial review finding). An explicit `mcp.socket_path`
+//! override may name only a bare FILE NAME inside that same owned
+//! directory; anything with directory components is refused with a typed
+//! configuration error, so the startup `0700` chmod can never land on a
+//! directory Harmonia does not own (#653).
 
 // NOTE: `Permissions`/`PermissionsExt` live at module scope — `from_mode` is
 // a pure value builder (not I/O), and keeping the `std::fs::` path out of the
@@ -41,6 +45,7 @@ use std::sync::Arc;
 use apotheke::DbPools;
 use paroche::state::{DynQueueManager, DynSearchService, EnqueueItem, ServiceError};
 use serde_json::{Value, json};
+use snafu::Snafu;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tracing::Instrument;
 use url::Url;
@@ -93,28 +98,72 @@ impl BridgeContext {
     }
 }
 
+/// Typed refusal of an `mcp.socket_path` override that is not a bare file
+/// name (#653). Bridge startup chmods the socket's parent directory `0700`,
+/// so the socket MUST live in the Harmonia-owned runtime directory —
+/// accepting an arbitrary parent would hand a socket-location option
+/// directory-wide authority (`socket_path = "/tmp/harmonia.sock"` under
+/// privilege would privatize `/tmp`).
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+#[non_exhaustive]
+pub enum SocketPathError {
+    #[snafu(display(
+        "mcp.socket_path '{}' must be a bare file name (e.g. \"harmonia-mcp.sock\"); the bridge \
+         socket lives in the Harmonia-owned `harmonia-mcp/` runtime directory beside \
+         `database.db_path`, and directory components are refused so startup never creates or \
+         changes permissions on a directory Harmonia does not own",
+        path.display()
+    ))]
+    NotBareFileName {
+        path: PathBuf,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
 /// Derives the bridge socket path FROM config — the SAME derivation both
 /// `harmonia serve` (binds) and `harmonia mcp` (connects) run
 /// independently, so the two processes agree without operator wiring.
-/// `mcp.socket_path` overrides; otherwise a DEDICATED `harmonia-mcp/`
-/// runtime subdirectory beside `database.db_path`, holding
-/// `harmonia-mcp.sock`.
+/// The socket ALWAYS lives in a DEDICATED `harmonia-mcp/` runtime
+/// subdirectory beside `database.db_path`: `mcp.socket_path` overrides only
+/// the FILE NAME beneath it, with `harmonia-mcp.sock` as the default.
 ///
-/// WHY a dedicated subdir, not a sibling file: `spawn` chmods the socket's
-/// parent directory `0700` so only the operator can enter it. `db_path`'s
-/// own directory may be shared (other files, other users) — chmodding it
-/// would be wrong (and its failure would be a false-fatal serve-startup
-/// error). A subdirectory we alone create is ours to chmod.
-pub fn resolve_socket_path(config: &horismos::Config) -> PathBuf {
-    config.mcp.socket_path.clone().unwrap_or_else(|| {
-        let parent = config
-            .database
-            .db_path
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-            .unwrap_or_else(|| Path::new("."));
-        parent.join("harmonia-mcp").join("harmonia-mcp.sock")
-    })
+/// WHY the override is constrained to a bare file name: `spawn` creates
+/// the socket's parent directory and chmods it `0700` so only the operator
+/// can enter it. That is sound only for a directory this process owns — an
+/// arbitrary parent (`/tmp` for `/tmp/harmonia.sock`, or any shared
+/// application directory) would be created or have its permissions changed
+/// by socket configuration alone (#653). Refusing directory components
+/// keeps the `0700` chmod attached to the dedicated directory "we alone
+/// create", and keeps this function a pure, deterministic function of
+/// config — no filesystem probing both processes could disagree on.
+///
+/// WHY a dedicated subdir, not a sibling file: `db_path`'s own directory
+/// may be shared (other files, other users) — chmodding it would be wrong
+/// (and its failure would be a false-fatal serve-startup error). A
+/// subdirectory we alone create is ours to chmod.
+pub fn resolve_socket_path(config: &horismos::Config) -> Result<PathBuf, SocketPathError> {
+    let runtime_dir = config
+        .database
+        .db_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .join("harmonia-mcp");
+    match &config.mcp.socket_path {
+        None => Ok(runtime_dir.join("harmonia-mcp.sock")),
+        Some(name) => {
+            let mut components = name.components();
+            if let (Some(std::path::Component::Normal(file_name)), None) =
+                (components.next(), components.next())
+            {
+                Ok(runtime_dir.join(file_name))
+            } else {
+                NotBareFileNameSnafu { path: name.clone() }.fail()
+            }
+        }
+    }
 }
 
 // ── JSON-RPC / MCP tool-result envelope helpers ─────────────────────────────
@@ -660,10 +709,12 @@ async fn run_accept_loop(
 /// Binds the acquisition bridge's Unix domain socket and spawns its accept
 /// loop. Bind is FATAL — mirrors the HTTP listener's startup posture: a
 /// server that cannot bind its configured surface must not come up
-/// half-alive. The socket's parent directory is a dedicated runtime dir
-/// this process owns (see `resolve_socket_path`) — created and `chmod`'d
-/// `0700`; a failure here is a legitimate fatal (it means another user owns
-/// what should be our runtime dir). The socket file itself is `chmod`'d
+/// half-alive. The socket's parent directory is the dedicated runtime dir
+/// this process owns — `resolve_socket_path` refuses any override that
+/// would place the socket elsewhere (#653), so creating it and chmodding
+/// it `0700` here can only ever touch Harmonia's own directory; a failure
+/// is a legitimate fatal (it means another user owns what should be our
+/// runtime dir). The socket file itself is `chmod`'d
 /// `0600` after bind, belt-and-suspenders on top of the directory
 /// permission. If a socket already exists at the target path, it is
 /// LIVENESS-CHECKED, not blindly unlinked: a successful connect means
@@ -1728,8 +1779,8 @@ mod tests {
         // `harmonia mcp` (this second call, standing in for the stdio
         // client) run independently — calling it twice from the same
         // config proves they land on the identical path.
-        let serve_side = resolve_socket_path(&config);
-        let mcp_side = resolve_socket_path(&config);
+        let serve_side = resolve_socket_path(&config).unwrap();
+        let mcp_side = resolve_socket_path(&config).unwrap();
         assert_eq!(
             serve_side, mcp_side,
             "serve and mcp must derive the identical socket path from the same config"
@@ -1757,6 +1808,109 @@ mod tests {
         let socket_meta = tokio::fs::metadata(&serve_side).await.unwrap();
         assert_eq!(socket_meta.permissions().mode() & 0o777, 0o600);
 
+        shutdown.cancel();
+        handle.await.unwrap();
+    }
+
+    // ── #653: overrides are constrained to the owned runtime dir ──────────
+
+    fn config_with_socket_override(
+        db_dir: &Path,
+        socket_path: Option<PathBuf>,
+    ) -> horismos::Config {
+        horismos::Config {
+            database: horismos::DatabaseConfig {
+                db_path: db_dir.join("harmonia.sqlite"),
+                ..horismos::DatabaseConfig::default()
+            },
+            mcp: horismos::McpConfig {
+                socket_path,
+                ..horismos::McpConfig::default()
+            },
+            ..horismos::Config::default()
+        }
+    }
+
+    #[test]
+    fn socket_path_override_pointing_at_tmp_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let config =
+            config_with_socket_override(dir.path(), Some(PathBuf::from("/tmp/harmonia.sock")));
+        let error = resolve_socket_path(&config).expect_err("a /tmp parent must be refused");
+        assert!(
+            matches!(error, SocketPathError::NotBareFileName { .. }),
+            "expected NotBareFileName, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("/tmp/harmonia.sock"),
+            "the refusal must name the rejected value: {message}"
+        );
+    }
+
+    #[test]
+    fn socket_path_override_inside_a_shared_directory_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let shared = dir.path().join("shared");
+        std::fs::create_dir(&shared).unwrap();
+        std::fs::write(shared.join("other-service.pid"), b"1").unwrap();
+        let mode_before = std::fs::metadata(&shared).unwrap().permissions().mode() & 0o777;
+
+        let config = config_with_socket_override(dir.path(), Some(shared.join("harmonia.sock")));
+        let error = resolve_socket_path(&config)
+            .expect_err("a socket inside a directory Harmonia does not own must be refused");
+        assert!(
+            matches!(error, SocketPathError::NotBareFileName { .. }),
+            "expected NotBareFileName, got {error:?}"
+        );
+
+        // WHY: refusal is pure validation — the shared directory is never
+        // created, chmod'd, or otherwise touched, and no socket inode
+        // appears in it.
+        let mode_after = std::fs::metadata(&shared).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode_before, mode_after);
+        assert!(shared.join("other-service.pid").exists());
+        assert!(!shared.join("harmonia.sock").exists());
+    }
+
+    #[test]
+    fn socket_path_overrides_with_directory_components_are_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        for bad in ["../harmonia.sock", "sub/harmonia.sock", "./harmonia.sock"] {
+            let config = config_with_socket_override(dir.path(), Some(PathBuf::from(bad)));
+            assert!(
+                matches!(
+                    resolve_socket_path(&config),
+                    Err(SocketPathError::NotBareFileName { .. })
+                ),
+                "override {bad:?} must be refused"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn socket_path_override_bare_file_name_lands_in_the_owned_runtime_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_socket_override(dir.path(), Some(PathBuf::from("custom.sock")));
+        let resolved = resolve_socket_path(&config).expect("a bare file name is accepted");
+        assert_eq!(
+            resolved,
+            dir.path().join("harmonia-mcp").join("custom.sock")
+        );
+
+        // The owned runtime dir still gets created `0700` with a `0600`
+        // socket inside it.
+        let ctx = test_ctx(empty_search(), StubQueue::default()).await;
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = spawn(resolved.clone(), ctx, shutdown.clone())
+            .await
+            .expect("bridge binds");
+        let subdir_meta = tokio::fs::metadata(resolved.parent().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(subdir_meta.permissions().mode() & 0o777, 0o700);
+        let socket_meta = tokio::fs::metadata(&resolved).await.unwrap();
+        assert_eq!(socket_meta.permissions().mode() & 0o777, 0o600);
         shutdown.cancel();
         handle.await.unwrap();
     }

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -39,8 +39,8 @@ use tracing::{Instrument, info};
 use crate::cli::ServeArgs;
 use crate::error::{
     ConfigSnafu, DatabaseSnafu, DownloadEngineSnafu, DownloadQueueSnafu, FeedSchedulerSnafu,
-    HostError, ListenAddrSnafu, McpBridgeBindSnafu, ReloadTaskPanickedSnafu, ScannerSnafu,
-    ServerSnafu,
+    HostError, ListenAddrSnafu, McpBridgeBindSnafu, McpSocketPathSnafu, ReloadTaskPanickedSnafu,
+    ScannerSnafu, ServerSnafu,
 };
 use crate::shutdown::shutdown_signal;
 use crate::startup::{ensure_admin_user, init_tracing};
@@ -1341,7 +1341,8 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
     // the HTTP listener's startup posture below — the bridge is part of the
     // configured surface; a bind failure must not leave the server half-alive
     // (a mounted `harmonia mcp` would silently report "server not running").
-    let mcp_socket_path = archon::mcp_bridge::resolve_socket_path(&boot_config);
+    let mcp_socket_path =
+        archon::mcp_bridge::resolve_socket_path(&boot_config).context(McpSocketPathSnafu)?;
     let mcp_bridge_handle = archon::mcp_bridge::spawn(
         mcp_socket_path.clone(),
         archon::mcp_bridge::BridgeContext::new(search_adapter, queue_adapter, db),

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -650,11 +650,16 @@ impl Default for AitesisConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct McpConfig {
-    /// Unix-domain-socket path the acquisition bridge binds and the stdio
-    /// surface connects to. `None` derives a default: `harmonia-mcp.sock`
-    /// inside a dedicated `harmonia-mcp/` runtime subdirectory beside
-    /// `database.db_path` (never `db_path`'s own directory, which the
-    /// bridge does not own and must not chmod).
+    /// Unix-domain-socket FILE NAME the acquisition bridge binds and the
+    /// stdio surface connects to. `None` uses `harmonia-mcp.sock`. The
+    /// socket always lives inside a dedicated `harmonia-mcp/` runtime
+    /// subdirectory beside `database.db_path` (never `db_path`'s own
+    /// directory, which the bridge does not own and must not chmod): the
+    /// bridge creates that subdirectory and restricts it to `0700` at
+    /// startup, so an override may name only a child file within it — a
+    /// value with directory components is refused as a configuration error
+    /// rather than letting a socket-location option create or change
+    /// permissions on a directory Harmonia does not own.
     #[serde(default)]
     pub socket_path: Option<PathBuf>,
     /// Deadline (seconds) for one `tools/call` round trip over the bridge

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -204,9 +204,12 @@ post-subscription events).
 | `socket_path` | the acquisition bridge binds this Unix domain socket once at `harmonia serve` startup and `harmonia mcp` resolves it once at its own process start — a live-rebind has no consumer (both sides would have to re-derive the path together) |
 | `call_timeout_secs` | the stdio `harmonia mcp` process reads it once at start to size its per-call deadline; `harmonia serve` never reads it |
 
-The socket path defaults to a sibling of `database.db_path` named
-`harmonia-mcp.sock` — the SAME derivation both processes run independently, so
-they agree without operator wiring. Validation rejects a `call_timeout_secs`
+The socket path defaults to `harmonia-mcp.sock` inside a dedicated
+`harmonia-mcp/` runtime subdirectory beside `database.db_path` — the SAME
+derivation both processes run independently, so they agree without operator
+wiring. An explicit `socket_path` override may name only a bare file name
+inside that owned directory; directory components are refused at startup
+(#653). Validation rejects a `call_timeout_secs`
 below `zetesis.search_timeout_seconds` (a shorter MCP deadline would cut off a
 legitimate full indexer fan-out).
 


### PR DESCRIPTION
## Summary

Fixes the security defect from #653: an explicit `mcp.socket_path` override was returned unchanged by `resolve_socket_path`, while bridge startup unconditionally ran `create_dir_all(parent)` + `chmod 0700` on the socket's parent. `socket_path = "/tmp/harmonia.sock"` under privilege would privatize `/tmp`; any shared application directory could have its permissions narrowed by socket configuration alone.

Per the issue's own direction, overrides are now constrained to a **bare file name** resolved beneath the Harmonia-owned `harmonia-mcp/` runtime directory beside `database.db_path`:

- `resolve_socket_path` returns `Result<PathBuf, SocketPathError>`. Any override carrying directory components (absolute paths such as `/tmp/harmonia.sock`, relative ones such as `sub/harmonia.sock`, `../`, `./`) is refused with the typed `SocketPathError::NotBareFileName` configuration error, surfaced as `HostError::McpSocketPath` at both `harmonia serve` and `harmonia mcp` startup.
- The derivation stays a pure function of config — no filesystem probing the two processes (`serve` binding, `mcp` connecting) could disagree on, preserving the #609 both-sides-agree invariant.
- `spawn`'s parent `create_dir_all` + `0700` chmod is unchanged and is now correct by construction: the parent is always the dedicated directory Harmonia owns.
- The `horismos` `McpConfig.socket_path` doc now states the file-name constraint.

Config-semantics break, deliberate: a full-path `socket_path` now fails fast at startup with a self-explanatory typed configuration error instead of silently chmodding an arbitrary directory.

## Verification

Failing-test-first per VERIFICATION.md. The three scenarios the issue names were written as tests against the pre-fix code and captured failing, then rewritten against the new fallible API and captured passing.

### Pre-fix (red)

`cargo test -p archon --lib mcp_bridge::tests::socket_path_override` — exit 101, all three red. `left` is what the pre-fix code resolved, i.e. the directory startup would have chmod'd `0700`:

```text
running 3 tests
test mcp_bridge::tests::socket_path_override_bare_file_name_lands_in_the_owned_runtime_dir ... FAILED
test mcp_bridge::tests::socket_path_override_pointing_at_tmp_stays_inside_the_owned_runtime_dir ... FAILED
test mcp_bridge::tests::socket_path_override_inside_a_shared_directory_stays_inside_the_owned_runtime_dir ... FAILED

---- socket_path_override_pointing_at_tmp_stays_inside_the_owned_runtime_dir ----
assertion `left == right` failed: an override must never place the socket outside the Harmonia-owned runtime dir
  left: "/tmp"
 right: "/tmp/.tmpCKiREV/harmonia-mcp"

---- socket_path_override_inside_a_shared_directory_stays_inside_the_owned_runtime_dir ----
assertion `left == right` failed: an override must never place the socket in a shared directory Harmonia does not own
  left: "/tmp/.tmpORQ1a5/shared"
 right: "/tmp/.tmpORQ1a5/harmonia-mcp"

---- socket_path_override_bare_file_name_lands_in_the_owned_runtime_dir ----
assertion `left == right` failed: a bare file-name override resolves beneath the Harmonia-owned runtime dir
  left: "custom.sock"
 right: "/tmp/.tmpIsuR9Y/harmonia-mcp/custom.sock"

test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 32 filtered out
```

### Post-fix (green)

`cargo test -p archon --lib mcp_bridge` — 28 passed, 0 failed (the three #653 refusal cases, the bare-name acceptance case with 0700/0600 assertions, and the pre-existing derived-default/round-trip tests):

```text
test mcp_bridge::tests::socket_path_override_pointing_at_tmp_is_refused ... ok
test mcp_bridge::tests::socket_path_override_inside_a_shared_directory_is_refused ... ok
test mcp_bridge::tests::socket_path_overrides_with_directory_components_are_refused ... ok
test mcp_bridge::tests::socket_path_override_bare_file_name_lands_in_the_owned_runtime_dir ... ok
test mcp_bridge::tests::socket_lives_in_a_dedicated_0700_subdir_with_a_0600_socket_and_both_sides_agree ... ok

test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out
```

### Locally verified vs CI-carried

- Local: `cargo check -p archon -p horismos --all-targets`, `cargo test -p archon --lib mcp_bridge` (the three #653 refusal/acceptance cases plus the pre-existing derived-default test), `cargo fmt`, `kanon lint`.
- CI carries the full workspace gate (clippy/nextest/deny).

Refs #653
