### PR TITLE
feat(archon): start/status/stop lifecycle ops for playback and renderer

### DIFF
--- a/_llm/apis.toml
+++ b/_llm/apis.toml
@@ -1,8 +1,8 @@
-# WHY: `harmonia mcp` is a stdio JSON-RPC MCP server (protocol 2025-06-18).
-# The 4 offline tools run in-process (no server needed); the 4 acquisition
-# tools forward to a running `harmonia serve` over its local Unix-domain
-# bridge socket (#609). download_url is credential-redacted on every
-# acquisition-tool output.
+# WHY: `harmonia mcp` is a stdio JSON-RPC MCP server (protocol version
+# negotiated; server latest 2025-11-25). The 10 offline tools run in-process
+# (no server needed); the 4 acquisition tools forward to a running
+# `harmonia serve` over its local Unix-domain bridge socket (#609).
+# download_url is credential-redacted on every acquisition-tool output.
 [[mcp_tools]]
 name = "harmonia_db_migrate"
 description = "Apply embedded SQLite migrations from a harmonia.toml config path (offline; no server required)."
@@ -13,11 +13,35 @@ description = "Run the canonical storage migrator for music/books/audiobooks/pod
 
 [[mcp_tools]]
 name = "harmonia_play_file"
-description = "Play a local audio file through the Akouo engine; blocks until playback stops (offline)."
+description = "Play a local audio file through the Akouo engine, blocking until playback stops; cancelling the call stops playback (offline). Prefer the harmonia_play_file_start/status/stop lifecycle ops for long tracks; a blocking call is invisible to the lifecycle registry."
 
 [[mcp_tools]]
 name = "harmonia_render"
-description = "Run the headless renderer loop; blocks while active (offline)."
+description = "Run the headless renderer loop, blocking while active; cancelling the call stops the renderer (offline). Prefer the harmonia_render_start/status/stop lifecycle ops for a managed renderer; a blocking call is invisible to the lifecycle registry."
+
+[[mcp_tools]]
+name = "harmonia_play_file_start"
+description = "Start playback of a local file as a background op; returns an op id immediately (offline). One playback op at a time — a second start is refused."
+
+[[mcp_tools]]
+name = "harmonia_play_file_status"
+description = "Report the playback op's state: running / exited with summary / idle. Optional op_id must name the running or most recent op."
+
+[[mcp_tools]]
+name = "harmonia_play_file_stop"
+description = "Cancel the running playback op's token and await teardown; returns the exit summary. Stopping with nothing running is a tool error."
+
+[[mcp_tools]]
+name = "harmonia_render_start"
+description = "Start the headless renderer loop as a background op; returns an op id immediately (offline). One renderer op at a time — a second start is refused."
+
+[[mcp_tools]]
+name = "harmonia_render_status"
+description = "Report the renderer op's state: running / exited with summary / idle. Optional op_id must name the running or most recent op."
+
+[[mcp_tools]]
+name = "harmonia_render_stop"
+description = "Cancel the running renderer op's token and await teardown; returns the exit summary. Stopping with nothing running is a tool error."
 
 [[mcp_tools]]
 name = "harmonia_search_releases"
@@ -70,7 +94,7 @@ purpose = "Migrate library state and canonical filesystem layout."
 
 [[cli_commands]]
 name = "harmonia mcp"
-purpose = "Run the stdio JSON-RPC MCP server (8 tools). The 4 offline tools run in-process; the 4 acquisition tools forward to a running 'harmonia serve' over its local Unix-domain bridge socket. Takes --config to resolve the bridge socket path and call timeout."
+purpose = "Run the stdio JSON-RPC MCP server (14 tools). The 10 offline tools run in-process; the 4 acquisition tools forward to a running 'harmonia serve' over its local Unix-domain bridge socket. Takes --config to resolve the bridge socket path and call timeout."
 
 [[http_routes]]
 method = "various"

--- a/crates/archon/src/main.rs
+++ b/crates/archon/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod db;
 mod error;
 mod mcp;
+mod mcp_ops;
 mod migrate;
 mod paths;
 mod play;

--- a/crates/archon/src/mcp.rs
+++ b/crates/archon/src/mcp.rs
@@ -1,4 +1,4 @@
-//! MCP stdio surface (#652, PR 3 of the rmcp migration) — an rmcp server.
+//! MCP stdio surface (#652, PRs 2-4 of the rmcp migration) — an rmcp server.
 //!
 //! The hand-rolled `for line in reader.lines()` loop this module used to
 //! run was a single global critical section: one request completed before
@@ -20,8 +20,15 @@
 //! - Tool-level failures stay `isError: true` envelopes with
 //!   `structuredContent.ok`; only protocol failures become JSON-RPC
 //!   errors.
-//! - `play_file`/`render` still block to completion (or cancellation).
-//!   start/status/stop handles are PR 4.
+//! - `harmonia_play_file`/`harmonia_render` remain as blocking one-call
+//!   forms (cancellable through their request ct). The PR-4 lifecycle trios
+//!   — `harmonia_play_file_start`/`_status`/`_stop` and
+//!   `harmonia_render_start`/`_status`/`_stop` over the `mcp_ops` registry —
+//!   are the preferred shape for long-running work (#652's "state rather
+//!   than an indefinitely open RPC"); the blocking forms suit short work a
+//!   caller wants to await in one call. Blocking calls do NOT join the
+//!   registry: they are invisible to `*_status` and unstoppable via
+//!   `*_stop` (cancel the call itself instead).
 //!
 //! What PR 3 changed — cancellation wiring (rmcp cancellation is
 //! COOPERATIVE: the serve loop intercepts `notifications/cancelled` and
@@ -61,6 +68,7 @@
 //!   literals (whose advertised-vs-actual drift the DTO docs pin).
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use rmcp::handler::server::router::tool::ToolRouter;
@@ -76,20 +84,23 @@ use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, ServiceExt, tool, t
 use serde_json::{Value, json};
 use snafu::ResultExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use archon::mcp_params::{
     CancelDownloadParams, DbMigrateParams, EnqueueDownloadParams, ListDownloadsParams,
-    MigrateLibraryParams, MigrateMediaType, PlayFileParams, RenderParams, SearchReleasesParams,
+    MigrateLibraryParams, MigrateMediaType, PlayFileParams, PlayFileStatusParams,
+    PlayFileStopParams, RenderParams, RenderStatusParams, RenderStopParams, SearchReleasesParams,
 };
 
 use crate::cli::{CliMediaType, DbMigrateArgs, MigrateArgs, PlayArgs};
 use crate::error::{ConfigSnafu, HostError, McpSocketPathSnafu};
+use crate::mcp_ops::{self, OpSlot, OpStatus};
 
 const SERVER_NAME: &str = "harmonia";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-const INSTRUCTIONS: &str = "Local MCP stdio surface for Harmonia. The 4 offline tools (db_migrate, migrate_library, play_file, render) run in-process with no server required. The 4 acquisition tools (search_releases, enqueue_download, list_downloads, cancel_download) forward to a running 'harmonia serve' over its local acquisition bridge socket — if the server isn't running, those calls return a tool-level error naming the socket. The HTTP API remains the canonical remote service API.";
+const INSTRUCTIONS: &str = "Local MCP stdio surface for Harmonia. Offline tools run in-process with no server required: harmonia_db_migrate, harmonia_migrate_library, and playback/renderer control — the harmonia_play_file_start/status/stop and harmonia_render_start/status/stop lifecycle ops (preferred for long-running work: start returns an op id immediately, one op per kind at a time), plus the blocking one-call forms harmonia_play_file and harmonia_render for short work awaited in a single call. The 4 acquisition tools (search_releases, enqueue_download, list_downloads, cancel_download) forward to a running 'harmonia serve' over its local acquisition bridge socket — if the server isn't running, those calls return a tool-level error naming the socket. The HTTP API remains the canonical remote service API.";
 
 /// Resolved once at process start — the acquisition bridge socket path and
 /// per-call deadline. The 4 offline tools never touch this; the 4
