### PR TITLE
feat(syndesmos,horismos): Tidal OAuth token refresh and scheduled want-list sync

### DIFF
--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -1217,6 +1217,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
         event_tx.subscribe(),
         syndesmos_ct.clone(),
     );
+    let tidal_sync_handle = spawn_tidal_sync_scheduler(&syndesmos_svc, &boot_config, &syndesmos_ct);
     let syndesmos_supervisor = tokio::spawn(
         run_syndesmos_supervisor(
             Arc::clone(&external_adapter),
@@ -1226,6 +1227,7 @@ pub async fn run_serve(args: ServeArgs, out: &mut impl Write) -> Result<(), Host
             SyndesmosGeneration {
                 ct: syndesmos_ct,
                 handle: syndesmos_handle,
+                tidal_sync: tidal_sync_handle,
             },
             shutdown_token.child_token(),
         )
@@ -2334,17 +2336,22 @@ async fn run_prostheke_supervisor(
 /// One live syndesmos event-handler generation: its child cancellation token
 /// (a child of the supervisor's `shutdown`) plus the handler task itself —
 /// bundled so `run_syndesmos_supervisor` takes one argument for "the current
-/// generation" instead of two.
+/// generation" instead of two. `tidal_sync` is the scheduled Tidal want-list
+/// sync (`syndesmos.tidal.sync_interval_minutes`), `None` when the Tidal
+/// integration is unconfigured; it shares the generation token so a rebuild
+/// or shutdown stops it with the handler.
 struct SyndesmosGeneration {
     ct: CancellationToken,
     handle: JoinHandle<()>,
+    tidal_sync: Option<JoinHandle<()>>,
 }
 
 /// Runs the `syndesmos.*` external-integrations client under a REBUILD-class
 /// supervisor: on a section change it cancels the event handler's child
-/// token, awaits it, rebuilds the `ScrobbleClient` via `build_syndesmos`,
-/// respawns the handler on a fresh subscription, and swaps `ExternalAdapter`'s
-/// inner Arc. Two honest costs, logged: the circuit breakers reset (fresh
+/// token, awaits it (and the Tidal want-list scheduler with it), rebuilds
+/// the `ScrobbleClient` via `build_syndesmos`, respawns handler and
+/// scheduler on a fresh subscription, and swaps `ExternalAdapter`'s inner
+/// Arc. Two honest costs, logged: the circuit breakers reset (fresh
 /// breakers, `warn!`), and any event published between the cancel and the
 /// fresh subscribe is lost — broadcast receivers only see events published
 /// after they subscribe — a bounded scrobble-loss window (`warn!`).
@@ -2376,6 +2383,11 @@ async fn run_syndesmos_supervisor(
         if let Err(e) = generation.handle.await {
             tracing::warn!(error = %e, "syndesmos event handler panicked during rebuild");
         }
+        if let Some(tidal_sync) = generation.tidal_sync
+            && let Err(e) = tidal_sync.await
+        {
+            tracing::warn!(error = %e, "tidal want-list scheduler panicked during rebuild");
+        }
         tracing::warn!(
             subsystem = "syndesmos",
             "syndesmos rebuild: events published between handler cancel and resubscribe are \
@@ -2386,13 +2398,23 @@ async fn run_syndesmos_supervisor(
         let client = Arc::new(build_syndesmos(&cfg, &event_tx, db.clone()));
         external.set_client(Arc::clone(&client));
         let ct = shutdown.child_token();
+        let tidal_sync = spawn_tidal_sync_scheduler(&client, &cfg, &ct);
         let handle = spawn_syndesmos_handler(client, event_tx.subscribe(), ct.clone());
-        generation = SyndesmosGeneration { ct, handle };
+        generation = SyndesmosGeneration {
+            ct,
+            handle,
+            tidal_sync,
+        };
     }
 
     generation.ct.cancel();
     if let Err(e) = generation.handle.await {
         tracing::warn!(error = %e, "syndesmos event handler panicked during shutdown");
+    }
+    if let Some(tidal_sync) = generation.tidal_sync
+        && let Err(e) = tidal_sync.await
+    {
+        tracing::warn!(error = %e, "tidal want-list scheduler panicked during shutdown");
     }
 }
 
@@ -2437,6 +2459,28 @@ fn spawn_syndesmos_handler(
         }
         .instrument(span),
     )
+}
+
+/// Spawns the scheduled Tidal want-list sync (`sync_want_list` every
+/// `syndesmos.tidal.sync_interval_minutes`) on the same generation token as
+/// the event handler, so a rebuild or shutdown stops both. Returns `None`
+/// when no Tidal integration is configured.
+fn spawn_tidal_sync_scheduler(
+    service: &Arc<ScrobbleClient>,
+    config: &horismos::Config,
+    ct: &CancellationToken,
+) -> Option<JoinHandle<()>> {
+    let interval_minutes = config.syndesmos.tidal.as_ref()?.sync_interval_minutes;
+    let interval = std::time::Duration::from_secs(interval_minutes.saturating_mul(60));
+    let span = tracing::info_span!("tidal_want_list_scheduler");
+    Some(tokio::spawn(
+        syndesmos::tidal::scheduler::run_want_list_scheduler(
+            Arc::clone(service),
+            interval,
+            ct.clone(),
+        )
+        .instrument(span),
+    ))
 }
 
 // ── Config pre-flight ───────────────────────────────────────────────────────

