### PR TITLE
feat(archon): cooperative cancellation for the rmcp stdio surface (#652 PR 3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,10 +91,12 @@ serde_json      = "1"
 schemars        = "1"
 
 # ── MCP server framework ──────────────────────────────────────────────────────
-# WHY: requirement string deliberately matches kanon angelos's ("1.2" -> 1.7.0);
-# the lockfile pins the resolved version and cargo-deny/lock review owns upgrades
-# (#652). Feature flags live in archon's manifest (the only consumer).
-rmcp            = "1.2"
+# WHY 1.7: the cancellation wiring (#652 PR 3) needs FromContextPart for
+# CancellationToken, added in rmcp 1.3; we declare the resolved, CI-verified
+# 1.7 line rather than float an untested floor. The lockfile pins the exact
+# version and cargo-deny/lock review owns upgrades. Feature flags live in
+# archon's manifest (the only consumer).
+rmcp            = "1.7"
 
 # ── Error handling ─────────────────────────────────────────────────────────────
 snafu           = { version = "0.8", features = ["rust_1_65"] }

--- a/crates/archon/src/main.rs
+++ b/crates/archon/src/main.rs
@@ -12,6 +12,7 @@ mod startup;
 
 use clap::Parser;
 use cli::{Cli, Command};
+use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
 async fn main() {
@@ -32,16 +33,24 @@ async fn main() {
         Command::Db(db_args) => match db_args.command {
             cli::DbCommand::Migrate(args) => db::run_db_migrate(args, &mut stdout).await,
         },
-        Command::Play(args) => play::run_play(args, &mut stdout).await,
+        // WHY the fresh tokens: the CLI has no cancellation source — Ctrl+C
+        // terminates the process directly and the renderer's own signal
+        // handlers cover graceful stops — so the interactive subcommands
+        // pass a token that never fires. Only the MCP surface (mcp.rs)
+        // passes a live one (`RequestContext.ct`).
+        Command::Play(args) => play::run_play(args, &mut stdout, CancellationToken::new()).await,
         Command::Render(args) => {
-            render::run_render(render::RenderArgs {
-                server: args.server,
-                cert_dir: args
-                    .cert_dir
-                    .unwrap_or_else(paths::default_renderer_cert_dir),
-                name: args.name,
-                config_path: args.config,
-            })
+            render::run_render(
+                render::RenderArgs {
+                    server: args.server,
+                    cert_dir: args
+                        .cert_dir
+                        .unwrap_or_else(paths::default_renderer_cert_dir),
+                    name: args.name,
+                    config_path: args.config,
+                },
+                CancellationToken::new(),
+            )
             .await
         }
         Command::Migrate(args) => migrate::run_migrate(args, &mut stdout).await,

--- a/crates/archon/src/mcp.rs
+++ b/crates/archon/src/mcp.rs
@@ -1,4 +1,4 @@
-//! MCP stdio surface (#652, PR 2 of the rmcp migration) — an rmcp server.
+//! MCP stdio surface (#652, PR 3 of the rmcp migration) — an rmcp server.
 //!
 //! The hand-rolled `for line in reader.lines()` loop this module used to
 //! run was a single global critical section: one request completed before
@@ -20,11 +20,30 @@
 //! - Tool-level failures stay `isError: true` envelopes with
 //!   `structuredContent.ok`; only protocol failures become JSON-RPC
 //!   errors.
-//! - `play_file`/`render` still block to completion. start/status/stop is
-//!   PR 4; wiring `RequestContext.ct` cancellation into the long-runners
-//!   and bridged calls is PR 3.
+//! - `play_file`/`render` still block to completion (or cancellation).
+//!   start/status/stop handles are PR 4.
 //!
-//! Behavior changes this PR makes deliberately (witness-mandated
+//! What PR 3 changed — cancellation wiring (rmcp cancellation is
+//! COOPERATIVE: the serve loop intercepts `notifications/cancelled` and
+//! cancels that request's token promptly, but the handler future keeps
+//! running unless it observes the token):
+//! - Every tool method takes the request's `RequestContext.ct` as a
+//!   trailing `CancellationToken` argument (rmcp's `FromContextPart`
+//!   impls supply it from the tool-call context).
+//! - Bridged acquisition calls select on the token around the bridge
+//!   round-trip: a cancelled call drops the `forward_to_bridge` future —
+//!   and with it the Unix socket — immediately instead of lingering to
+//!   `call_timeout`, answering a tool-level "cancelled" envelope.
+//! - `play_file` threads the token into `run_play`, whose event loop
+//!   selects on it; cancellation runs the same `engine.stop()` teardown a
+//!   finished track runs — the real stop path (decode/DSP tasks aborted
+//!   and joined), proved by the play.rs falsifier test.
+//! - `render` threads the token into `run_renderer_loop`, whose internal
+//!   shutdown tree becomes a child of it; cancellation breaks the
+//!   reconnect loop through the same shutdown path SIGINT/SIGTERM use,
+//!   proved by the runner.rs falsifier test.
+//!
+//! Behavior changes made deliberately in PR 2 (witness-mandated
 //! normalizations from the #700 review; see `mcp_params.rs` module docs
 //! for the full schema-delta list):
 //! - Non-object `arguments`: explicit `null`/absent still runs a tool with
@@ -57,6 +76,7 @@ use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, ServiceExt, tool, t
 use serde_json::{Value, json};
 use snafu::ResultExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
 
 use archon::mcp_params::{
     CancelDownloadParams, DbMigrateParams, EnqueueDownloadParams, ListDownloadsParams,
@@ -198,11 +218,12 @@ impl HarmoniaServer {
     #[tool(
         name = "harmonia_play_file",
         title = "Play a local audio file",
-        description = "Play a local file through the Akouo audio engine. This blocks until playback stops."
+        description = "Play a local file through the Akouo audio engine. This blocks until playback stops; cancelling the call stops playback."
     )]
     async fn play_file(
         &self,
         Parameters(params): Parameters<PlayFileParams>,
+        ct: CancellationToken,
     ) -> Result<CallToolResult, McpError> {
         let mut output = Vec::new();
         match crate::play::run_play(
@@ -211,6 +232,7 @@ impl HarmoniaServer {
                 device: params.device,
             },
             &mut output,
+            ct,
         )
         .await
         {
@@ -230,20 +252,24 @@ impl HarmoniaServer {
     #[tool(
         name = "harmonia_render",
         title = "Run Harmonia renderer mode",
-        description = "Run the headless renderer loop. This blocks while the renderer is active."
+        description = "Run the headless renderer loop. This blocks while the renderer is active; cancelling the call stops the renderer."
     )]
     async fn render(
         &self,
         Parameters(params): Parameters<RenderParams>,
+        ct: CancellationToken,
     ) -> Result<CallToolResult, McpError> {
-        match crate::render::run_render(crate::render::RenderArgs {
-            server: params.server,
-            cert_dir: params
-                .cert_dir
-                .unwrap_or_else(crate::paths::default_renderer_cert_dir),
-            name: params.name,
-            config_path: params.config,
-        })
+        match crate::render::run_render(
+            crate::render::RenderArgs {
+                server: params.server,
+                cert_dir: params
+                    .cert_dir
+                    .unwrap_or_else(crate::paths::default_renderer_cert_dir),
+                name: params.name,
+                config_path: params.config,
+            },
+            ct,
+        )
         .await
         {
             Ok(()) => Ok(tool_success("renderer completed".to_string())),
@@ -259,9 +285,10 @@ impl HarmoniaServer {
     async fn search_releases(
         &self,
         Parameters(params): Parameters<SearchReleasesParams>,
+        ct: CancellationToken,
     ) -> Result<CallToolResult, McpError> {
         Ok(self
-            .call_via_bridge("harmonia_search_releases", &params)
+            .call_via_bridge("harmonia_search_releases", &params, ct)
             .await)
     }
 
@@ -273,9 +300,10 @@ impl HarmoniaServer {
     async fn enqueue_download(
         &self,
         Parameters(params): Parameters<EnqueueDownloadParams>,
+        ct: CancellationToken,
     ) -> Result<CallToolResult, McpError> {
         Ok(self
-            .call_via_bridge("harmonia_enqueue_download", &params)
+            .call_via_bridge("harmonia_enqueue_download", &params, ct)
             .await)
     }
 
@@ -287,9 +315,10 @@ impl HarmoniaServer {
     async fn list_downloads(
         &self,
         Parameters(params): Parameters<ListDownloadsParams>,
+        ct: CancellationToken,
     ) -> Result<CallToolResult, McpError> {
         Ok(self
-            .call_via_bridge("harmonia_list_downloads", &params)
+            .call_via_bridge("harmonia_list_downloads", &params, ct)
             .await)
     }
 
@@ -301,9 +330,10 @@ impl HarmoniaServer {
     async fn cancel_download(
         &self,
         Parameters(params): Parameters<CancelDownloadParams>,
+        ct: CancellationToken,
     ) -> Result<CallToolResult, McpError> {
         Ok(self
-            .call_via_bridge("harmonia_cancel_download", &params)
+            .call_via_bridge("harmonia_cancel_download", &params, ct)
             .await)
     }
 
@@ -315,6 +345,7 @@ impl HarmoniaServer {
         &self,
         name: &'static str,
         params: &P,
+        ct: CancellationToken,
     ) -> CallToolResult {
         let arguments = match serde_json::to_value(params) {
             Ok(arguments) => arguments,
@@ -322,15 +353,24 @@ impl HarmoniaServer {
         };
         // WHY the literal id: one request line in, one response line out
         // per connection — the response is matched positionally, never by
-        // id, and the stdio side only extracts result/error. PR 3 threads
-        // the real `RequestContext` through here for `ct` cancellation.
+        // id, and the stdio side only extracts result/error.
         let message = json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": "tools/call",
             "params": { "name": name, "arguments": arguments }
         });
-        match forward_to_bridge(&self.ctx, &message).await {
+        // WHY the select: rmcp cancellation is cooperative — the handler
+        // future keeps running after `notifications/cancelled` unless it
+        // observes `ct`. Dropping the `forward_to_bridge` future mid-flight
+        // drops its UnixStream, so a cancelled call closes the bridge
+        // socket immediately instead of lingering to `call_timeout`.
+        let forwarded = tokio::select! {
+            biased;
+            _ = ct.cancelled() => Err(BridgeCallError::Cancelled),
+            result = forward_to_bridge(&self.ctx, &message) => result,
+        };
+        match forwarded {
             Ok(response) => {
                 if let Some(result) = response.get("result") {
                     // WHY: the bridge only ever emits the
@@ -350,6 +390,9 @@ impl HarmoniaServer {
                     tool_error("malformed response from the harmonia server's MCP bridge")
                 }
             }
+            Err(BridgeCallError::Cancelled) => tool_error(
+                "call cancelled by the client; the MCP bridge connection was dropped".to_string(),
+            ),
             Err(BridgeCallError::Unavailable) => tool_error(format!(
                 "harmonia server is not running (socket {} unavailable); start 'harmonia serve'",
                 self.ctx.socket_path.display()
@@ -399,12 +442,17 @@ impl ServerHandler for HarmoniaServer {
 enum BridgeCallError {
     Unavailable,
     Timeout,
+    Cancelled,
     Protocol(String),
 }
 
 /// Connects to the bridge socket per call (no pooling), writes one
 /// `tools/call` request line, and awaits exactly one response line under
 /// `ctx.call_timeout`.
+///
+/// Cancel-safe by construction: the stream is a plain local, so dropping
+/// this future mid-flight (the caller's `ct` select) closes the socket —
+/// there is no partially-sent state to clean up beyond that.
 async fn forward_to_bridge(ctx: &McpContext, message: &Value) -> Result<Value, BridgeCallError> {
     let connect = tokio::net::UnixStream::connect(&ctx.socket_path);
     let mut stream = tokio::time::timeout(ctx.call_timeout, connect)
@@ -961,6 +1009,98 @@ mod tests {
             Some(&Value::Bool(true)),
             "the hung bridged call ends in its timeout tool error: {second:?}"
         );
+
+        stop_test_server(client, running).await;
+    }
+
+    // ── #652 PR 3 falsifier: cancellation is effective, not just delivered ──
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_notification_drops_a_hung_bridged_call() {
+        use tokio::io::AsyncReadExt as _;
+
+        // WHY: the memo §6 falsifier for bridged calls. rmcp's serve loop
+        // intercepts `notifications/cancelled` and cancels the request's
+        // token — but the handler future keeps running unless it observes
+        // the token. This test proves the EFFECT: a bridge that never
+        // answers would otherwise hold the call for the full 30s
+        // call_timeout; the cancelled call must answer in ~ms and the
+        // bridge side must observe its socket die.
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("hang.sock");
+        let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            let Ok((mut stream, _addr)) = listener.accept().await else {
+                return;
+            };
+            // Read until EOF and never answer: the request line arrives
+            // first, then Ok(0) proves the stdio side dropped the socket.
+            let mut buf = [0u8; 256];
+            loop {
+                match stream.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {}
+                }
+            }
+            dropped_tx.send(()).ok();
+        });
+
+        let ctx = McpContext {
+            socket_path,
+            call_timeout: Duration::from_secs(30),
+        };
+        let (mut client, running) = start_test_server(ctx).await;
+        client
+            .send(json!({
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": { "name": "harmonia_list_downloads", "arguments": {} }
+            }))
+            .await;
+        // WHY: give the serve loop a beat to dispatch the call task before
+        // the ping and the cancel land behind it on the wire.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // The issue's core concurrency guarantee still holds mid-call.
+        client
+            .send(json!({ "jsonrpc": "2.0", "id": 11, "method": "ping" }))
+            .await;
+        let pong = client.next_message_within(Duration::from_secs(2)).await;
+        assert_eq!(
+            pong.pointer("/id"),
+            Some(&json!(11)),
+            "ping must be answered while the bridged call is in flight: {pong:?}"
+        );
+
+        client
+            .send(json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/cancelled",
+                "params": { "requestId": 10, "reason": "test cancel" }
+            }))
+            .await;
+
+        let response = client.next_message_within(Duration::from_secs(5)).await;
+        assert_eq!(response.pointer("/id"), Some(&json!(10)), "{response:?}");
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(true)),
+            "a cancelled bridged call is a tool-level error, not a protocol error: {response:?}"
+        );
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(text.contains("cancelled"), "{text}");
+
+        // The effect that matters: the bridge socket died with the cancel,
+        // long before the 30s call_timeout could have ended the call.
+        tokio::time::timeout(Duration::from_secs(2), dropped_rx)
+            .await
+            .expect("the cancelled call must drop the bridge socket")
+            .unwrap();
 
         stop_test_server(client, running).await;
     }

--- a/crates/archon/src/play.rs
+++ b/crates/archon/src/play.rs
@@ -5,39 +5,106 @@ use std::sync::Arc;
 
 use akouo_core::{AudioSource, Engine, EngineConfig, EngineEvent};
 use snafu::ResultExt;
+use tokio_util::sync::CancellationToken;
 
 use crate::cli::PlayArgs;
 use crate::error::{AudioEngineSnafu, HostError};
 
-pub async fn run_play(args: PlayArgs, out: &mut impl Write) -> Result<(), HostError> {
-    let config = EngineConfig::default();
+pub async fn run_play(
+    args: PlayArgs,
+    out: &mut impl Write,
+    cancel: CancellationToken,
+) -> Result<(), HostError> {
+    run_play_with_config(args, EngineConfig::default(), out, cancel).await
+}
+
+/// Plays `args.file` until the track ends, the engine reports an error, or
+/// `cancel` fires. Cancellation is cooperative: the event loop selects on
+/// the token, and the existing `engine.stop()` teardown below is the real
+/// stop path — it aborts the decode/DSP tasks and awaits their joins, so a
+/// cancelled call releases the audio device instead of lingering.
+async fn run_play_with_config(
+    args: PlayArgs,
+    config: EngineConfig,
+    out: &mut impl Write,
+    cancel: CancellationToken,
+) -> Result<(), HostError> {
     let engine = Arc::new(Engine::new(config).context(AudioEngineSnafu)?);
     let mut events = engine.subscribe_events();
 
     let source = AudioSource::File(args.file);
     engine.play(source).context(AudioEngineSnafu)?;
 
-    // WHY: block until playback finishes or an error occurs.
-    loop {
-        match events.recv().await {
-            Ok(EngineEvent::PlaybackStopped | EngineEvent::TrackEnded { .. }) => break,
-            Ok(EngineEvent::Error { message }) => {
-                // WHY: writeln! to stdout is non-fatal; broken pipe on exit is expected behavior
-                writeln!(out, "playback error: {message}").ok();
-                break;
-            }
-            Ok(_) => {}
-            Err(_) => break,
+    // WHY: block until playback finishes or an error occurs — or the caller
+    // cancels (MCP `notifications/cancelled` lands on this token). A fresh,
+    // never-cancelled token from the CLI pends forever and changes nothing.
+    let cancelled = loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => break true,
+            event = events.recv() => match event {
+                Ok(EngineEvent::PlaybackStopped | EngineEvent::TrackEnded { .. }) => break false,
+                Ok(EngineEvent::Error { message }) => {
+                    // WHY: writeln! to stdout is non-fatal; broken pipe on exit is expected behavior
+                    writeln!(out, "playback error: {message}").ok();
+                    break false;
+                }
+                Ok(_) => {}
+                Err(_) => break false,
+            },
         }
-    }
+    };
 
     engine.stop().await.context(AudioEngineSnafu)?;
+    if cancelled {
+        // WHY: names the stop cause so an MCP client can tell a cancelled
+        // playback apart from a track that merely ran to completion.
+        writeln!(out, "playback stopped (cancelled)").ok();
+    }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write as _;
+    use std::time::Duration;
+
     use super::*;
+
+    /// Writes a silent 16-bit PCM WAV; mirrored on akouo-core's own
+    /// `make_wav` test helper, kept local so this test owns its fixture.
+    fn write_wav(
+        dir: &std::path::Path,
+        channels: u16,
+        sample_rate: u32,
+        secs: f32,
+    ) -> std::path::PathBuf {
+        let n_samples = (sample_rate as f32 * secs) as u32 * u32::from(channels);
+        let data_len = n_samples * 2;
+        let byte_rate = sample_rate * u32::from(channels) * 2;
+        let block_align = channels * 2;
+
+        let mut v: Vec<u8> = Vec::new();
+        v.extend_from_slice(b"RIFF");
+        v.extend_from_slice(&(36 + data_len).to_le_bytes());
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(b"fmt ");
+        v.extend_from_slice(&16u32.to_le_bytes());
+        v.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        v.extend_from_slice(&channels.to_le_bytes());
+        v.extend_from_slice(&sample_rate.to_le_bytes());
+        v.extend_from_slice(&byte_rate.to_le_bytes());
+        v.extend_from_slice(&block_align.to_le_bytes());
+        v.extend_from_slice(&16u16.to_le_bytes()); // bit depth
+        v.extend_from_slice(b"data");
+        v.extend_from_slice(&data_len.to_le_bytes());
+        v.extend(std::iter::repeat_n(0u8, data_len as usize));
+
+        let path = dir.join("tone.wav");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(&v).unwrap();
+        path
+    }
 
     #[tokio::test]
     async fn run_play_output_param_accepted() {
@@ -47,7 +114,55 @@ mod tests {
             device: None,
         };
         // Verify the function accepts a Vec<u8> writer and completes without panic.
-        let result = run_play(args, &mut out).await;
+        let result = run_play(args, &mut out, CancellationToken::new()).await;
         assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn cancellation_triggers_the_engine_stop_path() {
+        // WHY: the #652 PR-3 falsifier for playback — a cancelled call must
+        // STOP the engine, not just return. With output disabled the engine
+        // decodes into a ring no hardware drains: once the ring fills, the
+        // 300s track never reaches TrackEnded on its own, so a prompt return
+        // after cancel() can only come from the ct branch + engine.stop().
+        let dir = tempfile::tempdir().unwrap();
+        let wav = write_wav(dir.path(), 1, 8000, 300.0);
+
+        let mut config = EngineConfig::default();
+        config.output.enabled = false;
+        let args = PlayArgs {
+            file: wav,
+            device: None,
+        };
+        let cancel = CancellationToken::new();
+        let mut out = Vec::new();
+
+        // WHY the inner scope: `pin!` stores the future in a hidden local
+        // dropped at scope end; the scope ends the `&mut out` borrow before
+        // the output is inspected below.
+        {
+            let mut run =
+                std::pin::pin!(run_play_with_config(args, config, &mut out, cancel.clone()));
+            // Let playback start and the ring backpressure engage.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            assert!(
+                tokio::time::timeout(Duration::from_millis(1), &mut run)
+                    .await
+                    .is_err(),
+                "the 300s track must still be playing before the cancel lands"
+            );
+
+            cancel.cancel();
+            tokio::time::timeout(Duration::from_secs(5), &mut run)
+                .await
+                .expect("a cancelled play must return promptly, not at track end")
+                .expect("cancelled play returns Ok");
+        }
+
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("cancelled"),
+            "the stop cause must be named in the output: {text:?}"
+        );
     }
 }

--- a/crates/archon/src/render/mod.rs
+++ b/crates/archon/src/render/mod.rs
@@ -17,6 +17,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 pub use server::RendererRegistry;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::error::HostError;
@@ -52,7 +53,12 @@ fn default_renderer_name() -> String {
 ///
 /// On first run (no credentials), initiates pairing with the discovered server.
 /// On subsequent runs, reconnects using the stored API key.
-pub async fn run_render(args: RenderArgs) -> Result<(), HostError> {
+///
+/// `cancel` is the caller's cooperative stop signal (#652 PR 3): the MCP
+/// surface passes the request's `RequestContext.ct` so
+/// `notifications/cancelled` stops the renderer; the CLI passes a fresh,
+/// never-cancelled token and keeps relying on the runner's signal handlers.
+pub async fn run_render(args: RenderArgs, cancel: CancellationToken) -> Result<(), HostError> {
     let name = args.name.unwrap_or_else(default_renderer_name);
 
     let creds = credentials::load_credentials(&args.cert_dir).map_err(|e| HostError::Render {
@@ -99,13 +105,16 @@ pub async fn run_render(args: RenderArgs) -> Result<(), HostError> {
                 );
             }
 
-            runner::run_renderer_loop(runner::RunnerArgs {
-                server_addr: s.addr,
-                name,
-                config_path: args.config_path,
-                server_fingerprint: creds.server_fingerprint,
-                api_key: creds.api_key,
-            })
+            runner::run_renderer_loop(
+                runner::RunnerArgs {
+                    server_addr: s.addr,
+                    name,
+                    config_path: args.config_path,
+                    server_fingerprint: creds.server_fingerprint,
+                    api_key: creds.api_key,
+                },
+                cancel,
+            )
             .await
             .map_err(|e| HostError::Render {
                 message: e.to_string(),

--- a/crates/archon/src/render/runner.rs
+++ b/crates/archon/src/render/runner.rs
@@ -74,7 +74,16 @@ pub struct RunnerArgs {
 
 /// QUIC connection loop: connects to a server, negotiates a session,
 /// receives audio frames, and plays them through the local DSP pipeline.
-pub async fn run_renderer_loop(args: RunnerArgs) -> Result<(), RenderError> {
+///
+/// `cancel` is the caller's cooperative stop signal (#652 PR 3): the
+/// renderer's internal shutdown tree is a CHILD of it, so cancelling `cancel`
+/// (an MCP `notifications/cancelled`) stops the loop exactly like the
+/// runner's own SIGINT/SIGTERM path, while those signal handlers cancelling
+/// the child never propagate back up to the caller's token.
+pub async fn run_renderer_loop(
+    args: RunnerArgs,
+    cancel: CancellationToken,
+) -> Result<(), RenderError> {
     let config = load_renderer_config(args.config_path.as_deref())?;
 
     let client_config = tls::build_client_config(&args.server_fingerprint)?;
@@ -82,7 +91,7 @@ pub async fn run_renderer_loop(args: RunnerArgs) -> Result<(), RenderError> {
     let dsp_config = config.dsp_config();
     let (dsp_tx, _) = watch::channel(dsp_config);
 
-    let shutdown = CancellationToken::new();
+    let shutdown = cancel.child_token();
 
     spawn_sighup_handler(
         args.config_path.clone(),
@@ -177,13 +186,23 @@ async fn connect_and_run(
     endpoint.set_default_client_config(client_config.clone());
 
     info!(server = %args.server_addr, "connecting");
-    let connection = endpoint
+    let connecting = endpoint
         .connect(args.server_addr, "harmonia")
         .map_err(|e| RenderError::Connection {
             message: e.to_string(),
             location: snafu::location!(),
-        })?
-        .await?;
+        })?;
+    // WHY the select: a QUIC connect to an unreachable server only fails at
+    // the handshake timeout (~30s), and rmcp cancellation is cooperative —
+    // without observing `shutdown` here, a cancelled MCP render call would
+    // linger for that whole window and then surface the stale connect error
+    // instead of stopping. Ok(()) is the established "shutdown requested"
+    // outcome; the post-session tasks keep their own shutdown branches.
+    let connection = tokio::select! {
+        biased;
+        _ = shutdown.cancelled() => return Ok(()),
+        result = connecting => result?,
+    };
     info!("QUIC connection established");
 
     // Session establishment on bidirectional stream.
@@ -595,6 +614,40 @@ mod tests {
         });
         handle.abort();
         assert!(join_outcome("audio", handle.await).is_ok());
+    }
+
+    #[tokio::test]
+    async fn external_cancellation_stops_the_renderer_loop() {
+        // WHY: the #652 PR-3 falsifier for the renderer — cancelling the
+        // caller's token must STOP the loop, not just be delivered. The
+        // server address is a dead loopback port, so the loop is inside its
+        // connect/backoff cycle when the cancel lands; pre-wiring, no
+        // external signal could break that cycle at all.
+        let args = RunnerArgs {
+            server_addr: "127.0.0.1:9".parse().expect("loopback addr"),
+            name: "ct-falsifier".to_string(),
+            config_path: None,
+            server_fingerprint: "ab".repeat(32),
+            api_key: "k".to_string(),
+        };
+        let cancel = CancellationToken::new();
+        let mut renderer = tokio::spawn(run_renderer_loop(args, cancel.clone()));
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        cancel.cancel();
+
+        // WHY the prompt bound: the cancel lands mid-connect (a dead UDP
+        // port only fails at quinn's ~30s handshake timeout), and the
+        // connect await selects on the shutdown token — a clean exit must
+        // arrive in milliseconds, not at the handshake timeout.
+        let result = tokio::time::timeout(Duration::from_secs(10), &mut renderer)
+            .await
+            .expect("the renderer loop must stop promptly after external cancellation")
+            .expect("renderer task panicked");
+        assert!(
+            result.is_ok(),
+            "a cancelled renderer exits cleanly: {result:?}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

PR 3 of the #652 rmcp migration (stacked on #701): wires `RequestContext.ct` into every tool that can outlive a client's interest. rmcp cancellation is **cooperative** — the serve loop intercepts `notifications/cancelled` and cancels the request's token promptly, but the handler future keeps running unless it observes the token — so each long-runner now selects on it:

- **Acquisition tools (4):** `call_via_bridge` selects on `ct` around the bridge round-trip. A cancelled call drops the `forward_to_bridge` future — and with it the Unix socket — immediately instead of lingering to `call_timeout`, answering a tool-level `isError` "cancelled" envelope (failure-envelope semantics unchanged).
- **`harmonia_play_file`:** `run_play`'s event loop selects on `ct`; cancellation runs the same `engine.stop()` teardown a finished track runs — decode/DSP tasks aborted and joined, the real stop path.
- **`harmonia_render`:** `run_renderer_loop`'s internal shutdown tree is now a child of `ct`, and the QUIC connect await selects on it. The falsifier caught this gap: pre-change, a cancel mid-connect waited out quinn's ~30s handshake timeout and surfaced the stale connect *error* instead of stopping. Post-session task wiring (signal handlers, reap) is untouched.

Each tool method takes the token as a trailing `CancellationToken` arg via rmcp 1.7.0's `FromContextPart`; advertised input schemas are unchanged.

## Falsifier verdict (memo §6)

**Cooperative cancellation is effective — play and render genuinely stop.** PR 4's start/status/stop stays *preferred* (richer UX), not mandatory.

- `cancelled_notification_drops_a_hung_bridged_call` (protocol test, in-memory duplex): hung bridge + 30s `call_timeout`; ping answered mid-call; `notifications/cancelled` → the call answers in ms with the cancelled envelope **and the bridge side observes its socket hit EOF**.
- `cancellation_triggers_the_engine_stop_path` (play.rs): headless engine (output disabled → a 300s WAV never reaches TrackEnded) returns within 5s of cancel — only reachable via the ct branch + `engine.stop()`. Hardware-independent, so CI-deterministic.
- `external_cancellation_stops_the_renderer_loop` (runner.rs): cancel lands mid-connect to a dead port; the loop exits cleanly in ms (this is the test that exposed the connect-select gap above).

## Verification

- `cargo test -p archon`: 288 passed, 0 failed (full archon suite, all PR-2 behavior pins green)
- `cargo clippy -p archon --all-targets`: clean
- `cargo fmt --all`: applied
- `kanon lint . --summary`: 11 violations = main's baseline; zero in touched files
- Local run covered everything; CI carries the full workspace gate.

## Behavior changes

- A cancelled bridged call now answers promptly with `isError: true` + "call cancelled by the client; the MCP bridge connection was dropped" instead of answering at `call_timeout`.
- `play_file` cancelled mid-playback stops the engine and reports "playback stopped (cancelled)".
- `render` cancelled mid-connect/reconnect stops the loop cleanly instead of erroring at the handshake timeout.
- The CLI subcommands pass a never-cancelled token — interactive `harmonia play`/`harmonia render` behavior is unchanged (Ctrl+C path untouched).

Refs #652