@@ -142,12 +153,15 @@ pub(crate) async fn run_stdio(config_path: PathBuf) -> Result<(), HostError> {
     Ok(())
 }
 
-/// The rmcp stdio server — 8 tools as `#[tool]` methods over the typed
-/// `mcp_params` DTOs. Holds only the bridge context; the 4 offline tools
-/// build their CLI args per call exactly as the CLI subcommands do.
+/// The rmcp stdio server — 14 tools as `#[tool]` methods over the typed
+/// `mcp_params` DTOs. Holds the bridge context plus the two lifecycle op
+/// slots (`mcp_ops::OpSlot`, one per long-running kind); the 4 short offline
+/// tools build their CLI args per call exactly as the CLI subcommands do.
 #[derive(Clone)]
 pub(crate) struct HarmoniaServer {
     ctx: McpContext,
+    playback: Arc<Mutex<OpSlot>>,
+    renderer: Arc<Mutex<OpSlot>>,
     tool_router: ToolRouter<Self>,
 }
 
@@ -156,6 +170,8 @@ impl HarmoniaServer {
     fn new(ctx: McpContext) -> Self {
         Self {
             ctx,
+            playback: Arc::new(Mutex::new(OpSlot::new("playback"))),
+            renderer: Arc::new(Mutex::new(OpSlot::new("renderer"))),
             tool_router: Self::tool_router(),
         }
     }
@@ -218,7 +234,7 @@ impl HarmoniaServer {
     #[tool(
         name = "harmonia_play_file",
         title = "Play a local audio file",
-        description = "Play a local file through the Akouo audio engine. This blocks until playback stops; cancelling the call stops playback."
+        description = "Play a local file through the Akouo audio engine, blocking until playback stops; cancelling the call stops playback. Prefer the harmonia_play_file_start/status/stop lifecycle ops for long tracks or anything you may stop later — they keep the connection free and represent the work as an op you can poll. This blocking form suits short clips you want to await in one call. A blocking call does not join the lifecycle registry: it is invisible to harmonia_play_file_status and cannot be stopped via harmonia_play_file_stop."
     )]
     async fn play_file(
         &self,
@@ -252,7 +268,7 @@ impl HarmoniaServer {
     #[tool(
         name = "harmonia_render",
         title = "Run Harmonia renderer mode",
-        description = "Run the headless renderer loop. This blocks while the renderer is active; cancelling the call stops the renderer."
+        description = "Run the headless renderer loop, blocking while the renderer is active; cancelling the call stops the renderer. Prefer the harmonia_render_start/status/stop lifecycle ops to run the renderer as a managed op you can monitor and stop with separate calls. A blocking call does not join the lifecycle registry: it is invisible to harmonia_render_status and cannot be stopped via harmonia_render_stop."
     )]
     async fn render(
         &self,
@@ -274,6 +290,116 @@ impl HarmoniaServer {
         {
             Ok(()) => Ok(tool_success("renderer completed".to_string())),
             Err(e) => Ok(tool_error(e.to_string())),
+        }
+    }
+
+    // ── Lifecycle ops (#652 PR 4): the long-runners as registry state ──────
+
+    #[tool(
+        name = "harmonia_play_file_start",
+        title = "Start playing a local audio file",
+        description = "Start playing a local file through the Akouo audio engine as a background op and return its op id immediately. One playback op at a time: a start while one is running is refused, not replaced. Poll harmonia_play_file_status for the exit summary; stop playback with harmonia_play_file_stop."
+    )]
+    async fn play_file_start(
+        &self,
+        Parameters(params): Parameters<PlayFileParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut slot = self.playback.lock().await;
+        match slot.start(|ct| mcp_ops::spawn_playback(params, ct)).await {
+            Ok(op_id) => Ok(tool_success_data(
+                format!("playback started as op {op_id}"),
+                json!({ "state": "running", "op_id": op_id.as_str() }),
+            )),
+            Err(message) => Ok(tool_error(message)),
+        }
+    }
+
+    #[tool(
+        name = "harmonia_play_file_status",
+        title = "Report playback op status",
+        description = "Report the playback op's state: running, exited (with the exit summary), or idle. With op_id omitted, describes the running op or the most recent exit; an op_id must name one of those two — anything else is a tool error."
+    )]
+    async fn play_file_status(
+        &self,
+        Parameters(params): Parameters<PlayFileStatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut slot = self.playback.lock().await;
+        match slot.status(params.op_id.as_deref()).await {
+            Ok(status) => Ok(status_result("playback", status)),
+            Err(message) => Ok(tool_error(message)),
+        }
+    }
+
+    #[tool(
+        name = "harmonia_play_file_stop",
+        title = "Stop the playback op",
+        description = "Cancel the running playback op's token and await its teardown (the engine stop path that releases the audio device), then return the exit summary. Stopping when no playback is running — or with an op_id that is not the running op — is a tool error and stops nothing."
+    )]
+    async fn play_file_stop(
+        &self,
+        Parameters(params): Parameters<PlayFileStopParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut slot = self.playback.lock().await;
+        match slot.stop(params.op_id.as_deref()).await {
+            Ok(exit) => Ok(tool_success_data(
+                format!("stopped playback op {}: {}", exit.op_id, exit.summary),
+                json!({ "state": "exited", "op_id": exit.op_id.as_str(), "summary": exit.summary }),
+            )),
+            Err(message) => Ok(tool_error(message)),
+        }
+    }
+
+    #[tool(
+        name = "harmonia_render_start",
+        title = "Start the Harmonia renderer",
+        description = "Start the headless renderer loop as a background op and return its op id immediately. One renderer op at a time: a start while one is running is refused, not replaced. Poll harmonia_render_status for the exit summary; stop the renderer with harmonia_render_stop."
+    )]
+    async fn render_start(
+        &self,
+        Parameters(params): Parameters<RenderParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut slot = self.renderer.lock().await;
+        match slot.start(|ct| mcp_ops::spawn_renderer(params, ct)).await {
+            Ok(op_id) => Ok(tool_success_data(
+                format!("renderer started as op {op_id}"),
+                json!({ "state": "running", "op_id": op_id.as_str() }),
+            )),
+            Err(message) => Ok(tool_error(message)),
+        }
+    }
+
+    #[tool(
+        name = "harmonia_render_status",
+        title = "Report renderer op status",
+        description = "Report the renderer op's state: running, exited (with the exit summary), or idle. With op_id omitted, describes the running op or the most recent exit; an op_id must name one of those two — anything else is a tool error."
+    )]
+    async fn render_status(
+        &self,
+        Parameters(params): Parameters<RenderStatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut slot = self.renderer.lock().await;
+        match slot.status(params.op_id.as_deref()).await {
+            Ok(status) => Ok(status_result("renderer", status)),
+            Err(message) => Ok(tool_error(message)),
+        }
+    }
+
+    #[tool(
+        name = "harmonia_render_stop",
+        title = "Stop the renderer op",
+        description = "Cancel the running renderer op's token and await its teardown (the same shutdown path SIGINT/SIGTERM take), then return the exit summary. Stopping when no renderer is running — or with an op_id that is not the running op — is a tool error and stops nothing."
+    )]
+    async fn render_stop(
+        &self,
+        Parameters(params): Parameters<RenderStopParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut slot = self.renderer.lock().await;
+        match slot.stop(params.op_id.as_deref()).await {
+            Ok(exit) => Ok(tool_success_data(
+                format!("stopped renderer op {}: {}", exit.op_id, exit.summary),
+                json!({ "state": "exited", "op_id": exit.op_id.as_str(), "summary": exit.summary }),
+            )),
+            Err(message) => Ok(tool_error(message)),
         }
     }
 