--- a/crates/horismos/src/diff.rs
+++ b/crates/horismos/src/diff.rs
@@ -162,6 +162,13 @@ pub const LIVE: &[&str] = &[
     "syndesmos.lastfm.shared_secret",
     "syndesmos.lastfm.session_key",
     "syndesmos.tidal.access_token",
+    // #596: read by the TidalClient the rebuild supervisor swaps in (OAuth
+    // token refresh) and by the want-list sync scheduler respawned with each
+    // generation (`sync_interval_minutes` is that scheduler's tick period).
+    "syndesmos.tidal.client_id",
+    "syndesmos.tidal.client_secret",
+    "syndesmos.tidal.refresh_token",
+    "syndesmos.tidal.sync_interval_minutes",
     "syndesmos.circuit_break_minutes",
     // NOTE: `circuit_break_failure_threshold` reaches the rebuild supervisor
     // (a change to it triggers the same teardown+rebuild as every other
@@ -551,7 +558,11 @@ mod tests {
             session_key: Some("sample-session".to_string()),
         });
         config.syndesmos.tidal = Some(TidalConfig {
+            client_id: "sample-client-id".to_string(),
+            client_secret: "sample-client-secret".to_string(),
             access_token: Some("sample-access".to_string()),
+            refresh_token: Some("sample-refresh".to_string()),
+            sync_interval_minutes: 60,
         });
 
         config

--- a/crates/horismos/src/lib.rs
+++ b/crates/horismos/src/lib.rs
@@ -111,6 +111,30 @@ mod tests {
         assert_eq!(config.syndesmos.circuit_break_minutes, 5);
     }
 
+    #[test]
+    fn tidal_section_without_oauth_fields_still_deserializes() {
+        // WHY: configs written while the four fields were removed carry only
+        // `access_token`; they must keep loading, with the new keys falling
+        // back to the type's Default shape (rotation off, 60-minute sync).
+        with_jail(|jail| {
+            jail.create_file(
+                "harmonia.toml",
+                &format!(
+                    "[exousia]\njwt_secret = \"{}\"\n\n[syndesmos.tidal]\naccess_token = \"tok\"\n",
+                    valid_jwt_secret()
+                ),
+            )
+            .unwrap();
+            let (config, _) = load_config(Some(Path::new("harmonia.toml"))).unwrap();
+            let tidal = config.syndesmos.tidal.expect("tidal section parses");
+            assert_eq!(tidal.access_token.as_deref(), Some("tok"));
+            assert!(tidal.client_id.is_empty());
+            assert!(tidal.client_secret.is_empty());
+            assert!(tidal.refresh_token.is_none());
+            assert_eq!(tidal.sync_interval_minutes, 60);
+        });
+    }
+
     // ── TOML file overrides defaults ──────────────────────────────────────────
 
     #[test]

--- a/crates/horismos/src/subsystems.rs
+++ b/crates/horismos/src/subsystems.rs
@@ -580,18 +580,56 @@ impl std::fmt::Debug for LastfmConfig {
     }
 }
 
-#[derive(Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TidalConfig {
+    /// OAuth2 client id; with `client_secret` and `refresh_token`, enables
+    /// automatic access-token rotation.
+    #[serde(default)]
+    pub client_id: String,
+    /// OAuth2 client secret; see `client_id`.
+    #[serde(default)]
+    pub client_secret: String,
     /// OAuth2 access token; refreshed automatically when expired.
     pub access_token: Option<String>,
