### PR TITLE
feat(syndesmos,paroche): Plex collection sync and viewing-stats endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5898,6 +5898,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/archon/src/serve.rs
+++ b/crates/archon/src/serve.rs
@@ -27,7 +27,7 @@ use paroche::state::{
 use prostheke::providers::Provider;
 use prostheke::{SubtitleManager, SubtitleService};
 use snafu::ResultExt;
-use syndesmos::{ScrobbleClient, ScrobbleClientBuilder};
+use syndesmos::{ExternalIntegration, ScrobbleClient, ScrobbleClientBuilder};
 use syntaxis::{DownloadQueue, QueueManager};
 use themelion::{MediaId, MediaType, create_event_bus};
 use tokio::signal::unix::SignalKind;
@@ -675,11 +675,10 @@ fn request_media_types(media_type: themelion::MediaType) -> Option<(&'static str
 
 /// Swappable behind a std `RwLock` (never held across an .await) so the
 /// #529 step-8 syndesmos supervisor can swap in a rebuilt client on a
-/// `syndesmos.*` change. `DynExternalIntegration` is currently marker-only
-/// (no forwarding methods) — the real consumer of `ScrobbleClient`'s
-/// behavior is the event handler task, which holds its own Arc clone
-/// directly; this field keeps `AppState`'s view in sync for when a future
-/// `DynExternalIntegration` method needs the live client.
+/// `syndesmos.*` change. The event handler task holds its own Arc clone
+/// directly; the `DynExternalIntegration` methods below forward paroche's
+/// Plex collection/stats routes to the live client, snapshotting the Arc and
+/// dropping the guard before any async work.
 struct ExternalAdapter {
     inner: std::sync::RwLock<Arc<ScrobbleClient>>,
 }
@@ -697,9 +696,41 @@ impl ExternalAdapter {
         let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
         *guard = new;
     }
+
+    fn client(&self) -> Arc<ScrobbleClient> {
+        self.inner.read().unwrap_or_else(|e| e.into_inner()).clone()
+    }
 }
 
-impl DynExternalIntegration for ExternalAdapter {}
+impl DynExternalIntegration for ExternalAdapter {
+    fn sync_plex_collection(
+        &self,
+        name: String,
+        media_type: MediaType,
+        rating_keys: Vec<String>,
+    ) -> ServiceFut<()> {
+        let client = self.client();
+        Box::pin(async move {
+            client
+                .sync_plex_collection(name, media_type, rating_keys)
+                .await
+                .map_err(|err| ServiceError::Internal(err.to_string()))
+        })
+    }
+
+    fn plex_watch_history(
+        &self,
+        account_id: Option<String>,
+    ) -> ServiceFut<Vec<themelion::WatchRecord>> {
+        let client = self.client();
+        Box::pin(async move {
+            client
+                .fetch_plex_watch_history(account_id)
+                .await
+                .map_err(|err| ServiceError::Internal(err.to_string()))
+        })
+    }
+}
 
 /// Swappable behind a std `RwLock` (never held across an .await — every
 /// method snapshots the Arc and drops the guard before any async work) so
@@ -3237,6 +3268,31 @@ mod tests {
             read: pool.clone(),
             write: pool,
         })
+    }
+
+    #[tokio::test]
+    async fn external_adapter_forwards_and_degrades_when_plex_unconfigured() {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite opens");
+        MIGRATOR.run(&pool).await.expect("migrations run");
+        let (tx, _rx) = create_event_bus(8);
+        let client = Arc::new(ScrobbleClientBuilder::new(tx, pool).build());
+        let adapter = ExternalAdapter::new(client);
+
+        adapter
+            .sync_plex_collection(
+                "Jazz".to_string(),
+                MediaType::Music,
+                vec!["101".to_string()],
+            )
+            .await
+            .expect("unconfigured plex collection sync degrades to Ok");
+        let records = adapter
+            .plex_watch_history(None)
+            .await
+            .expect("unconfigured plex watch history degrades to an empty list");
+        assert!(records.is_empty());
     }
 
     #[tokio::test]