@@ -493,6 +619,38 @@ fn tool_success(output: String) -> CallToolResult {
     result
 }
 
+/// `tool_success` with extra structured fields merged in — the lifecycle
+/// ops report `state`/`op_id`/`summary` a client can match on without
+/// parsing the text line.
+fn tool_success_data(output: String, data: Value) -> CallToolResult {
+    let mut result = CallToolResult::success(vec![Content::text(output)]);
+    let mut structured = json!({ "ok": true });
+    if let (Some(fields), Value::Object(extra)) = (structured.as_object_mut(), data) {
+        fields.extend(extra);
+    }
+    result.structured_content = Some(structured);
+    result
+}
+
+/// Renders a registry status into the tool envelope: a text line for logs
+/// plus the structured `state` (`running`/`exited`/`idle`) clients poll on.
+fn status_result(kind: &str, status: OpStatus) -> CallToolResult {
+    match status {
+        OpStatus::Idle => tool_success_data(
+            format!("no {kind} op is running and none has exited"),
+            json!({ "state": "idle" }),
+        ),
+        OpStatus::Running { op_id } => tool_success_data(
+            format!("{kind} op {op_id} is running"),
+            json!({ "state": "running", "op_id": op_id.as_str() }),
+        ),
+        OpStatus::Exited { op_id, summary } => tool_success_data(
+            format!("{kind} op {op_id} exited: {summary}"),
+            json!({ "state": "exited", "op_id": op_id.as_str(), "summary": summary }),
+        ),
+    }
+}
+
 /// A tool-level failure (`isError: true`) — a normal JSON-RPC SUCCESS
 /// response whose result reports the tool itself failed, matching the
 /// bridge's own `tool_error` envelope shape.
@@ -548,6 +706,18 @@ mod tests {
                 .expect("server response timed out")
                 .unwrap();
             serde_json::from_str(&line).unwrap()
+        }
+
+        /// One `tools/call` round trip; returns the raw response value.
+        async fn call_tool(&mut self, id: i64, name: &str, arguments: Value) -> Value {
+            self.send(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": { "name": name, "arguments": arguments }
+            }))
+            .await;
+            self.next_message().await
         }
     }
 
@@ -662,7 +832,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tools_list_includes_all_eight_tools() {
+    async fn tools_list_includes_all_fourteen_tools() {
         let (mut client, running) = start_test_server(McpContext::default()).await;
 
         client
@@ -683,11 +853,17 @@ mod tests {
             .filter_map(|tool| tool.get("name").and_then(Value::as_str))
             .collect();
 
-        assert_eq!(names.len(), 8, "{names:?}");
+        assert_eq!(names.len(), 14, "{names:?}");
         assert!(names.contains(&"harmonia_db_migrate"));
         assert!(names.contains(&"harmonia_migrate_library"));
         assert!(names.contains(&"harmonia_play_file"));
         assert!(names.contains(&"harmonia_render"));
+        assert!(names.contains(&"harmonia_play_file_start"));
+        assert!(names.contains(&"harmonia_play_file_status"));
+        assert!(names.contains(&"harmonia_play_file_stop"));
+        assert!(names.contains(&"harmonia_render_start"));
+        assert!(names.contains(&"harmonia_render_status"));
+        assert!(names.contains(&"harmonia_render_stop"));
         assert!(names.contains(&"harmonia_search_releases"));
         assert!(names.contains(&"harmonia_enqueue_download"));
         assert!(names.contains(&"harmonia_list_downloads"));
@@ -702,6 +878,30 @@ mod tests {
             play.pointer("/inputSchema/required"),
             Some(&json!(["file"])),
             "{play:?}"
+        );
+        // The lifecycle start tools reuse the blocking tools' param DTOs, so
+        // they advertise the same required sets; status/stop take only an
+        // optional op_id and must require nothing.
+        let play_start = tools
+            .iter()
+            .find(|tool| {
+                tool.get("name").and_then(Value::as_str) == Some("harmonia_play_file_start")
+            })
+            .unwrap();
+        assert_eq!(
+            play_start.pointer("/inputSchema/required"),
+            Some(&json!(["file"])),
+            "{play_start:?}"
+        );
+        let play_stop = tools
+            .iter()
+            .find(|tool| {
+                tool.get("name").and_then(Value::as_str) == Some("harmonia_play_file_stop")
+            })
+            .unwrap();
+        assert!(
+            play_stop.pointer("/inputSchema/required").is_none(),
+            "status/stop params are all-optional: {play_stop:?}"
         );
 
         stop_test_server(client, running).await;
@@ -1101,6 +1301,272 @@ mod tests {
             .await
             .expect("the cancelled call must drop the bridge socket")
             .unwrap();
+
+        stop_test_server(client, running).await;
+    }
+
+    // ── #652 PR 4: start/status/stop lifecycle ops over the op registry ────
+
+    #[tokio::test]
+    async fn play_file_lifecycle_reports_the_exit_of_a_missing_file() {
+        // WHY: the playback registry path at protocol level, without audio
+        // hardware — a missing file fails fast on any machine, so the op
+        // exits on its own and the registry must reap it with the engine's
+        // summary. The running/stop-semantics coverage that needs a
+        // controllable long-runner lives in the mcp_ops unit tests (synthetic
+        // work) and in play.rs's PR-3 falsifier (real cancellation effect).
+        let (mut client, running) = start_test_server(McpContext::default()).await;
+
+        let response = client
+            .call_tool(
+                20,
+                "harmonia_play_file_start",
+                json!({ "file": "/nonexistent/harmonia-pr4.flac" }),
+            )
+            .await;
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(false)),
+            "{response:?}"
+        );
+        assert_eq!(
+            response.pointer("/result/structuredContent/op_id"),
+            Some(&json!("playback-1")),
+            "{response:?}"
+        );
+        assert_eq!(
+            response.pointer("/result/structuredContent/state"),
+            Some(&json!("running")),
+            "{response:?}"
+        );
+
+        // Poll status until the lazy reap lands — the op's finish timing is
+        // the engine's, the reap is the first status call after that.
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let summary = loop {
+            let response = client
+                .call_tool(
+                    21,
+                    "harmonia_play_file_status",
+                    json!({ "op_id": "playback-1" }),
+                )
+                .await;
+            let state = response
+                .pointer("/result/structuredContent/state")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if state == "exited" {
+                break response
+                    .pointer("/result/structuredContent/summary")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the missing-file op never exited: {response:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        };
+        assert!(
+            !summary.is_empty(),
+            "the exit must carry the engine's summary"
+        );
+
+        // An op id that never existed is a tool error, not a status.
+        let response = client
+            .call_tool(
+                22,
+                "harmonia_play_file_status",
+                json!({ "op_id": "playback-zz" }),
+            )
+            .await;
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(true)),
+            "{response:?}"
+        );
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(text.contains("unknown playback op"), "{text}");
+
+        // Stopping the already-exited op is a clean tool error.
+        let response = client
+            .call_tool(
+                23,
+                "harmonia_play_file_stop",
+                json!({ "op_id": "playback-1" }),
+            )
+            .await;
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(true)),
+            "{response:?}"
+        );
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(text.contains("no playback op is running"), "{text}");
+
+        stop_test_server(client, running).await;
+    }
+
+    #[tokio::test]
+    async fn render_lifecycle_start_status_stop_round_trip() {
+        // WHY: the full registry lifecycle at protocol level, hardware-free.
+        // With credentials on disk and an explicit dead server address,
+        // run_render enters the runner's connect/backoff cycle and stays
+        // there (mDNS discovery is skipped, no audio device is touched) until
+        // the registry's stop token breaks it through the same teardown path
+        // PR 3's runner falsifier proved.
+        let cert_dir = tempfile::tempdir().unwrap();
+        crate::render::credentials::save_credentials(
+            cert_dir.path(),
+            &crate::render::credentials::RendererCredentials {
+                api_key: "test-key".to_string(),
+                server_fingerprint: "ab".repeat(32),
+                server_name: "test-server".to_string(),
+                paired_at: "2026-08-12T00:00:00Z".to_string(),
+            },
+        )
+        .unwrap();
+        let start_args = json!({ "server": "127.0.0.1:9", "cert_dir": cert_dir.path() });
+
+        let (mut client, running) = start_test_server(McpContext::default()).await;
+
+        let response = client
+            .call_tool(30, "harmonia_render_start", start_args.clone())
+            .await;
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(false)),
+            "{response:?}"
+        );
+        assert_eq!(
+            response.pointer("/result/structuredContent/op_id"),
+            Some(&json!("renderer-1")),
+            "{response:?}"
+        );
+        assert_eq!(
+            response.pointer("/result/structuredContent/state"),
+            Some(&json!("running")),
+            "{response:?}"
+        );
+
+        // A second start while renderer-1 runs is refused, not replaced.
+        let response = client
+            .call_tool(31, "harmonia_render_start", start_args)
+            .await;
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(true)),
+            "{response:?}"
+        );
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(text.contains("already running"), "{text}");
+        assert!(text.contains("renderer-1"), "{text}");
+
+        // Status reports it running — by id and as "the current one".
+        for arguments in [json!({ "op_id": "renderer-1" }), json!({})] {
+            let response = client
+                .call_tool(32, "harmonia_render_status", arguments)
+                .await;
+            assert_eq!(
+                response.pointer("/result/structuredContent/state"),
+                Some(&json!("running")),
+                "{response:?}"
+            );
+            assert_eq!(
+                response.pointer("/result/structuredContent/op_id"),
+                Some(&json!("renderer-1")),
+                "{response:?}"
+            );
+        }
+
+        // A stop addressed to the wrong op refuses and stops nothing.
+        let response = client
+            .call_tool(
+                33,
+                "harmonia_render_stop",
+                json!({ "op_id": "renderer-99" }),
+            )
+            .await;
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(true)),
+            "{response:?}"
+        );
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(text.contains("renderer-99"), "{text}");
+        assert!(text.contains("renderer-1"), "{text}");
+        let response = client
+            .call_tool(34, "harmonia_render_status", json!({}))
+            .await;
+        assert_eq!(
+            response.pointer("/result/structuredContent/state"),
+            Some(&json!("running")),
+            "the refused stop must leave the op running: {response:?}"
+        );
+
+        // The real stop cancels the op's token and awaits teardown.
+        let response = client
+            .call_tool(35, "harmonia_render_stop", json!({}))
+            .await;
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(false)),
+            "{response:?}"
+        );
+        assert_eq!(
+            response.pointer("/result/structuredContent/state"),
+            Some(&json!("exited")),
+            "{response:?}"
+        );
+        let summary = response
+            .pointer("/result/structuredContent/summary")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(
+            summary.contains("cancelled"),
+            "the stop must name the stop cause: {summary}"
+        );
+
+        // Status reports the recorded exit; a second stop is a clean error.
+        let response = client
+            .call_tool(
+                36,
+                "harmonia_render_status",
+                json!({ "op_id": "renderer-1" }),
+            )
+            .await;
+        assert_eq!(
+            response.pointer("/result/structuredContent/state"),
+            Some(&json!("exited")),
+            "{response:?}"
+        );
+        let response = client
+            .call_tool(37, "harmonia_render_stop", json!({}))
+            .await;
+        assert_eq!(
+            response.pointer("/result/isError"),
+            Some(&Value::Bool(true)),
+            "{response:?}"
+        );
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(text.contains("no renderer op is running"), "{text}");
 
         stop_test_server(client, running).await;
     }