+    /// OAuth2 refresh token; exchanged for a fresh access token on expiry or
+    /// when the API rejects the cached one.
+    pub refresh_token: Option<String>,
+    /// How often to sync the Tidal favorites list (minutes); 0 disables the
+    /// scheduled sync.
+    #[serde(default = "default_tidal_sync_interval_minutes")]
+    pub sync_interval_minutes: u64,
 }
 impl std::fmt::Debug for TidalConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TidalConfig")
+            .field("client_id", &"[redacted]")
+            .field("client_secret", &"[redacted]")
             .field("access_token", &"[redacted]")
+            .field("refresh_token", &"[redacted]")
+            .field("sync_interval_minutes", &self.sync_interval_minutes)
             .finish()
     }
+}
+
+impl Default for TidalConfig {
+    fn default() -> Self {
+        Self {
+            client_id: String::new(),
+            client_secret: String::new(),
+            access_token: None,
+            refresh_token: None,
+            sync_interval_minutes: default_tidal_sync_interval_minutes(),
+        }
+    }
+}
+
+// WHY: the four re-added fields must stay optional in TOML — configs
+// written while they were removed (#575) lack them, and a required field
+// would fail those configs at startup. Missing keys fall back to the
+// type's Default shape (empty credentials = rotation off; 60-minute sync).
+fn default_tidal_sync_interval_minutes() -> u64 {
+    60
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/syndesmos/src/test_support.rs
+++ b/crates/syndesmos/src/test_support.rs
@@ -207,6 +207,55 @@ pub(crate) async fn spawn_one_shot_http(
     (base_url, handle)
 }
 
+/// Spawns a TCP server that answers `responses.len()` sequential HTTP
+/// requests (one connection each) with the given status and body, then
+/// resolves to the raw request bytes it received, in order. The same URL is
+/// returned twice — API base and auth base — so a client under test can
+/// point both at this one server (epignosis's provider-test pattern).
+pub(crate) async fn spawn_sequential_http(
+    responses: Vec<(u16, String)>,
+) -> (String, String, JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+
+    let handle = tokio::spawn(async move {
+        let mut requests = Vec::new();
+        for (status, body) in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+
+            let header_end = loop {
+                let n = stream.read(&mut chunk).await.unwrap();
+                assert!(n > 0, "client closed before sending full headers");
+                buf.extend_from_slice(&chunk[..n]);
+                if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+
+            let content_length = parse_content_length(&buf[..header_end]);
+            while buf.len() < header_end + content_length {
+                let n = stream.read(&mut chunk).await.unwrap();
+                assert!(n > 0, "client closed before sending full body");
+                buf.extend_from_slice(&chunk[..n]);
+            }
+
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+
+            requests.push(String::from_utf8_lossy(&buf).into_owned());
+        }
+        requests
+    });
+
+    (base_url.clone(), base_url, handle)
+}
+
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack.windows(needle.len()).position(|w| w == needle)
 }

--- a/crates/syndesmos/src/tidal/mod.rs
+++ b/crates/syndesmos/src/tidal/mod.rs
@@ -1,17 +1,25 @@
 //! Tidal API integration.
 
+pub mod scheduler;
 pub mod wantlist;
 
 use std::future::Future;
 use std::pin::Pin;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use horismos::TidalConfig;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
+use tokio::sync::RwLock;
 
-use crate::error::{SyndesmodError, TidalApiCallSnafu};
+use crate::error::{
+    AuthenticationFailedSnafu, ConfigMissingSnafu, SyndesmodError, TidalApiCallSnafu,
+};
 
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+// WHY: refresh slightly before the server-side expiry so an in-flight call
+// never carries a token that dies mid-request.
+const TOKEN_EXPIRY_MARGIN_SECS: u64 = 60;
 
 // WHY: domain newtype — external API identifier, not a semantic struct.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -39,57 +47,216 @@ pub(crate) trait TidalApi: Send + Sync {
     fn fetch_favorites(&self) -> BoxFuture<'_, Result<Vec<TidalFavorite>, SyndesmodError>>;
 }
 