--- a/crates/paroche/src/lib.rs
+++ b/crates/paroche/src/lib.rs
@@ -49,6 +49,7 @@ fn api_routes() -> Router<AppState> {
         .nest("/api/v1/downloads", routes::download::download_routes())
         .nest("/api/v1/requests", routes::request::request_routes())
         .nest("/api/v1/wanted", routes::wanted::wanted_routes())
+        .nest("/api/v1/plex", routes::plex::plex_routes())
         .nest("/api/v1", routes::subtitle::subtitle_routes())
         .nest("/api/renderers", routes::renderer::renderer_routes())
         .nest("/opds", opds::opds_routes())

--- a/crates/paroche/src/routes/mod.rs
+++ b/crates/paroche/src/routes/mod.rs
@@ -10,6 +10,7 @@ pub mod metadata;
 pub mod movie;
 pub mod music;
 pub mod news;
+pub mod plex;
 pub mod podcast;
 pub mod read;
 pub mod renderer;

--- a/crates/paroche/src/routes/plex.rs
+++ b/crates/paroche/src/routes/plex.rs
@@ -1,0 +1,379 @@
+//! Plex integration endpoints — collection sync (the Kometa replacement) and
+//! viewing-history stats (the Wrapperr replacement), delegated to syndesmos
+//! via `DynExternalIntegration`.
+use axum::Json;
+use axum::extract::{Query, State};
+use exousia::AuthenticatedUser;
+use serde::{Deserialize, Serialize};
+use themelion::MediaType;
+
+use crate::error::ParocheError;
+use crate::response::ApiResponse;
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Request/response types
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct SyncCollectionRequest {
+    pub name: String,
+    pub media_type: MediaType,
+    pub rating_keys: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct SyncCollectionResponse {
+    pub name: String,
+    pub items: usize,
+}
+
+#[derive(Deserialize)]
+pub struct WatchHistoryQuery {
+    pub account_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+pub async fn sync_collection(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Json(body): Json<SyncCollectionRequest>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let name = body.name.trim().to_string();
+    if name.is_empty() {
+        return Err(ParocheError::Validation {
+            message: "name must not be empty".to_string(),
+        });
+    }
+    if body.rating_keys.is_empty() {
+        return Err(ParocheError::Validation {
+            message: "rating_keys must not be empty".to_string(),
+        });
+    }
+    let items = body.rating_keys.len();
+    state
+        .external
+        .sync_plex_collection(name.clone(), body.media_type, body.rating_keys)
+        .await?;
+
+    Ok(ApiResponse::ok(SyncCollectionResponse { name, items }))
+}
+
+pub async fn watch_history(
+    State(state): State<AppState>,
+    _auth: AuthenticatedUser,
+    Query(query): Query<WatchHistoryQuery>,
+) -> Result<impl axum::response::IntoResponse, ParocheError> {
+    let records = state.external.plex_watch_history(query.account_id).await?;
+
+    Ok(ApiResponse::ok(records))
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn plex_routes() -> axum::Router<AppState> {
+    use axum::routing::{get, post};
+    axum::Router::new()
+        .route("/collections/sync", post(sync_collection))
+        .route("/stats/history", get(watch_history))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use exousia::AuthService;
+    use exousia::user::{CreateUserRequest, UserRole};
+    use tower::ServiceExt;
+
+    #[expect(
+        unused_imports,
+        reason = "kanon: test-missing-use-super; parent items accessed via explicit super:: prefix in test bodies"
+    )]
+    use super::*;
+    use crate::state::{DynExternalIntegration, ServiceFut};
+    use crate::test_helpers::test_state;
+
+    #[derive(Default)]
+    struct RecordingExternal {
+        sync_calls: Mutex<Vec<(String, themelion::MediaType, Vec<String>)>>,
+        history_calls: Mutex<Vec<Option<String>>>,
+        history_records: Vec<themelion::WatchRecord>,
+    }
+
+    impl RecordingExternal {
+        fn with_records(records: Vec<themelion::WatchRecord>) -> Self {
+            Self {
+                sync_calls: Mutex::new(Vec::new()),
+                history_calls: Mutex::new(Vec::new()),
+                history_records: records,
+            }
+        }
+
+        fn sync_calls(&self) -> Vec<(String, themelion::MediaType, Vec<String>)> {
+            self.sync_calls.lock().unwrap().clone()
+        }
+
+        fn history_calls(&self) -> Vec<Option<String>> {
+            self.history_calls.lock().unwrap().clone()
+        }
+    }
+
+    impl DynExternalIntegration for RecordingExternal {
+        fn sync_plex_collection(
+            &self,
+            name: String,
+            media_type: themelion::MediaType,
+            rating_keys: Vec<String>,
+        ) -> ServiceFut<()> {
+            self.sync_calls
+                .lock()
+                .unwrap()
+                .push((name, media_type, rating_keys));
+            Box::pin(async { Ok(()) })
+        }
+
+        fn plex_watch_history(
+            &self,
+            account_id: Option<String>,
+        ) -> ServiceFut<Vec<themelion::WatchRecord>> {
+            self.history_calls.lock().unwrap().push(account_id);
+            let records = self.history_records.clone();
+            Box::pin(async move { Ok(records) })
+        }
+    }
+
+    async fn user_token(auth: &Arc<exousia::ExousiaServiceImpl>) -> String {
+        auth.create_user(CreateUserRequest {
+            username: "member".to_string(),
+            display_name: "member".to_string(),
+            password: "password123".to_string(),
+            role: UserRole::Member,
+        })
+        .await
+        .unwrap();
+        auth.login("member", "password123")
+            .await
+            .unwrap()
+            .access_token
+    }
+
+    fn sample_record() -> themelion::WatchRecord {
+        themelion::WatchRecord {
+            source_ref: "101".to_string(),
+            title: "Gantz Graf".to_string(),
+            grandparent_title: Some("Autechre".to_string()),
+            media_kind: "track".to_string(),
+            account_id: Some(42),
+            viewed_at: Some(1_700_000_000),
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_collection_invokes_external_service() {
+        let (mut state, auth) = test_state().await;
+        let external = Arc::new(RecordingExternal::default());
+        state.external = external.clone();
+        let token = user_token(&auth).await;
+
+        let body = serde_json::json!({
+            "name": "Jazz",
+            "media_type": "music",
+            "rating_keys": ["101", "102"],
+        });
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/plex/collections/sync")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let calls = external.sync_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "Jazz");
+        assert_eq!(calls[0].1, themelion::MediaType::Music);
+        assert_eq!(calls[0].2, vec!["101".to_string(), "102".to_string()]);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(payload["data"]["name"], "Jazz");
+        assert_eq!(payload["data"]["items"], 2);
+    }
+
+    #[tokio::test]
+    async fn sync_collection_rejects_empty_name() {
+        let (mut state, auth) = test_state().await;
+        let external = Arc::new(RecordingExternal::default());
+        state.external = external.clone();
+        let token = user_token(&auth).await;
+
+        let body = serde_json::json!({
+            "name": "   ",
+            "media_type": "music",
+            "rating_keys": ["101"],
+        });
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/plex/collections/sync")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(external.sync_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sync_collection_rejects_empty_rating_keys() {
+        let (mut state, auth) = test_state().await;
+        let external = Arc::new(RecordingExternal::default());
+        state.external = external.clone();
+        let token = user_token(&auth).await;
+
+        let body = serde_json::json!({
+            "name": "Jazz",
+            "media_type": "music",
+            "rating_keys": [],
+        });
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/plex/collections/sync")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(external.sync_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn watch_history_returns_records_and_forwards_account_filter() {
+        let (mut state, auth) = test_state().await;
+        let external = Arc::new(RecordingExternal::with_records(vec![sample_record()]));
+        state.external = external.clone();
+        let token = user_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/plex/stats/history?account_id=42")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(external.history_calls(), vec![Some("42".to_string())]);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(payload["data"][0]["source_ref"], "101");
+        assert_eq!(payload["data"][0]["title"], "Gantz Graf");
+        assert_eq!(payload["data"][0]["grandparent_title"], "Autechre");
+        assert_eq!(payload["data"][0]["media_kind"], "track");
+        assert_eq!(payload["data"][0]["account_id"], 42);
+        assert_eq!(payload["data"][0]["viewed_at"], 1_700_000_000i64);
+    }
+
+    #[tokio::test]
+    async fn watch_history_without_filter_passes_none() {
+        let (mut state, auth) = test_state().await;
+        let external = Arc::new(RecordingExternal::default());
+        state.external = external.clone();
+        let token = user_token(&auth).await;
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/plex/stats/history")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(external.history_calls(), vec![None]);
+    }
+
+    #[tokio::test]
+    async fn sync_collection_unavailable_when_external_not_wired() {
+        let (state, auth) = test_state().await;
+        let token = user_token(&auth).await;
+
+        let body = serde_json::json!({
+            "name": "Jazz",
+            "media_type": "music",
+            "rating_keys": ["101"],
+        });
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/plex/collections/sync")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn watch_history_rejects_unauthenticated() {
+        let (state, _auth) = test_state().await;
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/plex/stats/history")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/paroche/src/state.rs
+++ b/crates/paroche/src/state.rs
@@ -270,7 +270,27 @@ pub trait DynRequestService: Send + Sync {
         user_id: themelion::UserId,
     ) -> RequestServiceFut<'_, ()>;
 }
-pub trait DynExternalIntegration: Send + Sync {}
+/// External media-server integration via syndesmos: Plex collection sync
+/// (the Kometa replacement) and Plex viewing stats (the Wrapperr
+/// replacement).
+pub trait DynExternalIntegration: Send + Sync {
+    /// Synchronises a Plex collection from a Harmonia grouping: creates the
+    /// named collection in the Plex library section mapped from `media_type`,
+    /// containing the given Plex rating keys.
+    fn sync_plex_collection(
+        &self,
+        name: String,
+        media_type: themelion::MediaType,
+        rating_keys: Vec<String>,
+    ) -> ServiceFut<()>;
+
+    /// Fetches Plex watch history as typed viewing records, filtered to one
+    /// Plex account when `account_id` is set.
+    fn plex_watch_history(
+        &self,
+        account_id: Option<String>,
+    ) -> ServiceFut<Vec<themelion::WatchRecord>>;
+}
 
 /// Subtitle acquisition via prostheke.
 pub trait DynSubtitleService: Send + Sync {
@@ -465,7 +485,23 @@ impl DynRequestService for NullRequestService {
 }
 
 struct NullExternalIntegration;
-impl DynExternalIntegration for NullExternalIntegration {}
+impl DynExternalIntegration for NullExternalIntegration {
+    fn sync_plex_collection(
+        &self,
+        _name: String,
+        _media_type: themelion::MediaType,
+        _rating_keys: Vec<String>,
+    ) -> ServiceFut<()> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+
+    fn plex_watch_history(
+        &self,
+        _account_id: Option<String>,
+    ) -> ServiceFut<Vec<themelion::WatchRecord>> {
+        Box::pin(async { Err(ServiceError::NotAvailable) })
+    }
+}
 
 struct NullFeedService;
 impl DynFeedService for NullFeedService {

--- a/crates/syndesmos/Cargo.toml
+++ b/crates/syndesmos/Cargo.toml
@@ -18,6 +18,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
+url.workspace = true
 uuid.workspace = true
 jiff.workspace = true
 md5.workspace = true

--- a/crates/syndesmos/src/lib.rs
+++ b/crates/syndesmos/src/lib.rs
@@ -278,8 +278,8 @@ impl ExternalIntegration for ScrobbleClient {
             None => return Ok(vec![]),
         };
 
-        let account = account_id.unwrap_or_else(String::new);
-        with_retry(|| stats.fetch_watch_history(&account), &self.plex_circuit).await
+        let account = account_id.as_deref().unwrap_or("");
+        with_retry(|| stats.fetch_watch_history(account), &self.plex_circuit).await
     }
 }
 

--- a/crates/syndesmos/src/lib.rs
+++ b/crates/syndesmos/src/lib.rs
@@ -16,14 +16,16 @@ pub use error::SyndesmodError;
 pub use lastfm::artist::ArtistInfo as ArtistData;
 use snafu::{OptionExt, ResultExt};
 use sqlx::SqlitePool;
-use themelion::{EventSender, MediaId, MediaType, UserId};
+use themelion::{EventSender, MediaId, MediaType, UserId, WatchRecord};
 use tracing::instrument;
 
 use crate::error::{DatabaseSnafu, ScrobbleMetadataMissingSnafu, WantProfileMissingSnafu};
 use crate::lastfm::scrobble::TrackMetadata;
 use crate::lastfm::{LastfmApi, LastfmClient};
+use crate::plex::collections::{CollectionManager, PlexCollectionKind};
+use crate::plex::stats::StatsProvider;
 use crate::plex::{PlexApi, PlexClient};
-use crate::retry::CircuitBreaker;
+use crate::retry::{CircuitBreaker, with_retry};
 use crate::tidal::wantlist::{NewFavorite, TIDAL_WANT_SOURCE};
 use crate::tidal::{TidalApi, TidalClient, TidalId};
 
@@ -53,6 +55,21 @@ pub trait ExternalIntegration: Send + Sync {
         &self,
         artist_name: &str,
     ) -> Result<Option<ArtistData>, SyndesmodError>;
+    /// Synchronises a Plex collection from a Harmonia grouping: creates the
+    /// named collection in the Plex library section mapped from `media_type`,
+    /// containing the given Plex rating keys.
+    async fn sync_plex_collection(
+        &self,
+        name: String,
+        media_type: MediaType,
+        rating_keys: Vec<String>,
+    ) -> Result<(), SyndesmodError>;
+    /// Fetches Plex watch history as typed viewing records, filtered to one
+    /// Plex account when `account_id` is set.
+    async fn fetch_plex_watch_history(
+        &self,
+        account_id: Option<String>,
+    ) -> Result<Vec<WatchRecord>, SyndesmodError>;
 }
 
 /// Live implementation of all external integrations.
@@ -61,6 +78,8 @@ pub trait ExternalIntegration: Send + Sync {
 /// method degrades gracefully rather than returning an error.
 pub struct ScrobbleClient {
     plex_api: Option<Arc<dyn PlexApi>>,
+    plex_collections: Option<Arc<dyn CollectionManager>>,
+    plex_stats: Option<Arc<dyn StatsProvider>>,
     // WHY: section mapping is stored separately so mock tests can inject
     // a MockPlexApi alongside a custom section map without a real PlexClient.
     plex_sections: HashMap<MediaType, u32>,
@@ -215,6 +234,53 @@ impl ExternalIntegration for ScrobbleClient {
 
         lastfm::artist::fetch_artist_data(api.as_ref(), artist_name, &self.lastfm_circuit).await
     }
+
+    #[instrument(skip(self), fields(name = %name, media_type = %media_type, items = rating_keys.len()))]
+    async fn sync_plex_collection(
+        &self,
+        name: String,
+        media_type: MediaType,
+        rating_keys: Vec<String>,
+    ) -> Result<(), SyndesmodError> {
+        let collections = match &self.plex_collections {
+            Some(c) => c.clone(),
+            None => return Ok(()),
+        };
+        let Some(section_id) = self.plex_sections.get(&media_type).copied() else {
+            tracing::debug!(
+                media_type = %media_type,
+                "no Plex section configured for media type; skipping collection sync"
+            );
+            return Ok(());
+        };
+        let Some(kind) = PlexCollectionKind::for_media_type(media_type) else {
+            tracing::debug!(
+                media_type = %media_type,
+                "Plex has no collection kind for media type; skipping collection sync"
+            );
+            return Ok(());
+        };
+
+        with_retry(
+            || collections.sync_collection(&name, section_id, kind, &rating_keys),
+            &self.plex_circuit,
+        )
+        .await
+    }
+
+    #[instrument(skip(self))]
+    async fn fetch_plex_watch_history(
+        &self,
+        account_id: Option<String>,
+    ) -> Result<Vec<WatchRecord>, SyndesmodError> {
+        let stats = match &self.plex_stats {
+            Some(s) => s.clone(),
+            None => return Ok(vec![]),
+        };
+
+        let account = account_id.unwrap_or_else(String::new);
+        with_retry(|| stats.fetch_watch_history(&account), &self.plex_circuit).await
+    }
 }
 
 /// Builds a `ScrobbleClient` from real config or injected mocks.
@@ -222,6 +288,8 @@ pub struct ScrobbleClientBuilder {
     event_tx: EventSender,
     db: SqlitePool,
     plex_api: Option<Arc<dyn PlexApi>>,
+    plex_collections: Option<Arc<dyn CollectionManager>>,
+    plex_stats: Option<Arc<dyn StatsProvider>>,
     plex_sections: HashMap<MediaType, u32>,
     lastfm_api: Option<Arc<dyn LastfmApi>>,
     tidal_api: Option<Arc<dyn TidalApi>>,
@@ -236,6 +304,8 @@ impl ScrobbleClientBuilder {
             event_tx,
             db,
             plex_api: None,
+            plex_collections: None,
+            plex_stats: None,
             plex_sections: HashMap::new(),
             lastfm_api: None,
             tidal_api: None,
@@ -247,7 +317,10 @@ impl ScrobbleClientBuilder {
 
     pub fn with_plex(mut self, client: PlexClient) -> Self {
         self.plex_sections = client.config.library_sections.clone();
-        self.plex_api = Some(Arc::new(client));
+        let client = Arc::new(client);
+        self.plex_api = Some(client.clone());
+        self.plex_collections = Some(client.clone());
+        self.plex_stats = Some(client);
         self
     }
 
@@ -289,6 +362,18 @@ impl ScrobbleClientBuilder {
     }
 
     #[cfg(test)]
+    pub(crate) fn with_mock_plex_collections(mut self, mock: Arc<dyn CollectionManager>) -> Self {
+        self.plex_collections = Some(mock);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_mock_plex_stats(mut self, mock: Arc<dyn StatsProvider>) -> Self {
+        self.plex_stats = Some(mock);
+        self
+    }
+
+    #[cfg(test)]
     pub(crate) fn with_mock_tidal(mut self, mock: Arc<dyn TidalApi>) -> Self {
         self.tidal_api = Some(mock);
         self
@@ -298,6 +383,8 @@ impl ScrobbleClientBuilder {
         let cooldown = Duration::from_secs(self.circuit_break_minutes * 60);
         ScrobbleClient {
             plex_api: self.plex_api,
+            plex_collections: self.plex_collections,
+            plex_stats: self.plex_stats,
             plex_sections: self.plex_sections,
             lastfm_api: self.lastfm_api,
             tidal_api: self.tidal_api,
@@ -331,6 +418,8 @@ mod tests {
     use super::*;
     use crate::lastfm::artist::ArtistInfo;
     use crate::lastfm::tests::MockLastfmApi;
+    use crate::plex::collections::tests::MockCollectionManager;
+    use crate::plex::stats::tests::MockStatsProvider;
     use crate::plex::tests::MockPlexApi;
     use crate::test_support::{
         seed_scrobble_track, seed_tidal_want, seed_track_without_artist, test_pool,
@@ -386,6 +475,28 @@ mod tests {
         assert!(result.is_none());
     }
 
+    #[tokio::test]
+    async fn sync_plex_collection_returns_ok_when_unconfigured() {
+        let (tx, _rx) = create_event_bus(32);
+        let service = build_service(tx).await;
+        let result = service
+            .sync_plex_collection(
+                "Jazz".to_string(),
+                MediaType::Music,
+                vec!["101".to_string()],
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn fetch_plex_watch_history_returns_empty_when_unconfigured() {
+        let (tx, _rx) = create_event_bus(32);
+        let service = build_service(tx).await;
+        let records = service.fetch_plex_watch_history(None).await.unwrap();
+        assert!(records.is_empty());
+    }
+
     // ── Plex configured ───────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -437,6 +548,134 @@ mod tests {
             vec![2u32],
             "only the Movie section may be refreshed — the Music section must stay untouched"
         );
+    }
+
+    // ── Plex collections + stats configured ───────────────────────────────────
+
+    #[tokio::test]
+    async fn sync_plex_collection_resolves_section_and_kind_from_media_type() {
+        let (tx, _rx) = create_event_bus(32);
+        let mock = Arc::new(MockCollectionManager::new());
+
+        let mut sections = HashMap::new();
+        sections.insert(MediaType::Music, 7u32);
+
+        let service = ScrobbleClientBuilder::new(tx, test_pool().await)
+            .with_mock_plex(Arc::new(MockPlexApi::new()), sections)
+            .with_mock_plex_collections(mock.clone())
+            .build();
+
+        service
+            .sync_plex_collection(
+                "Jazz".to_string(),
+                MediaType::Music,
+                vec!["101".to_string(), "102".to_string()],
+            )
+            .await
+            .unwrap();
+
+        let recorded = mock.recorded();
+        assert_eq!(recorded.len(), 1);
+        let (name, section_id, kind, keys) = &recorded[0];
+        assert_eq!(name, "Jazz");
+        assert_eq!(*section_id, 7u32);
+        assert_eq!(*kind, PlexCollectionKind::Artist);
+        assert_eq!(keys, &vec!["101".to_string(), "102".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn sync_plex_collection_skips_media_type_without_section() {
+        let (tx, _rx) = create_event_bus(32);
+        let mock = Arc::new(MockCollectionManager::new());
+
+        let service = ScrobbleClientBuilder::new(tx, test_pool().await)
+            .with_mock_plex_collections(mock.clone())
+            .build();
+
+        // Movie has a Plex collection kind but no configured section here.
+        service
+            .sync_plex_collection(
+                "Sci-Fi".to_string(),
+                MediaType::Movie,
+                vec!["1".to_string()],
+            )
+            .await
+            .unwrap();
+
+        assert!(mock.recorded().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sync_plex_collection_skips_media_type_plex_cannot_host() {
+        let (tx, _rx) = create_event_bus(32);
+        let mock = Arc::new(MockCollectionManager::new());
+
+        let mut sections = HashMap::new();
+        sections.insert(MediaType::Book, 3u32);
+
+        let service = ScrobbleClientBuilder::new(tx, test_pool().await)
+            .with_mock_plex(Arc::new(MockPlexApi::new()), sections)
+            .with_mock_plex_collections(mock.clone())
+            .build();
+
+        // Books have a configured section but no Plex collection kind.
+        service
+            .sync_plex_collection("Reads".to_string(), MediaType::Book, vec!["1".to_string()])
+            .await
+            .unwrap();
+
+        assert!(mock.recorded().is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_plex_watch_history_returns_records_and_forwards_filter() {
+        let (tx, _rx) = create_event_bus(32);
+        let expected = vec![
+            WatchRecord {
+                source_ref: "101".to_string(),
+                title: "Gantz Graf".to_string(),
+                grandparent_title: Some("Autechre".to_string()),
+                media_kind: "track".to_string(),
+                account_id: Some(42),
+                viewed_at: Some(1_700_000_000),
+            },
+            WatchRecord {
+                source_ref: "202".to_string(),
+                title: "Alien".to_string(),
+                grandparent_title: None,
+                media_kind: "movie".to_string(),
+                account_id: Some(42),
+                viewed_at: Some(1_700_000_100),
+            },
+        ];
+        let mock = Arc::new(MockStatsProvider::new(expected.clone()));
+
+        let service = ScrobbleClientBuilder::new(tx, test_pool().await)
+            .with_mock_plex_stats(mock.clone())
+            .build();
+
+        let records = service
+            .fetch_plex_watch_history(Some("42".to_string()))
+            .await
+            .unwrap();
+
+        assert_eq!(records, expected);
+        assert_eq!(mock.requested_users(), vec!["42".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn fetch_plex_watch_history_passes_empty_filter_as_all_accounts() {
+        let (tx, _rx) = create_event_bus(32);
+        let mock = Arc::new(MockStatsProvider::new(vec![]));
+
+        let service = ScrobbleClientBuilder::new(tx, test_pool().await)
+            .with_mock_plex_stats(mock.clone())
+            .build();
+
+        let records = service.fetch_plex_watch_history(None).await.unwrap();
+
+        assert!(records.is_empty());
+        assert_eq!(mock.requested_users(), vec![String::new()]);
     }
 
     // ── Last.fm configured ────────────────────────────────────────────────────

--- a/crates/syndesmos/src/plex/collections.rs
+++ b/crates/syndesmos/src/plex/collections.rs
@@ -3,21 +3,336 @@
 //! Maps Harmonia media tags to Plex collections, keeping library metadata
 //! consistent without a separate Kometa/PMM process.
 
-use crate::error::SyndesmodError;
+use snafu::ResultExt;
+use themelion::MediaType;
+
+use super::BoxFuture;
+use crate::error::{PlexApiCallSnafu, SyndesmodError};
+use crate::plex::PlexClient;
+
+/// Plex library item kind a collection groups, keyed by its Plex API type code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlexCollectionKind {
+    /// Plex type 1 — movie libraries.
+    Movie,
+    /// Plex type 2 — TV show libraries.
+    TvShow,
+    /// Plex type 8 — music libraries (collections of artists).
+    Artist,
+}
+
+impl PlexCollectionKind {
+    fn type_code(self) -> u8 {
+        match self {
+            Self::Movie => 1,
+            Self::TvShow => 2,
+            Self::Artist => 8,
+        }
+    }
+
+    /// The Plex collection kind a Harmonia media type maps to, or `None` when
+    /// Plex has no native collection for it — the caller degrades to a logged
+    /// no-op, matching the unconfigured-section path.
+    pub(crate) fn for_media_type(media_type: MediaType) -> Option<Self> {
+        match media_type {
+            MediaType::Movie => Some(Self::Movie),
+            MediaType::Tv => Some(Self::TvShow),
+            MediaType::Music => Some(Self::Artist),
+            _ => None,
+        }
+    }
+}
 
 /// Manages Plex collections derived from Harmonia metadata.
-///
-/// Placeholder for v1: defines the trait surface; full implementation
-/// maps Harmonia tags → Plex collection create/update calls.
-#[expect(
-    dead_code,
-    reason = "held: placeholder trait surface defined by spec; implementation deferred to post-v1, tracked in #642"
-)]
 pub(crate) trait CollectionManager: Send + Sync {
-    /// Synchronises a named collection, creating or updating it in Plex.
-    fn sync_collection(
-        &self,
-        name: &str,
-        media_ids: &[String],
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), SyndesmodError>> + Send + '_>>;
+    /// Creates a Plex collection named `name` in library section `section_id`,
+    /// containing the items named by their Plex rating keys.
+    fn sync_collection<'a>(
+        &'a self,
+        name: &'a str,
+        section_id: u32,
+        kind: PlexCollectionKind,
+        rating_keys: &'a [String],
+    ) -> BoxFuture<'a, Result<(), SyndesmodError>>;
+}
+
+impl CollectionManager for PlexClient {
+    fn sync_collection<'a>(
+        &'a self,
+        name: &'a str,
+        section_id: u32,
+        kind: PlexCollectionKind,
+        rating_keys: &'a [String],
+    ) -> BoxFuture<'a, Result<(), SyndesmodError>> {
+        Box::pin(async move {
+            let machine_id = self.machine_identifier().await?;
+            let url = format!(
+                "{}/library/collections",
+                self.config.url.trim_end_matches('/')
+            );
+            self.http
+                .post(&url)
+                .header("X-Plex-Token", &self.config.token)
+                .query(&[
+                    ("type", kind.type_code().to_string()),
+                    ("title", name.to_string()),
+                    ("smart", "0".to_string()),
+                    ("sectionId", section_id.to_string()),
+                    ("uri", collection_uri(&machine_id, rating_keys)),
+                ])
+                .send()
+                .await
+                .context(PlexApiCallSnafu)?
+                .error_for_status()
+                .context(PlexApiCallSnafu)?;
+            Ok(())
+        })
+    }
+}
+
+impl PlexClient {
+    /// The server's `machineIdentifier`, required to build `library://` item
+    /// URIs for collection membership.
+    async fn machine_identifier(&self) -> Result<String, SyndesmodError> {
+        let url = self.config.url.trim_end_matches('/').to_string();
+        let identity: ServerIdentity = self
+            .http
+            .get(&url)
+            .header("X-Plex-Token", &self.config.token)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .context(PlexApiCallSnafu)?
+            .error_for_status()
+            .context(PlexApiCallSnafu)?
+            .json()
+            .await
+            .context(PlexApiCallSnafu)?;
+        Ok(identity.media_container.machine_identifier)
+    }
+}
+
+/// Builds the `library://<machine>/directory/<item paths>` membership URI Plex
+/// expects on collection create. The paths segment is percent-encoded once
+/// here and again by the query serializer — the double encoding is the wire
+/// shape Plex clients produce.
+fn collection_uri(machine_id: &str, rating_keys: &[String]) -> String {
+    let paths = rating_keys
+        .iter()
+        .map(|key| format!("/library/metadata/{key}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let encoded: String = url::form_urlencoded::byte_serialize(paths.as_bytes()).collect();
+    format!("library://{machine_id}/directory/{encoded}")
+}
+
+// WHY: wire DTO — Plex server identity response (`GET /` as JSON).
+#[derive(serde::Deserialize)]
+struct ServerIdentity {
+    #[serde(rename = "MediaContainer")]
+    media_container: ServerIdentityContainer,
+}
+
+#[derive(serde::Deserialize)]
+struct ServerIdentityContainer {
+    #[serde(rename = "machineIdentifier")]
+    machine_identifier: String,
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::sync::Mutex;
+
+    use horismos::PlexConfig;
+
+    use super::*;
+
+    pub(crate) struct RecordedCollection {
+        pub(crate) name: String,
+        pub(crate) section_id: u32,
+        pub(crate) kind: PlexCollectionKind,
+        pub(crate) rating_keys: Vec<String>,
+    }
+
+    #[derive(Default)]
+    pub(crate) struct MockCollectionManager {
+        pub(crate) calls: Mutex<Vec<RecordedCollection>>,
+    }
+
+    impl MockCollectionManager {
+        pub(crate) fn new() -> Self {
+            Self::default()
+        }
+
+        pub(crate) fn recorded(&self) -> Vec<(String, u32, PlexCollectionKind, Vec<String>)> {
+            self.calls
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|c| (c.name.clone(), c.section_id, c.kind, c.rating_keys.clone()))
+                .collect()
+        }
+    }
+
+    impl CollectionManager for MockCollectionManager {
+        fn sync_collection<'a>(
+            &'a self,
+            name: &'a str,
+            section_id: u32,
+            kind: PlexCollectionKind,
+            rating_keys: &'a [String],
+        ) -> BoxFuture<'a, Result<(), SyndesmodError>> {
+            self.calls.lock().unwrap().push(RecordedCollection {
+                name: name.to_string(),
+                section_id,
+                kind,
+                rating_keys: rating_keys.to_vec(),
+            });
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    fn test_config(url: String) -> PlexConfig {
+        PlexConfig {
+            url,
+            token: "plextok".to_string(),
+            library_sections: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn media_type_maps_to_expected_collection_kind() {
+        assert_eq!(
+            PlexCollectionKind::for_media_type(MediaType::Movie),
+            Some(PlexCollectionKind::Movie)
+        );
+        assert_eq!(
+            PlexCollectionKind::for_media_type(MediaType::Tv),
+            Some(PlexCollectionKind::TvShow)
+        );
+        assert_eq!(
+            PlexCollectionKind::for_media_type(MediaType::Music),
+            Some(PlexCollectionKind::Artist)
+        );
+    }
+
+    #[test]
+    fn unmapped_media_types_have_no_collection_kind() {
+        for media_type in [
+            MediaType::Audiobook,
+            MediaType::Book,
+            MediaType::Comic,
+            MediaType::Podcast,
+            MediaType::News,
+        ] {
+            assert_eq!(PlexCollectionKind::for_media_type(media_type), None);
+        }
+    }
+
+    #[test]
+    fn collection_uri_double_encodes_item_paths() {
+        let uri = collection_uri("machine1", &["101".to_string(), "102".to_string()]);
+        assert_eq!(
+            uri,
+            "library://machine1/directory/%2Flibrary%2Fmetadata%2F101%2C%2Flibrary%2Fmetadata%2F102"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_collection_fetches_identity_then_creates_collection() {
+        let identity = r#"{"MediaContainer":{"machineIdentifier":"machine1"}}"#;
+        let (base_url, _auth_url, server) = crate::test_support::spawn_sequential_http(vec![
+            (200, identity.to_string()),
+            (200, String::new()),
+        ])
+        .await;
+        let client = PlexClient::new(test_config(base_url));
+
+        client
+            .sync_collection(
+                "Jazz",
+                7,
+                PlexCollectionKind::Artist,
+                &["101".to_string(), "102".to_string()],
+            )
+            .await
+            .unwrap();
+
+        let requests = server.await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests[0].starts_with("GET / HTTP/1.1"),
+            "identity probe must hit the server root: {}",
+            requests[0].lines().next().unwrap()
+        );
+        let create_line = requests[1].lines().next().unwrap();
+        assert!(
+            create_line.starts_with("POST /library/collections?"),
+            "expected a collection create: {create_line}"
+        );
+        for expected in [
+            "type=8",
+            "title=Jazz",
+            "smart=0",
+            "sectionId=7",
+            "uri=library%3A%2F%2Fmachine1%2Fdirectory%2F%252Flibrary%252Fmetadata%252F101%252C%252Flibrary%252Fmetadata%252F102",
+        ] {
+            assert!(
+                create_line.contains(expected),
+                "create request missing {expected}: {create_line}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_collection_errors_when_identity_probe_fails() {
+        let (base_url, _auth_url, server) =
+            crate::test_support::spawn_sequential_http(vec![(401, String::new())]).await;
+        let client = PlexClient::new(test_config(base_url));
+
+        let result = client
+            .sync_collection("Jazz", 7, PlexCollectionKind::Artist, &["101".to_string()])
+            .await;
+
+        assert!(matches!(result, Err(SyndesmodError::PlexApiCall { .. })));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn sync_collection_errors_when_create_fails() {
+        let identity = r#"{"MediaContainer":{"machineIdentifier":"machine1"}}"#;
+        let (base_url, _auth_url, server) = crate::test_support::spawn_sequential_http(vec![
+            (200, identity.to_string()),
+            (500, String::new()),
+        ])
+        .await;
+        let client = PlexClient::new(test_config(base_url));
+
+        let result = client
+            .sync_collection("Jazz", 7, PlexCollectionKind::Artist, &["101".to_string()])
+            .await;
+
+        assert!(matches!(result, Err(SyndesmodError::PlexApiCall { .. })));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn sync_collection_survives_circuit_wrapper() {
+        // WHY: the production caller routes through `with_retry` — prove the
+        // trait future composes with it instead of only firing standalone.
+        use crate::retry::{CircuitBreaker, with_retry};
+
+        let mock = MockCollectionManager::new();
+        let circuit = CircuitBreaker::new("plex", 5, std::time::Duration::from_secs(300));
+        let keys = vec!["101".to_string()];
+
+        with_retry(
+            || mock.sync_collection("Jazz", 7, PlexCollectionKind::Artist, &keys),
+            &circuit,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(mock.recorded().len(), 1);
+    }
 }

--- a/crates/syndesmos/src/plex/mod.rs
+++ b/crates/syndesmos/src/plex/mod.rs
@@ -13,7 +13,7 @@ use snafu::ResultExt;
 
 use crate::error::{PlexApiCallSnafu, SyndesmodError};
 
-type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Abstraction over the Plex HTTP API, injectable for testing.
 pub(crate) trait PlexApi: Send + Sync {

--- a/crates/syndesmos/src/plex/stats.rs
+++ b/crates/syndesmos/src/plex/stats.rs
@@ -3,26 +3,245 @@
 //! Queries Plex watch history to power Harmonia's listening/viewing stats
 //! without a separate Wrapperr process.
 
-use crate::error::SyndesmodError;
+use snafu::ResultExt;
+use themelion::WatchRecord;
+
+use super::BoxFuture;
+use crate::error::{PlexApiCallSnafu, SyndesmodError};
+use crate::plex::PlexClient;
 
 /// Fetches viewing history from Plex.
-///
-/// Placeholder for v1: defines the trait surface; full implementation
-/// queries `/status/sessions/history/all` and maps to Harmonia records.
-#[expect(
-    dead_code,
-    reason = "held: placeholder trait surface defined by spec; implementation deferred to post-v1, tracked in #643"
-)]
 pub(crate) trait StatsProvider: Send + Sync {
-    /// Returns raw watch history entries for the given Plex user.
-    fn fetch_watch_history(
-        &self,
-        plex_user_id: &str,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<Vec<serde_json::Value>, SyndesmodError>>
-                + Send
-                + '_,
-        >,
-    >;
+    /// Returns the watch history for one Plex account, or every account when
+    /// `plex_user_id` is empty.
+    fn fetch_watch_history<'a>(
+        &'a self,
+        plex_user_id: &'a str,
+    ) -> BoxFuture<'a, Result<Vec<WatchRecord>, SyndesmodError>>;
+}
+
+impl StatsProvider for PlexClient {
+    fn fetch_watch_history<'a>(
+        &'a self,
+        plex_user_id: &'a str,
+    ) -> BoxFuture<'a, Result<Vec<WatchRecord>, SyndesmodError>> {
+        Box::pin(async move {
+            let url = format!(
+                "{}/status/sessions/history/all",
+                self.config.url.trim_end_matches('/')
+            );
+            let mut query: Vec<(&str, String)> = Vec::new();
+            if !plex_user_id.is_empty() {
+                query.push(("accountID", plex_user_id.to_string()));
+            }
+            let history: HistoryResponse = self
+                .http
+                .get(&url)
+                .header("X-Plex-Token", &self.config.token)
+                .header("Accept", "application/json")
+                .query(&query)
+                .send()
+                .await
+                .context(PlexApiCallSnafu)?
+                .error_for_status()
+                .context(PlexApiCallSnafu)?
+                .json()
+                .await
+                .context(PlexApiCallSnafu)?;
+            Ok(history.into_records())
+        })
+    }
+}
+
+// WHY: wire DTOs — Plex `GET /status/sessions/history/all` JSON shape. An
+// empty history omits the `Metadata` key entirely.
+#[derive(serde::Deserialize)]
+struct HistoryResponse {
+    #[serde(rename = "MediaContainer")]
+    media_container: HistoryContainer,
+}
+
+#[derive(serde::Deserialize)]
+struct HistoryContainer {
+    #[serde(rename = "Metadata", default)]
+    metadata: Vec<HistoryEntry>,
+}
+
+#[derive(serde::Deserialize)]
+struct HistoryEntry {
+    #[serde(rename = "ratingKey")]
+    rating_key: Option<String>,
+    title: Option<String>,
+    #[serde(rename = "grandparentTitle")]
+    grandparent_title: Option<String>,
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    #[serde(rename = "accountID")]
+    account_id: Option<i64>,
+    #[serde(rename = "viewedAt")]
+    viewed_at: Option<i64>,
+}
+
+impl HistoryResponse {
+    fn into_records(self) -> Vec<WatchRecord> {
+        let entries = self.media_container.metadata;
+        let mut skipped = 0usize;
+        let mut records = Vec::with_capacity(entries.len());
+        for entry in entries {
+            match entry.rating_key.filter(|key| !key.is_empty()) {
+                Some(source_ref) => records.push(WatchRecord {
+                    source_ref,
+                    title: entry.title.unwrap_or_default(),
+                    grandparent_title: entry.grandparent_title,
+                    media_kind: entry.kind.unwrap_or_default(),
+                    account_id: entry.account_id,
+                    viewed_at: entry.viewed_at,
+                }),
+                None => skipped += 1,
+            }
+        }
+        if skipped > 0 {
+            tracing::debug!(skipped, "plex history entries without ratingKey dropped");
+        }
+        records
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::sync::Mutex;
+
+    use horismos::PlexConfig;
+
+    use super::*;
+
+    #[derive(Default)]
+    pub(crate) struct MockStatsProvider {
+        pub(crate) calls: Mutex<Vec<String>>,
+        pub(crate) records: Vec<WatchRecord>,
+    }
+
+    impl MockStatsProvider {
+        pub(crate) fn new(records: Vec<WatchRecord>) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                records,
+            }
+        }
+
+        pub(crate) fn requested_users(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl StatsProvider for MockStatsProvider {
+        fn fetch_watch_history<'a>(
+            &'a self,
+            plex_user_id: &'a str,
+        ) -> BoxFuture<'a, Result<Vec<WatchRecord>, SyndesmodError>> {
+            self.calls.lock().unwrap().push(plex_user_id.to_string());
+            let records = self.records.clone();
+            Box::pin(async move { Ok(records) })
+        }
+    }
+
+    fn test_config(url: String) -> PlexConfig {
+        PlexConfig {
+            url,
+            token: "plextok".to_string(),
+            library_sections: std::collections::HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_watch_history_maps_entries_to_watch_records() {
+        let body = r#"{"MediaContainer":{"size":2,"Metadata":[
+            {"ratingKey":"101","title":"Gantz Graf","grandparentTitle":"Autechre","type":"track","accountID":1,"viewedAt":1700000000},
+            {"ratingKey":"202","title":"Alien","type":"movie","librarySectionID":2,"accountID":2,"viewedAt":1700000100}
+        ]}}"#;
+        let (base_url, server) = crate::test_support::spawn_one_shot_http(200, "OK", body).await;
+        let client = PlexClient::new(test_config(base_url));
+
+        let records = client.fetch_watch_history("").await.unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].source_ref, "101");
+        assert_eq!(records[0].title, "Gantz Graf");
+        assert_eq!(records[0].grandparent_title.as_deref(), Some("Autechre"));
+        assert_eq!(records[0].media_kind, "track");
+        assert_eq!(records[0].account_id, Some(1));
+        assert_eq!(records[0].viewed_at, Some(1_700_000_000));
+        assert_eq!(records[1].source_ref, "202");
+        assert_eq!(records[1].grandparent_title, None);
+
+        let request = server.await.unwrap();
+        let request_line = request.lines().next().unwrap();
+        assert!(
+            request_line.starts_with("GET /status/sessions/history/all"),
+            "unexpected history request: {request_line}"
+        );
+        assert!(
+            !request_line.contains("accountID"),
+            "empty user id must not send an accountID filter: {request_line}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_watch_history_filters_by_account_id() {
+        let body = r#"{"MediaContainer":{"size":1,"Metadata":[
+            {"ratingKey":"101","title":"Gantz Graf","type":"track","accountID":42,"viewedAt":1700000000}
+        ]}}"#;
+        let (base_url, server) = crate::test_support::spawn_one_shot_http(200, "OK", body).await;
+        let client = PlexClient::new(test_config(base_url));
+
+        let records = client.fetch_watch_history("42").await.unwrap();
+
+        assert_eq!(records.len(), 1);
+        let request = server.await.unwrap();
+        let request_line = request.lines().next().unwrap();
+        assert!(
+            request_line.contains("accountID=42"),
+            "account filter must reach the wire: {request_line}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_watch_history_returns_empty_when_history_empty() {
+        let body = r#"{"MediaContainer":{"size":0}}"#;
+        let (base_url, server) = crate::test_support::spawn_one_shot_http(200, "OK", body).await;
+        let client = PlexClient::new(test_config(base_url));
+
+        let records = client.fetch_watch_history("").await.unwrap();
+
+        assert!(records.is_empty());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fetch_watch_history_drops_entries_without_rating_key() {
+        let body = r#"{"MediaContainer":{"size":2,"Metadata":[
+            {"title":"Untracked","type":"movie","viewedAt":1700000000},
+            {"ratingKey":"101","title":"Gantz Graf","type":"track","viewedAt":1700000100}
+        ]}}"#;
+        let (base_url, server) = crate::test_support::spawn_one_shot_http(200, "OK", body).await;
+        let client = PlexClient::new(test_config(base_url));
+
+        let records = client.fetch_watch_history("").await.unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].source_ref, "101");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fetch_watch_history_errors_on_http_error_status() {
+        let (base_url, server) =
+            crate::test_support::spawn_one_shot_http(500, "Internal Server Error", "").await;
+        let client = PlexClient::new(test_config(base_url));
+
+        let result = client.fetch_watch_history("").await;
+
+        assert!(matches!(result, Err(SyndesmodError::PlexApiCall { .. })));
+        server.await.unwrap();
+    }
 }

--- a/crates/themelion/src/lib.rs
+++ b/crates/themelion/src/lib.rs
@@ -11,4 +11,4 @@ pub use ids::{
     ApiKeyId, DownloadId, EpisodeId, FeedId, HaveId, MediaId, QueryId, RegistryId, ReleaseId,
     RequestId, UserId, WantId,
 };
-pub use media::{MediaItemState, MediaType, QualityProfile};
+pub use media::{MediaItemState, MediaType, QualityProfile, WatchRecord};

--- a/crates/themelion/src/media.rs
+++ b/crates/themelion/src/media.rs
@@ -99,6 +99,26 @@ impl QualityProfile {
     }
 }
 
+/// One viewing or listening event reported by an external media server's
+/// watch history (Plex `/status/sessions/history/all`), mapped into
+/// Harmonia's domain so serving-layer stats stay server-agnostic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WatchRecord {
+    /// The server's own item key (Plex `ratingKey`).
+    pub source_ref: String,
+    /// Item title as the server reports it.
+    pub title: String,
+    /// Series or artist context for episodes and tracks (Plex
+    /// `grandparentTitle`); absent for films and loose items.
+    pub grandparent_title: Option<String>,
+    /// The server's item kind (`movie`, `episode`, `track`).
+    pub media_kind: String,
+    /// The server account that viewed the item (Plex `accountID`).
+    pub account_id: Option<i64>,
+    /// Epoch-seconds timestamp of the view (Plex `viewedAt`).
+    pub viewed_at: Option<i64>,
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json;
@@ -216,5 +236,20 @@ mod tests {
         let json = serde_json::to_string(&qp).unwrap();
         let recovered: QualityProfile = serde_json::from_str(&json).unwrap();
         assert_eq!(qp, recovered);
+    }
+
+    #[test]
+    fn watch_record_serde_roundtrip() {
+        let record = WatchRecord {
+            source_ref: "101".to_string(),
+            title: "Gantz Graf".to_string(),
+            grandparent_title: Some("Autechre".to_string()),
+            media_kind: "track".to_string(),
+            account_id: Some(1),
+            viewed_at: Some(1_700_000_000),
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        let recovered: WatchRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(record, recovered);
     }
 }


### PR DESCRIPTION
## Summary

Implements #642 and #643 for real — the `CollectionManager` (Kometa replacement) and `StatsProvider` (Wrapperr replacement) placeholders each land with a live caller.

**syndesmos:**
- `CollectionManager for PlexClient`: creates a named Plex collection in the configured library section — resolves the server `machineIdentifier`, builds the `library://<machine>/directory/<item paths>` membership URI (double-encoded, the wire shape Plex clients produce), POSTs `/library/collections`. `PlexCollectionKind` maps Movie/Tv/Music to Plex type codes 1/2/8; media types Plex cannot host degrade to a logged no-op, as do unconfigured sections.
- `StatsProvider for PlexClient`: pulls `/status/sessions/history/all` (optional `accountID` filter) into typed `themelion::WatchRecord`s — Harmonia-domain, server-agnostic; entries without a `ratingKey` are dropped with a debug log.
- Both join `ExternalIntegration` on `ScrobbleClient` with the Plex circuit breaker; `with_plex` now injects all three Plex facets from one client.

**paroche (the live callers):**
- `POST /api/v1/plex/collections/sync` — `{name, media_type, rating_keys}`; 422 on blank name or empty keys; 503 when the external integration is not wired (the null/stub path — production wiring degrades unconfigured Plex to a logged no-op and a success-shaped response, matching the existing unconfigured-section semantics).
- `GET /api/v1/plex/stats/history?account_id=` — typed history envelope.
- `DynExternalIntegration` (previously marker-only) gains the two methods; `ExternalAdapter` forwards to the live client behind the rebuild-safe RwLock swap; the null implementation returns `NotAvailable`.

**Named remainder (not descoped, just not this PR):** collection sync is create-only — updating/deleting existing collections and scheduled tag→collection automation are the Kometa feature tail; the stats endpoint returns raw history, not yet aggregated dashboard views.

## Verification

```text
cargo test -p paroche plex:  7 passed; 0 failed   (route auth, validation, forwarding, unavailable-degradation)
cargo test -p syndesmos:     83 passed; 0 failed  (kind mapping, URI double-encoding, identity→create wire sequence,
                                                  history DTO mapping, circuit-breaker paths, unconfigured degrade)
```

Route tests were written RED first (404s against the unregistered routes), then the handlers/router turned them green. Local: both suites, `cargo fmt`, `kanon lint` (zero new violations). CI carries the full workspace gate.

Refs #642, #643