--- a/crates/archon/src/mcp_ops.rs
+++ b/crates/archon/src/mcp_ops.rs
@@ -1,0 +1,522 @@
+//! Lifecycle op registry for the MCP stdio surface (#652, PR 4 of the rmcp
+//! migration) — long-lived playback and renderer work represented as STATE
+//! instead of an indefinitely open RPC.
+//!
+//! One slot per work kind on `HarmoniaServer` (`playback`, `renderer`); a
+//! slot holds at most one running op plus the exit summary of the most
+//! recent one. The six `*_start`/`*_status`/`*_stop` tools in `mcp.rs` are
+//! thin envelopes over `OpSlot`.
+//!
+//! Semantics (pinned by the tests below):
+//! - `start` spawns the work under a FRESH CancellationToken owned by the
+//!   slot — deliberately independent of the starting request's
+//!   `RequestContext.ct`, because the op must outlive the RPC that created
+//!   it. A second start while an op runs is REFUSED with the running op's
+//!   id; the registry never silently replaces live work.
+//! - `status` reports running / exited-with-summary / idle. With no `op_id`
+//!   it describes the running op, else the most recent exit, else idle; an
+//!   `op_id` must name one of those two or the call is a tool error (only
+//!   the running and most-recent op are queryable by id).
+//! - `stop` cancels the op's token and awaits its teardown, then records
+//!   the exit. With no `op_id` it targets the running op; an `op_id` naming
+//!   anything else is refused without touching the live op. Stopping when
+//!   nothing runs is a clean tool error.
+//! - Exit reaping is lazy: a naturally-finished op is joined and its summary
+//!   recorded by the next status/start call. `JoinHandle::is_finished` gates
+//!   that await, so the slot lock is never held across a pending join.
+//!
+//! Op ids are `{kind}-{n}`, monotonic within one server process. The stop
+//! await is unbounded on purpose: PR 3 proved both work loops tear down
+//! promptly on cancellation (the play.rs and runner.rs falsifier tests), so
+//! a wedged teardown is a bug to surface, not a timeout to paper over.
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use archon::mcp_params::{PlayFileParams, RenderParams};
+
+use crate::cli::PlayArgs;
+
+/// The terminal record of a spawned op: `Ok` carries the work's own exit
+/// summary, `Err` its failure text. Plain strings — the status/stop
+/// envelopes serialize them verbatim.
+pub(crate) type OpOutcome = Result<String, String>;
+
+/// A registry op identifier (`{kind}-{n}`, monotonic per server process).
+/// Newtype so a lifecycle op id cannot be silently crossed with the other
+/// stringly ids on the MCP surface (download queue rows, want UUIDs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OpId(String);
+
+impl OpId {
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for OpId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The recorded exit of a finished op.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OpExit {
+    pub(crate) op_id: OpId,
+    pub(crate) summary: String,
+}
+
+/// What `status` learned about a slot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OpStatus {
+    /// Nothing is running and no op has ever completed.
+    Idle,
+    /// An op is still running.
+    Running { op_id: OpId },
+    /// The named op finished; `summary` is its own exit or failure text.
+    Exited { op_id: OpId, summary: String },
+}
+
+struct RunningOp {
+    op_id: OpId,
+    stop: CancellationToken,
+    join: JoinHandle<OpOutcome>,
+}
+
+impl RunningOp {
+    /// Joins the work task and folds its outcome into the recorded summary.
+    /// A panicked or aborted task is reported in the summary, never
+    /// propagated — the registry must stay usable after a bad op.
+    async fn into_exit(self) -> OpExit {
+        let summary = match self.join.await {
+            Ok(Ok(summary)) => summary,
+            Ok(Err(failure)) => format!("failed: {failure}"),
+            Err(e) => format!("the work task did not join cleanly: {e}"),
+        };
+        OpExit {
+            op_id: self.op_id,
+            summary,
+        }
+    }
+}
+
+/// One lifecycle slot: at most one running op of a kind, plus the last exit.
+pub(crate) struct OpSlot {
+    kind: &'static str,
+    next_seq: u64,
+    running: Option<RunningOp>,
+    last_exit: Option<OpExit>,
+}
+
+impl OpSlot {
+    pub(crate) fn new(kind: &'static str) -> Self {
+        Self {
+            kind,
+            next_seq: 0,
+            running: None,
+            last_exit: None,
+        }
+    }
+
+    /// Starts `spawn` under a fresh slot-owned token and returns the new op
+    /// id. A finished-but-unreaped op is reaped first, so start-after-exit
+    /// works without an intervening status call; a genuinely running op
+    /// refuses the start.
+    pub(crate) async fn start(
+        &mut self,
+        spawn: impl FnOnce(CancellationToken) -> JoinHandle<OpOutcome>,
+    ) -> Result<OpId, String> {
+        self.reap_finished().await;
+        if let Some(running) = &self.running {
+            return Err(format!(
+                "{} is already running as op {}; stop it before starting another",
+                self.kind, running.op_id
+            ));
+        }
+        self.next_seq += 1;
+        let op_id = OpId(format!("{}-{}", self.kind, self.next_seq));
+        let stop = CancellationToken::new();
+        let join = spawn(stop.clone());
+        self.running = Some(RunningOp {
+            op_id: op_id.clone(),
+            stop,
+            join,
+        });
+        Ok(op_id)
+    }
+
+    pub(crate) async fn status(&mut self, op_id: Option<&str>) -> Result<OpStatus, String> {
+        self.reap_finished().await;
+        match op_id {
+            Some(id) => {
+                if let Some(running) = &self.running
+                    && running.op_id.as_str() == id
+                {
+                    return Ok(OpStatus::Running {
+                        op_id: running.op_id.clone(),
+                    });
+                }
+                if let Some(exit) = &self.last_exit
+                    && exit.op_id.as_str() == id
+                {
+                    return Ok(OpStatus::Exited {
+                        op_id: exit.op_id.clone(),
+                        summary: exit.summary.clone(),
+                    });
+                }
+                Err(format!(
+                    "unknown {} op {id}: it is neither the running op nor the most recent exit",
+                    self.kind
+                ))
+            }
+            None => {
+                if let Some(running) = &self.running {
+                    Ok(OpStatus::Running {
+                        op_id: running.op_id.clone(),
+                    })
+                } else if let Some(exit) = &self.last_exit {
+                    Ok(OpStatus::Exited {
+                        op_id: exit.op_id.clone(),
+                        summary: exit.summary.clone(),
+                    })
+                } else {
+                    Ok(OpStatus::Idle)
+                }
+            }
+        }
+    }
+
+    /// Cancels the running op's token and awaits its teardown. A mismatched
+    /// `op_id` refuses WITHOUT vacating the slot — the live op survives a
+    /// client that meant to stop something else.
+    pub(crate) async fn stop(&mut self, op_id: Option<&str>) -> Result<OpExit, String> {
+        let Some(running) = self.running.take() else {
+            return Err(format!("no {} op is running", self.kind));
+        };
+        if let Some(id) = op_id
+            && running.op_id.as_str() != id
+        {
+            let current = running.op_id.clone();
+            self.running = Some(running);
+            return Err(format!(
+                "{} op {id} is not the running op ({current}); refusing to stop",
+                self.kind
+            ));
+        }
+        running.stop.cancel();
+        let exit = running.into_exit().await;
+        self.last_exit = Some(exit.clone());
+        Ok(exit)
+    }
+
+    /// Joins a naturally-finished op and records its exit. The `is_finished`
+    /// gate means the await never pends on live work, so callers may hold
+    /// the slot lock across this without stalling on a running op.
+    async fn reap_finished(&mut self) {
+        let finished = self
+            .running
+            .as_ref()
+            .is_some_and(|op| op.join.is_finished());
+        if !finished {
+            return;
+        }
+        if let Some(running) = self.running.take() {
+            self.last_exit = Some(running.into_exit().await);
+        }
+    }
+}
+
+/// Spawns one playback of `params` under `stop`, the registry-owned token a
+/// `*_stop` call cancels. The `Ok` summary is the play loop's own output —
+/// which already names a cancellation (play.rs writes "playback stopped
+/// (cancelled)") — or "playback completed" when the track ran out silently.
+pub(crate) fn spawn_playback(
+    params: PlayFileParams,
+    stop: CancellationToken,
+) -> JoinHandle<OpOutcome> {
+    tokio::spawn(async move {
+        let mut out: Vec<u8> = Vec::new();
+        let result = crate::play::run_play(
+            PlayArgs {
+                file: params.file,
+                device: params.device,
+            },
+            &mut out,
+            stop,
+        )
+        .await;
+        match result {
+            Ok(()) => {
+                // WHY lossy: this is a human-readable exit summary, not a
+                // wire contract — one lossy line beats a third error path.
+                let text = String::from_utf8_lossy(&out).trim().to_string();
+                if text.is_empty() {
+                    Ok("playback completed".to_string())
+                } else {
+                    Ok(text)
+                }
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    })
+}
+
+/// Spawns the renderer loop under `stop` — same shape as `spawn_playback`.
+pub(crate) fn spawn_renderer(
+    params: RenderParams,
+    stop: CancellationToken,
+) -> JoinHandle<OpOutcome> {
+    let observed = stop.clone();
+    tokio::spawn(async move {
+        let result = crate::render::run_render(
+            crate::render::RenderArgs {
+                server: params.server,
+                cert_dir: params
+                    .cert_dir
+                    .unwrap_or_else(crate::paths::default_renderer_cert_dir),
+                name: params.name,
+                config_path: params.config,
+            },
+            stop,
+        )
+        .await;
+        match result {
+            // WHY: run_render returns Ok on both natural exit and a registry
+            // stop (its shutdown tree treats both as a clean drain); only the
+            // slot's token tells them apart, so name the stop cause here.
+            Ok(()) if observed.is_cancelled() => Ok("renderer stopped (cancelled)".to_string()),
+            Ok(()) => Ok("renderer exited".to_string()),
+            Err(e) => Err(e.to_string()),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use super::*;
+
+    /// A synthetic op that pends until its registry token fires — mirrors
+    /// the select structure of the real play/render loops without touching
+    /// audio hardware or the network.
+    fn spawn_synthetic(
+        stop: CancellationToken,
+        cancelled: Arc<AtomicBool>,
+    ) -> JoinHandle<OpOutcome> {
+        tokio::spawn(async move {
+            stop.cancelled().await;
+            cancelled.store(true, Ordering::SeqCst);
+            Ok("synthetic op stopped".to_string())
+        })
+    }
+
+    #[tokio::test]
+    async fn status_reports_idle_before_anything_runs() {
+        let mut slot = OpSlot::new("playback");
+        assert_eq!(slot.status(None).await.unwrap(), OpStatus::Idle);
+        // An op id is a tool error even before the first start.
+        assert!(slot.status(Some("playback-1")).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn start_assigns_monotonic_op_ids_and_refuses_a_second_start() {
+        let mut slot = OpSlot::new("test");
+        let first = slot
+            .start(|ct| spawn_synthetic(ct, Arc::new(AtomicBool::new(false))))
+            .await
+            .unwrap();
+        assert_eq!(first.as_str(), "test-1");
+
+        let err = slot
+            .start(|ct| spawn_synthetic(ct, Arc::new(AtomicBool::new(false))))
+            .await
+            .unwrap_err();
+        assert!(err.contains("already running"), "{err}");
+        // The refusal names the live op so the client can stop or poll it.
+        assert!(err.contains("test-1"), "{err}");
+
+        slot.stop(None).await.unwrap();
+        let second = slot
+            .start(|ct| spawn_synthetic(ct, Arc::new(AtomicBool::new(false))))
+            .await
+            .unwrap();
+        assert_eq!(second.as_str(), "test-2");
+        slot.stop(None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stop_without_a_running_op_is_a_clean_error() {
+        let mut slot = OpSlot::new("playback");
+        let err = slot.stop(None).await.unwrap_err();
+        assert!(err.contains("no playback op is running"), "{err}");
+        let err = slot.stop(Some("playback-9")).await.unwrap_err();
+        assert!(err.contains("no playback op is running"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn stop_cancels_the_op_and_status_reports_the_exit() {
+        let mut slot = OpSlot::new("playback");
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let op_id = slot
+            .start(|ct| spawn_synthetic(ct, cancelled.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            slot.status(None).await.unwrap(),
+            OpStatus::Running {
+                op_id: op_id.clone()
+            }
+        );
+
+        let exit = slot.stop(Some(op_id.as_str())).await.unwrap();
+        assert_eq!(exit.op_id, op_id);
+        assert!(exit.summary.contains("synthetic op stopped"), "{exit:?}");
+        // WHY: the point of the registry — the stop token IS the task's
+        // token, so the work itself observed the cancellation.
+        assert!(cancelled.load(Ordering::SeqCst));
+
+        assert_eq!(
+            slot.status(None).await.unwrap(),
+            OpStatus::Exited {
+                op_id: op_id.clone(),
+                summary: "synthetic op stopped".to_string()
+            }
+        );
+        // The exited op stays queryable by id…
+        assert!(matches!(
+            slot.status(Some(op_id.as_str())).await.unwrap(),
+            OpStatus::Exited { .. }
+        ));
+        // …but stopping it again is a clean error, not a no-op success.
+        assert!(slot.stop(Some(op_id.as_str())).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn status_reaps_a_naturally_finished_op_and_start_can_replace_it() {
+        let mut slot = OpSlot::new("test");
+        let op_id = slot
+            .start(|_ct| tokio::spawn(async { Ok("done on its own".to_string()) }))
+            .await
+            .unwrap();
+
+        // Poll until the lazy reap lands — the task's exact finish timing is
+        // the runtime's, the reap is the next status call after that.
+        let summary = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match slot.status(Some(op_id.as_str())).await.unwrap() {
+                    OpStatus::Exited { summary, .. } => break summary,
+                    _ => tokio::time::sleep(Duration::from_millis(10)).await,
+                }
+            }
+        })
+        .await
+        .expect("a finished op must be reaped by status");
+        assert!(summary.contains("done on its own"), "{summary}");
+
+        // The slot is free again without an explicit stop.
+        let second = slot
+            .start(|_ct| tokio::spawn(async { Ok("second".to_string()) }))
+            .await
+            .unwrap();
+        assert_eq!(second.as_str(), "test-2");
+    }
+
+    #[tokio::test]
+    async fn stop_with_a_mismatched_op_id_refuses_and_keeps_the_op_running() {
+        let mut slot = OpSlot::new("renderer");
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let op_id = slot
+            .start(|ct| spawn_synthetic(ct, cancelled.clone()))
+            .await
+            .unwrap();
+
+        let err = slot.stop(Some("renderer-99")).await.unwrap_err();
+        assert!(err.contains("renderer-99"), "{err}");
+        assert!(err.contains(op_id.as_str()), "{err}");
+
+        // The refusal left the live op untouched.
+        assert!(!cancelled.load(Ordering::SeqCst));
+        assert_eq!(
+            slot.status(None).await.unwrap(),
+            OpStatus::Running {
+                op_id: op_id.clone()
+            }
+        );
+
+        // And the correctly-addressed stop still works.
+        slot.stop(Some(op_id.as_str())).await.unwrap();
+        assert!(cancelled.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn only_the_running_and_most_recent_op_are_queryable_by_id() {
+        let mut slot = OpSlot::new("test");
+        let first = slot
+            .start(|ct| spawn_synthetic(ct, Arc::new(AtomicBool::new(false))))
+            .await
+            .unwrap();
+        slot.stop(None).await.unwrap();
+        let second = slot
+            .start(|ct| spawn_synthetic(ct, Arc::new(AtomicBool::new(false))))
+            .await
+            .unwrap();
+        slot.stop(None).await.unwrap();
+
+        // One exit deep: the older op id is now unknown, not a stale exit.
+        assert!(matches!(
+            slot.status(Some(second.as_str())).await.unwrap(),
+            OpStatus::Exited { .. }
+        ));
+        let err = slot.status(Some(first.as_str())).await.unwrap_err();
+        assert!(err.contains("unknown test op"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_failed_op_is_recorded_as_a_failed_exit() {
+        let mut slot = OpSlot::new("playback");
+        let op_id = slot
+            .start(|_ct| tokio::spawn(async { Err("engine blew up".to_string()) }))
+            .await
+            .unwrap();
+        let summary = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match slot.status(Some(op_id.as_str())).await.unwrap() {
+                    OpStatus::Exited { summary, .. } => break summary,
+                    _ => tokio::time::sleep(Duration::from_millis(10)).await,
+                }
+            }
+        })
+        .await
+        .expect("a failed op must be reaped by status");
+        assert!(summary.contains("failed: engine blew up"), "{summary}");
+    }
+
+    #[tokio::test]
+    async fn spawn_playback_of_a_missing_file_exits_promptly() {
+        // WHY: the registry-to-run_play seam without hardware. A missing
+        // file fails fast on any machine — either Engine setup or the decode
+        // task errors — so the op must EXIT promptly carrying the failure,
+        // never hang the slot. The Ok/Err split is the engine's environment-
+        // dependent choice; both are exits with a non-empty summary.
+        let join = spawn_playback(
+            PlayFileParams {
+                file: std::path::PathBuf::from("/nonexistent/harmonia-mcp-ops.flac"),
+                device: None,
+            },
+            CancellationToken::new(),
+        );
+        let outcome = tokio::time::timeout(Duration::from_secs(10), join)
+            .await
+            .expect("a missing file must not hang the playback op")
+            .expect("the playback task must not panic");
+        match outcome {
+            Ok(summary) => assert!(!summary.is_empty()),
+            Err(failure) => assert!(!failure.is_empty()),
+        }
+    }
+}

--- a/crates/archon/src/mcp_params.rs
+++ b/crates/archon/src/mcp_params.rs
@@ -1,23 +1,23 @@
 //! Typed MCP tool parameter DTOs (#652, PR 1 of the rmcp migration). // kanon:ignore STORAGE/no-migration-checksum -- false positive: this module holds wire DTOs for the db_migrate TOOL; no migration code or checksum-relevant logic lives here
 //!
-//! One struct per tool on the stdio surface — the 4 offline tools
-//! (`harmonia_db_migrate`, `harmonia_migrate_library`, `harmonia_play_file`,
-//! `harmonia_render`) and the 4 acquisition tools forwarded to the
-//! serve-hosted bridge (`harmonia_search_releases`, `harmonia_enqueue_download`,
-//! `harmonia_list_downloads`, `harmonia_cancel_download`). Each struct pins
-//! the arguments TODAY'S live surface accepts: the hand-rolled extractor in
-//! the bin's `mcp.rs` for the offline tools, and the bridge's own serde DTOs
-//! (`mcp_bridge.rs`, `paroche::routes::search::SearchRequest`) for the
-//! acquisition tools. The tests in this file are the parity evidence: they
-//! deserialize exactly the shapes the live surface accepts and assert failure
-//! for the shapes it rejects.
+//! One struct per tool on the stdio surface — the offline tools
+//! (`harmonia_db_migrate`, `harmonia_migrate_library`, the blocking
+//! `harmonia_play_file`/`harmonia_render`, and the PR-4 lifecycle trios
+//! `harmonia_play_file_start`/`_status`/`_stop` and
+//! `harmonia_render_start`/`_status`/`_stop`) and the 4 acquisition tools
+//! forwarded to the serve-hosted bridge (`harmonia_search_releases`,
+//! `harmonia_enqueue_download`, `harmonia_list_downloads`,
+//! `harmonia_cancel_download`). The lifecycle `*_start` tools reuse
+//! `PlayFileParams`/`RenderParams` verbatim — the spawned work takes exactly
+//! the blocking call's arguments; only the status/stop op-id DTOs are new
+//! shapes. Each struct pins the arguments the live surface accepts; the
+//! tests in this file are the parity evidence.
 //!
-//! Nothing consumes these structs yet — the rmcp stdio server (PR 2) takes
-//! them as `#[tool]` parameter types, and their schemars-generated
-//! `inputSchema` then replaces the hand-written `json!` literals. Where the
-//! hand-written schema and the live parser disagree today, the struct follows
-//! the LIVE parser (a client conforming to the advertised schema is always
-//! accepted); the known deltas a PR-2 schema swap will normalize:
+//! The rmcp stdio server (PR 2) takes these structs as `#[tool]` parameter
+//! types, so their schemars-generated `inputSchema` IS the advertised
+//! contract. Where the pre-rmcp hand-written schema and its live parser
+//! disagreed, the struct followed the live parser (a client conforming to
+//! the advertised schema is always accepted); the deltas PR 2 normalized:
 //!
 //! - Unknown object keys are ignored at every layer today; the advertised
 //!   `additionalProperties: false` was never enforced by any parser on the
@@ -32,10 +32,11 @@
 //!   out-of-range integers that the bridge then clamps; `want_id` deserializes
 //!   as optional because the "required" rejection is a bridge-level tool error
 //!   today. (`search_releases.limit` is forwarded unclamped.)
-//! - Non-object `arguments` (explicit `null`, arrays, scalars) are treated as
-//!   all-keys-absent by today's `Value::get` extraction — a client sending
-//!   `"arguments": null` runs the tool with defaults. The DTOs reject
-//!   non-object shapes; PR 2 must normalize this deliberately (witness
+//! - Non-object `arguments`: the pre-rmcp `Value::get` extraction treated
+//!   explicit `null`, arrays, and scalars as all-keys-absent. Since PR 2,
+//!   explicit `null`/absent runs a tool with defaults, but any other
+//!   non-object `arguments` value fails typed request dispatch and is
+//!   answered as an unknown method (`-32601`) before any tool runs (witness
 //!   finding on #700).
 
 use std::net::SocketAddr;
@@ -44,10 +45,11 @@ use std::path::PathBuf;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// WHY: the live extractor (`optional_bool` in the bin's `mcp.rs`) treats a
-/// missing flag and an explicit `null` identically — both mean `false`.
-/// Plain `#[serde(default)]` on a `bool` field rejects explicit null, so the
-/// two `migrate_library` flags deserialize through `Option` first.
+/// WHY: the pre-rmcp extractor (`optional_bool` in the old hand-rolled
+/// `mcp.rs`) treated a missing flag and an explicit `null` identically —
+/// both mean `false`. Plain `#[serde(default)]` on a `bool` field rejects
+/// explicit null, so the two `migrate_library` flags keep the tolerant
+/// behavior by deserializing through `Option` first.
 fn null_tolerant_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -108,8 +110,9 @@ pub struct MigrateLibraryParams {
     pub copy: bool,
 }
 
-/// Parameters for `harmonia_play_file` — plays one local file through the
-/// Akouo audio engine (blocks until playback stops today).
+/// Parameters for `harmonia_play_file` and `harmonia_play_file_start` —
+/// plays one local file through the Akouo audio engine. The blocking tool
+/// awaits the whole track; the start tool spawns it as a registry op.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub struct PlayFileParams {
     /// Path to the audio file.
@@ -118,8 +121,9 @@ pub struct PlayFileParams {
     pub device: Option<String>,
 }
 
-/// Parameters for `harmonia_render` — runs the headless renderer loop (blocks
-/// while the renderer is active today).
+/// Parameters for `harmonia_render` and `harmonia_render_start` — runs the
+/// headless renderer loop. The blocking tool awaits the renderer; the start
+/// tool spawns it as a registry op.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub struct RenderParams {
     /// Optional host:port server address.
@@ -130,6 +134,38 @@ pub struct RenderParams {
     pub name: Option<String>,
     /// Optional renderer TOML config path.
     pub config: Option<PathBuf>,
+}
+
+/// Parameters for `harmonia_play_file_status` — reports the playback op's
+/// state (running / exited with its summary / idle).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct PlayFileStatusParams {
+    /// Op id returned by harmonia_play_file_start. When omitted, describes the running op, else the most recent exit. When given, must name one of those two — anything else is a tool error.
+    pub op_id: Option<String>,
+}
+
+/// Parameters for `harmonia_play_file_stop` — cancels the running playback
+/// op's token and awaits its teardown.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct PlayFileStopParams {
+    /// Op id returned by harmonia_play_file_start. When omitted, stops the running op. When given, it must BE the running op — a mismatch refuses without stopping anything.
+    pub op_id: Option<String>,
+}
+
+/// Parameters for `harmonia_render_status` — reports the renderer op's
+/// state (running / exited with its summary / idle).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct RenderStatusParams {
+    /// Op id returned by harmonia_render_start. When omitted, describes the running op, else the most recent exit. When given, must name one of those two — anything else is a tool error.
+    pub op_id: Option<String>,
+}
+
+/// Parameters for `harmonia_render_stop` — cancels the running renderer
+/// op's token and awaits its teardown.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct RenderStopParams {
+    /// Op id returned by harmonia_render_start. When omitted, stops the running op. When given, it must BE the running op — a mismatch refuses without stopping anything.
+    pub op_id: Option<String>,
 }
 
 /// Parameters for `harmonia_search_releases` — searches configured
@@ -419,6 +455,44 @@ mod tests {
         assert!(parse::<RenderParams>(json!({ "cert_dir": 42 })).is_err());
     }
 
+    // ── Lifecycle status/stop params (play_file and render trios) ──────────
+
+    #[test]
+    fn lifecycle_status_and_stop_params_accept_an_optional_op_id() {
+        // Every status/stop DTO takes at most one optional string op_id;
+        // empty and explicit-null arguments both mean "the current op".
+        let status: PlayFileStatusParams = parse(json!({})).unwrap();
+        assert_eq!(status.op_id, None);
+        let status: PlayFileStatusParams = parse(json!({ "op_id": null })).unwrap();
+        assert_eq!(status.op_id, None);
+        let status: PlayFileStatusParams = parse(json!({ "op_id": "playback-1" })).unwrap();
+        assert_eq!(status.op_id.as_deref(), Some("playback-1"));
+
+        let stop: PlayFileStopParams = parse(json!({})).unwrap();
+        assert_eq!(stop.op_id, None);
+        let stop: PlayFileStopParams = parse(json!({ "op_id": "playback-2" })).unwrap();
+        assert_eq!(stop.op_id.as_deref(), Some("playback-2"));
+
+        let status: RenderStatusParams = parse(json!({})).unwrap();
+        assert_eq!(status.op_id, None);
+        let status: RenderStatusParams = parse(json!({ "op_id": "renderer-1" })).unwrap();
+        assert_eq!(status.op_id.as_deref(), Some("renderer-1"));
+
+        let stop: RenderStopParams = parse(json!({})).unwrap();
+        assert_eq!(stop.op_id, None);
+        let stop: RenderStopParams = parse(json!({ "op_id": "renderer-3" })).unwrap();
+        assert_eq!(stop.op_id.as_deref(), Some("renderer-3"));
+    }
+
+    #[test]
+    fn lifecycle_status_and_stop_params_reject_a_non_string_op_id() {
+        assert!(parse::<PlayFileStatusParams>(json!({ "op_id": 7 })).is_err());
+        assert!(parse::<PlayFileStatusParams>(json!({ "op_id": ["playback-1"] })).is_err());
+        assert!(parse::<PlayFileStopParams>(json!({ "op_id": true })).is_err());
+        assert!(parse::<RenderStatusParams>(json!({ "op_id": 1.5 })).is_err());
+        assert!(parse::<RenderStopParams>(json!({ "op_id": { "id": "x" } })).is_err());
+    }
+
     // ── harmonia_search_releases ───────────────────────────────────────────
 
     #[test]
@@ -683,11 +757,15 @@ mod tests {
             "{enqueue}"
         );
 
-        // Schema generation must not panic for any of the 8 DTOs.
+        // Schema generation must not panic for any of the 12 DTOs.
         let _ = schemars::schema_for!(DbMigrateParams);
         let _ = schemars::schema_for!(RenderParams);
         let _ = schemars::schema_for!(SearchReleasesParams);
         let _ = schemars::schema_for!(ListDownloadsParams);
         let _ = schemars::schema_for!(CancelDownloadParams);
+        let _ = schemars::schema_for!(PlayFileStatusParams);
+        let _ = schemars::schema_for!(PlayFileStopParams);
+        let _ = schemars::schema_for!(RenderStatusParams);
+        let _ = schemars::schema_for!(RenderStopParams);
     }
 }

--- a/docs/architecture/binary-modes.md
+++ b/docs/architecture/binary-modes.md
@@ -61,12 +61,17 @@ canonical storage layout.
 
 Local MCP stdio server (rmcp) for agent-driven maintenance operations. It
 exposes machine-callable tools for command modes that are intentionally local
-or long-running:
+or long-running.
+
+Offline tools, run in-process with no server required:
 
 - `harmonia_db_migrate`
 - `harmonia_migrate_library`
-- `harmonia_play_file`
-- `harmonia_render`
+- The playback and renderer lifecycle trios: `harmonia_play_file_start` /
+  `harmonia_play_file_status` / `harmonia_play_file_stop` and
+  `harmonia_render_start` / `harmonia_render_status` / `harmonia_render_stop`
+- Their blocking one-call forms `harmonia_play_file` and `harmonia_render`,
+  kept for short work a caller wants to await in a single call
 
 plus four acquisition tools (`harmonia_search_releases`,
 `harmonia_enqueue_download`, `harmonia_list_downloads`,
@@ -78,7 +83,16 @@ The server speaks MCP over newline-delimited JSON-RPC stdio via the `rmcp`
 crate: each request runs as its own task (a `ping` is answered while a long
 call is in flight), the protocol version is negotiated rather than echoed,
 and each tool's `inputSchema` is generated from its typed parameter struct.
-`play_file` and `render` still block to completion today.
+
+Playback and rendering are long-lived, so the lifecycle trios represent them
+as state rather than an indefinitely open RPC (#652): `*_start` spawns the
+work and returns an op id immediately, `*_status` reports running / exited
+(with the exit summary) / idle, and `*_stop` cancels the op's token and
+awaits its teardown. The registry holds one op per kind per server process —
+a start while one runs is refused, never replaced, and op ids (`playback-1`,
+`renderer-2`, …) are monotonic per process. The blocking forms do not join
+the registry: they cancel through the MCP `notifications/cancelled` path and
+are invisible to `*_status`.
 
 The HTTP API served by `paroche` remains the canonical remote service surface
 for library, acquisition, request, renderer, and user-facing operations. The MCP
@@ -87,7 +101,7 @@ output.
 
 **Active subsystems:** only the subsystem required by the invoked tool.
 **Does NOT run by default:** HTTP API, acquisition scheduler, library watchers,
-or renderer transport unless the caller invokes `harmonia_render`.
+or renderer transport unless the caller invokes a renderer tool.
 
 ## Mode selection
 


### PR DESCRIPTION
## Summary

PR 4 of the #652 rmcp migration — the playback and renderer long-runners become explicit start/status/stop lifecycle ops over a handle registry, per the issue's "state rather than an indefinitely open RPC".

- New `crates/archon/src/mcp_ops.rs`: `OpSlot` (one running op plus the most recent exit, per kind), an `OpId` newtype (`playback-1`, `renderer-1`, monotonic per server process), and the `spawn_playback`/`spawn_renderer` seams into `run_play`/`run_render`.
- Six new tools on `HarmoniaServer`: `harmonia_play_file_start` / `_status` / `_stop` and `harmonia_render_start` / `_status` / `_stop`. The server now advertises 14 tools.
- Registry semantics: `start` spawns under a slot-owned `CancellationToken` — deliberately independent of the starting request's `RequestContext.ct`, because the op must outlive the RPC that created it — and returns the op id immediately. A start while an op runs is **refused**, never replaced (the refusal names the running op). `status` reports running / exited-with-summary / idle; with no `op_id` it describes the running or most recent op, and an unknown `op_id` is a tool error. `stop` cancels the op's token and awaits teardown; stopping with nothing running, or with an `op_id` that is not the running op, is a clean tool error that stops nothing. Natural exits are reaped lazily by the next status/start call.
- **Blocking variants kept.** `harmonia_play_file` / `harmonia_render` remain: PR 3 made them cancellation-effective through the request `ct`, so for short work awaited in one call they are the simpler shape, and the memo only mandates deletion when cancellation is ineffective. Their descriptions now say when to prefer the lifecycle ops, and that a blocking call does not join the registry (invisible to `*_status`, unstoppable via `*_stop` — cancel the call itself).
- Doc sweep in the same PR (memo §3.7): tool descriptions, the `harmonia mcp` section of `docs/architecture/binary-modes.md` (registry semantics + the 14-tool surface), and the `_llm/apis.toml` tool list.
- New param DTOs in `mcp_params.rs`: `PlayFileStatusParams` / `PlayFileStopParams` / `RenderStatusParams` / `RenderStopParams` (single optional `op_id`); the `*_start` tools reuse `PlayFileParams` / `RenderParams` verbatim.

## Verification

- `cargo test -p archon`: 301 green (58 lib + 209 bin + 34 integration/doc). New coverage:
  - `mcp_ops` unit tests with synthetic ct-driven work: monotonic op ids, double-start refusal, stop→teardown→recorded exit (the task observes the token), status reaping after natural exit, start-after-exit without a stop, wrong-id stop refusal leaving the op running, stop-when-nothing as a clean error, failed-op summaries, one-exit-deep id history.
  - Protocol tests in `mcp.rs` (in-process rmcp server over a duplex): playback start → exit-summary reaping for a missing file (hardware-free), and the full renderer lifecycle — start → status running (by id and anonymous) → double-start refused → wrong-id stop refused → stop → status exited — against a dead loopback server with temp-dir credentials, no mDNS and no audio device. Cancellation effectiveness itself remains covered by PR 3's play.rs/runner.rs falsifier tests.
  - `tools/list` asserts the 14-tool surface and the lifecycle schemas (`*_start` reuses the blocking tools' required sets; status/stop require nothing).
- `cargo clippy -p archon --all-targets -- -D warnings`: clean. `cargo fmt --all -- --check`: clean.
- `kanon lint . --summary`: 11 violations, exactly main's baseline (the `OpId` newtype is what keeps it there — a stringly op id tripped `RUST/primitive-for-domain-id`).
- CI carries the full workspace gate.

## Behavior changes

- Six new tools; no existing tool's behavior changed (blocking `harmonia_play_file`/`harmonia_render` descriptions updated only).
- Op ids are per-process and only the running plus most-recent op are queryable by id — documented in the tool descriptions.

Refs #652