+/// A bearer token held by `TidalClient`'s cache.
+///
+/// `valid_until: None` marks the statically configured access token — its
+/// expiry is unknown to the client, so it is trusted until the API rejects
+/// it (401), at which point the cache is dropped and the refresh token takes
+/// over. Refreshed tokens carry the instant they stop being valid.
+#[derive(Debug, Clone)]
+struct CachedToken {
+    access_token: String,
+    valid_until: Option<Instant>,
+}
+
+impl CachedToken {
+    fn is_valid(&self) -> bool {
+        self.valid_until.is_none_or(|until| Instant::now() < until)
+    }
+}
+
 /// Production Tidal API client backed by reqwest.
 pub struct TidalClient {
     http: reqwest::Client,
     pub(crate) config: TidalConfig,
     base_url: String,
+    auth_base_url: String,
+    // WHY: interior mutability — TidalApi methods take &self. Token cache
+    // pattern mirrors the TVDB provider's (epignosis).
+    token: RwLock<Option<CachedToken>>,
 }
 
 impl TidalClient {
     const DEFAULT_BASE_URL: &'static str = "https://openapi.tidal.com";
+    const DEFAULT_AUTH_BASE_URL: &'static str = "https://auth.tidal.com";
 
     pub fn new(config: TidalConfig) -> Self {
         Self::with_base_url(config, Self::DEFAULT_BASE_URL.to_string())
     }
 
     pub fn with_base_url(config: TidalConfig, base_url: String) -> Self {
+        Self::with_base_urls(config, base_url, Self::DEFAULT_AUTH_BASE_URL.to_string())
+    }
+
+    pub fn with_base_urls(config: TidalConfig, base_url: String, auth_base_url: String) -> Self {
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(15))
             .build()
             .unwrap_or_default(); // WHY: reqwest::Client::default() is a valid fallback; build fails only with invalid TLS config
+        let seeded = config.access_token.as_ref().map(|token| CachedToken {
+            access_token: token.clone(),
+            valid_until: None,
+        });
         Self {
             http,
             config,
             base_url,
+            auth_base_url,
+            token: RwLock::new(seeded),
         }
     }
 
-    fn access_token(&self) -> Option<&str> {
-        self.config.access_token.as_deref()
+    /// True when the OAuth client credentials and refresh token needed to
+    /// rotate the access token are all configured.
+    fn refresh_configured(&self) -> bool {
+        !self.config.client_id.is_empty()
+            && !self.config.client_secret.is_empty()
+            && self.config.refresh_token.is_some()
     }
+
+    /// Returns a bearer token for the API, refreshing first when the cached
+    /// token is absent or past its reuse window. Returns `None` when no
+    /// token is configured at all.
+    async fn bearer_token(&self) -> Result<Option<String>, SyndesmodError> {
+        if let Some(cached) = self.token.read().await.as_ref()
+            && cached.is_valid()
+        {
+            return Ok(Some(cached.access_token.clone()));
+        }
+
+        let mut slot = self.token.write().await;
+        // WHY: double-checked — a concurrent caller may have refreshed the
+        // token while this one waited for the write lock.
+        if let Some(cached) = slot.as_ref()
+            && cached.is_valid()
+        {
+            return Ok(Some(cached.access_token.clone()));
+        }
+
+        if self.refresh_configured() {
+            let refreshed = self.refresh_access_token().await?;
+            let token = refreshed.access_token.clone();
+            *slot = Some(refreshed);
+            return Ok(Some(token));
+        }
+
+        Ok(None)
+    }
+
+    /// Exchanges the configured refresh token for a fresh access token at
+    /// the Tidal OAuth token endpoint.
+    async fn refresh_access_token(&self) -> Result<CachedToken, SyndesmodError> {
+        let url = format!("{}/v1/oauth2/token", self.auth_base_url);
+        let response = self
+            .http
+            .post(&url)
+            .form(&[
+                ("grant_type", "refresh_token"),
+                (
+                    "refresh_token",
+                    self.config.refresh_token.as_deref().unwrap_or_default(),
+                ),
+                ("client_id", self.config.client_id.as_str()),
+                ("client_secret", self.config.client_secret.as_str()),
+            ])
+            .send()
+            .await
+            .context(TidalApiCallSnafu)?;
+
+        // WHY: a 401 here means the refresh token itself is rejected — that
+        // is an authentication failure, not a transient API error.
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return AuthenticationFailedSnafu {
+                service: "tidal".to_string(),
+            }
+            .fail();
+        }
+
+        let parsed: TidalTokenResponse = response
+            .error_for_status()
+            .context(TidalApiCallSnafu)?
+            .json()
+            .await
+            .context(TidalApiCallSnafu)?;
+
+        Ok(CachedToken {
+            access_token: parsed.access_token,
+            valid_until: Some(
+                Instant::now()
+                    + Duration::from_secs(
+                        parsed.expires_in.saturating_sub(TOKEN_EXPIRY_MARGIN_SECS),
+                    ),
+            ),
+        })
+    }
+
+    /// Drops the cached token after the API answers 401, so the next call
+    /// re-authenticates instead of replaying a rejected bearer.
+    async fn invalidate_token(&self) {
+        *self.token.write().await = None;
+    }
+
+    async fn get_favorites(
+        &self,
+        url: &str,
+        token: &str,
+    ) -> Result<reqwest::Response, SyndesmodError> {
+        self.http
+            .get(url)
+            .header("Authorization", format!("Bearer {token}"))
+            .send()
+            .await
+            .context(TidalApiCallSnafu)
+    }
+
+    #[cfg(test)]
+    async fn seed_token(&self, token: &str, valid_until: Option<Instant>) {
+        *self.token.write().await = Some(CachedToken {
+            access_token: token.to_string(),
+            valid_until,
+        });
+    }
+}
+
+// WHY: API schema — Tidal OAuth token endpoint response.
+#[derive(Debug, serde::Deserialize)]
+struct TidalTokenResponse {
+    access_token: String,
+    expires_in: u64,
 }
 
 impl TidalApi for TidalClient {
     fn fetch_favorites(&self) -> BoxFuture<'_, Result<Vec<TidalFavorite>, SyndesmodError>> {
         Box::pin(async move {
-            let token = match self.access_token() {
-                Some(t) => t.to_string(),
-                None => return Ok(vec![]),
+            let Some(token) = self.bearer_token().await? else {
+                return Ok(vec![]);
             };
 
             let url = format!("{}/v2/my-collection/tracks/favoriteTracks", self.base_url);
-            let response = self
-                .http
-                .get(&url)
-                .header("Authorization", format!("Bearer {}", token))
-                .send()
-                .await
-                .context(TidalApiCallSnafu)?
-                .error_for_status()
-                .context(TidalApiCallSnafu)?;
+            let response = self.get_favorites(&url, &token).await?;
 
-            let body: serde_json::Value = response.json().await.context(TidalApiCallSnafu)?;
+            // WHY: a 401 means the server no longer honors the cached token;
+            // drop it, re-authenticate via the refresh token, and retry once
+            // with the fresh bearer. Without refresh credentials the 401
+            // surfaces unchanged, preserving static-token behavior.
+            let response = if response.status() == reqwest::StatusCode::UNAUTHORIZED
+                && self.refresh_configured()
+            {
+                self.invalidate_token().await;
+                let fresh = self.bearer_token().await?.context(ConfigMissingSnafu {
+                    service: "tidal".to_string(),
+                })?;
+                self.get_favorites(&url, &fresh).await?
+            } else {
+                response
+            };
+
+            let body: serde_json::Value = response
+                .error_for_status()
+                .context(TidalApiCallSnafu)?
+                .json()
+                .await
+                .context(TidalApiCallSnafu)?;
             Ok(parse_favorites(&body))
         })
     }
@@ -152,10 +319,29 @@ pub(crate) mod tests {
         }
     }
 
+    /// Static-token-only config — no OAuth refresh credentials.
     fn test_config() -> TidalConfig {
         TidalConfig {
             access_token: Some("tidaltok".to_string()),
+            ..TidalConfig::default()
         }
+    }
+
+    /// Full OAuth config: client credentials + refresh token, seeded with a
+    /// static access token.
+    fn oauth_config() -> TidalConfig {
+        TidalConfig {
+            client_id: "client-id".to_string(),
+            client_secret: "client-secret".to_string(),
+            access_token: Some("seeded-access".to_string()),
+            refresh_token: Some("refresh-tok".to_string()),
+            sync_interval_minutes: 60,
+        }
+    }
+
+    fn token_body(token: &str) -> String {
+        serde_json::json!({ "access_token": token, "token_type": "Bearer", "expires_in": 3600 })
+            .to_string()
     }
 
     #[tokio::test]
@@ -178,6 +364,139 @@ pub(crate) mod tests {
 
         let favorites = client.fetch_favorites().await.unwrap();
         assert!(favorites.is_empty());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fetch_favorites_returns_empty_when_no_token_configured() {
+        let client = TidalClient::new(TidalConfig::default());
+
+        let favorites = client.fetch_favorites().await.unwrap();
+        assert!(favorites.is_empty());
+    }
+
+    #[tokio::test]
+    async fn expired_cached_token_refreshes_before_the_api_call() {
+        let (base_url, auth_url, server) = crate::test_support::spawn_sequential_http(vec![
+            (200, token_body("tok-fresh")),
+            (200, r#"{"data":[]}"#.to_string()),
+        ])
+        .await;
+        let client = TidalClient::with_base_urls(oauth_config(), base_url, auth_url);
+        // NOTE: a deadline of "now" is already past by the time the cache is read.
+        client.seed_token("tok-stale", Some(Instant::now())).await;
+
+        client.fetch_favorites().await.unwrap();
+
+        let requests = server.await.unwrap();
+        assert_eq!(requests.len(), 2, "one token refresh plus one API call");
+        assert!(requests[0].starts_with("POST /v1/oauth2/token"));
+        let body = requests[0].to_ascii_lowercase();
+        assert!(
+            body.contains("grant_type=refresh_token"),
+            "refresh grant: {body}"
+        );
+        assert!(
+            body.contains("refresh_token=refresh-tok"),
+            "refresh token: {body}"
+        );
+        assert!(body.contains("client_id=client-id"), "client id: {body}");
+        assert!(
+            body.contains("client_secret=client-secret"),
+            "client secret: {body}"
+        );
+        assert!(
+            requests[1]
+                .to_ascii_lowercase()
+                .contains("authorization: bearer tok-fresh"),
+            "the API call must carry the freshly refreshed token, not the stale one"
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_cached_token_skips_refresh() {
+        let (base_url, auth_url, server) =
+            crate::test_support::spawn_sequential_http(vec![(200, r#"{"data":[]}"#.to_string())])
+                .await;
+        let client = TidalClient::with_base_urls(oauth_config(), base_url, auth_url);
+        client
+            .seed_token("tok-live", Some(Instant::now() + Duration::from_secs(600)))
+            .await;
+
+        client.fetch_favorites().await.unwrap();
+
+        let requests = server.await.unwrap();
+        assert_eq!(requests.len(), 1, "no refresh request may be issued");
+        assert!(
+            requests[0]
+                .to_ascii_lowercase()
+                .contains("authorization: bearer tok-live")
+        );
+    }
+
+    #[tokio::test]
+    async fn unauthorized_response_refreshes_and_retries_once() {
+        let (base_url, auth_url, server) = crate::test_support::spawn_sequential_http(vec![
+            (401, "{}".to_string()),
+            (200, token_body("tok-next")),
+            (200, r#"{"data":[]}"#.to_string()),
+        ])
+        .await;
+        // WHY: the seeded static token (no known expiry) is trusted until the
+        // API rejects it — the 401 must drop it and rotate via refresh_token.
+        let client = TidalClient::with_base_urls(oauth_config(), base_url, auth_url);
+
+        client.fetch_favorites().await.unwrap();
+
+        let requests = server.await.unwrap();
+        assert_eq!(requests.len(), 3, "rejected call, refresh, retried call");
+        assert!(
+            requests[0]
+                .to_ascii_lowercase()
+                .contains("authorization: bearer seeded-access"),
+            "the first call carries the seeded static token"
+        );
+        assert!(
+            requests[1].starts_with("POST /v1/oauth2/token"),
+            "a 401 must force a token refresh"
+        );
+        assert!(
+            requests[2]
+                .to_ascii_lowercase()
+                .contains("authorization: bearer tok-next"),
+            "the retried call must carry the re-issued token"
+        );
+    }
+
+    #[tokio::test]
+    async fn unauthorized_static_token_without_refresh_credentials_surfaces_error() {
+        let (base_url, server) =
+            crate::test_support::spawn_one_shot_http(401, "Unauthorized", "{}").await;
+        let client = TidalClient::with_base_url(test_config(), base_url);
+
+        let result = client.fetch_favorites().await;
+
+        assert!(
+            matches!(result, Err(SyndesmodError::TidalApiCall { .. })),
+            "without refresh credentials a 401 surfaces unchanged: {result:?}"
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejected_refresh_token_is_an_authentication_failure() {
+        let (base_url, auth_url, server) =
+            crate::test_support::spawn_sequential_http(vec![(401, "{}".to_string())]).await;
+        let mut config = oauth_config();
+        config.access_token = None; // no seed — the first call must refresh
+        let client = TidalClient::with_base_urls(config, base_url, auth_url);
+
+        let result = client.fetch_favorites().await;
+
+        assert!(
+            matches!(result, Err(SyndesmodError::AuthenticationFailed { .. })),
+            "a 401 from the token endpoint is an auth failure: {result:?}"
+        );
         server.await.unwrap();
     }
 }

--- a/crates/syndesmos/src/tidal/scheduler.rs
+++ b/crates/syndesmos/src/tidal/scheduler.rs
@@ -1,0 +1,132 @@
+//! Scheduled Tidal want-list sync — a supervisor ticker driving `sync_want_list`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::{ExternalIntegration, ScrobbleClient};
+
+/// Runs the Tidal want-list sync every `interval` until `shutdown` fires.
+///
+/// The first tick lands one full interval out — the wants persisted by the
+/// previous run are the diff baseline, so boot needs no immediate sync
+/// (mirrors the zetesis caps-refresh supervisor's tick). Missed ticks Delay
+/// rather than Burst: a slow sync must not be chased by a back-to-back
+/// catch-up sync. An interval of zero disables the scheduled sync.
+pub async fn run_want_list_scheduler(
+    service: Arc<ScrobbleClient>,
+    interval: Duration,
+    shutdown: CancellationToken,
+) {
+    if interval.is_zero() {
+        tracing::info!("tidal want-list scheduler disabled (sync_interval_minutes = 0)");
+        return;
+    }
+
+    let mut tick = tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            _ = tick.tick() => {
+                // WHY: the sync runs retry loops with backoff sleeps — raced
+                // against the token so shutdown is prompt even mid-retry,
+                // instead of waiting out the full backoff.
+                tokio::select! {
+                    biased;
+                    _ = shutdown.cancelled() => break,
+                    result = service.sync_tidal_want_list() => {
+                        if let Err(e) = result {
+                            tracing::warn!(error = %e, "scheduled tidal want-list sync failed");
+                        }
+                    }
+                }
+            }
+        }
+    }
+    tracing::info!("tidal want-list scheduler shutting down");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use themelion::create_event_bus;
+
+    use super::*;
+    use crate::ScrobbleClientBuilder;
+    use crate::tidal::tests::MockTidalApi;
+    use crate::tidal::{TidalFavorite, TidalId};
+
+    fn favorite(id: &str) -> TidalFavorite {
+        TidalFavorite {
+            tidal_id: TidalId(id.to_string()),
+            title: format!("Track {id}"),
+            artist: "Test Artist".to_string(),
+        }
+    }
+
+    /// The zetesis caps-refresh supervisor test pattern: a REAL scheduler on
+    /// a short test tick, a bounded real wait for the effect to land, then a
+    /// clean shutdown join.
+    #[tokio::test]
+    async fn fires_sync_on_the_configured_interval() {
+        let mock = Arc::new(MockTidalApi::new(vec![favorite("t1")]));
+        let calls = Arc::clone(&mock.call_count);
+        let (tx, _rx) = create_event_bus(32);
+        let service = Arc::new(
+            ScrobbleClientBuilder::new(tx, crate::test_support::test_pool().await)
+                .with_mock_tidal(mock)
+                .build(),
+        );
+
+        let shutdown = CancellationToken::new();
+        let scheduler = tokio::spawn(run_want_list_scheduler(
+            service,
+            Duration::from_millis(50),
+            shutdown.clone(),
+        ));
+
+        // WHY: two fires prove the interval repeats, not just the first tick.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while calls.load(Ordering::SeqCst) < 2 {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "scheduler never fired a second sync on the 50ms interval"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(2), scheduler)
+            .await
+            .expect("scheduler joins cleanly after ticks")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn zero_interval_disables_the_scheduler() {
+        let mock = Arc::new(MockTidalApi::new(vec![favorite("t1")]));
+        let calls = Arc::clone(&mock.call_count);
+        let (tx, _rx) = create_event_bus(32);
+        let service = Arc::new(
+            ScrobbleClientBuilder::new(tx, crate::test_support::test_pool().await)
+                .with_mock_tidal(mock)
+                .build(),
+        );
+
+        let shutdown = CancellationToken::new();
+        let scheduler = tokio::spawn(run_want_list_scheduler(service, Duration::ZERO, shutdown));
+
+        tokio::time::timeout(Duration::from_secs(1), scheduler)
+            .await
+            .expect("a zero interval disables the scheduler instead of spinning")
+            .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "no sync may fire");
+    }
+}

--- a/docs/architecture/config-reload.md
+++ b/docs/architecture/config-reload.md
@@ -175,7 +175,8 @@ client survive, and no config reload is involved (#577).
 |---|---|---|
 | `plex.url` / `.token` / `.library_sections` | LIVE | rebuild + swap |
 | `lastfm.api_key` / `.shared_secret` / `.session_key` | LIVE | rebuild + swap |
-| `tidal.access_token` | LIVE | the only Tidal field a real client reads |
+| `tidal.access_token` / `.client_id` / `.client_secret` / `.refresh_token` | LIVE | the rebuilt `TidalClient` reads them — client credentials + refresh token drive OAuth access-token rotation; the access token seeds the token cache |
+| `tidal.sync_interval_minutes` | LIVE | tick period of the want-list sync scheduler, which is respawned with the rebuilt generation |
 | `circuit_break_minutes` | LIVE | feeds `CircuitBreaker` cooldown |
 | `circuit_break_failure_threshold` | LIVE | reaches the rebuild supervisor like every other `syndesmos.*` leaf, but `ScrobbleClientBuilder::build()` currently hardcodes the breaker threshold to 5 — a within-crate wiring gap tracked separately, NOT part of #575's dead-config list |
 

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -182,7 +182,11 @@ api_key = "..."
 shared_secret = "..."
 
 [syndesmos.tidal]
-access_token = "..."               # OAuth2 access token; refreshed automatically when expired
+client_id = "..."                  # OAuth2 client credentials — enable access-token rotation
+client_secret = "..."
+refresh_token = "..."              # Exchanged for a fresh access token on expiry or API rejection
+access_token = "..."               # Optional seed token; used until it expires or is rejected
+sync_interval_minutes = 60         # Non-secret; 0 disables the scheduled want-list sync
 ```
 
 **CRITICAL: JWT secret validation.** The JWT secret must never come from `harmonia.toml` (committed). Horismos validates at startup that `exousia.jwt_secret` is not empty and not a placeholder value (`"changeme"` or `"default"`), and is at least 32 bytes. A failing check is a startup error — the process exits before serving any requests.

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -185,7 +185,7 @@ shared_secret = "..."
 client_id = "..."                  # OAuth2 client credentials — enable access-token rotation
 client_secret = "..."
 refresh_token = "..."              # Exchanged for a fresh access token on expiry or API rejection
-access_token = "..."               # Optional seed token; used until it expires or is rejected
+access_token = "..."               # Optional seed token; used until the API rejects it, then rotated
 sync_interval_minutes = 60         # Non-secret; 0 disables the scheduled want-list sync
 ```
 


### PR DESCRIPTION
## Summary

Implements #596 — Tidal OAuth token refresh + scheduled want-list sync, re-adding the four config fields removed in #575 as one unit, this time with live readers.

**`syndesmos::tidal` (client):**
- `TidalClient` gains a token cache mirroring the TVDB provider pattern: a statically configured `access_token` seeds the cache (trusted until the API rejects it, since its expiry is unknown); refreshed tokens carry their expiry with a 60s safety margin.
- Refresh-before-expiry on every call; a 401 from the API invalidates the cache, refreshes via `POST {auth}/v1/oauth2/token` (refresh_token grant), and retries once. A 401 from the token endpoint itself surfaces as a typed `AuthenticationFailed`. Without refresh credentials, behavior is unchanged from the static-token client.
- New `tidal::scheduler::run_want_list_scheduler`: interval ticker on `sync_interval_minutes` (0 disables), first tick one full interval out, `MissedTickBehavior::Delay`, and the sync raced against the shutdown token so teardown is prompt mid-retry.

**Wiring:** the scheduler spawns per syndesmos generation (boot + each REBUILD-class config reload) on the generation token, torn down on rebuild/shutdown (`archon/src/serve.rs`).

**Config (horismos):** `client_id`, `client_secret`, `refresh_token`, `sync_interval_minutes` re-added with `serde` defaults — configs written while the fields were absent (post-#575) keep loading; missing keys take the type's Default shape (rotation off, 60-minute sync). All four leaves classified LIVE in `diff.rs`; `docs/architecture/configuration.md` + `config-reload.md` updated.

## Verification

New tests (all in-package): expired-token refresh precedes the API call and the call carries the fresh bearer; valid cached token skips refresh; 401 → invalidate → refresh → retry once; 401 without refresh credentials surfaces unchanged; rejected refresh token = `AuthenticationFailed`; no token = empty favorites; scheduler fires repeatedly on a 50ms interval and joins cleanly on shutdown; zero interval disables; tidal section carrying only `access_token` still deserializes.

```text
cargo test -p horismos: 85 passed; 0 failed  (includes the four-leaf classification and the backwards-compat deserialization test)
```

- Local: `cargo test -p horismos`, `cargo fmt`, `kanon lint` (zero new violations).
- CI carries `cargo test -p syndesmos` and the full workspace gate.

Refs #596
